### PR TITLE
fix: address cursor bugbot review comments

### DIFF
--- a/packages/core/src/__tests__/plugin-registry.test.ts
+++ b/packages/core/src/__tests__/plugin-registry.test.ts
@@ -262,6 +262,38 @@ describe("loadBuiltins", () => {
     });
   });
 
+  it("strips package and path loading metadata from notifier config", async () => {
+    const registry = createPluginRegistry();
+    const fakeWebhook = makePlugin("notifier", "webhook");
+    const cfg = makeOrchestratorConfig({
+      configPath: "/test/config.yaml",
+      notifiers: {
+        mywebhook: {
+          plugin: "webhook",
+          // These are loading metadata fields that should be stripped:
+          package: "@composio/ao-plugin-notifier-webhook",
+          path: "./plugins/custom-webhook", // Filesystem path that could leak
+          // These are plugin-specific fields that should be passed through:
+          url: "https://webhook.example.com/notify",
+          retries: 3,
+        },
+      },
+    });
+
+    await registry.loadBuiltins(cfg, async (pkg: string) => {
+      if (pkg === "@composio/ao-plugin-notifier-webhook") return fakeWebhook;
+      throw new Error(`Not found: ${pkg}`);
+    });
+
+    // Loading metadata (package, path) should be stripped to prevent leakage
+    // Plugin-specific fields (url, retries) should be passed through
+    expect(fakeWebhook.create).toHaveBeenCalledWith({
+      url: "https://webhook.example.com/notify",
+      retries: 3,
+      configPath: "/test/config.yaml",
+    });
+  });
+
   it("does not match notifier key when explicit plugin points to another notifier", async () => {
     const registry = createPluginRegistry();
     const fakeOpenClaw = makePlugin("notifier", "openclaw");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,7 +16,6 @@ export {
   getDefaultConfig,
   findConfig,
   findConfigFile,
-  collectExternalPluginConfigs,
 } from "./config.js";
 
 // Plugin registry

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -76,7 +76,16 @@ function extractPluginConfig(
       const hasExplicitPlugin = typeof configuredPlugin === "string" && configuredPlugin.length > 0;
       const matches = hasExplicitPlugin ? configuredPlugin === name : notifierName === name;
       if (matches) {
-        const { plugin: _plugin, ...rest } = notifierConfig as Record<string, unknown>;
+        // Strip loading metadata fields (plugin, package, path) from config passed to plugin.
+        // These are used for plugin resolution, not plugin-specific configuration.
+        // The path field is particularly important to strip since plugins may use it
+        // for their own purposes (e.g., API endpoint path).
+        const {
+          plugin: _plugin,
+          package: _package,
+          path: _path,
+          ...rest
+        } = notifierConfig as Record<string, unknown>;
         return config.configPath ? { ...rest, configPath: config.configPath } : rest;
       }
     }


### PR DESCRIPTION
- Strip package and path loading metadata from notifier config passed to plugin create(). These fields are used for plugin resolution, not plugin-specific configuration. Prevents filesystem paths from leaking into plugin config where they could conflict with plugin-specific fields of the same name.

- Remove collectExternalPluginConfigs from public API exports since it is only used internally within config.ts during validateConfig.