### PR TITLE
feat(web): add "Hey AO" wake word detection for hands-free voice activation

### DIFF
--- a/packages/web/src/components/VoicePanel.tsx
+++ b/packages/web/src/components/VoicePanel.tsx
@@ -10,10 +10,16 @@
  * - Spacebar shortcut for push-to-talk
  * - Focus/follow mode display
  * - Query input for testing
+ *
+ * V5 Features:
+ * - Hands-free mode with wake word detection ("Hey AO")
+ * - Auto-activates Gemini streaming on wake word
+ * - Resumes wake word listening after response playback
  */
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useVoiceCopilot, type VoiceStatus, type VoiceContext } from "@/hooks/useVoiceCopilot";
+import { useWakeWord } from "@/hooks/useWakeWord";
 
 /**
  * Get status indicator color based on connection state
@@ -145,6 +151,37 @@ function MuteIcon({ className }: { className?: string }) {
 }
 
 /**
+ * V5: Headphones icon SVG for hands-free mode
+ */
+function HeadphonesIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 14h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-7a9 9 0 0 1 18 0v7a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3" />
+    </svg>
+  );
+}
+
+/**
+ * V5: Mic handoff delay (ms) to allow SpeechRecognition to release mic
+ */
+const MIC_HANDOFF_DELAY = 150;
+
+/**
+ * V5: Resume delay (ms) after playback completes before restarting wake word
+ */
+const RESUME_DELAY = 500;
+
+/**
  * Voice Copilot panel component
  */
 export function VoicePanel({ defaultExpanded = false }: VoicePanelProps) {
@@ -156,6 +193,21 @@ export function VoicePanel({ defaultExpanded = false }: VoicePanelProps) {
     followingSessionId: null,
     notificationsPaused: false,
   });
+
+  // V5: Hands-free mode state
+  const [handsFreeModeEnabled, setHandsFreeModeEnabled] = useState(false);
+  const [wakeWordFlash, setWakeWordFlash] = useState(false);
+  const resumeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // V5: Callback to resume wake word listening after playback
+  const handlePlaybackComplete = useCallback(() => {
+    if (handsFreeModeEnabled && !resumeTimeoutRef.current) {
+      resumeTimeoutRef.current = setTimeout(() => {
+        resumeTimeoutRef.current = null;
+        resumeWakeWord();
+      }, RESUME_DELAY);
+    }
+  }, [handsFreeModeEnabled]);
 
   const {
     status,
@@ -190,6 +242,34 @@ export function VoicePanel({ defaultExpanded = false }: VoicePanelProps) {
     },
     onContextChange: (newContext) => {
       setVoiceContext(newContext);
+    },
+    onPlaybackComplete: handlePlaybackComplete,
+  });
+
+  // V5: Wake word detection hook
+  const {
+    state: wakeWordState,
+    isSupported: isWakeWordSupported,
+    start: startWakeWord,
+    stop: stopWakeWord,
+    pause: pauseWakeWord,
+    resume: resumeWakeWord,
+    error: wakeWordError,
+  } = useWakeWord({
+    onWakeWord: (wakeTranscript, matchedWord) => {
+      console.log(`[voice-panel] Wake word detected: "${matchedWord}"`);
+      // Flash animation
+      setWakeWordFlash(true);
+      setTimeout(() => setWakeWordFlash(false), 300);
+
+      // Pause wake word listening and start recording after mic handoff delay
+      pauseWakeWord();
+      setTimeout(() => {
+        startRecording();
+      }, MIC_HANDOFF_DELAY);
+    },
+    onError: (err) => {
+      setTranscript((prev) => [...prev.slice(-4), `Wake word error: ${err}`]);
     },
   });
 
@@ -269,7 +349,56 @@ export function VoicePanel({ defaultExpanded = false }: VoicePanelProps) {
     };
   }, [isConnected, isRecording, startRecording, stopRecording]);
 
