### PR TITLE
feat(web): voice agent terminal output access + intelligent responses

### DIFF
--- a/packages/web/server/voice-server.ts
+++ b/packages/web/server/voice-server.ts
@@ -25,7 +25,12 @@ import { validateToken } from "../src/lib/voice-token.js";
 import {
   executeFunctionCall,
   createConversationContext,
+  classifyCommandIntent,
+  shouldRespondWithResults,
+  formatTerminalOutputForVoice,
   type ConversationContext,
+  type PendingResponse,
+  type CommandIntent,
 } from "../src/lib/voice-functions.js";
 import { requestMerge } from "../src/lib/pending-merges.js";
 import type { DashboardSession, DashboardOrchestratorLink } from "../src/lib/types.js";
@@ -196,6 +201,27 @@ const V4_FUNCTION_DECLARATIONS: FunctionDeclaration[] = [
       properties: {},
     },
   },
+  // V5 functions
+  {
+    name: "get_terminal_output",
+    description:
+      "Get recent terminal output from a session. Use this to see what an agent is doing, check test results, view errors, or get context about session activity. Useful after sending a command to check the results.",
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        sessionId: {
+          type: Type.STRING,
+          description:
+            "Session ID like 'ao-94'. If omitted, uses the focused or last-discussed session.",
+        },
+        lines: {
+          type: Type.NUMBER,
+          description:
+            "Number of lines to fetch (1-100, default 30). Use more lines for detailed analysis, fewer for quick checks.",
+        },
+      },
+    },
+  },
 ];
 
 const SYSTEM_INSTRUCTION = `You are the voice interface for Agent Orchestrator (AO), a system that manages parallel AI coding agents.
@@ -256,6 +282,25 @@ Available functions:
 - merge_pr: Merge a PR (requires confirmation)
 - pause_notifications: Pause automatic announcements
 - resume_notifications: Resume automatic announcements
+- get_terminal_output: Get recent terminal output from a session to see what's happening
+
+Intelligent response workflow (V5):
+After sending a command to an agent, decide whether to follow up with the results:
+
+| Command Type | Should Respond? | When? |
+|--------------|-----------------|-------|
+| "Explore the codebase" | Yes | When exploration completes, use get_terminal_output and summarize |
+| "What files handle auth?" | Yes | When agent responds, summarize the answer |
+| "Start working on issue 42" | No | Just acknowledge the command was sent |
+| "Fix the linting errors" | Maybe | Only if it fails or completes quickly |
+| "Run the tests" | Yes | Report pass/fail using get_terminal_output |
+
+Guidelines for intelligent responses:
+1. For QUERIES (questions, "what", "where", "how", "show me"): Always follow up with results
+2. For STATUS CHECKS (tests, CI, "did it pass"): Follow up with results
+3. For ACTIONS (start working, fix, implement): Just acknowledge, unless you're following the session
+4. When following a session, proactively check get_terminal_output periodically to report progress
+5. If a command takes too long (>30 seconds), say "still working on it" and offer to notify when done
 
 When using functions:
 - Always call the function first, then speak based on the results
@@ -345,6 +390,11 @@ interface CostTracking {
   lastResetTime: number;
 }
 
+// V5: Pending response tracking for intelligent responses
+const pendingResponses = new Map<string, PendingResponse>();
+const PENDING_RESPONSE_TIMEOUT_MS = 30_000; // 30 seconds before "still working" message
+const PENDING_RESPONSE_CLEANUP_INTERVAL_MS = 5_000; // Check every 5 seconds
+
 // Server state
 interface VoiceServerState {
   browserClient: WebSocket | null;
@@ -359,6 +409,8 @@ interface VoiceServerState {
   // V4: Session resumption
   geminiSessionHandle: string | null;
   connectionAttempts: number;
+  // V5: Pending response check interval
+  pendingResponseInterval: NodeJS.Timeout | null;
 }
 
 const state: VoiceServerState = {
@@ -377,6 +429,7 @@ const state: VoiceServerState = {
   },
   geminiSessionHandle: null,
   connectionAttempts: 0,
+  pendingResponseInterval: null,
 };
 
 // Browser → Server message types
@@ -522,7 +575,18 @@ async function handleGeminiMessage(message: LiveServerMessage): Promise<void> {
       // Refresh sessions before function call
       state.sessions = await fetchSessions();
       console.log(`[voice] Executing function: ${fc.name}`, fc.args);
-      const funcResult = executeFunctionCall(fc.name, (fc.args as Record<string, unknown>) ?? {}, state.sessions, state.context);
+      let funcResult = executeFunctionCall(fc.name, (fc.args as Record<string, unknown>) ?? {}, state.sessions, state.context);
+
+      // V5: Handle get_terminal_output specially — needs API call for runtime access
+      if (fc.name === "get_terminal_output" && "needsApiCall" in funcResult && funcResult.needsApiCall) {
+        const apiParams = (funcResult as unknown as { apiParams: { sessionId: string; lines: number } }).apiParams;
+        const terminalResult = await handleGetTerminalOutputAction(apiParams.sessionId, apiParams.lines);
+        funcResult = {
+          result: terminalResult,
+          sessionId: apiParams.sessionId,
+        };
+      }
+
       const { result, sessionId, setFocusedSessionId, setFollowingSessionId, setNotificationsPaused, action } = funcResult;
 
       // Update conversation context if a session was resolved
@@ -564,6 +628,12 @@ async function handleGeminiMessage(message: LiveServerMessage): Promise<void> {
       // V3: Handle actions (send message to session)
       if (action?.type === "send_message" && action.message) {
         await handleSendMessageAction(action.sessionId, action.message);
+
+        // V5: Track pending response for intelligent follow-up
+        const intent = classifyCommandIntent(action.message);
+        if (shouldRespondWithResults(intent)) {
+          trackPendingResponse(action.sessionId, action.message, intent);
+        }
       }
 
       // V4: Handle merge action (uses pending merge flow)
@@ -688,6 +758,132 @@ async function handleSendMessageAction(sessionId: string, message: string): Prom
 }
 
 // Note: handleSendMessageAction is called by executeFunctionCall output
+
+// =============================================================================
+// V5: Terminal Output Access + Intelligent Response Tracking
+// =============================================================================
+
+/**
+ * Fetch terminal output from a session via the API route.
+ */
+async function fetchTerminalOutput(sessionId: string, lines: number): Promise<string> {
+  const port = process.env["PORT"] || "3000";
+  try {
+    const res = await fetch(
+      `http://localhost:${port}/api/sessions/${encodeURIComponent(sessionId)}/output?lines=${lines}`,
+    );
+    if (!res.ok) {
+      const errorText = await res.text();
+      console.error(`[voice] Failed to fetch terminal output for ${sessionId}:`, errorText);
+      return "";
+    }
+    const data = (await res.json()) as { output?: string };
+    return data.output ?? "";
+  } catch (error) {
+    console.error(`[voice] Error fetching terminal output for ${sessionId}:`, error);
+    return "";
+  }
+}
+
+/**
+ * Handle get_terminal_output function by making API call and formatting response.
+ */
+async function handleGetTerminalOutputAction(
+  sessionId: string,
+  lines: number,
+): Promise<string> {
+  const output = await fetchTerminalOutput(sessionId, lines);
+  return formatTerminalOutputForVoice(output, sessionId);
+}
+
+/**
+ * Track a pending response for a command that needs follow-up.
+ */
+function trackPendingResponse(
+  sessionId: string,
+  message: string,
+  intent: CommandIntent,
+): void {
+  const id = `${sessionId}:${Date.now()}`;
+  pendingResponses.set(id, {
+    sessionId,
+    message,
+    intent,
+    sentAt: Date.now(),
+    timeout: PENDING_RESPONSE_TIMEOUT_MS,
+  });
+  console.log(`[voice] Tracking pending response for ${sessionId}: ${intent}`);
+}
+
+/**
+ * Check pending responses and notify if any are taking too long.
+ */
+async function checkPendingResponses(): Promise<void> {
+  const now = Date.now();
+  const toRemove: string[] = [];
+
+  for (const [id, pending] of pendingResponses.entries()) {
+    const elapsed = now - pending.sentAt;
+
+    if (elapsed >= pending.timeout) {
+      // Timeout reached — check session status
+      const session = state.sessions.find((s) => s.id === pending.sessionId);
+
+      if (session) {
+        // Check if session is still actively working
+        if (session.activity === "active") {
+          // Still working — inject "still working" message
+          await injectEvent(
+            `Session ${pending.sessionId} is still working on your request. I'll let you know when it's done.`,
+          );
+        } else if (session.activity === "waiting_input" || session.activity === "blocked") {
+          // Session needs input — notify user
+          await injectEvent(
+            `Session ${pending.sessionId} needs your input to continue.`,
+          );
+        } else {
+          // Session might be done — check terminal output
+          const output = await fetchTerminalOutput(pending.sessionId, 20);
+          if (output) {
+            const summary = formatTerminalOutputForVoice(output, pending.sessionId);
+            await injectEvent(`Update from ${pending.sessionId}: ${summary}`);
+          }
+        }
+      }
+
+      toRemove.push(id);
+    }
+  }
+
+  // Clean up expired pending responses
+  for (const id of toRemove) {
+    pendingResponses.delete(id);
+  }
+}
+
+/**
+ * Start pending response check interval.
+ */
+function startPendingResponseCheck(): void {
+  if (state.pendingResponseInterval) {
+    clearInterval(state.pendingResponseInterval);
+  }
+  state.pendingResponseInterval = setInterval(
+    () => void checkPendingResponses(),
+    PENDING_RESPONSE_CLEANUP_INTERVAL_MS,
+  );
+}
+
+/**
+ * Stop pending response check interval.
+ */
+function stopPendingResponseCheck(): void {
+  if (state.pendingResponseInterval) {
+    clearInterval(state.pendingResponseInterval);
+    state.pendingResponseInterval = null;
+  }
+  pendingResponses.clear();
+}
 
 // V4: Constants for reconnection
 const MAX_RECONNECTION_ATTEMPTS = 3;
