### PR TITLE
fix(core): pre-populate states map to prevent false killed notifications

### DIFF
--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1303,6 +1303,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     try {
       const sessions = await sessionManager.list(scopedProjectId);
 
+      // Pre-populate states map on first poll to establish baseline for each session.
+      // This prevents false "session killed" notifications for sessions that were
+      // already dead before the lifecycle manager started. Using session.status
+      // (which list() computes from current runtime state) rather than stale metadata
+      // ensures we don't detect false transitions on startup.
+      for (const s of sessions) {
+        if (!states.has(s.id)) {
+          states.set(s.id, s.status);
+        }
+      }
+
       // Include sessions that are active OR whose status changed from what we last saw
       // (e.g., list() detected a dead runtime and marked it "killed" — we need to
       // process that transition even though the new status is terminal)


### PR DESCRIPTION
## Summary

- Pre-populates the `states` map in `pollAll()` with each session's current status before running `checkSession()`
- This prevents false "session killed" notifications on lifecycle manager startup for sessions that were already dead

## Problem

On lifecycle manager startup, the `states` map is empty. When `checkSession()` runs for a session:
1. `tracked = states.get(session.id)` returns `undefined`
2. `oldStatus` falls back to metadata status (e.g., "working" from persisted state)
3. `determineStatus()` detects the runtime is dead and returns "killed"
4. A false transition from "working" to "killed" is detected
5. Spurious "session killed" notification is sent

## Solution

Pre-populate the `states` map before calling `checkSession()`:
- For each session without a tracked state, seed `states` with `session.status`
- `session.status` from `list()` already reflects the current runtime state
- This ensures the tracked state matches actual runtime state, so no false transitions are detected

## Test plan

- [x] Existing lifecycle-manager tests pass (617 tests)
- [x] Build passes
- [x] No new lint errors

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)