+  // V5: Handle hands-free mode toggle
+  const handleHandsFreeToggle = useCallback(() => {
+    const newEnabled = !handsFreeModeEnabled;
+    setHandsFreeModeEnabled(newEnabled);
+
+    if (newEnabled) {
+      // Start wake word listening when enabled
+      startWakeWord();
+    } else {
+      // Stop wake word listening when disabled
+      stopWakeWord();
+      // Clear any pending resume timeout
+      if (resumeTimeoutRef.current) {
+        clearTimeout(resumeTimeoutRef.current);
+        resumeTimeoutRef.current = null;
+      }
+    }
+  }, [handsFreeModeEnabled, startWakeWord, stopWakeWord]);
+
+  // V5: Pause wake word during recording or playback
+  useEffect(() => {
+    if (!handsFreeModeEnabled) return;
+
+    if (isRecording || isPlaying) {
+      // Pause wake word while recording or playing
+      pauseWakeWord();
+    }
+  }, [handsFreeModeEnabled, isRecording, isPlaying, pauseWakeWord]);
+
+  // V5: Stop wake word when disconnecting
+  useEffect(() => {
+    if (!isConnected && handsFreeModeEnabled) {
+      stopWakeWord();
+      setHandsFreeModeEnabled(false);
+    }
+  }, [isConnected, handsFreeModeEnabled, stopWakeWord]);
+
+  // V5: Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (resumeTimeoutRef.current) {
+        clearTimeout(resumeTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const contextLabel = getContextLabel(voiceContext);
+
+  // V5: Wake word listening state for UI
+  const isListeningForWakeWord = handsFreeModeEnabled && wakeWordState === "listening";
 
   return (
     <div className="fixed bottom-4 right-4 z-50 flex flex-col items-end gap-2">
@@ -338,6 +467,75 @@ export function VoicePanel({ defaultExpanded = false }: VoicePanelProps) {
             </div>
           )}
 
+          {/* V5: Hands-free mode toggle (only show when connected and supported) */}
+          {isConnected && isWakeWordSupported && (
+            <div
+              className="flex items-center justify-between border-b px-4 py-2"
+              style={{ borderColor: "var(--color-border-subtle)" }}
+            >
+              <div className="flex items-center gap-2">
+                <HeadphonesIcon />
+                <span
+                  className="text-sm"
+                  style={{ color: "var(--color-text-secondary)" }}
+                >
+                  Hands-free mode
+                </span>
+              </div>
+              <button
+                onClick={handleHandsFreeToggle}
+                className="relative h-6 w-11 rounded-full transition-colors"
+                style={{
+                  backgroundColor: handsFreeModeEnabled
+                    ? "var(--color-accent)"
+                    : "var(--color-bg-hover)",
+                }}
+                aria-label={handsFreeModeEnabled ? "Disable hands-free mode" : "Enable hands-free mode"}
+                aria-pressed={handsFreeModeEnabled}
+              >
+                <span
+                  className="absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform"
+                  style={{
+                    transform: handsFreeModeEnabled ? "translateX(22px)" : "translateX(2px)",
+                  }}
+                />
+              </button>
+            </div>
+          )}
+
+          {/* V5: Wake word listening indicator */}
+          {isListeningForWakeWord && (
+            <div
+              className="flex items-center gap-2 border-b px-4 py-2 transition-colors"
+              style={{
+                borderColor: "var(--color-border-subtle)",
+                backgroundColor: wakeWordFlash ? "var(--color-accent)" : "var(--color-bg-base)",
+                color: wakeWordFlash ? "white" : "var(--color-text-secondary)",
+              }}
+            >
+              <span
+                className="inline-block h-2 w-2 animate-pulse rounded-full"
+                style={{ backgroundColor: wakeWordFlash ? "white" : "var(--color-accent)" }}
+              />
+              <span className="text-sm">
+                {wakeWordFlash ? "Wake word detected!" : "Listening for \"Hey AO\"..."}
+              </span>
+            </div>
+          )}
+
+          {/* V5: Wake word error display */}
+          {handsFreeModeEnabled && wakeWordError && (
+            <div
+              className="border-b px-4 py-2 text-sm"
+              style={{
+                borderColor: "var(--color-border-subtle)",
+                color: "var(--color-status-error)",
+              }}
+            >
+              {wakeWordError}
+            </div>
+          )}
+
           {/* Transcript */}
           <div
             className="h-32 overflow-y-auto px-4 py-2 text-sm"
@@ -346,7 +544,9 @@ export function VoicePanel({ defaultExpanded = false }: VoicePanelProps) {
             {transcript.length === 0 ? (
               <p className="italic">
                 {isConnected
-                  ? "Hold space or click mic to talk..."
+                  ? handsFreeModeEnabled
+                    ? "Say \"Hey AO\" or hold space to talk..."
+                    : "Hold space or click mic to talk..."
                   : "Click the button to enable voice"}
               </p>
             ) : (

--- a/packages/web/src/hooks/__tests__/useWakeWord.test.ts
+++ b/packages/web/src/hooks/__tests__/useWakeWord.test.ts
@@ -1,0 +1,464 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWakeWord } from "../useWakeWord";
+
+// Mock SpeechRecognition class
+function createMockSpeechRecognition() {
+  const listeners: {
+    onstart: (() => void) | null;
+    onend: (() => void) | null;
+    onerror: ((event: { error: string; message: string }) => void) | null;
+    onresult: ((event: MockSpeechRecognitionEvent) => void) | null;
+  } = {
+    onstart: null,
+    onend: null,
+    onerror: null,
+    onresult: null,
+  };
+
+  const mockRecognition = {
+    continuous: false,
+    interimResults: false,
+    lang: "",
+    maxAlternatives: 1,
+    // Note: start() and stop() don't auto-fire events - use _fireStart/_fireEnd manually
+    start: vi.fn(),
+    stop: vi.fn(),
+    abort: vi.fn(),
+    set onstart(handler: (() => void) | null) {
+      listeners.onstart = handler;
+    },
+    set onend(handler: (() => void) | null) {
+      listeners.onend = handler;
+    },
+    set onerror(handler: ((event: { error: string; message: string }) => void) | null) {
+      listeners.onerror = handler;
+    },
+    set onresult(
+      handler: ((event: MockSpeechRecognitionEvent) => void) | null,
+    ) {
+      listeners.onresult = handler;
+    },
+    // Test helpers - use these to manually trigger events
+    _fireStart() {
+      listeners.onstart?.();
+    },
+    _fireEnd() {
+      listeners.onend?.();
+    },
+    _fireError(error: string, message = "") {
+      listeners.onerror?.({ error, message });
+    },
+    _fireResult(transcript: string, isFinal = false) {
+      const event = createMockResultEvent(transcript, isFinal);
+      listeners.onresult?.(event);
+    },
+  };
+
+  return mockRecognition;
+}
+
+interface MockSpeechRecognitionEvent {
+  resultIndex: number;
+  results: {
+    length: number;
+    [index: number]: {
+      length: number;
+      isFinal: boolean;
+      [index: number]: {
+        transcript: string;
+        confidence: number;
+      };
+    };
+  };
+}
+
+function createMockResultEvent(transcript: string, isFinal: boolean): MockSpeechRecognitionEvent {
+  return {
+    resultIndex: 0,
+    results: {
+      length: 1,
+      0: {
+        length: 1,
+        isFinal,
+        0: {
+          transcript,
+          confidence: 0.9,
+        },
+      },
+    },
+  };
+}
+
+type MockRecognition = ReturnType<typeof createMockSpeechRecognition>;
+
+describe("useWakeWord", () => {
+  let mockRecognition: MockRecognition;
+
+  beforeEach(() => {
+    mockRecognition = createMockSpeechRecognition();
+
+    // Mock window.SpeechRecognition
+    Object.defineProperty(window, "SpeechRecognition", {
+      writable: true,
+      configurable: true,
+      value: vi.fn(() => mockRecognition),
+    });
+
+    // Clear webkit fallback
+    Object.defineProperty(window, "webkitSpeechRecognition", {
+      writable: true,
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns isSupported=true when SpeechRecognition is available", () => {
+    const { result } = renderHook(() => useWakeWord());
+    expect(result.current.isSupported).toBe(true);
+  });
+
+  it("returns isSupported=false when SpeechRecognition is unavailable", () => {
+    Object.defineProperty(window, "SpeechRecognition", {
+      writable: true,
+      configurable: true,
+      value: undefined,
+    });
+
+    const { result } = renderHook(() => useWakeWord());
+    expect(result.current.isSupported).toBe(false);
+  });
+
+  it("uses webkitSpeechRecognition as fallback", () => {
+    Object.defineProperty(window, "SpeechRecognition", {
+      writable: true,
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(window, "webkitSpeechRecognition", {
+      writable: true,
+      configurable: true,
+      value: vi.fn(() => mockRecognition),
+    });
+
+    const { result } = renderHook(() => useWakeWord());
+    expect(result.current.isSupported).toBe(true);
+  });
+
+  it("starts in idle state", () => {
+    const { result } = renderHook(() => useWakeWord());
+    expect(result.current.state).toBe("idle");
+  });
+
+  it("transitions to listening state when start() is called", async () => {
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    expect(result.current.state).toBe("listening");
+    expect(mockRecognition.start).toHaveBeenCalled();
+  });
+
+  it("transitions to idle state when stop() is called", async () => {
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    expect(result.current.state).toBe("listening");
+
+    await act(async () => {
+      result.current.stop();
+      // stop() sets state directly, no need to wait
+    });
+
+    expect(result.current.state).toBe("idle");
+    expect(mockRecognition.stop).toHaveBeenCalled();
+  });
+
+  it("transitions to paused state when pause() is called", async () => {
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      result.current.pause();
+    });
+
+    expect(result.current.state).toBe("paused");
+  });
+
+  it("transitions back to listening when resume() is called from paused", async () => {
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      result.current.pause();
+    });
+
+    await act(async () => {
+      result.current.resume();
+      mockRecognition._fireStart();
+    });
+
+    expect(result.current.state).toBe("listening");
+  });
+
+  it("detects default wake word 'ao'", async () => {
+    const onWakeWord = vi.fn();
+    const { result } = renderHook(() => useWakeWord({ onWakeWord }));
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      mockRecognition._fireResult("ao", true);
+    });
+
+    expect(onWakeWord).toHaveBeenCalledWith("ao", "ao");
+    expect(result.current.state).toBe("detected");
+  });
+
+  it("detects 'hey ao' wake word", async () => {
+    const onWakeWord = vi.fn();
+    const { result } = renderHook(() => useWakeWord({ onWakeWord }));
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      mockRecognition._fireResult("hey ao", true);
+    });
+
+    expect(onWakeWord).toHaveBeenCalledWith("hey ao", "hey ao");
+    expect(result.current.state).toBe("detected");
+  });
+
+  it("detects 'okay ao' wake word", async () => {
+    const onWakeWord = vi.fn();
+    const { result } = renderHook(() => useWakeWord({ onWakeWord }));
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      mockRecognition._fireResult("okay ao", true);
+    });
+
+    expect(onWakeWord).toHaveBeenCalledWith("okay ao", "okay ao");
+  });
+
+  it("detects wake word at end of longer phrase", async () => {
+    const onWakeWord = vi.fn();
+    const { result } = renderHook(() => useWakeWord({ onWakeWord }));
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      mockRecognition._fireResult("something something hey ao", true);
+    });
+
+    expect(onWakeWord).toHaveBeenCalledWith("something something hey ao", "hey ao");
+  });
+
+  it("does not trigger on partial wake word", async () => {
+    const onWakeWord = vi.fn();
+    const { result } = renderHook(() => useWakeWord({ onWakeWord }));
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      mockRecognition._fireResult("hello", true);
+    });
+
+    expect(onWakeWord).not.toHaveBeenCalled();
+    expect(result.current.state).toBe("listening");
+  });
+
+  it("uses custom wake words when provided", async () => {
+    const onWakeWord = vi.fn();
+    const { result } = renderHook(() =>
+      useWakeWord({
+        wakeWords: ["computer", "jarvis"],
+        onWakeWord,
+      }),
+    );
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    // Default wake word should not trigger
+    await act(async () => {
+      mockRecognition._fireResult("ao", true);
+    });
+    expect(onWakeWord).not.toHaveBeenCalled();
+
+    // Custom wake word should trigger
+    await act(async () => {
+      mockRecognition._fireResult("jarvis", true);
+    });
+    expect(onWakeWord).toHaveBeenCalledWith("jarvis", "jarvis");
+  });
+
+  it("updates lastTranscript on speech results", async () => {
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      mockRecognition._fireResult("hello world", false);
+    });
+
+    expect(result.current.lastTranscript).toBe("hello world");
+  });
+
+  it("handles not-allowed error", async () => {
+    const onError = vi.fn();
+    const { result } = renderHook(() => useWakeWord({ onError }));
+
+    await act(async () => {
+      result.current.start();
+    });
+
+    await act(async () => {
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      mockRecognition._fireError("not-allowed", "Permission denied");
+    });
+
+    expect(result.current.state).toBe("error");
+    expect(result.current.error).toBe("Microphone access denied");
+    expect(onError).toHaveBeenCalledWith("Microphone access denied");
+  });
+
+  it("handles network error", async () => {
+    const onError = vi.fn();
+    const { result } = renderHook(() => useWakeWord({ onError }));
+
+    await act(async () => {
+      result.current.start();
+    });
+
+    await act(async () => {
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      mockRecognition._fireError("network", "Network error");
+    });
+
+    expect(result.current.state).toBe("error");
+    expect(result.current.error).toBe("Network error - check connection");
+    expect(onError).toHaveBeenCalledWith("Network error");
+  });
+
+  it("configures recognition with correct settings", async () => {
+    const { result } = renderHook(() => useWakeWord({ lang: "es-ES" }));
+
+    await act(async () => {
+      result.current.start();
+    });
+
+    expect(mockRecognition.continuous).toBe(true);
+    expect(mockRecognition.interimResults).toBe(true);
+    expect(mockRecognition.lang).toBe("es-ES");
+    expect(mockRecognition.maxAlternatives).toBe(3);
+  });
+
+  it("stops recognition on wake word detection for mic handoff", async () => {
+    const onWakeWord = vi.fn();
+    const { result } = renderHook(() => useWakeWord({ onWakeWord }));
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      mockRecognition._fireResult("ao", true);
+    });
+
+    expect(mockRecognition.stop).toHaveBeenCalled();
+  });
+
+  it("cleans up recognition on unmount", async () => {
+    const { result, unmount } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    unmount();
+
+    expect(mockRecognition.stop).toHaveBeenCalled();
+  });
+
+  it("sets error when starting on unsupported browser", async () => {
+    Object.defineProperty(window, "SpeechRecognition", {
+      writable: true,
+      configurable: true,
+      value: undefined,
+    });
+
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      result.current.start();
+    });
+
+    expect(result.current.state).toBe("unsupported");
+    expect(result.current.error).toBe("Speech recognition not supported in this browser");
+  });
+
+  it("handles case-insensitive wake word detection", async () => {
+    const onWakeWord = vi.fn();
+    const { result } = renderHook(() => useWakeWord({ onWakeWord }));
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      mockRecognition._fireResult("HEY AO", true);
+    });
+
+    expect(onWakeWord).toHaveBeenCalledWith("HEY AO", "hey ao");
+  });
+});

