### PR TITLE
fix(core): complete event type mappings for all session statuses (#47)

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -87,9 +87,23 @@ describe("start / stop", () => {
 });
 
 describe("check (single session)", () => {
-  it("detects transition from spawning to working", async () => {
+  it("detects transition from spawning to working and emits session.spawned", async () => {
+    const notifier = createMockNotifier();
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    config.notificationRouting.info = ["desktop"];
+
     const lm = setupCheck("app-1", {
       session: makeSession({ status: "spawning" }),
+      registry,
     });
 
     await lm.check("app-1");
@@ -97,6 +111,10 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("working");
     const meta = readMetadataRaw(env.sessionsDir, "app-1");
     expect(meta!["status"]).toBe("working");
+    // Verify session.spawned event is emitted when transitioning FROM spawning
+    expect(notifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "session.spawned" }),
+    );
   });
 
   it("uses worker-specific agent fallback when metadata does not persist an agent", async () => {
@@ -1330,7 +1348,12 @@ describe("reactions", () => {
     );
   });
 
-  it("emits session.exited event when session transitions to done status", async () => {
+  // Table-driven tests for terminal status transitions that emit session.exited
+  it.each([
+    { status: "done" as SessionStatus, description: "done" },
+    { status: "terminated" as SessionStatus, description: "terminated" },
+    { status: "cleanup" as SessionStatus, description: "cleanup" },
+  ])("emits session.exited event when session transitions to $description status", async ({ status }) => {
     const notifier = createMockNotifier();
     const registry: PluginRegistry = {
       ...mockRegistry,
@@ -1344,9 +1367,9 @@ describe("reactions", () => {
 
     config.notificationRouting.info = ["desktop"];
 
-    // Session has status "done" but metadata has "working" to trigger a transition
+    // Session has terminal status but metadata has "working" to trigger a transition
     vi.mocked(mockSessionManager.get).mockResolvedValue(
-      makeSession({ status: "done" as SessionStatus, metadata: { status: "working" } }),
+      makeSession({ status, metadata: { status: "working" } }),
     );
 
     writeMetadata(env.sessionsDir, "app-1", {
@@ -1364,87 +1387,7 @@ describe("reactions", () => {
 
     await lm.check("app-1");
 
-    expect(lm.getStates().get("app-1")).toBe("done");
-    expect(notifier.notify).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "session.exited" }),
-    );
-  });
-
-  it("emits session.exited event when session transitions to terminated status", async () => {
-    const notifier = createMockNotifier();
-    const registry: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string, name: string) => {
-        if (slot === "runtime") return plugins.runtime;
-        if (slot === "agent") return plugins.agent;
-        if (slot === "notifier" && name === "desktop") return notifier;
-        return null;
-      }),
-    };
-
-    config.notificationRouting.info = ["desktop"];
-
-    // Session has status "terminated" but metadata has "working" to trigger a transition
-    vi.mocked(mockSessionManager.get).mockResolvedValue(
-      makeSession({ status: "terminated" as SessionStatus, metadata: { status: "working" } }),
-    );
-
-    writeMetadata(env.sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "working",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry,
-      sessionManager: mockSessionManager,
-    });
-
-    await lm.check("app-1");
-
-    expect(lm.getStates().get("app-1")).toBe("terminated");
-    expect(notifier.notify).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "session.exited" }),
-    );
-  });
-
-  it("emits session.exited event when session transitions to cleanup status", async () => {
-    const notifier = createMockNotifier();
-    const registry: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string, name: string) => {
-        if (slot === "runtime") return plugins.runtime;
-        if (slot === "agent") return plugins.agent;
-        if (slot === "notifier" && name === "desktop") return notifier;
-        return null;
-      }),
-    };
-
-    config.notificationRouting.info = ["desktop"];
-
-    // Session has status "cleanup" but metadata has "working" to trigger a transition
-    vi.mocked(mockSessionManager.get).mockResolvedValue(
-      makeSession({ status: "cleanup" as SessionStatus, metadata: { status: "working" } }),
-    );
-
-    writeMetadata(env.sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "working",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry,
-      sessionManager: mockSessionManager,
-    });
-
-    await lm.check("app-1");
-
-    expect(lm.getStates().get("app-1")).toBe("cleanup");
+    expect(lm.getStates().get("app-1")).toBe(status);
     expect(notifier.notify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "session.exited" }),
     );

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1329,6 +1329,126 @@ describe("reactions", () => {
       expect.objectContaining({ type: "merge.completed" }),
     );
   });
