### PR TITLE
fix: enable wake word detection for 'Hey AO' voice activation

### DIFF
--- a/packages/web/src/components/VoicePanel.tsx
+++ b/packages/web/src/components/VoicePanel.tsx
@@ -201,20 +201,29 @@ export function VoicePanel({ defaultExpanded = false }: VoicePanelProps) {
   // Memory leak fix: Track flash timeout for cleanup
   const flashTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
+  // V5: Ref to track hands-free mode for use in callbacks without stale closures
+  const handsFreeModeEnabledRef = useRef(handsFreeModeEnabled);
+  useEffect(() => {
+    handsFreeModeEnabledRef.current = handsFreeModeEnabled;
+  }, [handsFreeModeEnabled]);
+
+  // V5: Ref to track resumeWakeWord for use in callbacks
+  const resumeWakeWordRef = useRef<(() => void) | null>(null);
+
   // V5: Callback to resume wake word listening after playback
-  // Memory leak fix: Clear existing timeout before creating new one
+  // Uses refs to avoid stale closures
   const handlePlaybackComplete = useCallback(() => {
-    if (handsFreeModeEnabled) {
+    if (handsFreeModeEnabledRef.current) {
       // Clear any existing resume timeout to prevent duplicates
       if (resumeTimeoutRef.current) {
         clearTimeout(resumeTimeoutRef.current);
       }
       resumeTimeoutRef.current = setTimeout(() => {
         resumeTimeoutRef.current = null;
-        resumeWakeWord();
+        resumeWakeWordRef.current?.();
       }, RESUME_DELAY);
     }
-  }, [handsFreeModeEnabled]);
+  }, []);
 
   const {
     status,
@@ -294,6 +303,11 @@ export function VoicePanel({ defaultExpanded = false }: VoicePanelProps) {
       setTranscript((prev) => [...prev.slice(-4), `Wake word error: ${err}`]);
     },
   });
+
+  // V5: Keep resumeWakeWord ref updated for use in callbacks
+  useEffect(() => {
+    resumeWakeWordRef.current = resumeWakeWord;
+  }, [resumeWakeWord]);
 
   // Keep voiceContext in sync with hook context
   useEffect(() => {
@@ -399,15 +413,37 @@ export function VoicePanel({ defaultExpanded = false }: VoicePanelProps) {
     }
   }, [handsFreeModeEnabled, startWakeWord, stopWakeWord]);
 