--- a/packages/web/src/hooks/useVoiceCopilot.ts
+++ b/packages/web/src/hooks/useVoiceCopilot.ts
@@ -74,6 +74,8 @@ interface UseVoiceCopilotOptions {
   }) => void;
   /** V3: Callback when context changes */
   onContextChange?: (context: VoiceContext) => void;
+  /** V5: Callback when audio playback completes (queue empties) */
+  onPlaybackComplete?: () => void;
 }
 
 /**
@@ -119,6 +121,7 @@ export function useVoiceCopilot(
     onError,
     onAction,
     onContextChange,
+    onPlaybackComplete,
   } = options;
 
   const [status, setStatus] = useState<VoiceStatus>("disconnected");
@@ -140,6 +143,7 @@ export function useVoiceCopilot(
   const onErrorRef = useRef(onError);
   const onActionRef = useRef(onAction);
   const onContextChangeRef = useRef(onContextChange);
+  const onPlaybackCompleteRef = useRef(onPlaybackComplete);
 
   // V3: Microphone recording refs
   const mediaStreamRef = useRef<MediaStream | null>(null);
@@ -151,7 +155,8 @@ export function useVoiceCopilot(
     onErrorRef.current = onError;
     onActionRef.current = onAction;
     onContextChangeRef.current = onContextChange;
-  }, [onText, onError, onAction, onContextChange]);
+    onPlaybackCompleteRef.current = onPlaybackComplete;
+  }, [onText, onError, onAction, onContextChange, onPlaybackComplete]);
 
   /**
    * Process audio queue sequentially
@@ -226,7 +231,11 @@ export function useVoiceCopilot(
     // in the buffers we scheduled. But for simple UI, this is okay for now.
     // Better: set timeout until nextPlayTimeRef.current
     const finalDelay = (nextPlayTimeRef.current - (audioContextRef.current?.currentTime || 0)) * 1000;
-    setTimeout(() => setIsPlaying(false), Math.max(0, finalDelay));
+    setTimeout(() => {
+      setIsPlaying(false);
+      // V5: Fire playback complete callback
+      onPlaybackCompleteRef.current?.();
+    }, Math.max(0, finalDelay));
   }, []);
 
   /**

--- a/packages/web/src/hooks/useWakeWord.ts
+++ b/packages/web/src/hooks/useWakeWord.ts
@@ -1,0 +1,369 @@
+/**
+ * Wake word detection hook using Web Speech API.
+ *
+ * Provides hands-free voice activation by continuously listening for
+ * wake words ("AO", "Hey AO", "Okay AO") and triggering a callback
+ * when detected.
+ *
+ * Uses SpeechRecognition in continuous mode for low-latency detection.
+ * Automatically handles browser prefixes (webkit) and restarts on end.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  SpeechRecognition,
+  SpeechRecognitionConstructor,
+  SpeechRecognitionEvent,
+  SpeechRecognitionErrorEvent,
+} from "@/types/speech-recognition";
+
+/**
+ * Wake word detection states
+ */
+export type WakeWordState =
+  | "idle" // Not started
+  | "listening" // Actively listening for wake word
+  | "detected" // Wake word was detected (transient state)
+  | "paused" // Temporarily paused (e.g., during playback)
+  | "error" // Error occurred
+  | "unsupported"; // Browser doesn't support SpeechRecognition
+
+/**
+ * Wake word hook configuration options
+ */
+interface UseWakeWordOptions {
+  /** Wake words to listen for (default: ["ao", "hey ao", "okay ao"]) */
+  wakeWords?: string[];
+  /** Callback when wake word is detected */
+  onWakeWord?: (transcript: string, matchedWord: string) => void;
+  /** Callback when error occurs */
+  onError?: (error: string) => void;
+  /** Language for recognition (default: "en-US") */
+  lang?: string;
+}
+
+/**
+ * Wake word hook return type
+ */
+interface UseWakeWordReturn {
+  /** Current wake word detection state */
+  state: WakeWordState;
+  /** Whether SpeechRecognition is supported */
+  isSupported: boolean;
+  /** Start listening for wake word */
+  start: () => void;
+  /** Stop listening for wake word */
+  stop: () => void;
+  /** Resume listening after pause */
+  resume: () => void;
+  /** Pause listening (for mic handoff) */
+  pause: () => void;
+  /** Last transcript heard */
+  lastTranscript: string | null;
+  /** Last error message */
+  error: string | null;
+}
+
+/**
+ * Default wake words that trigger activation
+ */
+const DEFAULT_WAKE_WORDS = ["ao", "hey ao", "okay ao", "a o", "hey a o", "okay a o"];
+
+/**
+ * Get the SpeechRecognition constructor (with webkit prefix fallback)
+ */
+function getSpeechRecognition(): SpeechRecognitionConstructor | null {
+  if (typeof window === "undefined") return null;
+  return window.SpeechRecognition || window.webkitSpeechRecognition || null;
+}
+
+/**
+ * Check if any wake word is present in the transcript
+ * Returns the longest matching wake word to avoid partial matches
+ */
+function findWakeWord(transcript: string, wakeWords: string[]): string | null {
+  const normalizedTranscript = transcript.toLowerCase().trim();
+
+  // Sort by length descending to match longer phrases first (e.g., "hey ao" before "ao")
+  const sortedWakeWords = [...wakeWords].sort((a, b) => b.length - a.length);
+
+  for (const word of sortedWakeWords) {
+    // Check if wake word appears at the end of transcript (most recent speech)
+    // or if the transcript is just the wake word
+    if (
+      normalizedTranscript === word ||
+      normalizedTranscript.endsWith(word) ||
+      normalizedTranscript.endsWith(` ${word}`)
+    ) {
+      return word;
+    }
+  }
+  return null;
+}
+
+/**
+ * Hook for wake word detection using Web Speech API
+ */
+export function useWakeWord(options: UseWakeWordOptions = {}): UseWakeWordReturn {
+  const {
+    wakeWords = DEFAULT_WAKE_WORDS,
+    onWakeWord,
+    onError,
+    lang = "en-US",
+  } = options;
+
+  const [state, setState] = useState<WakeWordState>("idle");
+  const [lastTranscript, setLastTranscript] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const shouldRestartRef = useRef(false);
+  const onWakeWordRef = useRef(onWakeWord);
+  const onErrorRef = useRef(onError);
+  const stateRef = useRef(state);
+
+  // Keep refs updated
+  useEffect(() => {
+    onWakeWordRef.current = onWakeWord;
+    onErrorRef.current = onError;
+  }, [onWakeWord, onError]);
+
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  // Check browser support
+  const isSupported = typeof window !== "undefined" && getSpeechRecognition() !== null;
+
+  /**
+   * Initialize SpeechRecognition instance
+   */
+  const initRecognition = useCallback(() => {
+    const SpeechRecognitionClass = getSpeechRecognition();
+    if (!SpeechRecognitionClass) {
+      setState("unsupported");
+      return null;
+    }
+
+    const recognition = new SpeechRecognitionClass();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = lang;
+    recognition.maxAlternatives = 3;
+
+    recognition.onstart = () => {
+      console.log("[wake-word] Recognition started");
+      setState("listening");
+      setError(null);
+    };
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      // Get the most recent result
+      const lastResultIndex = event.results.length - 1;
+      const result = event.results[lastResultIndex];
+
+      // Check all alternatives for wake word
+      for (let i = 0; i < result.length; i++) {
+        const transcript = result[i].transcript;
+        setLastTranscript(transcript);
+
+        const matchedWord = findWakeWord(transcript, wakeWords);
+        if (matchedWord) {
+          console.log(`[wake-word] Detected: "${matchedWord}" in "${transcript}"`);
+          setState("detected");
+          shouldRestartRef.current = false;
+
+          // Stop recognition for mic handoff
+          recognition.stop();
+
+          // Notify callback
+          onWakeWordRef.current?.(transcript, matchedWord);
+          return;
+        }
+      }
+    };
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      console.error("[wake-word] Error:", event.error, event.message);
+
+      // Handle specific errors
+      switch (event.error) {
+        case "not-allowed":
+          setError("Microphone access denied");
+          setState("error");
+          onErrorRef.current?.("Microphone access denied");
+          break;
+        case "no-speech":
+          // This is normal - just restart if we should be listening
+          if (shouldRestartRef.current && stateRef.current === "listening") {
+            recognition.start();
+          }
+          break;
+        case "network":
+          setError("Network error - check connection");
+          setState("error");
+          onErrorRef.current?.("Network error");
+          break;
+        case "aborted":
+          // User aborted - don't restart
+          break;
+        default:
+          setError(`Recognition error: ${event.error}`);
+          onErrorRef.current?.(`Recognition error: ${event.error}`);
+      }
+    };
+
+    recognition.onend = () => {
+      console.log("[wake-word] Recognition ended, shouldRestart:", shouldRestartRef.current);
+
+      // Auto-restart if we should still be listening
+      if (shouldRestartRef.current && stateRef.current === "listening") {
+        try {
+          // Small delay to prevent rapid restart loops
+          setTimeout(() => {
+            if (shouldRestartRef.current && recognitionRef.current) {
+              recognitionRef.current.start();
+            }
+          }, 100);
+        } catch (err) {
+          console.error("[wake-word] Failed to restart:", err);
+        }
+      }
+    };
+
+    return recognition;
+  }, [lang, wakeWords]);
+
+  /**
+   * Start listening for wake word
+   */
+  const start = useCallback(() => {
+    if (!isSupported) {
+      setState("unsupported");
+      setError("Speech recognition not supported in this browser");
+      return;
+    }
+
+    // Create new recognition instance if needed
+    if (!recognitionRef.current) {
+      recognitionRef.current = initRecognition();
+    }
+
+    if (recognitionRef.current) {
+      shouldRestartRef.current = true;
+      setError(null);
+      try {
+        recognitionRef.current.start();
+      } catch (err) {
+        // May throw if already started
+        console.warn("[wake-word] Start failed (may already be running):", err);
+      }
+    }
+  }, [isSupported, initRecognition]);
+
+  /**
+   * Stop listening for wake word
+   */
+  const stop = useCallback(() => {
+    shouldRestartRef.current = false;
+    if (recognitionRef.current) {
+      try {
+        recognitionRef.current.stop();
+      } catch (err) {
+        console.warn("[wake-word] Stop failed:", err);
+      }
+    }
+    setState("idle");
+  }, []);
+
+  /**
+   * Pause listening (for mic handoff to Gemini)
+   */
+  const pause = useCallback(() => {
+    shouldRestartRef.current = false;
+    if (recognitionRef.current) {
+      try {
+        recognitionRef.current.stop();
+      } catch (err) {
+        console.warn("[wake-word] Pause failed:", err);
+      }
+    }
+    setState("paused");
+  }, []);
+
+  /**
+   * Resume listening after pause
+   */
+  const resume = useCallback(() => {
+    if (!isSupported) return;
+
+    // Create new recognition instance if needed
+    if (!recognitionRef.current) {
+      recognitionRef.current = initRecognition();
+    }
+
+    if (recognitionRef.current) {
+      shouldRestartRef.current = true;
+      setError(null);
+      setState("listening");
+      try {
+        recognitionRef.current.start();
+      } catch (err) {
+        console.warn("[wake-word] Resume failed:", err);
+      }
+    }
+  }, [isSupported, initRecognition]);
+
+  // Handle tab visibility changes
+  useEffect(() => {
+    if (!isSupported) return;
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        // Tab hidden - SpeechRecognition will stop automatically
+        // We just mark that we shouldn't restart
+        if (stateRef.current === "listening") {
+          shouldRestartRef.current = false;
+        }
+      } else {
+        // Tab visible again - restart if we were listening
+        if (stateRef.current === "listening" || stateRef.current === "paused") {
+          // Don't auto-restart if paused - user must explicitly resume
+          if (stateRef.current === "listening") {
+            shouldRestartRef.current = true;
+            resume();
+          }
+        }
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [isSupported, resume]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      shouldRestartRef.current = false;
+      if (recognitionRef.current) {
+        recognitionRef.current.stop();
+        recognitionRef.current = null;
+      }
+    };
+  }, []);
+
+  return {
+    state,
+    isSupported,
+    start,
+    stop,
+    pause,
+    resume,
+    lastTranscript,
+    error,
+  };
+}

