### PR TITLE
fix(web): address PR review feedback for orchestrator enrichment

### DIFF
--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -35,29 +35,35 @@ export async function GET(request: Request) {
     const orchestrators = listDashboardOrchestrators(visibleSessions, config.projects);
     const orchestratorId = orchestrators.length === 1 ? (orchestrators[0]?.id ?? null) : null;
 
+    // Compute session prefixes once (used by both branches)
+    const allSessionPrefixes = Object.entries(config.projects).map(
+      ([projectId, p]) => p.sessionPrefix ?? projectId,
+    );
+
     if (orchestratorOnly) {
-      // Enrich orchestrator info with activity state
-      const allSessionPrefixes = Object.entries(config.projects).map(
-        ([projectId, p]) => p.sessionPrefix ?? projectId,
-      );
-      const enrichedOrchestrators = orchestrators.map((link) => {
-        const session = visibleSessions.find(
-          (s) =>
-            s.id === link.id &&
+      // Build a Map for O(1) session lookups
+      const orchestratorSessionsById = new Map(
+        visibleSessions
+          .filter((s) =>
             isOrchestratorSession(
               s,
               config.projects[s.projectId]?.sessionPrefix ?? s.projectId,
               allSessionPrefixes,
             ),
-        );
+          )
+          .map((s) => [s.id, s] as const),
+      );
+
+      const enrichedOrchestrators = orchestrators.map((link) => {
+        const session = orchestratorSessionsById.get(link.id);
         return {
           id: link.id,
           projectId: link.projectId,
           projectName: link.projectName,
           activity: session?.activity ?? null,
-          status: session?.status ?? "unknown",
-          createdAt: session?.createdAt.toISOString() ?? new Date().toISOString(),
-          lastActivityAt: session?.lastActivityAt.toISOString() ?? new Date().toISOString(),
+          status: session?.status ?? null,
+          createdAt: session?.createdAt.toISOString() ?? null,
+          lastActivityAt: session?.lastActivityAt.toISOString() ?? null,
         };
       });
 
@@ -83,9 +89,6 @@ export async function GET(request: Request) {
       );
     }
 
-    const allSessionPrefixes = Object.entries(config.projects).map(
-      ([projectId, p]) => p.sessionPrefix ?? projectId,
-    );
     let workerSessions = visibleSessions.filter(
       (session) =>
         !isOrchestratorSession(

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -784,6 +784,7 @@ function OrchestratorControl({
         <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-text-tertiary)] opacity-80" />
         orchestrators
         <svg
+          aria-hidden="true"
           className="h-3 w-3 opacity-70"
           fill="none"
           stroke="currentColor"
@@ -806,6 +807,7 @@ function OrchestratorControl({
         <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)] opacity-80" />
         orchestrator
         <svg
+          aria-hidden="true"
           className="h-3 w-3 opacity-70"
           fill="none"
           stroke="currentColor"
@@ -825,6 +827,7 @@ function OrchestratorControl({
         <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)] opacity-80" />
         {orchestrators.length} orchestrators
         <svg
+          aria-hidden="true"
           className="h-3 w-3 opacity-70 transition-transform group-open:rotate-90"
           fill="none"
           stroke="currentColor"
@@ -848,6 +851,7 @@ function OrchestratorControl({
               <span className="truncate">{orchestrator.projectName}</span>
             </span>
             <svg
+              aria-hidden="true"
               className="h-3 w-3 shrink-0 opacity-60"
               fill="none"
               stroke="currentColor"

--- a/packages/web/src/components/__tests__/Dashboard.projectOverview.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.projectOverview.test.tsx
@@ -193,6 +193,20 @@ describe("Dashboard OrchestratorControl in single-project view", () => {
     expect(orchestratorsLink).toHaveAttribute("href", "/orchestrators?project=my-app");
   });
 
+  it("shows direct link to session for single orchestrator", () => {
+    render(
+      <Dashboard
+        initialSessions={[makeSession({ projectId: "my-app" })]}
+        projectId="my-app"
+        projectName="My App"
+        orchestrators={[{ id: "my-app-orchestrator", projectId: "my-app", projectName: "My App" }]}
+      />,
+    );
+
+    const orchestratorLink = screen.getByRole("link", { name: /orchestrator/i });
+    expect(orchestratorLink).toHaveAttribute("href", "/sessions/my-app-orchestrator");
+  });
+
   it("shows dropdown with Manage all orchestrators link for multiple orchestrators", () => {
     // Need orchestrators from different projects to avoid mergeOrchestrators deduplication
     render(

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -136,6 +136,14 @@ export interface DashboardOrchestratorLink {
   projectName: string;
 }
 
+/** Enriched orchestrator data returned by /api/sessions?orchestratorOnly=true */
+export interface EnrichedOrchestratorLink extends DashboardOrchestratorLink {
+  activity: ActivityState | null;
+  status: SessionStatus | null;
+  createdAt: string | null;
+  lastActivityAt: string | null;
+}
+
 /** SSE snapshot event from /api/events */
 export interface SSESnapshotEvent {
   type: "snapshot";


### PR DESCRIPTION
- Hoist allSessionPrefixes above conditional to eliminate duplication
- Use Map for O(1) session lookups instead of linear .find()
- Return null instead of synthetic values for missing session data
- Add aria-hidden to decorative SVG icons for accessibility
- Add EnrichedOrchestratorLink type for API response contract
- Add test for single-orchestrator direct link behavior