### PR TITLE
fix: prevent ao start from spawning duplicate orchestrators

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -28,6 +28,7 @@ import {
   generateConfigFromUrl,
   configToYaml,
   normalizeOrchestratorSessionStrategy,
+  isOrchestratorSession,
   ConfigNotFoundError,
   type OrchestratorConfig,
   type ProjectConfig,
@@ -987,31 +988,52 @@ async function runStartup(
     }
   }
 
-  // Create orchestrator session (unless --no-orchestrator or already exists)
+  // Create orchestrator session (unless --no-orchestrator or existing orchestrators found)
   let tmuxTarget = sessionId;
+  let hasExistingOrchestrators = false;
+  let selectedOrchestratorId: string | null = null;
+
   if (opts?.orchestrator !== false) {
     const sm = await getSessionManager(config);
 
-    try {
-      spinner.start("Creating orchestrator session");
-      const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
-      const session = await sm.spawnOrchestrator({ projectId, systemPrompt });
-      if (session.runtimeHandle?.id) {
-        tmuxTarget = session.runtimeHandle.id;
-      }
-      reused =
-        orchestratorSessionStrategy === "reuse" &&
-        session.metadata?.["orchestratorSessionReused"] === "true";
-      spinner.succeed(reused ? "Orchestrator session reused" : "Orchestrator session created");
-    } catch (err) {
-      spinner.fail("Orchestrator setup failed");
-      if (dashboardProcess) {
-        dashboardProcess.kill();
-      }
-      throw new Error(
-        `Failed to setup orchestrator: ${err instanceof Error ? err.message : String(err)}`,
-        { cause: err },
+    // Check for existing orchestrator sessions for this project
+    const allSessions = await sm.list(projectId);
+    const existingOrchestrators = allSessions.filter((s) =>
+      isOrchestratorSession(s, project.sessionPrefix ?? projectId),
+    );
+
+    if (existingOrchestrators.length > 0) {
+      // Existing orchestrators found — don't spawn a new one
+      // Let the dashboard handle orchestrator selection
+      hasExistingOrchestrators = true;
+      spinner.info(
+        `Found ${existingOrchestrators.length} existing orchestrator session(s). ` +
+          `Open the dashboard to select or start a new one.`,
       );
+    } else {
+      // No existing orchestrators — spawn a new one
+      try {
+        spinner.start("Creating orchestrator session");
+        const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
+        const session = await sm.spawnOrchestrator({ projectId, systemPrompt });
+        selectedOrchestratorId = session.id;
+        if (session.runtimeHandle?.id) {
+          tmuxTarget = session.runtimeHandle.id;
+        }
+        reused =
+          orchestratorSessionStrategy === "reuse" &&
+          session.metadata?.["orchestratorSessionReused"] === "true";
+        spinner.succeed(reused ? "Orchestrator session reused" : "Orchestrator session created");
+      } catch (err) {
+        spinner.fail("Orchestrator setup failed");
+        if (dashboardProcess) {
+          dashboardProcess.kill();
+        }
+        throw new Error(
+          `Failed to setup orchestrator: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
+        );
+      }
     }
   }
 
@@ -1030,7 +1052,12 @@ async function runStartup(
     console.log(chalk.cyan("Lifecycle:"), lifecycleTarget);
   }
 
-  if (opts?.orchestrator !== false && !reused) {
+  if (hasExistingOrchestrators) {
+    console.log(
+      chalk.cyan("Orchestrator:"),
+      "existing sessions found — select one in the dashboard",
+    );
+  } else if (opts?.orchestrator !== false && !reused) {
     console.log(chalk.cyan("Orchestrator:"), `tmux attach -t ${tmuxTarget}`);
   } else if (reused) {
     console.log(chalk.cyan("Orchestrator:"), `reused existing session (${sessionId})`);
@@ -1038,21 +1065,26 @@ async function runStartup(
 
   console.log(chalk.dim(`Config: ${config.configPath}`));
 
-  // Show next step hint
-  const projectIds = Object.keys(config.projects);
-  if (projectIds.length > 0) {
-    console.log(chalk.bold("\nNext step:\n"));
-    console.log(`  Spawn an agent session:`);
-    console.log(chalk.cyan(`     ao spawn <issue-number>\n`));
+  // Show next step hint (only if no existing orchestrators requiring selection)
+  if (!hasExistingOrchestrators) {
+    const projectIds = Object.keys(config.projects);
+    if (projectIds.length > 0) {
+      console.log(chalk.bold("\nNext step:\n"));
+      console.log(`  Spawn an agent session:`);
+      console.log(chalk.cyan(`     ao spawn <issue-number>\n`));
+    }
   }
 
-  // Auto-open browser to orchestrator session page once the server is accepting connections.
+  // Auto-open browser to orchestrator session page (or selection page) once the server is ready.
   // Polls the port instead of using a fixed delay — deterministic and works regardless of
   // how long Next.js takes to compile. AbortController cancels polling on early exit.
   let openAbort: AbortController | undefined;
   if (opts?.dashboard !== false) {
     openAbort = new AbortController();
-    const orchestratorUrl = `http://localhost:${port}/sessions/${sessionId}`;
+    // If existing orchestrators found, open the selection page; otherwise open the session page
+    const orchestratorUrl = hasExistingOrchestrators
+      ? `http://localhost:${port}/orchestrators?project=${projectId}`
+      : `http://localhost:${port}/sessions/${selectedOrchestratorId ?? sessionId}`;
     void waitForPortAndOpen(port, orchestratorUrl, openAbort.signal);
   }
 

--- a/packages/web/src/app/api/orchestrators/route.ts
+++ b/packages/web/src/app/api/orchestrators/route.ts
@@ -1,7 +1,54 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { generateOrchestratorPrompt } from "@composio/ao-core";
+import { generateOrchestratorPrompt, isOrchestratorSession } from "@composio/ao-core";
 import { getServices } from "@/lib/services";
 import { validateIdentifier, validateConfiguredProject } from "@/lib/validation";
+
+/**
+ * GET /api/orchestrators?project=<projectId>
+ * List existing orchestrator sessions for a project.
+ */
+export async function GET(request: NextRequest) {
+  const projectId = request.nextUrl.searchParams.get("project");
+
+  if (!projectId) {
+    return NextResponse.json({ error: "Missing project query parameter" }, { status: 400 });
+  }
+
+  const projectErr = validateIdentifier(projectId, "projectId");
+  if (projectErr) {
+    return NextResponse.json({ error: projectErr }, { status: 400 });
+  }
+
+  try {
+    const { config, sessionManager } = await getServices();
+    const configProjectErr = validateConfiguredProject(config.projects, projectId);
+    if (configProjectErr) {
+      return NextResponse.json({ error: configProjectErr }, { status: 404 });
+    }
+    const project = config.projects[projectId];
+    const sessionPrefix = project.sessionPrefix ?? projectId;
+
+    const allSessions = await sessionManager.list(projectId);
+    const orchestrators = allSessions
+      .filter((s) => isOrchestratorSession(s, sessionPrefix))
+      .map((s) => ({
+        id: s.id,
+        projectId: s.projectId,
+        projectName: project.name,
+        status: s.status,
+        activity: s.activity,
+        createdAt: s.createdAt?.toISOString() ?? null,
+        lastActivityAt: s.lastActivityAt?.toISOString() ?? null,
+      }));
+
+    return NextResponse.json({ orchestrators, projectName: project.name });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to list orchestrators" },
+      { status: 500 },
+    );
+  }
+}
 
 export async function POST(request: NextRequest) {
   const body = (await request.json().catch(() => null)) as Record<string, unknown> | null;

--- a/packages/web/src/app/orchestrators/page.tsx
+++ b/packages/web/src/app/orchestrators/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from "next";
+import { OrchestratorSelector } from "@/components/OrchestratorSelector";
+import { getServices } from "@/lib/services";
+import { isOrchestratorSession } from "@composio/ao-core/types";
+import { getAllProjects } from "@/lib/project-name";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata(props: {
+  searchParams: Promise<{ project?: string }>;
+}): Promise<Metadata> {
+  const searchParams = await props.searchParams;
+  const projectId = searchParams.project;
+  let projectName = "Orchestrator";
+  if (projectId) {
+    const projects = getAllProjects();
+    const project = projects.find((p) => p.id === projectId);
+    if (project) {
+      projectName = project.name;
+    }
+  }
+  return { title: { absolute: `ao | ${projectName} - Select Orchestrator` } };
+}
+
+interface Orchestrator {
+  id: string;
+  projectId: string;
+  projectName: string;
+  status: string;
+  activity: string | null;
+  createdAt: string | null;
+  lastActivityAt: string | null;
+}
+
+export default async function OrchestratorsRoute(props: {
+  searchParams: Promise<{ project?: string }>;
+}) {
+  const searchParams = await props.searchParams;
+  const projectId = searchParams.project;
+
+  if (!projectId) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-[var(--color-bg-base)]">
+        <div className="text-center">
+          <h1 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            Missing Project
+          </h1>
+          <p className="mt-2 text-[var(--color-text-secondary)]">
+            No project specified. Please provide a project parameter.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  let orchestrators: Orchestrator[] = [];
+  let projectName = projectId;
+  let error: string | null = null;
+
+  try {
+    const { config, sessionManager } = await getServices();
+    const project = config.projects[projectId];
+
+    if (!project) {
+      error = `Project "${projectId}" not found`;
+    } else {
+      projectName = project.name;
+      const sessionPrefix = project.sessionPrefix ?? projectId;
+      const allSessions = await sessionManager.list(projectId);
+
+      orchestrators = allSessions
+        .filter((s) => isOrchestratorSession(s, sessionPrefix))
+        .map((s) => ({
+          id: s.id,
+          projectId: s.projectId,
+          projectName: project.name,
+          status: s.status,
+          activity: s.activity,
+          createdAt: s.createdAt?.toISOString() ?? null,
+          lastActivityAt: s.lastActivityAt?.toISOString() ?? null,
+        }));
+    }
+  } catch (err) {
+    error = err instanceof Error ? err.message : "Failed to load orchestrators";
+  }
+
+  const projects = getAllProjects();
+
+  return (
+    <OrchestratorSelector
+      orchestrators={orchestrators}
+      projectId={projectId}
+      projectName={projectName}
+      projects={projects}
+      error={error}
+    />
+  );
+}

--- a/packages/web/src/components/OrchestratorSelector.tsx
+++ b/packages/web/src/components/OrchestratorSelector.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { cn } from "@/lib/cn";
+import type { ProjectInfo } from "@/lib/project-name";
+
+interface Orchestrator {
+  id: string;
+  projectId: string;
+  projectName: string;
+  status: string;
+  activity: string | null;
+  createdAt: string | null;
+  lastActivityAt: string | null;
+}
+
+interface OrchestratorSelectorProps {
+  orchestrators: Orchestrator[];
+  projectId: string;
+  projectName: string;
+  projects: ProjectInfo[];
+  error: string | null;
+}
+
+function formatRelativeTime(isoDate: string | null): string {
+  if (!isoDate) return "Unknown";
+  const date = new Date(isoDate);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffMins < 1) return "Just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return `${diffDays}d ago`;
+}
+
+function getStatusColor(status: string): string {
+  switch (status) {
+    case "working":
+      return "var(--color-status-working)";
+    case "spawning":
+      return "var(--color-status-attention)";
+    case "pr_open":
+    case "review_pending":
+    case "approved":
+    case "mergeable":
+      return "var(--color-status-ready)";
+    case "ci_failed":
+    case "changes_requested":
+      return "var(--color-status-error)";
+    case "merged":
+    case "done":
+    case "killed":
+    case "terminated":
+      return "var(--color-text-tertiary)";
+    default:
+      return "var(--color-text-secondary)";
+  }
+}
+
+function getActivityLabel(activity: string | null): string {
+  if (!activity) return "";
+  switch (activity) {
+    case "active":
+      return "Active";
+    case "ready":
+      return "Ready";
+    case "idle":
+      return "Idle";
+    case "waiting_input":
+      return "Waiting";
+    case "blocked":
+      return "Blocked";
+    case "exited":
+      return "Exited";
+    default:
+      return activity;
+  }
+}
+
+export function OrchestratorSelector({
+  orchestrators,
+  projectId,
+  projectName,
+  projects: _projects,
+  error,
+}: OrchestratorSelectorProps) {
+  const router = useRouter();
+  const [isSpawning, setIsSpawning] = useState(false);
+  const [spawnError, setSpawnError] = useState<string | null>(null);
+
+  const handleSpawnNew = async () => {
+    setIsSpawning(true);
+    setSpawnError(null);
+
+    try {
+      const response = await fetch("/api/orchestrators", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to spawn orchestrator");
+      }
+
+      const data = await response.json();
+      router.push(`/sessions/${data.orchestrator.id}`);
+    } catch (err) {
+      setSpawnError(err instanceof Error ? err.message : "Failed to spawn orchestrator");
+      setIsSpawning(false);
+    }
+  };
+
+  if (error) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-[var(--color-bg-base)]">
+        <div className="text-center">
+          <h1 className="text-xl font-semibold text-[var(--color-text-primary)]">Error</h1>
+          <p className="mt-2 text-[var(--color-text-secondary)]">{error}</p>
+          <Link
+            href="/"
+            className="orchestrator-btn mt-4 inline-flex items-center gap-2 px-4 py-2 text-sm font-medium"
+          >
+            Go to Dashboard
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-[var(--color-bg-base)]">
+      {/* Header */}
+      <header className="nav-glass sticky top-0 z-10 border-b border-[var(--color-border-subtle)] px-6 py-4">
+        <div className="mx-auto flex max-w-3xl items-center justify-between">
+          <div>
+            <h1 className="text-lg font-semibold text-[var(--color-text-primary)]">
+              {projectName}
+            </h1>
+            <p className="text-sm text-[var(--color-text-secondary)]">Select an orchestrator</p>
+          </div>
+          <Link
+            href={`/?project=${projectId}`}
+            className="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+          >
+            Dashboard
+          </Link>
+        </div>
+      </header>
+
+      {/* Content */}
+      <main className="flex-1 px-6 py-8">
+        <div className="mx-auto max-w-3xl">
+          {/* Info banner */}
+          <div className="mb-6 rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4">
+            <p className="text-sm text-[var(--color-text-secondary)]">
+              Found{" "}
+              <span className="font-medium text-[var(--color-text-primary)]">
+                {orchestrators.length}
+              </span>{" "}
+              existing orchestrator session{orchestrators.length !== 1 ? "s" : ""}. You can resume
+              an existing session or start a new one.
+            </p>
+          </div>
+
+          {/* Existing orchestrators */}
+          <div className="mb-6">
+            <h2 className="mb-3 text-sm font-medium text-[var(--color-text-secondary)]">
+              Existing Sessions
+            </h2>
+            <div className="space-y-2">
+              {orchestrators.map((orch) => (
+                <Link
+                  key={orch.id}
+                  href={`/sessions/${orch.id}`}
+                  className={cn(
+                    "flex items-center justify-between rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4",
+                    "transition-all hover:border-[var(--color-border-default)] hover:shadow-sm",
+                  )}
+                >
+                  <div className="flex items-center gap-3">
+                    <div
+                      className="h-2.5 w-2.5 rounded-full"
+                      style={{ backgroundColor: getStatusColor(orch.status) }}
+                    />
+                    <div>
+                      <div className="font-medium text-[var(--color-text-primary)]">{orch.id}</div>
+                      <div className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
+                        <span className="capitalize">{orch.status.replace(/_/g, " ")}</span>
+                        {orch.activity && (
+                          <>
+                            <span className="text-[var(--color-text-tertiary)]">&middot;</span>
+                            <span>{getActivityLabel(orch.activity)}</span>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="text-right text-xs text-[var(--color-text-tertiary)]">
+                    <div>Created {formatRelativeTime(orch.createdAt)}</div>
+                    {orch.lastActivityAt && (
+                      <div>Active {formatRelativeTime(orch.lastActivityAt)}</div>
+                    )}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+
+          {/* Start new section */}
+          <div className="border-t border-[var(--color-border-subtle)] pt-6">
+            <h2 className="mb-3 text-sm font-medium text-[var(--color-text-secondary)]">
+              Or Start Fresh
+            </h2>
+            <button
+              type="button"
+              onClick={handleSpawnNew}
+              disabled={isSpawning}
+              className={cn(
+                "orchestrator-btn w-full px-4 py-3 text-sm font-medium",
+                "disabled:cursor-wait disabled:opacity-70",
+              )}
+            >
+              {isSpawning ? (
+                <span className="flex items-center justify-center gap-2">
+                  <svg
+                    className="h-4 w-4 animate-spin"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                  Creating new orchestrator...
+                </span>
+              ) : (
+                "Start New Orchestrator"
+              )}
+            </button>
+            {spawnError && (
+              <p className="mt-2 text-sm text-[var(--color-status-error)]">{spawnError}</p>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/packages/web/src/components/__tests__/OrchestratorSelector.test.tsx
+++ b/packages/web/src/components/__tests__/OrchestratorSelector.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OrchestratorSelector } from "../OrchestratorSelector";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+const mockOrchestrators = [
+  {
+    id: "app-orchestrator-1",
+    projectId: "my-project",
+    projectName: "My Project",
+    status: "working",
+    activity: "active",
+    createdAt: new Date(Date.now() - 3600000).toISOString(), // 1 hour ago
+    lastActivityAt: new Date(Date.now() - 300000).toISOString(), // 5 min ago
+  },
+  {
+    id: "app-orchestrator-2",
+    projectId: "my-project",
+    projectName: "My Project",
+    status: "spawning",
+    activity: null,
+    createdAt: new Date(Date.now() - 7200000).toISOString(), // 2 hours ago
+    lastActivityAt: null,
+  },
+];
+
+const defaultProps = {
+  orchestrators: mockOrchestrators,
+  projectId: "my-project",
+  projectName: "My Project",
+  projects: [{ id: "my-project", name: "My Project" }],
+  error: null,
+};
+
+describe("OrchestratorSelector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it("renders orchestrator list", () => {
+    render(<OrchestratorSelector {...defaultProps} />);
+
+    expect(screen.getByText("app-orchestrator-1")).toBeInTheDocument();
+    expect(screen.getByText("app-orchestrator-2")).toBeInTheDocument();
+  });
+
+  it("displays project name in header", () => {
+    render(<OrchestratorSelector {...defaultProps} />);
+
+    expect(screen.getByText("My Project")).toBeInTheDocument();
+    expect(screen.getByText("Select an orchestrator")).toBeInTheDocument();
+  });
+
+  it("shows count of existing sessions", () => {
+    render(<OrchestratorSelector {...defaultProps} />);
+
+    expect(screen.getByText(/existing orchestrator sessions/)).toBeInTheDocument();
+    // The count "2" appears in multiple places, so we check the full info banner text
+    expect(screen.getByText(/Found/)).toBeInTheDocument();
+  });
+
+  it("shows error state", () => {
+    render(
+      <OrchestratorSelector
+        {...defaultProps}
+        orchestrators={[]}
+        error="Project not found"
+      />,
+    );
+
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(screen.getByText("Project not found")).toBeInTheDocument();
+  });
+
+  it("shows start new orchestrator button", () => {
+    render(<OrchestratorSelector {...defaultProps} />);
+
+    expect(screen.getByRole("button", { name: /start new orchestrator/i })).toBeInTheDocument();
+  });
+
+  it("spawns new orchestrator on button click", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          orchestrator: { id: "app-orchestrator-3" },
+        }),
+    });
+    global.fetch = mockFetch;
+
+    render(<OrchestratorSelector {...defaultProps} />);
+
+    const button = screen.getByRole("button", { name: /start new orchestrator/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith("/api/orchestrators", expect.any(Object));
+    });
+  });
+
+  it("shows loading state while spawning", async () => {
+    const mockFetch = vi.fn().mockImplementation(
+      () => new Promise(() => {}), // Never resolves
+    );
+    global.fetch = mockFetch;
+
+    render(<OrchestratorSelector {...defaultProps} />);
+
+    const button = screen.getByRole("button", { name: /start new orchestrator/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText(/creating new orchestrator/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error when spawn fails", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: "Failed to spawn" }),
+    });
+    global.fetch = mockFetch;
+
+    render(<OrchestratorSelector {...defaultProps} />);
+
+    const button = screen.getByRole("button", { name: /start new orchestrator/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to spawn")).toBeInTheDocument();
+    });
+  });
+
+  it("links to orchestrator session page", () => {
+    render(<OrchestratorSelector {...defaultProps} />);
+
+    const link = screen.getByRole("link", { name: /app-orchestrator-1/i });
+    expect(link).toHaveAttribute("href", "/sessions/app-orchestrator-1");
+  });
+
+  it("displays status and activity for each orchestrator", () => {
+    render(<OrchestratorSelector {...defaultProps} />);
+
+    expect(screen.getByText("working")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("spawning")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
When ao start is run and existing orchestrator sessions exist for the project, the CLI now skips spawning a new one. Instead:

- Detects existing orchestrator sessions before spawning
- Opens the dashboard to a new /orchestrators page for session selection
- Users can resume an existing orchestrator or start a new one

Changes:
- packages/cli/src/commands/start.ts: Check for existing orchestrators, redirect to selection page if found
- packages/web/src/app/api/orchestrators/route.ts: Add GET endpoint to list orchestrators for a project
- packages/web/src/app/orchestrators/page.tsx: New page for orchestrator selection
- packages/web/src/components/OrchestratorSelector.tsx: UI component for selecting or spawning orchestrators
- packages/web/src/components/__tests__/OrchestratorSelector.test.tsx: Tests for the selector component