--- a/packages/web/src/types/speech-recognition.d.ts
+++ b/packages/web/src/types/speech-recognition.d.ts
@@ -1,0 +1,113 @@
+/**
+ * TypeScript declarations for the Web Speech API (SpeechRecognition).
+ *
+ * The Web Speech API is not included in lib.dom.d.ts by default for all methods,
+ * so we declare the interfaces here. These types are based on the W3C Speech API spec.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API
+ */
+
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error:
+    | "no-speech"
+    | "aborted"
+    | "audio-capture"
+    | "network"
+    | "not-allowed"
+    | "service-not-available"
+    | "bad-grammar"
+    | "language-not-supported";
+  readonly message: string;
+}
+
+interface SpeechRecognitionAlternative {
+  readonly transcript: string;
+  readonly confidence: number;
+}
+
+interface SpeechRecognitionResult {
+  readonly length: number;
+  readonly isFinal: boolean;
+  item(index: number): SpeechRecognitionAlternative;
+  [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number;
+  item(index: number): SpeechRecognitionResult;
+  [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number;
+  readonly results: SpeechRecognitionResultList;
+}
+
+interface SpeechGrammar {
+  src: string;
+  weight: number;
+}
+
+interface SpeechGrammarList {
+  readonly length: number;
+  item(index: number): SpeechGrammar;
+  addFromString(string: string, weight?: number): void;
+  addFromURI(src: string, weight?: number): void;
+  [index: number]: SpeechGrammar;
+}
+
+interface SpeechRecognition extends EventTarget {
+  grammars: SpeechGrammarList;
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  maxAlternatives: number;
+
+  onaudiostart: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onaudioend: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onend: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onerror: ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null;
+  onnomatch: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null;
+  onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null;
+  onsoundstart: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onsoundend: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onspeechstart: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onspeechend: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onstart: ((this: SpeechRecognition, ev: Event) => void) | null;
+
+  abort(): void;
+  start(): void;
+  stop(): void;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognition;
+  prototype: SpeechRecognition;
+}
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+    SpeechGrammarList?: {
+      new (): SpeechGrammarList;
+      prototype: SpeechGrammarList;
+    };
+    webkitSpeechGrammarList?: {
+      new (): SpeechGrammarList;
+      prototype: SpeechGrammarList;
+    };
+  }
+}
+
+export type {
+  SpeechRecognition,
+  SpeechRecognitionConstructor,
+  SpeechRecognitionEvent,
+  SpeechRecognitionErrorEvent,
+  SpeechRecognitionResult,
+  SpeechRecognitionResultList,
+  SpeechRecognitionAlternative,
+  SpeechGrammar,
+  SpeechGrammarList,
+};


