### PR TITLE
fix(core): exclude orchestrator IDs from cross-project collision check

### DIFF
--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -53,7 +53,8 @@ describe("isOrchestratorSession", () => {
     // app-worker-1 matches the worker pattern for prefix "app-worker"
     // so it should be filtered out when checking prefix "app"
     const allPrefixes = ["app", "app-worker"];
-    // Note: "app-worker-1" does not match "^app-orchestrator-\d+$" so it returns false at line 204
+    // Note: "app-worker-1" does not match the orchestrator pattern "^app-orchestrator-\d+$"
+    // so it fails the orchestrator format check before reaching the cross-project guard
     expect(
       isOrchestratorSession({ id: "app-worker-1", metadata: {} }, "app", allPrefixes),
     ).toBe(false);

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -34,6 +34,30 @@ describe("isOrchestratorSession", () => {
       ),
     ).toBe(true);
   });
+
+  it("does not filter out valid orchestrators when another project has orchestrator suffix as prefix", () => {
+    // Project A has prefix "app", Project B has prefix "app-orchestrator"
+    // app-orchestrator-1 is a valid orchestrator for Project A
+    // The cross-project check should NOT filter it out just because
+    // it matches the worker pattern for Project B
+    const allPrefixes = ["app", "app-orchestrator"];
+    expect(
+      isOrchestratorSession({ id: "app-orchestrator-1", metadata: {} }, "app", allPrefixes),
+    ).toBe(true);
+    expect(
+      isOrchestratorSession({ id: "app-orchestrator-42", metadata: {} }, "app", allPrefixes),
+    ).toBe(true);
+  });
+
+  it("still filters out workers that match another project's worker pattern", () => {
+    // app-worker-1 matches the worker pattern for prefix "app-worker"
+    // so it should be filtered out when checking prefix "app"
+    const allPrefixes = ["app", "app-worker"];
+    // Note: "app-worker-1" does not match "^app-orchestrator-\d+$" so it returns false at line 204
+    expect(
+      isOrchestratorSession({ id: "app-worker-1", metadata: {} }, "app", allPrefixes),
+    ).toBe(false);
+  });
 });
 
 describe("isIssueNotFoundError", () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -208,8 +208,13 @@ export function isOrchestratorSession(
   // numbered worker for any other known prefix (e.g. prefix "app-orchestrator"
   // matches "app-orchestrator-1" as a worker), it is not an orchestrator.
   if (allSessionPrefixes) {
+    const orchestratorSuffix = `${sessionPrefix}-orchestrator`;
     for (const prefix of allSessionPrefixes) {
       if (prefix === sessionPrefix) continue;
+      // Skip prefixes that would incorrectly filter out valid orchestrator IDs.
+      // E.g., if sessionPrefix is "app" and another prefix is "app-orchestrator",
+      // the pattern "app-orchestrator-\d+" would match our valid orchestrator ID.
+      if (prefix === orchestratorSuffix) continue;
       if (new RegExp(`^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-\\d+$`).test(session.id)) {
         return false;
       }


### PR DESCRIPTION
## Summary
- Fixes cross-project collision detection regex in `isOrchestratorSession` that incorrectly filtered out valid orchestrators
- When another project has prefix `{sessionPrefix}-orchestrator`, valid orchestrator IDs were being filtered because they matched the worker pattern for that project
- Added check to skip collision detection when other prefix equals `{sessionPrefix}-orchestrator`

## Test plan
- [x] Added test case: "does not filter out valid orchestrators when another project has orchestrator suffix as prefix"
- [x] Added test case: "still filters out workers that match another project's worker pattern"
- [x] All existing `isOrchestratorSession` tests pass
- [x] Typecheck passes

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)