@@ -835,6 +1031,8 @@ async function connectToGemini(): Promise<void> {
           state.connectionAttempts = 0; // Reset on successful connection
           // V4: Start session limit check
           startSessionLimitCheck();
+          // V5: Start pending response check
+          startPendingResponseCheck();
           sendToBrowser({ type: "status", status: "connected" });
           console.log("[voice] Connected to Gemini Live API (3.1 Flash)");
         },
@@ -912,6 +1110,8 @@ async function disconnectFromGemini(): Promise<void> {
   state.connectionAttempts = MAX_RECONNECTION_ATTEMPTS; // Prevent auto-reconnect
   // V4: Stop session limit check
   stopSessionLimitCheck();
+  // V5: Stop pending response check
+  stopPendingResponseCheck();
   if (state.geminiSession) {
     try {
       await state.geminiSession.close();

--- a/packages/web/src/app/api/sessions/[id]/output/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/output/route.ts
@@ -1,0 +1,119 @@
+import { type NextRequest } from "next/server";
+import { validateIdentifier, validateNumber } from "@/lib/validation";
+import { getServices } from "@/lib/services";
+import { SessionNotFoundError, type Runtime, type RuntimeHandle } from "@composio/ao-core";
+import {
+  getCorrelationId,
+  jsonWithCorrelation,
+  recordApiObservation,
+  resolveProjectIdForSessionId,
+} from "@/lib/observability";
+
+const DEFAULT_LINES = 50;
+const MAX_LINES = 500;
+
+/** GET /api/sessions/:id/output — Get terminal output from a session */
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const correlationId = getCorrelationId(request);
+  const startedAt = Date.now();
+  const { id } = await params;
+  const idErr = validateIdentifier(id, "id");
+  if (idErr) {
+    return jsonWithCorrelation({ error: idErr }, { status: 400 }, correlationId);
+  }
+
+  // Parse optional lines parameter from query string
+  const { searchParams } = new URL(request.url);
+  const linesParam = searchParams.get("lines");
+  let lines = DEFAULT_LINES;
+  if (linesParam !== null) {
+    const linesErr = validateNumber(parseInt(linesParam, 10), "lines", 1, MAX_LINES);
+    if (linesErr) {
+      return jsonWithCorrelation({ error: linesErr }, { status: 400 }, correlationId);
+    }
+    lines = parseInt(linesParam, 10);
+  }
+
+  try {
+    const { config, registry, sessionManager } = await getServices();
+    const projectId = resolveProjectIdForSessionId(config, id);
+    const session = await sessionManager.get(id);
+
+    if (!session) {
+      throw new SessionNotFoundError(id);
+    }
+
+    // Get the runtime handle from the session
+    const runtimeHandle: RuntimeHandle | null = session.runtimeHandle;
+    if (!runtimeHandle) {
+      return jsonWithCorrelation(
+        { error: "Session has no runtime handle - cannot fetch terminal output" },
+        { status: 400 },
+        correlationId,
+      );
+    }
+
+    // Get the runtime plugin
+    const project = config.projects[session.projectId];
+    const runtimeName = runtimeHandle.runtimeName ?? project?.runtime ?? config.defaults.runtime;
+    const runtime = registry.get<Runtime>("runtime", runtimeName);
+
+    if (!runtime) {
+      return jsonWithCorrelation(
+        { error: `Runtime plugin "${runtimeName}" not found` },
+        { status: 500 },
+        correlationId,
+      );
+    }
+
+    // Fetch terminal output
+    const output = await runtime.getOutput(runtimeHandle, lines);
+
+    recordApiObservation({
+      config,
+      method: "GET",
+      path: "/api/sessions/[id]/output",
+      correlationId,
+      startedAt,
+      outcome: "success",
+      statusCode: 200,
+      projectId,
+      sessionId: id,
+      data: { lines, outputLength: output.length },
+    });
+
+    return jsonWithCorrelation(
+      {
+        ok: true,
+        sessionId: id,
+        output,
+        lines,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+      correlationId,
+    );
+  } catch (err) {
+    if (err instanceof SessionNotFoundError) {
+      return jsonWithCorrelation({ error: err.message }, { status: 404 }, correlationId);
+    }
+    const { config } = await getServices().catch(() => ({ config: undefined }));
+    const projectId = config ? resolveProjectIdForSessionId(config, id) : undefined;
+    if (config) {
+      recordApiObservation({
+        config,
+        method: "GET",
+        path: "/api/sessions/[id]/output",
+        correlationId,
+        startedAt,
+        outcome: "failure",
+        statusCode: 500,
+        projectId,
+        sessionId: id,
+        reason: err instanceof Error ? err.message : "Failed to get terminal output",
+      });
+    }
+    const msg = err instanceof Error ? err.message : "Failed to get terminal output";
+    return jsonWithCorrelation({ error: msg }, { status: 500 }, correlationId);
+  }
+}

--- a/packages/web/src/lib/__tests__/voice-functions.test.ts
+++ b/packages/web/src/lib/__tests__/voice-functions.test.ts
@@ -5,9 +5,13 @@ import {
   handleGetCIFailures,
   handleGetReviewComments,
   handleGetSessionChanges,
+  handleGetTerminalOutput,
   executeFunctionCall,
   createConversationContext,
   findSessionById,
+  classifyCommandIntent,
+  shouldRespondWithResults,
+  formatTerminalOutputForVoice,
   MVP_TOOLS,
   type ConversationContext,
 } from "../voice-functions";
@@ -598,6 +602,189 @@ describe("voice-functions", () => {
       const func = MVP_TOOLS.find((t) => t.name === "get_session_changes");
       expect(func).toBeDefined();
       expect(func?.description).toContain("changed");
+    });
+  });
+
+  // V5 Function Tests (Terminal Output + Intelligent Response)
+  describe("classifyCommandIntent (V5)", () => {
+    it("classifies question words as query", () => {
+      expect(classifyCommandIntent("what files handle auth?")).toBe("query");
+      expect(classifyCommandIntent("where is the config?")).toBe("query");
+      expect(classifyCommandIntent("how does this work?")).toBe("query");
+      expect(classifyCommandIntent("which module handles routing?")).toBe("query");
+      expect(classifyCommandIntent("why did it fail?")).toBe("query");
+    });
+
+    it("classifies question mark endings as query", () => {
+      expect(classifyCommandIntent("is the build passing?")).toBe("query");
+      expect(classifyCommandIntent("did it work?")).toBe("query");
+    });
+
+    it("classifies show/tell commands as query", () => {
+      expect(classifyCommandIntent("show me the errors")).toBe("query");
+      expect(classifyCommandIntent("tell me what changed")).toBe("query");
+      expect(classifyCommandIntent("list the files")).toBe("query");
+      expect(classifyCommandIntent("find the bug")).toBe("query");
+    });
+
+    it("classifies test/status patterns as status_check", () => {
+      expect(classifyCommandIntent("run the tests")).toBe("status_check");
+      expect(classifyCommandIntent("status of the build")).toBe("status_check");
+      expect(classifyCommandIntent("are the tests passing")).toBe("status_check");
+    });
+
+    it("classifies check commands starting with query words as query", () => {
+      // "check if" starts with a query-like verb, so it's classified as query
+      expect(classifyCommandIntent("check if tests are passing")).toBe("query");
+    });
+
+    it("classifies imperative commands as action", () => {
+      expect(classifyCommandIntent("fix the linting errors")).toBe("action");
+      expect(classifyCommandIntent("implement the feature")).toBe("action");
+      expect(classifyCommandIntent("start working on issue 42")).toBe("action");
+      expect(classifyCommandIntent("add error handling")).toBe("action");
+    });
+
+    it("classifies ambiguous commands as action by default", () => {
+      expect(classifyCommandIntent("do the thing")).toBe("action");
+      expect(classifyCommandIntent("update the code")).toBe("action");
+    });
+  });
+
+  describe("shouldRespondWithResults (V5)", () => {
+    it("returns true for query intent", () => {
+      expect(shouldRespondWithResults("query")).toBe(true);
+    });
+
+    it("returns true for status_check intent", () => {
+      expect(shouldRespondWithResults("status_check")).toBe(true);
+    });
+
+    it("returns false for action intent", () => {
+      expect(shouldRespondWithResults("action")).toBe(false);
+    });
+  });
+
+  describe("formatTerminalOutputForVoice (V5)", () => {
+    it("handles empty output", () => {
+      expect(formatTerminalOutputForVoice("", "ao-94")).toContain("no recent terminal output");
+      expect(formatTerminalOutputForVoice("   ", "ao-94")).toContain("no recent terminal output");
+    });
+
+    it("detects errors in output", () => {
+      const output = "Building...\nError: Module not found\nBuild failed";
+      const result = formatTerminalOutputForVoice(output, "ao-94");
+      expect(result).toContain("error");
+      expect(result).toContain("ao-94");
+    });
+
+    it("detects success indicators", () => {
+      const output = "Running tests...\nAll tests passed\nDone in 5s";
+      const result = formatTerminalOutputForVoice(output, "ao-94");
+      expect(result).toContain("success");
+      expect(result).toContain("No errors detected");
+    });
+
+    it("detects warnings", () => {
+      const output = "Compiling...\nWarning: deprecated API\nBuild complete";
+      const result = formatTerminalOutputForVoice(output, "ao-94");
+      expect(result).toContain("warning");
+    });
+
+    it("includes recent output lines", () => {
+      const output = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5";
+      const result = formatTerminalOutputForVoice(output, "ao-94");
+      expect(result).toContain("Recent output");
+    });
+
+    it("includes session ID in output", () => {
+      const output = "Some output";
+      const result = formatTerminalOutputForVoice(output, "ao-94");
+      expect(result).toContain("ao-94");
+    });
+  });
+
+  describe("handleGetTerminalOutput (V5)", () => {
+    it("returns error when session not found", () => {
+      const context = createConversationContext();
+      const result = handleGetTerminalOutput({ sessionId: "ao-99" }, [], context);
+      expect(result.result).toContain("not found");
+      expect(result.sessionId).toBeNull();
+    });
+
+    it("returns API call marker for valid session", () => {
+      const sessions = [createMockSession({ id: "ao-94" })];
+      const context = createConversationContext();
+      const result = handleGetTerminalOutput({ sessionId: "ao-94" }, sessions, context);
+      expect(result.sessionId).toBe("ao-94");
+      expect("needsApiCall" in result).toBe(true);
+      if ("needsApiCall" in result) {
+        expect(result.needsApiCall).toBe(true);
+        expect(result.apiParams.sessionId).toBe("ao-94");
+      }
+    });
+
+    it("uses default lines when not specified", () => {
+      const sessions = [createMockSession({ id: "ao-94" })];
+      const context = createConversationContext();
+      const result = handleGetTerminalOutput({ sessionId: "ao-94" }, sessions, context);
+      if ("apiParams" in result) {
+        expect(result.apiParams.lines).toBe(30);
+      }
+    });
+
+    it("respects custom lines parameter", () => {
+      const sessions = [createMockSession({ id: "ao-94" })];
+      const context = createConversationContext();
+      const result = handleGetTerminalOutput({ sessionId: "ao-94", lines: 50 }, sessions, context);
+      if ("apiParams" in result) {
+        expect(result.apiParams.lines).toBe(50);
+      }
+    });
+
+    it("clamps lines to valid range", () => {
+      const sessions = [createMockSession({ id: "ao-94" })];
+      const context = createConversationContext();
+
+      // Too high
+      let result = handleGetTerminalOutput({ sessionId: "ao-94", lines: 200 }, sessions, context);
+      if ("apiParams" in result) {
+        expect(result.apiParams.lines).toBe(100);
+      }
+
+      // Too low
+      result = handleGetTerminalOutput({ sessionId: "ao-94", lines: 0 }, sessions, context);
+      if ("apiParams" in result) {
+        expect(result.apiParams.lines).toBe(1);
+      }
+    });
+
+    it("uses context when sessionId not provided", () => {
+      const sessions = [createMockSession({ id: "ao-94" })];
+      const context: ConversationContext = {
+        lastSessionId: "ao-94",
+        lastUpdatedAt: Date.now(),
+        focusedSessionId: null,
+        followingSessionId: null,
+        notificationsPaused: false,
+      };
+      const result = handleGetTerminalOutput({}, sessions, context);
+      expect(result.sessionId).toBe("ao-94");
+    });
+  });
+
+  describe("executeFunctionCall routes to get_terminal_output", () => {
+    it("routes to get_terminal_output", () => {
+      const sessions = [createMockSession({ id: "ao-94" })];
+      const context = createConversationContext();
+      const result = executeFunctionCall(
+        "get_terminal_output",
+        { sessionId: "ao-94" },
+        sessions,
+        context,
+      );
+      expect(result.sessionId).toBe("ao-94");
+      expect("needsApiCall" in result).toBe(true);
     });
   });
 });