### PR DESCRIPTION
## Summary

- Add hands-free mode to voice copilot using Web Speech API for wake word detection
- Users can enable a toggle to continuously listen for wake words ("AO", "Hey AO", "Okay AO")
- Wake word detection automatically triggers Gemini streaming - like saying "Hey Siri"

## Changes

### New Files
- `packages/web/src/hooks/useWakeWord.ts` - Hook for SpeechRecognition-based wake word detection
- `packages/web/src/types/speech-recognition.d.ts` - TypeScript declarations for Web Speech API
- `packages/web/src/hooks/__tests__/useWakeWord.test.ts` - 22 unit tests

### Modified Files
- `packages/web/src/components/VoicePanel.tsx` - Added hands-free toggle, listening indicator, flash animation
- `packages/web/src/hooks/useVoiceCopilot.ts` - Added `onPlaybackComplete` callback

## Key Behaviors

- Wake word detection pauses during recording/playback (mic handoff)
- Auto-resumes after response playback completes (500ms delay)
- Spacebar push-to-talk works alongside hands-free mode
- Graceful fallback for browsers that don't support SpeechRecognition (toggle hidden)

## Test plan

- [x] Build check: `pnpm --filter @composio/ao-web build` passes
- [x] Unit tests: 617 tests passing
- [ ] Enable voice → Enable hands-free toggle
- [ ] Say "Hey AO" → Should flash indicator and start recording
- [ ] Speak command → Should stream to Gemini
- [ ] Wait for response → Should auto-resume wake word listening
- [ ] Test spacebar still works alongside hands-free
- [ ] Test in Chrome, Edge, Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)