-  // V5: Pause wake word during recording or playback
+  // V5: Pause wake word during recording or playback, resume when done
+  // Track previous state to detect transitions
+  const wasRecordingRef = useRef(false);
+  const wasPlayingRef = useRef(false);
+
   useEffect(() => {
     if (!handsFreeModeEnabled) return;
 
     if (isRecording || isPlaying) {
       // Pause wake word while recording or playing
       pauseWakeWord();
+    } else if (wasRecordingRef.current && !isRecording && !isPlaying) {
+      // Recording just stopped and not playing - resume wake word after a delay
+      // This handles the case where Gemini doesn't respond (error, timeout, etc.)
+      // Clear any existing resume timeout
+      if (resumeTimeoutRef.current) {
+        clearTimeout(resumeTimeoutRef.current);
+      }
+      resumeTimeoutRef.current = setTimeout(() => {
+        resumeTimeoutRef.current = null;
+        // Only resume if still in hands-free mode and not playing
+        if (handsFreeModeEnabledRef.current && !isPlaying) {
+          resumeWakeWord();
+        }
+      }, RESUME_DELAY);
     }
-  }, [handsFreeModeEnabled, isRecording, isPlaying, pauseWakeWord]);
+
+    // Track previous state
+    wasRecordingRef.current = isRecording;
+    wasPlayingRef.current = isPlaying;
+  }, [handsFreeModeEnabled, isRecording, isPlaying, pauseWakeWord, resumeWakeWord]);
 
   // V5: Stop wake word when disconnecting
   useEffect(() => {

--- a/packages/web/src/hooks/__tests__/useWakeWord.test.ts
+++ b/packages/web/src/hooks/__tests__/useWakeWord.test.ts
@@ -286,6 +286,39 @@ describe("useWakeWord", () => {
     expect(onWakeWord).toHaveBeenCalledWith("something something hey ao", "hey ao");
   });
 
+  it("detects wake word at start of phrase (command following wake word)", async () => {
+    const onWakeWord = vi.fn();
+    const { result } = renderHook(() => useWakeWord({ onWakeWord }));
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      mockRecognition._fireResult("hey ao what is the status", true);
+    });
+
+    expect(onWakeWord).toHaveBeenCalledWith("hey ao what is the status", "hey ao");
+    expect(result.current.state).toBe("detected");
+  });
+
+  it("detects 'ao' at start of phrase", async () => {
+    const onWakeWord = vi.fn();
+    const { result } = renderHook(() => useWakeWord({ onWakeWord }));
+
+    await act(async () => {
+      result.current.start();
+      mockRecognition._fireStart();
+    });
+
+    await act(async () => {
+      mockRecognition._fireResult("ao check the ci status", true);
+    });
+
+    expect(onWakeWord).toHaveBeenCalledWith("ao check the ci status", "ao");
+  });
+
   it("does not trigger on partial wake word", async () => {
     const onWakeWord = vi.fn();
     const { result } = renderHook(() => useWakeWord({ onWakeWord }));

--- a/packages/web/src/hooks/useWakeWord.ts
+++ b/packages/web/src/hooks/useWakeWord.ts
@@ -82,6 +82,11 @@ function getSpeechRecognition(): SpeechRecognitionConstructor | null {
 /**
  * Check if any wake word is present in the transcript
  * Returns the longest matching wake word to avoid partial matches
+ *
+ * Matches wake word at:
+ * - Exact match: "hey ao"
+ * - Start of phrase: "hey ao what's the status" (for commands following wake word)
+ * - End of phrase: "um hey ao" (for hesitation before wake word)
  */
 function findWakeWord(transcript: string, wakeWords: string[]): string | null {
   const normalizedTranscript = transcript.toLowerCase().trim();
@@ -90,10 +95,14 @@ function findWakeWord(transcript: string, wakeWords: string[]): string | null {
   const sortedWakeWords = [...wakeWords].sort((a, b) => b.length - a.length);
 
   for (const word of sortedWakeWords) {
-    // Check if wake word appears at the end of transcript (most recent speech)
-    // or if the transcript is just the wake word
+    // Check if wake word appears:
+    // 1. Exact match
+    // 2. At the start (for "hey ao, do something")
+    // 3. At the end (for "um hey ao")
     if (
       normalizedTranscript === word ||
+      normalizedTranscript.startsWith(`${word} `) ||
+      normalizedTranscript.startsWith(word) ||
       normalizedTranscript.endsWith(word) ||
       normalizedTranscript.endsWith(` ${word}`)
     ) {


### PR DESCRIPTION
## Summary

- Fix wake word pattern matching to detect phrases **starting** with wake word (e.g., "Hey AO, what's the status?") in addition to ending with it
- Fix stale closure bug in `handlePlaybackComplete` callback by using refs for `handsFreeModeEnabled` and `resumeWakeWord`
- Add effect to resume wake word listening when recording stops without playback (handles Gemini errors/timeouts)
- Track previous recording/playing state to properly detect transitions and resume wake word listening

## Test plan

- [x] Run existing wake word tests: `pnpm --filter @composio/ao-web test -- --run src/hooks/__tests__/useWakeWord.test.ts`
- [x] Verify new test cases for wake word at start of phrase pass
- [x] Run full web test suite: `pnpm --filter @composio/ao-web test -- --run`
- [ ] Manual testing: Enable hands-free mode, say "Hey AO, what's the status?" and verify wake word triggers
- [ ] Manual testing: Verify wake word resumes after Gemini response plays
- [ ] Manual testing: Verify wake word resumes even when Gemini doesn't respond (error case)

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)