### PR TITLE
test: add external plugin tests and documentation for PR #11

### DIFF
--- a/docs/EXTERNAL_PLUGINS.md
+++ b/docs/EXTERNAL_PLUGINS.md
@@ -1,0 +1,594 @@
+# External Plugins
+
+This guide explains how to create and use external plugins with Agent Orchestrator.
+
+## Overview
+
+External plugins allow you to extend Agent Orchestrator with custom integrations beyond the built-in plugins. Use them when you need to:
+
+- **Integrate with unsupported services** — Connect to Jira, Bitbucket, Azure DevOps, or internal tools
+- **Customize behavior** — Modify how issues are fetched, PRs are tracked, or notifications are sent
+- **Share plugins across projects** — Publish to npm or use local paths for team-wide plugins
+
+External plugins work identically to built-in plugins. They implement the same interfaces and are loaded at startup based on your `agent-orchestrator.yaml` configuration.
+
+## Plugin Structure
+
+Every plugin must export three things:
+
+### 1. Manifest
+
+Describes the plugin identity:
+
+```typescript
+export const manifest = {
+  name: "jira",                    // Unique name within the slot
+  slot: "tracker" as const,        // Which slot: tracker, scm, or notifier
+  description: "Tracker plugin: Jira integration",
+  version: "1.0.0",
+};
+```
+
+**Important:** The `slot` must use `as const` to preserve the literal type.
+
+### 2. create() Function
+
+Factory function that returns the plugin instance:
+
+```typescript
+export function create(config?: Record<string, unknown>): Tracker {
+  // config comes from your YAML configuration
+  const apiToken = config?.apiToken as string;
+  const baseUrl = config?.baseUrl as string;
+
+  return {
+    name: "jira",
+    // ... implement interface methods
+  };
+}
+```
+
+The `config` parameter receives plugin-specific settings from your YAML file (with `plugin`, `package`, and `path` fields stripped).
+
+### 3. Default Export
+
+Combine manifest and create for the module export:
+
+```typescript
+import type { PluginModule, Tracker } from "@composio/ao-core";
+
+export default { manifest, create } satisfies PluginModule<Tracker>;
+```
+
+### Optional: detect() Function
+
+Check if required dependencies are available:
+
+```typescript
+export function detect(): boolean {
+  // Return true if the plugin can run (e.g., CLI tool is installed)
+  try {
+    execSync("jira --version", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+```
+
+## Available Slots
+
+### Tracker
+
+Issue/task tracking integration (GitHub Issues, Linear, Jira, etc.)
+
+```typescript
+interface Tracker {
+  readonly name: string;
+
+  // Required methods
+  getIssue(identifier: string, project: ProjectConfig): Promise<Issue>;
+  isCompleted(identifier: string, project: ProjectConfig): Promise<boolean>;
+  issueUrl(identifier: string, project: ProjectConfig): string;
+  branchName(identifier: string, project: ProjectConfig): string;
+  generatePrompt(identifier: string, project: ProjectConfig): Promise<string>;
+
+  // Optional methods
+  issueLabel?(url: string, project: ProjectConfig): string;
+  listIssues?(filters: IssueFilters, project: ProjectConfig): Promise<Issue[]>;
+  updateIssue?(identifier: string, update: IssueUpdate, project: ProjectConfig): Promise<void>;
+  createIssue?(input: CreateIssueInput, project: ProjectConfig): Promise<Issue>;
+}
+
+interface Issue {
+  id: string;
+  title: string;
+  description: string;
+  url: string;
+  state: "open" | "in_progress" | "closed" | "cancelled";
+  labels: string[];
+  assignee?: string;
+  priority?: number;
+}
+```
+
+### SCM
+
+Source control management (PRs, CI checks, reviews, merging):
+
+```typescript
+interface SCM {
+  readonly name: string;
+
+  // PR Lifecycle
+  detectPR(session: Session, project: ProjectConfig): Promise<PRInfo | null>;
+  getPRState(pr: PRInfo): Promise<PRState>;
+  mergePR(pr: PRInfo, method?: MergeMethod): Promise<void>;
+  closePR(pr: PRInfo): Promise<void>;
+
+  // CI Tracking
+  getCIChecks(pr: PRInfo): Promise<CICheck[]>;
+  getCISummary(pr: PRInfo): Promise<CIStatus>;
+
+  // Review Tracking
+  getReviews(pr: PRInfo): Promise<Review[]>;
+  getReviewDecision(pr: PRInfo): Promise<ReviewDecision>;
+  getPendingComments(pr: PRInfo): Promise<ReviewComment[]>;
+  getAutomatedComments(pr: PRInfo): Promise<AutomatedComment[]>;
+
+  // Merge Readiness
+  getMergeability(pr: PRInfo): Promise<MergeReadiness>;
+
+  // Optional methods
+  resolvePR?(reference: string, project: ProjectConfig): Promise<PRInfo>;
+  getPRSummary?(pr: PRInfo): Promise<{ state: PRState; title: string; additions: number; deletions: number }>;
+  verifyWebhook?(request: SCMWebhookRequest, project: ProjectConfig): Promise<SCMWebhookVerificationResult>;
+  parseWebhook?(request: SCMWebhookRequest, project: ProjectConfig): Promise<SCMWebhookEvent | null>;
+}
+```
+
+### Notifier
+
+Push notifications to humans:
+
+```typescript
+interface Notifier {
+  readonly name: string;
+
+  // Required method
+  notify(event: OrchestratorEvent): Promise<void>;
+
+  // Optional methods
+  notifyWithActions?(event: OrchestratorEvent, actions: NotifyAction[]): Promise<void>;
+  post?(message: string, context?: NotifyContext): Promise<string | null>;
+}
+
+interface OrchestratorEvent {
+  id: string;
+  type: EventType;
+  priority: "urgent" | "action" | "warning" | "info";
+  sessionId: string;
+  projectId: string;
+  timestamp: Date;
+  message: string;
+  data: Record<string, unknown>;
+}
+```
+
+## Config Syntax
+
+### Loading via Local Path
+
+Reference a local plugin directory:
+
+```yaml
+projects:
+  my-app:
+    name: My App
+    repo: org/my-app
+    path: /path/to/repo
+    defaultBranch: main
+    sessionPrefix: app
+    tracker:
+      path: ./plugins/tracker-jira   # Relative to config file
+      apiToken: ${JIRA_API_TOKEN}
+      baseUrl: https://mycompany.atlassian.net
+```
+
+For notifiers:
+
+```yaml
+notifiers:
+  teams:
+    path: ./plugins/notifier-teams
+    webhookUrl: ${TEAMS_WEBHOOK_URL}
+```
+
+### Loading via npm Package
+
+Reference an npm package:
+
+```yaml
+projects:
+  my-app:
+    tracker:
+      package: "@mycompany/ao-plugin-tracker-jira"
+      apiToken: ${JIRA_API_TOKEN}
+```
+
+### Plugin Name Validation
+
+When you specify both `plugin` and `package`/`path`, the manifest name must match:
+
+```yaml
+# This will fail if the package's manifest.name is not "jira"
+tracker:
+  plugin: jira
+  package: "@mycompany/ao-plugin-tracker-jira"
+```
+
+When you omit `plugin`, the name is auto-inferred from the manifest:
+
+```yaml
+# manifest.name will be used automatically
+tracker:
+  package: "@mycompany/ao-plugin-tracker-jira"
+```
+
+## Examples
+
+### Minimal Tracker Plugin
+
+```typescript
+// tracker-mock/src/index.ts
+import type { PluginModule, Tracker, Issue, ProjectConfig } from "@composio/ao-core";
+
+const MOCK_ISSUES: Map<string, Issue> = new Map([
+  ["1", {
+    id: "1",
+    title: "Implement user authentication",
+    description: "Add OAuth 2.0 support",
+    url: "https://tracker.example.com/issues/1",
+    state: "open",
+    labels: ["feature"],
+  }],
+]);
+
+export const manifest = {
+  name: "mock",
+  slot: "tracker" as const,
+  description: "Tracker plugin: Mock issue tracker for testing",
+  version: "0.1.0",
+};
+
+export function create(config?: Record<string, unknown>): Tracker {
+  const baseUrl = (config?.baseUrl as string) || "https://tracker.example.com";
+
+  return {
+    name: "mock",
+
+    async getIssue(identifier: string, _project: ProjectConfig): Promise<Issue> {
+      const issue = MOCK_ISSUES.get(identifier.replace(/^#/, ""));
+      if (!issue) throw new Error(`Issue ${identifier} not found`);
+      return { ...issue, url: `${baseUrl}/issues/${issue.id}` };
+    },
+
+    async isCompleted(identifier: string, _project: ProjectConfig): Promise<boolean> {
+      const issue = MOCK_ISSUES.get(identifier.replace(/^#/, ""));
+      return issue?.state === "closed";
+    },
+
+    issueUrl(identifier: string, _project: ProjectConfig): string {
+      return `${baseUrl}/issues/${identifier.replace(/^#/, "")}`;
+    },
+
+    branchName(identifier: string, _project: ProjectConfig): string {
+      return `feat/issue-${identifier.replace(/^#/, "")}`;
+    },
+
+    async generatePrompt(identifier: string, project: ProjectConfig): Promise<string> {
+      const issue = await this.getIssue(identifier, project);
+      return [
+        `You are working on issue #${issue.id}: ${issue.title}`,
+        `Issue URL: ${issue.url}`,
+        "",
+        "## Description",
+        issue.description,
+        "",
+        "Please implement the changes and push when done.",
+      ].join("\n");
+    },
+  };
+}
+
+export default { manifest, create } satisfies PluginModule<Tracker>;
+```
+
+### Minimal SCM Plugin
+
+```typescript
+// scm-mock/src/index.ts
+import type {
+  PluginModule, SCM, Session, ProjectConfig, PRInfo, PRState,
+  CICheck, CIStatus, Review, ReviewDecision, ReviewComment,
+  AutomatedComment, MergeReadiness,
+} from "@composio/ao-core";
+
+const MOCK_PRS: Map<number, { info: PRInfo; state: PRState; ciStatus: CIStatus }> = new Map([
+  [1, {
+    info: {
+      number: 1,
+      url: "https://scm.example.com/pr/1",
+      title: "Add authentication",
+      owner: "org",
+      repo: "app",
+      branch: "feat/auth",
+      baseBranch: "main",
+      isDraft: false,
+    },
+    state: "open",
+    ciStatus: "passing",
+  }],
+]);
+
+export const manifest = {
+  name: "mock",
+  slot: "scm" as const,
+  description: "SCM plugin: Mock source control for testing",
+  version: "0.1.0",
+};
+
+export function create(_config?: Record<string, unknown>): SCM {
+  return {
+    name: "mock",
+
+    async detectPR(session: Session, _project: ProjectConfig): Promise<PRInfo | null> {
+      for (const pr of MOCK_PRS.values()) {
+        if (pr.info.branch === session.branch) return pr.info;
+      }
+      return null;
+    },
+
+    async getPRState(pr: PRInfo): Promise<PRState> {
+      return MOCK_PRS.get(pr.number)?.state ?? "closed";
+    },
+
+    async mergePR(pr: PRInfo, _method?: string): Promise<void> {
+      const data = MOCK_PRS.get(pr.number);
+      if (data) data.state = "merged";
+    },
+
+    async closePR(pr: PRInfo): Promise<void> {
+      const data = MOCK_PRS.get(pr.number);
+      if (data) data.state = "closed";
+    },
+
+    async getCIChecks(pr: PRInfo): Promise<CICheck[]> {
+      return [{ name: "build", status: "passed" }, { name: "test", status: "passed" }];
+    },
+
+    async getCISummary(pr: PRInfo): Promise<CIStatus> {
+      return MOCK_PRS.get(pr.number)?.ciStatus ?? "none";
+    },
+
+    async getReviews(_pr: PRInfo): Promise<Review[]> {
+      return [{ author: "reviewer", state: "approved", submittedAt: new Date() }];
+    },
+
+    async getReviewDecision(_pr: PRInfo): Promise<ReviewDecision> {
+      return "approved";
+    },
+
+    async getPendingComments(_pr: PRInfo): Promise<ReviewComment[]> {
+      return [];
+    },
+
+    async getAutomatedComments(_pr: PRInfo): Promise<AutomatedComment[]> {
+      return [];
+    },
+
+    async getMergeability(pr: PRInfo): Promise<MergeReadiness> {
+      const ciPassing = (await this.getCISummary(pr)) === "passing";
+      const approved = (await this.getReviewDecision(pr)) === "approved";
+      return {
+        mergeable: ciPassing && approved,
+        ciPassing,
+        approved,
+        noConflicts: true,
+        blockers: [],
+      };
+    },
+  };
+}
+
+export default { manifest, create } satisfies PluginModule<SCM>;
+```
+
+### Minimal Notifier Plugin
+
+```typescript
+// notifier-mock/src/index.ts
+import type { PluginModule, Notifier, OrchestratorEvent, NotifyAction } from "@composio/ao-core";
+
+export const manifest = {
+  name: "mock",
+  slot: "notifier" as const,
+  description: "Notifier plugin: Mock notifications for testing",
+  version: "0.1.0",
+};
+
+export function create(config?: Record<string, unknown>): Notifier {
+  const prefix = (config?.prefix as string) || "[NOTIFICATION]";
+  const silent = config?.silent === true;
+
+  return {
+    name: "mock",
+
+    async notify(event: OrchestratorEvent): Promise<void> {
+      if (!silent) {
+        console.log(`${prefix} ${event.priority.toUpperCase()}: ${event.message}`);
+      }
+    },
+
+    async notifyWithActions(event: OrchestratorEvent, actions: NotifyAction[]): Promise<void> {
+      if (!silent) {
+        const actionLabels = actions.map((a) => a.label).join(" | ");
+        console.log(`${prefix} ${event.message}\nActions: ${actionLabels}`);
+      }
+    },
+
+    async post(message: string, _context?: unknown): Promise<string | null> {
+      if (!silent) console.log(`${prefix} POST: ${message}`);
+      return `mock-post-${Date.now()}`;
+    },
+  };
+}
+
+export default { manifest, create } satisfies PluginModule<Notifier>;
+```
+
+### Package.json Template
+
+```json
+{
+  "name": "@mycompany/ao-plugin-tracker-jira",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}
+```
+
+### tsconfig.json Template
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}
+```
+
+## Troubleshooting
+
+### Slot Mismatch
+
+**Error:**
+```
+Plugin at projects.myapp.tracker has slot "notifier" but was configured as "tracker".
+The plugin will be registered under its declared slot "notifier".
+```
+
+**Cause:** Your plugin's `manifest.slot` doesn't match where it's referenced in config.
+
+**Fix:** Ensure `manifest.slot` matches the config location:
+- `tracker:` config → `slot: "tracker" as const`
+- `scm:` config → `slot: "scm" as const`
+- `notifiers:` config → `slot: "notifier" as const`
+
+### Name Mismatch
+
+**Error:**
+```
+Plugin manifest.name mismatch at projects.myapp.tracker:
+expected "jira" but package "@acme/ao-plugin-tracker-jira" has manifest.name "jira-cloud".
+Either update the 'plugin' field to match the actual manifest.name, or remove it to auto-infer.
+```
+
+**Cause:** You specified `plugin: jira` but the package's manifest has `name: "jira-cloud"`.
+
+**Fix:** Either:
+1. Update `plugin:` to match: `plugin: jira-cloud`
+2. Remove `plugin:` entirely to auto-infer from manifest
+
+### Module Not Found
+
+**Error:**
+```
+[plugin-registry] Could not resolve specifier for plugin "my-tracker" (source: local)
+```
+
+**Cause:** The path doesn't exist or doesn't have a valid entry point.
+
+**Fix:** Ensure:
+1. The path is relative to `agent-orchestrator.yaml` or absolute
+2. The directory contains `package.json` with `main` or `exports` field
+3. The built output exists (run `pnpm build` in the plugin directory)
+
+### Interface Method Missing
+
+**Error:**
+```
+TypeError: tracker.getIssue is not a function
+```
+
+**Cause:** Your `create()` function doesn't return all required interface methods.
+
+**Fix:** Implement all required methods for the interface. Check the [Available Slots](#available-slots) section for required vs optional methods.
+
+### Config Not Passed
+
+**Symptom:** Plugin doesn't receive configuration values.
+
+**Cause:** Plugin-specific config must be at the same level as `path:` or `package:`.
+
+**Wrong:**
+```yaml
+tracker:
+  path: ./plugins/tracker-jira
+  config:              # Wrong: nested under "config"
+    apiToken: xxx
+```
+
+**Correct:**
+```yaml
+tracker:
+  path: ./plugins/tracker-jira
+  apiToken: xxx        # Correct: same level as path
+  baseUrl: https://...
+```
+
+### Plugin Not Loading
+
+**Symptom:** Plugin appears to load but isn't used.
+
+**Debug steps:**
+1. Check plugin is built: `ls -la ./plugins/my-plugin/dist/`
+2. Add logging to `create()`: `console.log("[my-plugin] Loading with config:", config)`
+3. Verify the manifest name matches what's in config
+4. Check for errors in stderr during startup
+
+### TypeScript Errors
+
+**Error:**
+```
+Cannot find module '@composio/ao-core' or its corresponding type declarations.
+```
+
+**Fix:** Ensure your plugin is part of the pnpm workspace or has `@composio/ao-core` installed:
+
+```yaml
+# pnpm-workspace.yaml
+packages:
+  - "packages/*"
+  - "packages/plugins/*"
+  - "my-plugins/*"        # Add your plugins directory
+```
+
+Then run `pnpm install` to link dependencies.

--- a/packages/core/src/__tests__/external-plugins.test.ts
+++ b/packages/core/src/__tests__/external-plugins.test.ts
@@ -1,0 +1,448 @@
+/**
+ * Integration tests for external plugin loading via path: field.
+ *
+ * This test validates that PR #11's external plugin loading feature works correctly
+ * by loading mock plugins from the test-plugins/ directory.
+ */
+
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createPluginRegistry } from "../plugin-registry.js";
+import type { OrchestratorConfig, Tracker, SCM, Notifier } from "../types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Path to test-plugins directory (relative to this test file in packages/core/src/__tests__)
+const TEST_PLUGINS_DIR = resolve(__dirname, "../../../../test-plugins");
+
+// ---------------------------------------------------------------------------
+// Helper to create test config
+// ---------------------------------------------------------------------------
+
+function makeTestConfig(): OrchestratorConfig {
+  const configPath = resolve(TEST_PLUGINS_DIR, "test-config.yaml");
+
+  return {
+    configPath,
+    readyThresholdMs: 300000,
+    defaults: {
+      runtime: "tmux",
+      agent: "claude-code",
+      workspace: "worktree",
+      notifiers: ["mock"],
+    },
+    projects: {
+      "test-project": {
+        name: "Test Project",
+        repo: "test-org/test-repo",
+        path: "/tmp/test-repo",
+        defaultBranch: "main",
+        sessionPrefix: "test",
+        tracker: {
+          path: "./tracker-mock",
+        },
+        scm: {
+          path: "./scm-mock",
+        },
+      },
+    },
+    notifiers: {
+      mock: {
+        path: "./notifier-mock",
+        prefix: "[TEST]",
+        silent: true,
+      },
+    },
+    notificationRouting: {
+      urgent: ["mock"],
+      action: ["mock"],
+      warning: ["mock"],
+      info: ["mock"],
+    },
+    reactions: {},
+    // Internal: external plugin entries for manifest validation
+    _externalPluginEntries: [
+      {
+        source: "projects.test-project.tracker",
+        location: { kind: "project", projectId: "test-project", configType: "tracker" },
+        slot: "tracker",
+        path: "./tracker-mock",
+        // No expectedPluginName - will infer from manifest
+      },
+      {
+        source: "projects.test-project.scm",
+        location: { kind: "project", projectId: "test-project", configType: "scm" },
+        slot: "scm",
+        path: "./scm-mock",
+      },
+      {
+        source: "notifiers.mock",
+        location: { kind: "notifier", notifierId: "mock" },
+        slot: "notifier",
+        path: "./notifier-mock",
+      },
+    ],
+    plugins: [
+      {
+        name: "tracker-mock",
+        source: "local",
+        path: "./tracker-mock",
+        enabled: true,
+      },
+      {
+        name: "scm-mock",
+        source: "local",
+        path: "./scm-mock",
+        enabled: true,
+      },
+      {
+        name: "notifier-mock",
+        source: "local",
+        path: "./notifier-mock",
+        enabled: true,
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("External plugin loading via path:", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let trackerMock: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let scmMock: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let notifierMock: any;
+
+  beforeAll(async () => {
+    // Import the mock plugins directly to verify they export correctly
+    const trackerPath = join(TEST_PLUGINS_DIR, "tracker-mock/dist/index.js");
+    const scmPath = join(TEST_PLUGINS_DIR, "scm-mock/dist/index.js");
+    const notifierPath = join(TEST_PLUGINS_DIR, "notifier-mock/dist/index.js");
+
+    trackerMock = await import(trackerPath);
+    scmMock = await import(scmPath);
+    notifierMock = await import(notifierPath);
+  });
+
+  describe("Plugin manifest validation", () => {
+    it("tracker-mock exports correct manifest", () => {
+      expect(trackerMock.manifest).toEqual({
+        name: "mock",
+        slot: "tracker",
+        description: "Tracker plugin: Mock issue tracker for testing",
+        version: "0.1.0",
+      });
+    });
+
+    it("scm-mock exports correct manifest", () => {
+      expect(scmMock.manifest).toEqual({
+        name: "mock",
+        slot: "scm",
+        description: "SCM plugin: Mock source control for testing",
+        version: "0.1.0",
+      });
+    });
+
+    it("notifier-mock exports correct manifest", () => {
+      expect(notifierMock.manifest).toEqual({
+        name: "mock",
+        slot: "notifier",
+        description: "Notifier plugin: Mock notifications for testing",
+        version: "0.1.0",
+      });
+    });
+  });
+
+  describe("Plugin create() function", () => {
+    it("tracker-mock create() returns a valid Tracker", () => {
+      const tracker: Tracker = trackerMock.create();
+      expect(tracker.name).toBe("mock");
+      expect(typeof tracker.getIssue).toBe("function");
+      expect(typeof tracker.isCompleted).toBe("function");
+      expect(typeof tracker.issueUrl).toBe("function");
+      expect(typeof tracker.branchName).toBe("function");
+      expect(typeof tracker.generatePrompt).toBe("function");
+      expect(typeof tracker.listIssues).toBe("function");
+      expect(typeof tracker.updateIssue).toBe("function");
+      expect(typeof tracker.createIssue).toBe("function");
+    });
+
+    it("scm-mock create() returns a valid SCM", () => {
+      const scm: SCM = scmMock.create();
+      expect(scm.name).toBe("mock");
+      expect(typeof scm.detectPR).toBe("function");
+      expect(typeof scm.getPRState).toBe("function");
+      expect(typeof scm.mergePR).toBe("function");
+      expect(typeof scm.closePR).toBe("function");
+      expect(typeof scm.getCIChecks).toBe("function");
+      expect(typeof scm.getCISummary).toBe("function");
+      expect(typeof scm.getReviews).toBe("function");
+      expect(typeof scm.getReviewDecision).toBe("function");
+      expect(typeof scm.getPendingComments).toBe("function");
+      expect(typeof scm.getAutomatedComments).toBe("function");
+      expect(typeof scm.getMergeability).toBe("function");
+    });
+
+    it("notifier-mock create() returns a valid Notifier", () => {
+      const notifier: Notifier = notifierMock.create();
+      expect(notifier.name).toBe("mock");
+      expect(typeof notifier.notify).toBe("function");
+      expect(typeof notifier.notifyWithActions).toBe("function");
+      expect(typeof notifier.post).toBe("function");
+    });
+  });
+
+  describe("Tracker mock functionality", () => {
+    it("getIssue returns mock issue data", async () => {
+      const tracker: Tracker = trackerMock.create();
+      const issue = await tracker.getIssue("1", {
+        name: "test",
+        repo: "test/test",
+        path: "/tmp",
+        defaultBranch: "main",
+        sessionPrefix: "test",
+      });
+
+      expect(issue.id).toBe("1");
+      expect(issue.title).toContain("Mock Issue 1");
+      expect(issue.state).toBe("open");
+      expect(issue.labels).toContain("feature");
+    });
+
+    it("isCompleted returns correct state", async () => {
+      const tracker: Tracker = trackerMock.create();
+      const project = {
+        name: "test",
+        repo: "test/test",
+        path: "/tmp",
+        defaultBranch: "main",
+        sessionPrefix: "test",
+      };
+
+      expect(await tracker.isCompleted("1", project)).toBe(false);
+      expect(await tracker.isCompleted("3", project)).toBe(true);
+    });
+
+    it("throws error for non-existent issue", async () => {
+      const tracker: Tracker = trackerMock.create();
+      await expect(
+        tracker.getIssue("999", {
+          name: "test",
+          repo: "test/test",
+          path: "/tmp",
+          defaultBranch: "main",
+          sessionPrefix: "test",
+        }),
+      ).rejects.toThrow("Issue 999 not found");
+    });
+  });
+
+  describe("SCM mock functionality", () => {
+    it("getPRState returns correct state", async () => {
+      const scm: SCM = scmMock.create();
+      const pr1 = {
+        number: 1,
+        url: "https://mock-scm.example.com/pr/1",
+        title: "test",
+        owner: "test-org",
+        repo: "test-repo",
+        branch: "feat/mock-1",
+        baseBranch: "main",
+        isDraft: false,
+      };
+      expect(await scm.getPRState(pr1)).toBe("open");
+    });
+
+    it("getCISummary returns correct status", async () => {
+      const scm: SCM = scmMock.create();
+      const pr1 = {
+        number: 1,
+        url: "https://mock-scm.example.com/pr/1",
+        title: "test",
+        owner: "test-org",
+        repo: "test-repo",
+        branch: "feat/mock-1",
+        baseBranch: "main",
+        isDraft: false,
+      };
+      const pr2 = {
+        number: 2,
+        url: "https://mock-scm.example.com/pr/2",
+        title: "test",
+        owner: "test-org",
+        repo: "test-repo",
+        branch: "feat/mock-2",
+        baseBranch: "main",
+        isDraft: false,
+      };
+
+      expect(await scm.getCISummary(pr1)).toBe("passing");
+      expect(await scm.getCISummary(pr2)).toBe("failing");
+    });
+
+    it("getMergeability returns correct merge readiness", async () => {
+      const scm: SCM = scmMock.create();
+      const pr1 = {
+        number: 1,
+        url: "https://mock-scm.example.com/pr/1",
+        title: "test",
+        owner: "test-org",
+        repo: "test-repo",
+        branch: "feat/mock-1",
+        baseBranch: "main",
+        isDraft: false,
+      };
+
+      const mergeability = await scm.getMergeability(pr1);
+      expect(mergeability.mergeable).toBe(true);
+      expect(mergeability.ciPassing).toBe(true);
+      expect(mergeability.approved).toBe(true);
+      expect(mergeability.blockers).toHaveLength(0);
+    });
+  });
+
+  describe("Notifier mock functionality", () => {
+    it("notify logs event correctly", async () => {
+      const notifier: Notifier = notifierMock.create({ silent: true });
+      const event = {
+        id: "test-1",
+        type: "session.spawned" as const,
+        priority: "info" as const,
+        sessionId: "test-session",
+        projectId: "test-project",
+        timestamp: new Date(),
+        message: "Test notification",
+        data: {},
+      };
+
+      await expect(notifier.notify(event)).resolves.toBeUndefined();
+    });
+
+    it("post returns mock post ID", async () => {
+      const notifier: Notifier = notifierMock.create({ silent: true });
+      const postId = await notifier.post!("Test message", { sessionId: "test" });
+      expect(postId).toMatch(/^mock-post-\d+$/);
+    });
+  });
+
+  describe("Plugin registry integration", () => {
+    it("loads external plugins from config.plugins", async () => {
+      const registry = createPluginRegistry();
+      const config = makeTestConfig();
+
+      // Create mock import function that loads our test plugins
+      const importFn = async (specifier: string): Promise<unknown> => {
+        if (specifier.includes("tracker-mock")) {
+          return import(join(TEST_PLUGINS_DIR, "tracker-mock/dist/index.js"));
+        }
+        if (specifier.includes("scm-mock")) {
+          return import(join(TEST_PLUGINS_DIR, "scm-mock/dist/index.js"));
+        }
+        if (specifier.includes("notifier-mock")) {
+          return import(join(TEST_PLUGINS_DIR, "notifier-mock/dist/index.js"));
+        }
+        throw new Error(`Not found: ${specifier}`);
+      };
+
+      await registry.loadFromConfig(config, importFn);
+
+      // Verify plugins are registered
+      expect(registry.get("tracker", "mock")).not.toBeNull();
+      expect(registry.get("scm", "mock")).not.toBeNull();
+      expect(registry.get("notifier", "mock")).not.toBeNull();
+    });
+
+    it("updates config with actual manifest.name", async () => {
+      const registry = createPluginRegistry();
+      const config = makeTestConfig();
+
+      const importFn = async (specifier: string): Promise<unknown> => {
+        if (specifier.includes("tracker-mock")) {
+          return import(join(TEST_PLUGINS_DIR, "tracker-mock/dist/index.js"));
+        }
+        if (specifier.includes("scm-mock")) {
+          return import(join(TEST_PLUGINS_DIR, "scm-mock/dist/index.js"));
+        }
+        if (specifier.includes("notifier-mock")) {
+          return import(join(TEST_PLUGINS_DIR, "notifier-mock/dist/index.js"));
+        }
+        throw new Error(`Not found: ${specifier}`);
+      };
+
+      await registry.loadFromConfig(config, importFn);
+
+      // Config should be updated with manifest.name
+      expect(config.projects["test-project"].tracker?.plugin).toBe("mock");
+      expect(config.projects["test-project"].scm?.plugin).toBe("mock");
+      expect(config.notifiers.mock?.plugin).toBe("mock");
+    });
+
+    it("passes notifier config to create()", async () => {
+      const registry = createPluginRegistry();
+      const config = makeTestConfig();
+
+      const importFn = async (specifier: string): Promise<unknown> => {
+        if (specifier.includes("tracker-mock")) {
+          return import(join(TEST_PLUGINS_DIR, "tracker-mock/dist/index.js"));
+        }
+        if (specifier.includes("scm-mock")) {
+          return import(join(TEST_PLUGINS_DIR, "scm-mock/dist/index.js"));
+        }
+        if (specifier.includes("notifier-mock")) {
+          // Return a spy version to verify config is passed
+          const original = await import(join(TEST_PLUGINS_DIR, "notifier-mock/dist/index.js"));
+          const createSpy = vi.fn(original.create);
+          return { ...original, create: createSpy };
+        }
+        throw new Error(`Not found: ${specifier}`);
+      };
+
+      await registry.loadFromConfig(config, importFn);
+
+      // The notifier should be registered with config
+      const notifier = registry.get<Notifier>("notifier", "mock");
+      expect(notifier).not.toBeNull();
+      expect(notifier!.name).toBe("mock");
+    });
+  });
+
+  describe("Manifest name mismatch detection", () => {
+    it("logs error when expectedPluginName does not match manifest.name", async () => {
+      const registry = createPluginRegistry();
+      const config = makeTestConfig();
+
+      // Set an expected name that doesn't match
+      config._externalPluginEntries![0].expectedPluginName = "jira";
+
+      const importFn = async (specifier: string): Promise<unknown> => {
+        if (specifier.includes("tracker-mock")) {
+          // Returns plugin with manifest.name = "mock", not "jira"
+          return import(join(TEST_PLUGINS_DIR, "tracker-mock/dist/index.js"));
+        }
+        if (specifier.includes("scm-mock")) {
+          return import(join(TEST_PLUGINS_DIR, "scm-mock/dist/index.js"));
+        }
+        if (specifier.includes("notifier-mock")) {
+          return import(join(TEST_PLUGINS_DIR, "notifier-mock/dist/index.js"));
+        }
+        throw new Error(`Not found: ${specifier}`);
+      };
+
+      // Capture stderr to verify error is logged
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+      await registry.loadFromConfig(config, importFn);
+
+      // Should log error about mismatch
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to load plugin"));
+
+      stderrSpy.mockRestore();
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,6 +677,36 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@25.2.3)(jsdom@25.0.1)(lightningcss@1.30.2)
 
+  test-plugins/notifier-mock:
+    dependencies:
+      '@composio/ao-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+    devDependencies:
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+
+  test-plugins/scm-mock:
+    dependencies:
+      '@composio/ao-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+    devDependencies:
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+
+  test-plugins/tracker-mock:
+    dependencies:
+      '@composio/ao-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+    devDependencies:
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+
 packages:
 
   '@adobe/css-tools@4.4.4':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "packages/*"
   - "packages/plugins/*"
+  - "test-plugins/*"

--- a/test-plugins/notifier-mock/package.json
+++ b/test-plugins/notifier-mock/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@test/ao-plugin-notifier-mock",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/test-plugins/notifier-mock/src/index.ts
+++ b/test-plugins/notifier-mock/src/index.ts
@@ -1,0 +1,148 @@
+/**
+ * notifier-mock plugin — Mock notifier for testing external plugin loading.
+ *
+ * This plugin implements the Notifier interface with functional mock behavior.
+ */
+
+import type {
+  PluginModule,
+  Notifier,
+  OrchestratorEvent,
+  NotifyAction,
+  NotifyContext,
+} from "@composio/ao-core";
+
+// ---------------------------------------------------------------------------
+// Notification Storage
+// ---------------------------------------------------------------------------
+
+interface StoredNotification {
+  timestamp: Date;
+  title: string;
+  message: string;
+  event: OrchestratorEvent;
+  actions?: NotifyAction[];
+}
+
+const notifications: StoredNotification[] = [];
+
+// Track calls for testing
+const callLog: Array<{ method: string; args: unknown[] }> = [];
+
+function logCall(method: string, ...args: unknown[]): void {
+  callLog.push({ method, args });
+  console.log(`[notifier-mock] ${method}(${JSON.stringify(args).slice(1, -1)})`);
+}
+
+// ---------------------------------------------------------------------------
+// Notifier implementation
+// ---------------------------------------------------------------------------
+
+function createMockNotifier(config?: Record<string, unknown>): Notifier {
+  const prefix = (config?.prefix as string) || "[MOCK]";
+  const silent = config?.silent === true;
+
+  return {
+    name: "mock",
+
+    async notify(event: OrchestratorEvent): Promise<void> {
+      logCall("notify", event.type, event.sessionId);
+
+      const title = `${prefix} ${event.priority.toUpperCase()}: ${event.sessionId}`;
+      const message = event.message;
+
+      notifications.push({
+        timestamp: new Date(),
+        title,
+        message,
+        event,
+      });
+
+      if (!silent) {
+        console.log(`[notifier-mock] NOTIFICATION:`);
+        console.log(`  Title: ${title}`);
+        console.log(`  Message: ${message}`);
+        console.log(`  Type: ${event.type}`);
+        console.log(`  Priority: ${event.priority}`);
+      }
+    },
+
+    async notifyWithActions(event: OrchestratorEvent, actions: NotifyAction[]): Promise<void> {
+      logCall("notifyWithActions", event.type, event.sessionId, actions.length);
+
+      const title = `${prefix} ${event.priority.toUpperCase()}: ${event.sessionId}`;
+      const actionLabels = actions.map((a) => a.label).join(" | ");
+      const message = `${event.message}\n\nActions: ${actionLabels}`;
+
+      notifications.push({
+        timestamp: new Date(),
+        title,
+        message,
+        event,
+        actions,
+      });
+
+      if (!silent) {
+        console.log(`[notifier-mock] NOTIFICATION WITH ACTIONS:`);
+        console.log(`  Title: ${title}`);
+        console.log(`  Message: ${message}`);
+        console.log(`  Actions: ${actions.map((a) => a.label).join(", ")}`);
+      }
+    },
+
+    async post(message: string, context?: NotifyContext): Promise<string | null> {
+      logCall("post", message, context);
+
+      const postId = `mock-post-${Date.now()}`;
+
+      if (!silent) {
+        console.log(`[notifier-mock] POST:`);
+        console.log(`  Message: ${message}`);
+        if (context?.sessionId) console.log(`  Session: ${context.sessionId}`);
+        if (context?.projectId) console.log(`  Project: ${context.projectId}`);
+        if (context?.prUrl) console.log(`  PR: ${context.prUrl}`);
+        console.log(`  Post ID: ${postId}`);
+      }
+
+      return postId;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin module export
+// ---------------------------------------------------------------------------
+
+export const manifest = {
+  name: "mock",
+  slot: "notifier" as const,
+  description: "Notifier plugin: Mock notifications for testing",
+  version: "0.1.0",
+};
+
+export function create(config?: Record<string, unknown>): Notifier {
+  console.log("[notifier-mock] Creating mock notifier plugin", config);
+  return createMockNotifier(config);
+}
+
+/** Get all stored notifications (for testing) */
+export function getNotifications(): StoredNotification[] {
+  return [...notifications];
+}
+
+/** Clear stored notifications (for testing) */
+export function clearNotifications(): void {
+  notifications.length = 0;
+}
+
+/** Export call log for testing */
+export function getCallLog(): Array<{ method: string; args: unknown[] }> {
+  return [...callLog];
+}
+
+/** Clear call log for testing */
+export function clearCallLog(): void {
+  callLog.length = 0;
+}
+
+export default { manifest, create } satisfies PluginModule<Notifier>;

--- a/test-plugins/notifier-mock/tsconfig.json
+++ b/test-plugins/notifier-mock/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/test-plugins/scm-mock/package.json
+++ b/test-plugins/scm-mock/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@test/ao-plugin-scm-mock",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/test-plugins/scm-mock/src/index.ts
+++ b/test-plugins/scm-mock/src/index.ts
@@ -1,0 +1,317 @@
+/**
+ * scm-mock plugin — Mock SCM for testing external plugin loading.
+ *
+ * This plugin implements the SCM interface with functional mock data.
+ */
+
+import type {
+  PluginModule,
+  SCM,
+  Session,
+  ProjectConfig,
+  PRInfo,
+  PRState,
+  MergeMethod,
+  CICheck,
+  CIStatus,
+  Review,
+  ReviewDecision,
+  ReviewComment,
+  AutomatedComment,
+  MergeReadiness,
+} from "@composio/ao-core";
+
+// ---------------------------------------------------------------------------
+// Mock Data
+// ---------------------------------------------------------------------------
+
+interface MockPRData {
+  info: PRInfo;
+  state: PRState;
+  ciStatus: CIStatus;
+  reviewDecision: ReviewDecision;
+  checks: CICheck[];
+  reviews: Review[];
+  comments: ReviewComment[];
+  automatedComments: AutomatedComment[];
+}
+
+const MOCK_PRS: Map<number, MockPRData> = new Map([
+  [
+    1,
+    {
+      info: {
+        number: 1,
+        url: "https://mock-scm.example.com/pr/1",
+        title: "feat: Add user authentication",
+        owner: "test-org",
+        repo: "test-repo",
+        branch: "feat/mock-1",
+        baseBranch: "main",
+        isDraft: false,
+      },
+      state: "open",
+      ciStatus: "passing",
+      reviewDecision: "approved",
+      checks: [
+        {
+          name: "build",
+          status: "passed",
+          url: "https://mock-scm.example.com/checks/1/build",
+        },
+        {
+          name: "test",
+          status: "passed",
+          url: "https://mock-scm.example.com/checks/1/test",
+        },
+      ],
+      reviews: [
+        {
+          author: "reviewer1",
+          state: "approved",
+          body: "LGTM!",
+          submittedAt: new Date("2024-01-15T10:00:00Z"),
+        },
+      ],
+      comments: [],
+      automatedComments: [],
+    },
+  ],
+  [
+    2,
+    {
+      info: {
+        number: 2,
+        url: "https://mock-scm.example.com/pr/2",
+        title: "fix: Login bug on mobile",
+        owner: "test-org",
+        repo: "test-repo",
+        branch: "feat/mock-2",
+        baseBranch: "main",
+        isDraft: false,
+      },
+      state: "open",
+      ciStatus: "failing",
+      reviewDecision: "changes_requested",
+      checks: [
+        {
+          name: "build",
+          status: "passed",
+          url: "https://mock-scm.example.com/checks/2/build",
+        },
+        {
+          name: "test",
+          status: "failed",
+          url: "https://mock-scm.example.com/checks/2/test",
+        },
+      ],
+      reviews: [
+        {
+          author: "reviewer2",
+          state: "changes_requested",
+          body: "Please fix the test failures",
+          submittedAt: new Date("2024-01-16T14:00:00Z"),
+        },
+      ],
+      comments: [
+        {
+          id: "c1",
+          author: "reviewer2",
+          body: "This needs error handling",
+          path: "src/auth.ts",
+          line: 42,
+          isResolved: false,
+          createdAt: new Date("2024-01-16T14:05:00Z"),
+          url: "https://mock-scm.example.com/pr/2/comments/c1",
+        },
+      ],
+      automatedComments: [
+        {
+          id: "ac1",
+          botName: "mock-linter[bot]",
+          body: "ESLint: Unused variable 'foo'",
+          path: "src/auth.ts",
+          line: 15,
+          severity: "warning",
+          createdAt: new Date("2024-01-16T14:01:00Z"),
+          url: "https://mock-scm.example.com/pr/2/comments/ac1",
+        },
+      ],
+    },
+  ],
+]);
+
+// Track calls for testing
+const callLog: Array<{ method: string; args: unknown[] }> = [];
+
+function logCall(method: string, ...args: unknown[]): void {
+  callLog.push({ method, args });
+  console.log(`[scm-mock] ${method}(${JSON.stringify(args).slice(1, -1)})`);
+}
+
+// ---------------------------------------------------------------------------
+// SCM implementation
+// ---------------------------------------------------------------------------
+
+function createMockSCM(_config?: Record<string, unknown>): SCM {
+  return {
+    name: "mock",
+
+    // --- PR Lifecycle ---
+
+    async detectPR(session: Session, _project: ProjectConfig): Promise<PRInfo | null> {
+      logCall("detectPR", session.id, session.branch);
+      // Find PR by branch name
+      for (const prData of MOCK_PRS.values()) {
+        if (prData.info.branch === session.branch) {
+          return prData.info;
+        }
+      }
+      return null;
+    },
+
+    async resolvePR(reference: string, _project: ProjectConfig): Promise<PRInfo> {
+      logCall("resolvePR", reference);
+      const prNum = parseInt(reference.replace(/^#/, ""), 10);
+      const prData = MOCK_PRS.get(prNum);
+      if (!prData) {
+        throw new Error(`PR ${reference} not found`);
+      }
+      return prData.info;
+    },
+
+    async getPRState(pr: PRInfo): Promise<PRState> {
+      logCall("getPRState", pr.number);
+      const prData = MOCK_PRS.get(pr.number);
+      return prData?.state ?? "closed";
+    },
+
+    async getPRSummary(
+      pr: PRInfo,
+    ): Promise<{ state: PRState; title: string; additions: number; deletions: number }> {
+      logCall("getPRSummary", pr.number);
+      const prData = MOCK_PRS.get(pr.number);
+      return {
+        state: prData?.state ?? "closed",
+        title: prData?.info.title ?? pr.title,
+        additions: 42,
+        deletions: 10,
+      };
+    },
+
+    async mergePR(pr: PRInfo, method?: MergeMethod): Promise<void> {
+      logCall("mergePR", pr.number, method);
+      const prData = MOCK_PRS.get(pr.number);
+      if (prData) {
+        prData.state = "merged";
+      }
+    },
+
+    async closePR(pr: PRInfo): Promise<void> {
+      logCall("closePR", pr.number);
+      const prData = MOCK_PRS.get(pr.number);
+      if (prData) {
+        prData.state = "closed";
+      }
+    },
+
+    // --- CI Tracking ---
+
+    async getCIChecks(pr: PRInfo): Promise<CICheck[]> {
+      logCall("getCIChecks", pr.number);
+      const prData = MOCK_PRS.get(pr.number);
+      return prData?.checks ?? [];
+    },
+
+    async getCISummary(pr: PRInfo): Promise<CIStatus> {
+      logCall("getCISummary", pr.number);
+      const prData = MOCK_PRS.get(pr.number);
+      return prData?.ciStatus ?? "none";
+    },
+
+    // --- Review Tracking ---
+
+    async getReviews(pr: PRInfo): Promise<Review[]> {
+      logCall("getReviews", pr.number);
+      const prData = MOCK_PRS.get(pr.number);
+      return prData?.reviews ?? [];
+    },
+
+    async getReviewDecision(pr: PRInfo): Promise<ReviewDecision> {
+      logCall("getReviewDecision", pr.number);
+      const prData = MOCK_PRS.get(pr.number);
+      return prData?.reviewDecision ?? "none";
+    },
+
+    async getPendingComments(pr: PRInfo): Promise<ReviewComment[]> {
+      logCall("getPendingComments", pr.number);
+      const prData = MOCK_PRS.get(pr.number);
+      return prData?.comments.filter((c) => !c.isResolved) ?? [];
+    },
+
+    async getAutomatedComments(pr: PRInfo): Promise<AutomatedComment[]> {
+      logCall("getAutomatedComments", pr.number);
+      const prData = MOCK_PRS.get(pr.number);
+      return prData?.automatedComments ?? [];
+    },
+
+    // --- Merge Readiness ---
+
+    async getMergeability(pr: PRInfo): Promise<MergeReadiness> {
+      logCall("getMergeability", pr.number);
+      const prData = MOCK_PRS.get(pr.number);
+      if (!prData) {
+        return {
+          mergeable: false,
+          ciPassing: false,
+          approved: false,
+          noConflicts: true,
+          blockers: ["PR not found"],
+        };
+      }
+
+      const ciPassing = prData.ciStatus === "passing";
+      const approved = prData.reviewDecision === "approved";
+      const blockers: string[] = [];
+
+      if (!ciPassing) blockers.push("CI checks failing");
+      if (!approved) blockers.push("Awaiting review approval");
+
+      return {
+        mergeable: ciPassing && approved,
+        ciPassing,
+        approved,
+        noConflicts: true,
+        blockers,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin module export
+// ---------------------------------------------------------------------------
+
+export const manifest = {
+  name: "mock",
+  slot: "scm" as const,
+  description: "SCM plugin: Mock source control for testing",
+  version: "0.1.0",
+};
+
+export function create(config?: Record<string, unknown>): SCM {
+  console.log("[scm-mock] Creating mock SCM plugin", config);
+  return createMockSCM(config);
+}
+
+/** Export call log for testing */
+export function getCallLog(): Array<{ method: string; args: unknown[] }> {
+  return [...callLog];
+}
+
+/** Clear call log for testing */
+export function clearCallLog(): void {
+  callLog.length = 0;
+}
+
+export default { manifest, create } satisfies PluginModule<SCM>;

--- a/test-plugins/scm-mock/tsconfig.json
+++ b/test-plugins/scm-mock/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/test-plugins/test-config.yaml
+++ b/test-plugins/test-config.yaml
@@ -1,0 +1,47 @@
+# Test configuration for external plugin loading
+# This config references all three mock plugins via path:
+
+defaults:
+  runtime: tmux
+  agent: claude-code
+  workspace: worktree
+  notifiers:
+    - mock
+
+readyThresholdMs: 300000
+
+projects:
+  test-project:
+    name: Test Project
+    repo: test-org/test-repo
+    path: /tmp/test-repo
+    defaultBranch: main
+    sessionPrefix: test
+    # External tracker plugin via path
+    tracker:
+      path: ./tracker-mock
+    # External SCM plugin via path
+    scm:
+      path: ./scm-mock
+
+notifiers:
+  # External notifier plugin via path
+  mock:
+    path: ./notifier-mock
+    prefix: "[TEST]"
+    silent: false
+
+notificationRouting:
+  urgent:
+    - mock
+  action:
+    - mock
+  warning:
+    - mock
+  info:
+    - mock
+
+reactions:
+  ciFailure:
+    auto: false
+    action: notify

--- a/test-plugins/tracker-mock/package.json
+++ b/test-plugins/tracker-mock/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@test/ao-plugin-tracker-mock",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/test-plugins/tracker-mock/src/index.ts
+++ b/test-plugins/tracker-mock/src/index.ts
@@ -1,0 +1,243 @@
+/**
+ * tracker-mock plugin — Mock issue tracker for testing external plugin loading.
+ *
+ * This plugin implements the Tracker interface with functional mock data.
+ */
+
+import type {
+  PluginModule,
+  Tracker,
+  Issue,
+  IssueFilters,
+  IssueUpdate,
+  CreateIssueInput,
+  ProjectConfig,
+} from "@composio/ao-core";
+
+// ---------------------------------------------------------------------------
+// Mock Data
+// ---------------------------------------------------------------------------
+
+const MOCK_ISSUES: Map<string, Issue> = new Map([
+  [
+    "1",
+    {
+      id: "1",
+      title: "Mock Issue 1: Add user authentication",
+      description: "Implement user authentication with OAuth 2.0",
+      url: "https://mock-tracker.example.com/issues/1",
+      state: "open",
+      labels: ["feature", "high-priority"],
+      assignee: "test-user",
+    },
+  ],
+  [
+    "2",
+    {
+      id: "2",
+      title: "Mock Issue 2: Fix login bug",
+      description: "Users unable to login on mobile devices",
+      url: "https://mock-tracker.example.com/issues/2",
+      state: "in_progress",
+      labels: ["bug"],
+      assignee: "developer",
+    },
+  ],
+  [
+    "3",
+    {
+      id: "3",
+      title: "Mock Issue 3: Update documentation",
+      description: "Update README with new API endpoints",
+      url: "https://mock-tracker.example.com/issues/3",
+      state: "closed",
+      labels: ["docs"],
+    },
+  ],
+]);
+
+// Track calls for testing
+const callLog: Array<{ method: string; args: unknown[] }> = [];
+
+function logCall(method: string, ...args: unknown[]): void {
+  callLog.push({ method, args });
+  console.log(`[tracker-mock] ${method}(${JSON.stringify(args).slice(1, -1)})`);
+}
+
+// ---------------------------------------------------------------------------
+// Tracker implementation
+// ---------------------------------------------------------------------------
+
+function createMockTracker(config?: Record<string, unknown>): Tracker {
+  const baseUrl = (config?.baseUrl as string) || "https://mock-tracker.example.com";
+
+  return {
+    name: "mock",
+
+    async getIssue(identifier: string, _project: ProjectConfig): Promise<Issue> {
+      logCall("getIssue", identifier);
+      const id = identifier.replace(/^#/, "");
+      const issue = MOCK_ISSUES.get(id);
+
+      if (!issue) {
+        throw new Error(`Issue ${identifier} not found`);
+      }
+
+      return { ...issue, url: `${baseUrl}/issues/${id}` };
+    },
+
+    async isCompleted(identifier: string, _project: ProjectConfig): Promise<boolean> {
+      logCall("isCompleted", identifier);
+      const id = identifier.replace(/^#/, "");
+      const issue = MOCK_ISSUES.get(id);
+      return issue?.state === "closed";
+    },
+
+    issueUrl(identifier: string, _project: ProjectConfig): string {
+      logCall("issueUrl", identifier);
+      const id = identifier.replace(/^#/, "");
+      return `${baseUrl}/issues/${id}`;
+    },
+
+    issueLabel(url: string, _project: ProjectConfig): string {
+      logCall("issueLabel", url);
+      const match = url.match(/\/issues\/(\d+)/);
+      return match ? `MOCK-${match[1]}` : url;
+    },
+
+    branchName(identifier: string, _project: ProjectConfig): string {
+      logCall("branchName", identifier);
+      const id = identifier.replace(/^#/, "");
+      return `feat/mock-${id}`;
+    },
+
+    async generatePrompt(identifier: string, project: ProjectConfig): Promise<string> {
+      logCall("generatePrompt", identifier);
+      const issue = await this.getIssue(identifier, project);
+
+      const lines = [
+        `You are working on mock issue #${issue.id}: ${issue.title}`,
+        `Issue URL: ${issue.url}`,
+        "",
+      ];
+
+      if (issue.labels.length > 0) {
+        lines.push(`Labels: ${issue.labels.join(", ")}`);
+      }
+
+      if (issue.description) {
+        lines.push("## Description", "", issue.description);
+      }
+
+      lines.push(
+        "",
+        "Please implement the changes described in this issue. When done, commit and push your changes.",
+      );
+
+      return lines.join("\n");
+    },
+
+    async listIssues(filters: IssueFilters, _project: ProjectConfig): Promise<Issue[]> {
+      logCall("listIssues", filters);
+      let issues = Array.from(MOCK_ISSUES.values());
+
+      if (filters.state && filters.state !== "all") {
+        issues = issues.filter((i) => {
+          if (filters.state === "open") return i.state === "open" || i.state === "in_progress";
+          if (filters.state === "closed") return i.state === "closed";
+          return true;
+        });
+      }
+
+      if (filters.labels && filters.labels.length > 0) {
+        issues = issues.filter((i) => filters.labels!.some((l: string) => i.labels.includes(l)));
+      }
+
+      if (filters.assignee) {
+        issues = issues.filter((i) => i.assignee === filters.assignee);
+      }
+
+      const limit = filters.limit ?? 30;
+      return issues.slice(0, limit);
+    },
+
+    async updateIssue(
+      identifier: string,
+      update: IssueUpdate,
+      _project: ProjectConfig,
+    ): Promise<void> {
+      logCall("updateIssue", identifier, update);
+      const id = identifier.replace(/^#/, "");
+      const issue = MOCK_ISSUES.get(id);
+
+      if (!issue) {
+        throw new Error(`Issue ${identifier} not found`);
+      }
+
+      // Apply updates to mock data
+      if (update.state) {
+        issue.state = update.state;
+      }
+      if (update.labels) {
+        issue.labels = [...issue.labels, ...update.labels];
+      }
+      if (update.removeLabels) {
+        issue.labels = issue.labels.filter((l: string) => !update.removeLabels!.includes(l));
+      }
+      if (update.assignee) {
+        issue.assignee = update.assignee;
+      }
+      if (update.comment) {
+        console.log(`[tracker-mock] Comment added to #${id}: ${update.comment}`);
+      }
+
+      MOCK_ISSUES.set(id, issue);
+    },
+
+    async createIssue(input: CreateIssueInput, _project: ProjectConfig): Promise<Issue> {
+      logCall("createIssue", input);
+      const newId = String(MOCK_ISSUES.size + 1);
+
+      const newIssue: Issue = {
+        id: newId,
+        title: input.title,
+        description: input.description,
+        url: `${baseUrl}/issues/${newId}`,
+        state: "open",
+        labels: input.labels ?? [],
+        assignee: input.assignee,
+      };
+
+      MOCK_ISSUES.set(newId, newIssue);
+      return newIssue;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin module export
+// ---------------------------------------------------------------------------
+
+export const manifest = {
+  name: "mock",
+  slot: "tracker" as const,
+  description: "Tracker plugin: Mock issue tracker for testing",
+  version: "0.1.0",
+};
+
+export function create(config?: Record<string, unknown>): Tracker {
+  console.log("[tracker-mock] Creating mock tracker plugin", config);
+  return createMockTracker(config);
+}
+
+/** Export call log for testing */
+export function getCallLog(): Array<{ method: string; args: unknown[] }> {
+  return [...callLog];
+}
+
+/** Clear call log for testing */
+export function clearCallLog(): void {
+  callLog.length = 0;
+}
+
+export default { manifest, create } satisfies PluginModule<Tracker>;

--- a/test-plugins/tracker-mock/tsconfig.json
+++ b/test-plugins/tracker-mock/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Add test plugins (tracker-mock, scm-mock, notifier-mock) to validate the external plugin loading feature from PR #11
- Add comprehensive integration tests (18 tests) in the core package
- Add `docs/EXTERNAL_PLUGINS.md` with usage guide and examples

## Test plan

- [x] All 18 external plugin tests pass
- [x] All 582 core package tests pass
- [x] Plugins build successfully with `pnpm build`
- [x] Documentation covers all required sections (overview, structure, slots, config, examples, troubleshooting)

## Details

### Test Plugins Created

| Plugin | Slot | Description |
|--------|------|-------------|
| `tracker-mock` | tracker | Mock issue tracker with 3 sample issues |
| `scm-mock` | scm | Mock SCM with 2 sample PRs (passing/failing CI) |
| `notifier-mock` | notifier | Mock notifier with logging and storage |

### Tests Cover

- Plugin manifest validation (name, slot, version)
- Plugin `create()` returns valid interface implementations
- Tracker functionality (`getIssue`, `isCompleted`, error handling)
- SCM functionality (`getPRState`, `getCISummary`, `getMergeability`)
- Notifier functionality (`notify`, `post`)
- Plugin registry integration (loads external plugins, updates config)
- Manifest name mismatch detection

### Documentation Sections

1. Overview — What external plugins are and why you'd use them
2. Plugin Structure — manifest, create(), detect(), required exports
3. Available Slots — tracker, scm, notifier with their interface methods
4. Config Syntax — How to reference via `path:` and `package:`
5. Examples — Copy-paste ready implementations
6. Troubleshooting — Common errors and fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)