### PR TITLE
feat(web): add orchestrator picker page and dead session recovery

### DIFF
--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -318,6 +318,62 @@ describe("API Routes", () => {
       expect(mockSessionManager.list).toHaveBeenCalledWith("docs-app");
     });
 
+    it("returns enriched orchestrators when orchestratorOnly=true", async () => {
+      const orchestratorSessions: Session[] = [
+        makeSession({
+          id: "my-app-orchestrator",
+          projectId: "my-app",
+          status: "working",
+          activity: "active",
+          metadata: { role: "orchestrator" },
+        }),
+        makeSession({
+          id: "docs-orchestrator",
+          projectId: "docs-app",
+          status: "pr_open",
+          activity: "idle",
+          metadata: { role: "orchestrator" },
+        }),
+      ];
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        orchestratorSessions,
+      );
+
+      const res = await sessionsGET(
+        makeRequest("http://localhost:3000/api/sessions?orchestratorOnly=true"),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+
+      // orchestratorOnly returns empty sessions array
+      expect(data.sessions).toEqual([]);
+
+      // Enriched orchestrators should include activity/status fields
+      expect(data.orchestrators).toHaveLength(2);
+      expect(data.orchestrators[0]).toMatchObject({
+        id: expect.any(String),
+        projectId: expect.any(String),
+        projectName: expect.any(String),
+        activity: expect.any(String),
+        status: expect.any(String),
+        createdAt: expect.any(String),
+        lastActivityAt: expect.any(String),
+      });
+
+      // Verify activity state from sessions is included
+      const myAppOrchestrator = data.orchestrators.find(
+        (o: { projectId: string }) => o.projectId === "my-app",
+      );
+      expect(myAppOrchestrator.activity).toBe("active");
+      expect(myAppOrchestrator.status).toBe("working");
+
+      const docsOrchestrator = data.orchestrators.find(
+        (o: { projectId: string }) => o.projectId === "docs-app",
+      );
+      expect(docsOrchestrator.activity).toBe("idle");
+      expect(docsOrchestrator.status).toBe("pr_open");
+    });
+
     it("enriches all PRs concurrently, not sequentially", async () => {
       vi.useFakeTimers();
 

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -36,6 +36,31 @@ export async function GET(request: Request) {
     const orchestratorId = orchestrators.length === 1 ? (orchestrators[0]?.id ?? null) : null;
 
     if (orchestratorOnly) {
+      // Enrich orchestrator info with activity state
+      const allSessionPrefixes = Object.entries(config.projects).map(
+        ([projectId, p]) => p.sessionPrefix ?? projectId,
+      );
+      const enrichedOrchestrators = orchestrators.map((link) => {
+        const session = visibleSessions.find(
+          (s) =>
+            s.id === link.id &&
+            isOrchestratorSession(
+              s,
+              config.projects[s.projectId]?.sessionPrefix ?? s.projectId,
+              allSessionPrefixes,
+            ),
+        );
+        return {
+          id: link.id,
+          projectId: link.projectId,
+          projectName: link.projectName,
+          activity: session?.activity ?? null,
+          status: session?.status ?? "unknown",
+          createdAt: session?.createdAt.toISOString() ?? new Date().toISOString(),
+          lastActivityAt: session?.lastActivityAt.toISOString() ?? new Date().toISOString(),
+        };
+      });
+
       recordApiObservation({
         config,
         method: "GET",
@@ -50,7 +75,7 @@ export async function GET(request: Request) {
       return jsonWithCorrelation(
         {
           orchestratorId,
-          orchestrators,
+          orchestrators: enrichedOrchestrators,
           sessions: [],
         },
         { status: 200 },

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -554,7 +554,7 @@ function DashboardInner({
                   </a>
                 ) : null}
                 {!allProjectsView && !isMobile ? (
-                  <OrchestratorControl orchestrators={activeOrchestrators} />
+                  <OrchestratorControl orchestrators={activeOrchestrators} projectId={projectId} />
                 ) : null}
                 <ThemeToggle />
               </div>
@@ -762,8 +762,39 @@ export function Dashboard(props: DashboardProps) {
   );
 }
 
-function OrchestratorControl({ orchestrators }: { orchestrators: DashboardOrchestratorLink[] }) {
-  if (orchestrators.length === 0) return null;
+function OrchestratorControl({
+  orchestrators,
+  projectId,
+}: {
+  orchestrators: DashboardOrchestratorLink[];
+  projectId?: string;
+}) {
+  // Build the orchestrators picker URL
+  const orchestratorsHref = projectId
+    ? `/orchestrators?project=${encodeURIComponent(projectId)}`
+    : "/orchestrators";
+
+  if (orchestrators.length === 0) {
+    // Show "Orchestrators" button that links to picker even when no orchestrators running
+    return (
+      <a
+        href={orchestratorsHref}
+        className="orchestrator-btn flex items-center gap-2 px-4 py-2 text-[12px] font-semibold hover:no-underline"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-text-tertiary)] opacity-80" />
+        orchestrators
+        <svg
+          className="h-3 w-3 opacity-70"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+        >
+          <path d="m9 18 6-6-6-6" />
+        </svg>
+      </a>
+    );
+  }
 
   if (orchestrators.length === 1) {
     const orchestrator = orchestrators[0];
@@ -787,6 +818,7 @@ function OrchestratorControl({ orchestrators }: { orchestrators: DashboardOrches
     );
   }
 
+  // Multiple orchestrators: show dropdown with link to picker page
   return (
     <details className="group relative">
       <summary className="orchestrator-btn flex cursor-pointer list-none items-center gap-2 px-4 py-2 text-[12px] font-semibold hover:no-underline">
@@ -826,6 +858,12 @@ function OrchestratorControl({ orchestrators }: { orchestrators: DashboardOrches
             </svg>
           </a>
         ))}
+        <a
+          href={orchestratorsHref}
+          className="flex items-center justify-center gap-2 border-t border-[var(--color-border-subtle)] px-4 py-3 text-[11px] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:no-underline"
+        >
+          Manage all orchestrators
+        </a>
       </div>
     </details>
   );

--- a/packages/web/src/components/__tests__/Dashboard.projectOverview.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.projectOverview.test.tsx
@@ -165,3 +165,57 @@ describe("Dashboard project overview cards", () => {
     expect(screen.getAllByRole("button", { name: "Spawn Orchestrator" })).toHaveLength(2);
   });
 });
+
+describe("Dashboard OrchestratorControl in single-project view", () => {
+  beforeEach(() => {
+    global.EventSource = vi.fn(
+      () =>
+        ({
+          onmessage: null,
+          onerror: null,
+          close: vi.fn(),
+        }) as unknown as EventSource,
+    );
+    global.fetch = vi.fn();
+  });
+
+  it("shows orchestrators link to picker when no orchestrators are running", () => {
+    render(
+      <Dashboard
+        initialSessions={[makeSession({ projectId: "my-app" })]}
+        projectId="my-app"
+        projectName="My App"
+        orchestrators={[]}
+      />,
+    );
+
+    const orchestratorsLink = screen.getByRole("link", { name: /orchestrators/i });
+    expect(orchestratorsLink).toHaveAttribute("href", "/orchestrators?project=my-app");
+  });
+
+  it("shows dropdown with Manage all orchestrators link for multiple orchestrators", () => {
+    // Need orchestrators from different projects to avoid mergeOrchestrators deduplication
+    render(
+      <Dashboard
+        initialSessions={[makeSession({ projectId: "my-app" })]}
+        projectId="my-app"
+        projectName="My App"
+        orchestrators={[
+          { id: "my-app-orchestrator", projectId: "my-app", projectName: "My App" },
+          { id: "other-orchestrator", projectId: "other-app", projectName: "Other App" },
+        ]}
+      />,
+    );
+
+    // Find the dropdown summary element
+    const dropdown = screen.getByText("2 orchestrators");
+    expect(dropdown).toBeInTheDocument();
+
+    // Click to open dropdown
+    fireEvent.click(dropdown);
+
+    // Check for the "Manage all orchestrators" link
+    const manageLink = screen.getByRole("link", { name: /Manage all orchestrators/i });
+    expect(manageLink).toHaveAttribute("href", "/orchestrators?project=my-app");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #945 - Dashboard routes to `/sessions/{slug}-orchestrator` instead of orchestrator picker, leaving users stranded on dead session pages.

**Changes:**
- Add `/orchestrators` page with project-grouped orchestrator listing
- `OrchestratorSelector` component shows activity state (active/idle/exited/blocked), spawn buttons, and time since last activity
- Update `OrchestratorControl` in Dashboard to link to picker page (even when no orchestrators running)
- Session detail page detects dead orchestrator sessions and offers recovery options
- Enrich `/api/sessions?orchestratorOnly=true` API with activity state data

**User Experience:**
- Users can now view all orchestrators across projects with their current status
- Spawn new orchestrators directly from the picker page
- Navigate to specific orchestrator sessions
- When an orchestrator session is not found (killed/cleaned up), users see a helpful message with "View Orchestrators" button to return to the picker

## Test plan

- [x] Unit tests for `OrchestratorSelector` component (12 tests passing)
- [ ] Manual test: Navigate to `/orchestrators` - should show project sections with orchestrators
- [ ] Manual test: Click "Spawn New" - should create orchestrator and redirect to session
- [ ] Manual test: Navigate to dead orchestrator session URL - should show recovery options
- [ ] Manual test: Click orchestrator button in Dashboard header - should link to picker or session

🤖 Generated with [Claude Code](https://claude.com/claude-code)