+
+  it("emits session.exited event when session transitions to done status", async () => {
+    const notifier = createMockNotifier();
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    config.notificationRouting.info = ["desktop"];
+
+    // Session has status "done" but metadata has "working" to trigger a transition
+    vi.mocked(mockSessionManager.get).mockResolvedValue(
+      makeSession({ status: "done" as SessionStatus, metadata: { status: "working" } }),
+    );
+
+    writeMetadata(env.sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("done");
+    expect(notifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "session.exited" }),
+    );
+  });
+
+  it("emits session.exited event when session transitions to terminated status", async () => {
+    const notifier = createMockNotifier();
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    config.notificationRouting.info = ["desktop"];
+
+    // Session has status "terminated" but metadata has "working" to trigger a transition
+    vi.mocked(mockSessionManager.get).mockResolvedValue(
+      makeSession({ status: "terminated" as SessionStatus, metadata: { status: "working" } }),
+    );
+
+    writeMetadata(env.sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("terminated");
+    expect(notifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "session.exited" }),
+    );
+  });
+
+  it("emits session.exited event when session transitions to cleanup status", async () => {
+    const notifier = createMockNotifier();
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    config.notificationRouting.info = ["desktop"];
+
+    // Session has status "cleanup" but metadata has "working" to trigger a transition
+    vi.mocked(mockSessionManager.get).mockResolvedValue(
+      makeSession({ status: "cleanup" as SessionStatus, metadata: { status: "working" } }),
+    );
+
+    writeMetadata(env.sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("cleanup");
+    expect(notifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "session.exited" }),
+    );
+  });
 });
 
 describe("pollAll terminal status accounting", () => {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -106,6 +106,8 @@ function createEvent(
 /** Determine which event type corresponds to a status transition. */
 function statusToEventType(_from: SessionStatus | undefined, to: SessionStatus): EventType | null {
   switch (to) {
+    case "spawning":
+      return "session.spawned";
     case "working":
       return "session.working";
     case "pr_open":
@@ -122,6 +124,12 @@ function statusToEventType(_from: SessionStatus | undefined, to: SessionStatus):
       return "merge.ready";
     case "merged":
       return "merge.completed";
+    case "cleanup":
+    case "done":
+    case "terminated":
+      return "session.exited";
+    case "idle":
+      return "session.idle";
     case "needs_input":
       return "session.needs_input";
     case "stuck":

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -103,11 +103,25 @@ function createEvent(
   };
 }
 
-/** Determine which event type corresponds to a status transition. */
-function statusToEventType(_from: SessionStatus | undefined, to: SessionStatus): EventType | null {
+/**
+ * Determine which event type corresponds to a status transition.
+ *
+ * Most events are based on the target status (`to`), but some transitions
+ * are identified by the source status (`from`):
+ * - `spawning → *` emits `session.spawned` (session just became active)
+ *
+ * Note: `determineStatus()` never returns "spawning" or "idle" directly,
+ * so those target-based mappings are included for completeness if external
+ * code sets these statuses explicitly.
+ */
+function statusToEventType(from: SessionStatus | undefined, to: SessionStatus): EventType | null {
+  // Emit session.spawned when transitioning OUT of spawning state
+  // (determineStatus() converts spawning → working, so we detect via `from`)
+  if (from === "spawning" && to !== "spawning") {
+    return "session.spawned";
+  }
+
   switch (to) {
-    case "spawning":
-      return "session.spawned";
     case "working":
       return "session.working";
     case "pr_open":


### PR DESCRIPTION
## Summary

- Add missing event type mappings in `statusToEventType` function for all session statuses
- Map `spawning` → `session.spawned`
- Map `idle` → `session.idle`
- Map `cleanup`, `done`, `terminated` → `session.exited` (terminal states)
- Add tests to verify `session.exited` event is emitted for terminal status transitions

## Test plan

- [ ] Verify `pnpm --filter @composio/ao-core typecheck` passes
- [ ] Verify `pnpm --filter @composio/ao-core test` passes (excluding pre-existing plugin-integration issue)
- [ ] Verify new tests for `session.exited` events cover done, terminated, and cleanup transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)