### PR TITLE
fix(web): allow voice copilot to message ao-orchestrator

### DIFF
--- a/packages/web/server/voice-server.ts
+++ b/packages/web/server/voice-server.ts
@@ -28,7 +28,7 @@ import {
   type ConversationContext,
 } from "../src/lib/voice-functions.js";
 import { requestMerge } from "../src/lib/pending-merges.js";
-import type { DashboardSession } from "../src/lib/types.js";
+import type { DashboardSession, DashboardOrchestratorLink } from "../src/lib/types.js";
 
 // V4 function declarations using proper SDK types
 const V4_FUNCTION_DECLARATIONS: FunctionDeclaration[] = [
@@ -109,14 +109,14 @@ const V4_FUNCTION_DECLARATIONS: FunctionDeclaration[] = [
   {
     name: "send_message_to_session",
     description:
-      "Send a message or command to an agent session. Use this when the user wants to tell an agent to do something, like 'tell ao-25 to fix linting' or 'ask ao-94 to add tests'.",
+      "Send a message or command to an agent session. Use this when the user wants to tell an agent to do something, like 'tell ao-25 to fix linting', 'ask ao-94 to add tests', or 'tell the orchestrator to spawn an agent'.",
     parameters: {
       type: Type.OBJECT,
       properties: {
         sessionId: {
           type: Type.STRING,
           description:
-            "Session ID like 'ao-94'. If omitted, uses the focused or last-discussed session.",
+            "Session ID like 'ao-94' or 'orchestrator' for the orchestrator session. If omitted, uses the focused or last-discussed session.",
         },
         message: {
           type: Type.STRING,
@@ -209,6 +209,12 @@ Your role:
 - Use session IDs like "ao-94" consistently
 - When listing multiple sessions, group by urgency
 - If you don't know something, say so and suggest checking the dashboard
+
+Orchestrator sessions:
+- There's a special "orchestrator" session (e.g., "ao-orchestrator") that manages other agents
+- Users can send messages to the orchestrator using "tell the orchestrator to...", "orchestrator, spawn an agent", etc.
+- When the user says "orchestrator" without a prefix, match it to the session ending in "-orchestrator"
+- The orchestrator can spawn new agents, check status, and coordinate tasks
 
 Event announcements should be:
 - Clear and concise (under 15 seconds of speech)
@@ -427,13 +433,45 @@ function sendToBrowser(message: ServerMessage): void {
   }
 }
 
+/**
+ * Convert an orchestrator link to a minimal DashboardSession for voice functions.
+ * Orchestrators don't have PRs or the full session data, so we create a minimal representation.
+ */
+function orchestratorToSession(orchestrator: DashboardOrchestratorLink): DashboardSession {
+  return {
+    id: orchestrator.id,
+    projectId: orchestrator.projectId,
+    status: "working",
+    activity: "active",
+    branch: null,
+    issueId: null,
+    issueUrl: null,
+    issueLabel: orchestrator.projectName,
+    issueTitle: `${orchestrator.projectName} Orchestrator`,
+    summary: `Orchestrator session for ${orchestrator.projectName}`,
+    summaryIsFallback: true,
+    createdAt: new Date().toISOString(),
+    lastActivityAt: new Date().toISOString(),
+    pr: null,
+    metadata: { role: "orchestrator" },
+  };
+}
+
 async function fetchSessions(): Promise<DashboardSession[]> {
   try {
     const port = process.env["PORT"] || "3000";
     const res = await fetch(`http://localhost:${port}/api/sessions`);
     if (!res.ok) throw new Error(`Failed to fetch sessions: ${res.status}`);
-    const data = (await res.json()) as { sessions?: DashboardSession[] };
-    return data.sessions || [];
+    const data = (await res.json()) as {
+      sessions?: DashboardSession[];
+      orchestrators?: DashboardOrchestratorLink[];
+    };
+
+    // Combine worker sessions with orchestrator sessions
+    const workerSessions = data.sessions || [];
+    const orchestratorSessions = (data.orchestrators || []).map(orchestratorToSession);
+
+    return [...workerSessions, ...orchestratorSessions];
   } catch (error) {
     console.error("[voice] Failed to fetch sessions:", error);
     return state.sessions; // Return cached sessions

--- a/packages/web/src/lib/__tests__/voice-functions.test.ts
+++ b/packages/web/src/lib/__tests__/voice-functions.test.ts
@@ -7,6 +7,7 @@ import {
   handleGetSessionChanges,
   executeFunctionCall,
   createConversationContext,
+  findSessionById,
   MVP_TOOLS,
   type ConversationContext,
 } from "../voice-functions";
@@ -35,6 +36,96 @@ function createMockSession(overrides: Partial<DashboardSession> = {}): Dashboard
 }
 
 describe("voice-functions", () => {
+  describe("findSessionById", () => {
+    it("finds session by exact ID", () => {
+      const sessions = [createMockSession({ id: "ao-94" })];
+      const result = findSessionById("ao-94", sessions);
+      expect(result?.id).toBe("ao-94");
+    });
+
+    it("finds session by case-insensitive ID", () => {
+      const sessions = [createMockSession({ id: "AO-94" })];
+      const result = findSessionById("ao-94", sessions);
+      expect(result?.id).toBe("AO-94");
+    });
+
+    it("finds session by numeric suffix", () => {
+      const sessions = [createMockSession({ id: "ao-94" })];
+      const result = findSessionById("94", sessions);
+      expect(result?.id).toBe("ao-94");
+    });
+
+    it("does not match numeric suffix that is part of a longer number", () => {
+      const sessions = [
+        createMockSession({ id: "ao-194" }),
+        createMockSession({ id: "ao-94" }),
+      ];
+      const result = findSessionById("94", sessions);
+      expect(result?.id).toBe("ao-94");
+    });
+
+    it("returns null for non-existent session", () => {
+      const sessions = [createMockSession({ id: "ao-94" })];
+      const result = findSessionById("ao-999", sessions);
+      expect(result).toBeNull();
+    });
+
+    // Orchestrator matching tests
+    it("finds orchestrator session by exact ID", () => {
+      const sessions = [
+        createMockSession({ id: "ao-94" }),
+        createMockSession({ id: "ao-orchestrator", metadata: { role: "orchestrator" } }),
+      ];
+      const result = findSessionById("ao-orchestrator", sessions);
+      expect(result?.id).toBe("ao-orchestrator");
+    });
+
+    it("finds orchestrator session by 'orchestrator' keyword", () => {
+      const sessions = [
+        createMockSession({ id: "ao-94" }),
+        createMockSession({ id: "ao-orchestrator", metadata: { role: "orchestrator" } }),
+      ];
+      const result = findSessionById("orchestrator", sessions);
+      expect(result?.id).toBe("ao-orchestrator");
+    });
+
+    it("finds orchestrator session by 'orch' keyword", () => {
+      const sessions = [
+        createMockSession({ id: "ao-94" }),
+        createMockSession({ id: "app-orchestrator", metadata: { role: "orchestrator" } }),
+      ];
+      const result = findSessionById("orch", sessions);
+      expect(result?.id).toBe("app-orchestrator");
+    });
+
+    it("finds orchestrator session by 'the orchestrator' keyword", () => {
+      const sessions = [
+        createMockSession({ id: "ao-94" }),
+        createMockSession({ id: "ao-orchestrator", metadata: { role: "orchestrator" } }),
+      ];
+      const result = findSessionById("the orchestrator", sessions);
+      expect(result?.id).toBe("ao-orchestrator");
+    });
+
+    it("orchestrator keyword is case-insensitive", () => {
+      const sessions = [
+        createMockSession({ id: "ao-94" }),
+        createMockSession({ id: "ao-orchestrator", metadata: { role: "orchestrator" } }),
+      ];
+      const result = findSessionById("ORCHESTRATOR", sessions);
+      expect(result?.id).toBe("ao-orchestrator");
+    });
+
+    it("returns null when orchestrator keyword used but no orchestrator exists", () => {
+      const sessions = [
+        createMockSession({ id: "ao-94" }),
+        createMockSession({ id: "ao-95" }),
+      ];
+      const result = findSessionById("orchestrator", sessions);
+      expect(result).toBeNull();
+    });
+  });
+
   describe("MVP_TOOLS", () => {
     it("has correct structure for list_sessions", () => {
       const listSessions = MVP_TOOLS.find((t) => t.name === "list_sessions");

--- a/packages/web/src/lib/voice-functions.ts
+++ b/packages/web/src/lib/voice-functions.ts
@@ -81,12 +81,13 @@ export interface FunctionResult {
 }
 
 /**
- * Find a session by ID (supports exact, case-insensitive, and numeric suffix matching)
+ * Find a session by ID (supports exact, case-insensitive, numeric suffix, and orchestrator matching)
  *
  * Matching priority:
  * 1. Exact match: "ao-94" -> "ao-94"
  * 2. Case-insensitive: "AO-94" -> "ao-94"
  * 3. Numeric suffix: "94" -> "ao-94" (but NOT "ao-194")
+ * 4. Orchestrator keyword: "orchestrator" -> first session ending with "-orchestrator"
  */
 export function findSessionById(sessionId: string, sessions: DashboardSession[]): DashboardSession | null {
   // Try exact match first
@@ -105,6 +106,15 @@ export function findSessionById(sessionId: string, sessions: DashboardSession[])
       const match = s.id.match(/-(\d+)$/);
       return match?.[1] === sessionId;
     });
+    if (session) return session;
+  }
+
+  // Try orchestrator keyword match (e.g., "orchestrator" -> "ao-orchestrator")
+  // Supports variations: "orchestrator", "the orchestrator", "orch"
+  const normalizedInput = sessionId.toLowerCase().replace(/^the\s+/, "").trim();
+  if (normalizedInput === "orchestrator" || normalizedInput === "orch") {
+    session = sessions.find((s) => s.id.endsWith("-orchestrator"));
+    if (session) return session;
   }
 
   return session ?? null;


### PR DESCRIPTION
## Summary

- Fixed voice copilot to allow sending messages to the orchestrator session (`ao-orchestrator`)
- Previously, only worker sessions (`ao-1`, `ao-25`, etc.) were messageable via voice

## Changes

- Updated `findSessionById()` in `voice-functions.ts` to match "orchestrator" keyword to sessions ending with "-orchestrator"
- Updated `fetchSessions()` in `voice-server.ts` to include orchestrator sessions by converting `DashboardOrchestratorLink` to minimal `DashboardSession` objects  
- Updated Gemini system instruction to explain orchestrator session targeting
- Updated `send_message_to_session` function description to mention orchestrator support
- Added tests for orchestrator session matching

## Test plan

- [x] Run `pnpm test` - all 47 tests pass
- [x] Run `pnpm typecheck` - passes
- [ ] Manually test voice commands:
  - "Tell the orchestrator to spawn a new agent"
  - "Send message to ao-orchestrator"
  - "Ask orchestrator what sessions are stuck"

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)