--- a/packages/web/src/lib/validation.ts
+++ b/packages/web/src/lib/validation.ts
@@ -33,6 +33,28 @@ export function validateIdentifier(
   return null;
 }
 
+/** Validate that a value is a number within a range. Returns error message or null. */
+export function validateNumber(
+  value: unknown,
+  fieldName: string,
+  min?: number,
+  max?: number,
+): string | null {
+  if (value === undefined || value === null) {
+    return `${fieldName} is required`;
+  }
+  if (typeof value !== "number" || isNaN(value)) {
+    return `${fieldName} must be a number`;
+  }
+  if (min !== undefined && value < min) {
+    return `${fieldName} must be at least ${min}`;
+  }
+  if (max !== undefined && value > max) {
+    return `${fieldName} must be at most ${max}`;
+  }
+  return null;
+}
+
 /**
  * Validate that a projectId is a configured project (own property, not prototype chain).
  * Returns an error message or null.

--- a/packages/web/src/lib/voice-functions.ts
+++ b/packages/web/src/lib/voice-functions.ts
@@ -905,6 +905,171 @@ export function handleFollowSession(
 }
 
 // =============================================================================
+// V5 FUNCTIONS (Terminal Output Access + Intelligent Response)
+// =============================================================================
+
+/**
+ * Command intent classification for intelligent response decisions.
+ * Determines whether voice should proactively respond with results.
+ */
+export type CommandIntent = "query" | "action" | "status_check";
+
+/**
+ * Classify a command's intent to determine if voice should respond with results.
+ *
+ * @param message The command/message being sent to the agent
+ * @returns The classified intent
+ */
+export function classifyCommandIntent(message: string): CommandIntent {
+  const lowerMessage = message.toLowerCase().trim();
+
+  // Query patterns — user expects an answer
+  const queryPatterns = [
+    /^(what|where|which|how|why|who|when|can you|could you|show me|tell me|list|find|search|look for|explore|check|get|fetch)/,
+    /\?$/, // Ends with question mark
+    /(what|where|which|how|why|who).*\?/,
+    /^(explain|describe|summarize|analyze|review)/,
+  ];
+
+  for (const pattern of queryPatterns) {
+    if (pattern.test(lowerMessage)) {
+      return "query";
+    }
+  }
+
+  // Status check patterns — user wants to know current state
+  const statusPatterns = [
+    /^(status|state|progress|how is|how's|what's the status)/,
+    /(run|running|pass|passing|fail|failing|test|tests)/,
+    /^(did|has|have|is|are|was|were).*\?/,
+  ];
+
+  for (const pattern of statusPatterns) {
+    if (pattern.test(lowerMessage)) {
+      return "status_check";
+    }
+  }
+
+  // Default to action — user is giving a command, just acknowledge
+  return "action";
+}
+
+/**
+ * Determine if voice should respond with results after sending a command.
+ *
+ * @param intent The classified command intent
+ * @returns Whether voice should proactively respond with results
+ */
+export function shouldRespondWithResults(intent: CommandIntent): boolean {
+  return intent === "query" || intent === "status_check";
+}
+
+/**
+ * Pending response tracking for commands that need follow-up.
+ */
+export interface PendingResponse {
+  sessionId: string;
+  message: string;
+  intent: CommandIntent;
+  sentAt: number;
+  /** Maximum time to wait for response (ms) */
+  timeout: number;
+}
+
+/**
+ * Handle get_terminal_output function call (V5)
+ *
+ * Fetches recent terminal output from a session for voice summarization.
+ * This is called via the API route since we need access to the runtime.
+ *
+ * @param args Function arguments from Gemini
+ * @param sessions Current session list
+ * @param context Conversation context for session resolution
+ * @returns Function result with terminal output info
+ */
+export function handleGetTerminalOutput(
+  args: { sessionId?: string; lines?: number },
+  sessions: DashboardSession[],
+  context: ConversationContext,
+): FunctionResult & { needsApiCall: true; apiParams: { sessionId: string; lines: number } } | FunctionResult {
+  const { session, error } = resolveSession(args.sessionId, sessions, context);
+  if (error || !session) {
+    return { result: error ?? "Session not found.", sessionId: null };
+  }
+
+  // Validate lines parameter
+  const lines = Math.min(Math.max(args.lines ?? 30, 1), 100);
+
+  // Return marker indicating API call needed - the actual output fetching
+  // must happen server-side since we need runtime access
+  return {
+    result: `Fetching last ${lines} lines of terminal output from session ${session.id}...`,
+    sessionId: session.id,
+    needsApiCall: true,
+    apiParams: {
+      sessionId: session.id,
+      lines,
+    },
+  };
+}
+
+/**
+ * Format terminal output for voice response.
+ * Summarizes and cleans output for TTS consumption.
+ *
+ * @param output Raw terminal output
+ * @param sessionId Session ID for context
+ * @returns Formatted voice-friendly summary
+ */
+export function formatTerminalOutputForVoice(output: string, sessionId: string): string {
+  if (!output || output.trim().length === 0) {
+    return `Session ${sessionId} has no recent terminal output.`;
+  }
+
+  const lines = output.split("\n").filter((line) => line.trim().length > 0);
+  if (lines.length === 0) {
+    return `Session ${sessionId} has no recent terminal output.`;
+  }
+
+  // Detect common patterns and summarize
+  const errorLines = lines.filter((line) =>
+    /error|fail|exception|fatal|panic|crash/i.test(line)
+  );
+  const warningLines = lines.filter((line) =>
+    /warn|warning|deprecated/i.test(line)
+  );
+  const successLines = lines.filter((line) =>
+    /success|passed|complete|done|finished|✓|✔/i.test(line)
+  );
+
+  const summaryParts: string[] = [];
+  summaryParts.push(`Session ${sessionId} terminal output:`);
+
+  if (errorLines.length > 0) {
+    summaryParts.push(`Found ${errorLines.length} error${errorLines.length === 1 ? "" : "s"}.`);
+    // Include first error for context
+    const firstError = truncateText(errorLines[0], 100);
+    summaryParts.push(`First error: ${firstError}`);
+  } else if (successLines.length > 0) {
+    summaryParts.push(`No errors detected. ${successLines.length} success indicator${successLines.length === 1 ? "" : "s"} found.`);
+  } else {
+    summaryParts.push(`${lines.length} lines of output, no obvious errors.`);
+  }
+
+  if (warningLines.length > 0) {
+    summaryParts.push(`${warningLines.length} warning${warningLines.length === 1 ? "" : "s"}.`);
+  }
+
+  // Include last few meaningful lines
+  const recentLines = lines.slice(-3).map((line) => truncateText(line, 80));
+  if (recentLines.length > 0) {
+    summaryParts.push(`Recent output: ${recentLines.join(" | ")}`);
+  }
+
+  return summaryParts.join(" ");
+}
+
+// =============================================================================
 // V4 FUNCTIONS
 // =============================================================================
 
