### PR TITLE
fix(web): fetch ephemeral token before voice WebSocket connect

### DIFF
--- a/packages/web/src/hooks/useVoiceCopilot.ts
+++ b/packages/web/src/hooks/useVoiceCopilot.ts
@@ -302,13 +302,30 @@ export function useVoiceCopilot(
   /**
    * Connect to voice server
    */
-  const connect = useCallback(() => {
+  const connect = useCallback(async () => {
     if (wsRef.current?.readyState === WebSocket.OPEN || wsRef.current?.readyState === WebSocket.CONNECTING) {
       return;
     }
 
     setStatus("connecting");
     setError(null);
+
+    // Fetch ephemeral token first
+    let token: string;
+    try {
+      const tokenRes = await fetch("/api/voice/token");
+      if (!tokenRes.ok) {
+        const errData = await tokenRes.json().catch(() => ({ error: "Failed to fetch token" }));
+        throw new Error(errData.error || `Token fetch failed: ${tokenRes.status}`);
+      }
+      const tokenData = await tokenRes.json();
+      token = tokenData.token;
+    } catch (err) {
+      console.error("[voice] Failed to fetch token:", err);
+      setStatus("error");
+      setError(err instanceof Error ? err.message : "Failed to fetch voice token");
+      return;
+    }
 
     // Initialize AudioContext on user gesture
     if (!audioContextRef.current) {
@@ -326,8 +343,8 @@ export function useVoiceCopilot(
 
     ws.onopen = () => {
       console.log("[voice] WebSocket connected");
-      // Request Gemini connection
-      ws.send(JSON.stringify({ type: "connect" }));
+      // Request Gemini connection with token
+      ws.send(JSON.stringify({ type: "connect", token }));
     };
 
     ws.onmessage = handleMessage;


### PR DESCRIPTION
## Summary
- Fixed "Invalid token format" error when clicking Enable Voice button
- The browser hook now fetches an ephemeral token from `/api/voice/token` before connecting to the voice WebSocket server
- Token is included in the connect message for server-side authentication

## Test plan
- [ ] Set environment variables: `AO_VOICE_ENABLED=true`, `GEMINI_API_KEY`, `VOICE_TOKEN_SECRET`
- [ ] Run `pnpm dev` to start the dashboard
- [ ] Click "Enable Voice" button in bottom-right corner
- [ ] Verify connection succeeds without "Invalid token format" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)