### PR TITLE
fix(core): use canonical TERMINAL_STATUSES from types.ts

### DIFF
--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -281,3 +281,60 @@ describe("deleteSession retry loop", () => {
     expect(deleteCallCount).toBe(1);
   });
 });
+
+describe("terminal status handling", () => {
+  it("treats errored sessions as terminal - skips runtime/agent activity checks", async () => {
+    // Setup: Create a session with errored status
+    writeMetadata(sessionsDir, "app-errored", {
+      worktree: "/tmp/ws",
+      branch: "main",
+      status: "errored",
+      project: "my-app",
+      agent: "opencode",
+      runtimeHandle: JSON.stringify(makeHandle("rt-errored")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const sessions = await sm.list();
+
+    // Find our errored session
+    const erroredSession = sessions.find((s) => s.id === "app-errored");
+    expect(erroredSession).toBeDefined();
+
+    // Verify the session was treated as terminal:
+    // 1. Activity should be set to "exited" without calling runtime/agent methods
+    expect(erroredSession!.activity).toBe("exited");
+
+    // 2. Runtime.isAlive should NOT have been called for this session
+    //    (terminal sessions skip subprocess/IO work)
+    const isAliveCalls = vi.mocked(ctx.mockRuntime.isAlive).mock.calls;
+
+    // Filter calls that would be for our errored session's handle
+    const callsForErroredSession = isAliveCalls.filter(
+      (call) => call[0]?.id === "rt-errored",
+    );
+    expect(callsForErroredSession).toHaveLength(0);
+  });
+
+  it("does not overwrite errored status to killed", async () => {
+    // Setup: Create a session with errored status
+    writeMetadata(sessionsDir, "app-errored-2", {
+      worktree: "/tmp/ws",
+      branch: "main",
+      status: "errored",
+      project: "my-app",
+      agent: "opencode",
+      runtimeHandle: JSON.stringify(makeHandle("rt-errored-2")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const sessions = await sm.list();
+
+    // Find our errored session
+    const erroredSession = sessions.find((s) => s.id === "app-errored-2");
+    expect(erroredSession).toBeDefined();
+
+    // Status should remain "errored", not be changed to "killed"
+    expect(erroredSession!.status).toBe("errored");
+  });
+});

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -44,6 +44,7 @@ import {
   type Issue,
   type CostEstimate,
   PR_STATE,
+  TERMINAL_STATUSES,
 } from "./types.js";
 import {
   readMetadataRaw,
@@ -871,15 +872,13 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
    * Enrich session with live runtime state (alive/exited) and activity detection.
    * Mutates the session object in place.
    */
-  const TERMINAL_SESSION_STATUSES = new Set(["killed", "done", "merged", "terminated", "cleanup"]);
-
   async function enrichSessionWithRuntimeState(
     session: Session,
     plugins: ReturnType<typeof resolvePlugins>,
     handleFromMetadata: boolean,
   ): Promise<void> {
     // Skip all subprocess/IO work for sessions already known to be terminal.
-    if (TERMINAL_SESSION_STATUSES.has(session.status)) {
+    if (TERMINAL_STATUSES.has(session.status)) {
       session.activity = "exited";
       return;
     }


### PR DESCRIPTION
## Summary

- Replaced local `TERMINAL_SESSION_STATUSES` constant with canonical `TERMINAL_STATUSES` from `types.ts`
- The local constant was missing the `errored` status, causing sessions in errored state to not be recognized as terminal
- This could lead to unnecessary subprocess/IO work for errored sessions

## Test plan

- [x] TypeScript compiles without errors (`pnpm --filter @composio/ao-core typecheck`)
- [ ] Verify sessions with `errored` status are properly marked as terminal

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)