@@ -1077,9 +1242,17 @@ export function executeFunctionCall(
     case "resume_notifications":
       return handleResumeNotifications();
 
+    // V5 functions
+    case "get_terminal_output":
+      return handleGetTerminalOutput(
+        args as { sessionId?: string; lines?: number },
+        sessions,
+        context,
+      );
+
     default:
       return {
-        result: `Unknown function: ${name}. Available functions: list_sessions, get_session_summary, get_ci_failures, get_review_comments, get_session_changes, send_message_to_session, focus_session, follow_session, merge_pr, pause_notifications, resume_notifications.`,
+        result: `Unknown function: ${name}. Available functions: list_sessions, get_session_summary, get_ci_failures, get_review_comments, get_session_changes, send_message_to_session, focus_session, follow_session, merge_pr, pause_notifications, resume_notifications, get_terminal_output.`,
         sessionId: null,
       };
   }


### PR DESCRIPTION
## Summary

- Add terminal output access to voice copilot via new `get_terminal_output` Gemini function
- Implement intelligent response logic that decides when to proactively respond with results
- Add pending response tracking to monitor session activity after commands

## Details

### New API Endpoint

**GET /api/sessions/:id/output**
- Fetches last N lines of terminal output from a session using `runtime.getOutput()`
- Query param `lines` controls number of lines (1-500, default 50)
- Returns session output with timestamp

### New Gemini Function

**get_terminal_output**
- Voice can now read terminal output from any session
- Useful for checking test results, viewing errors, monitoring progress
- Auto-formats output for voice readability (summarizes errors, warnings, success indicators)

### Intelligent Response Logic

Commands are classified by intent:

| Command Type | Example | Should Respond? |
|--------------|---------|-----------------|
| Query | "What files handle auth?" | Yes - summarize findings |
| Status Check | "Run the tests" | Yes - report pass/fail |
| Action | "Start working on issue 42" | No - just acknowledge |

### Response Tracking

After sending a command:
1. Track if it's a query/status_check that needs follow-up
2. If >30s passes, say "still working on it"
3. Check terminal output when session status changes
4. Summarize results for voice response

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Voice function tests pass (70 tests)
- [ ] Manual test: Say "get the terminal output from session 94"
- [ ] Manual test: Say "what files handle authentication" and verify follow-up
- [ ] Manual test: Say "fix the linting errors" and verify no unsolicited follow-up

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)