### PR TITLE
fix(core): consistent metadata handling for role and prAutoDetect fields

### DIFF
--- a/packages/core/src/__tests__/session-manager/claim-pr.test.ts
+++ b/packages/core/src/__tests__/session-manager/claim-pr.test.ts
@@ -106,7 +106,7 @@ describe("claimPR", () => {
       status: "pr_open",
       pr: "https://github.com/org/my-app/pull/42",
     });
-    expect(raw!["prAutoDetect"]).toBeUndefined();
+    expect(raw!["prAutoDetect"]).toBe("off"); // PR explicitly claimed, auto-detect disabled
   });
 
   it("consolidates ownership by disabling PR auto-detect on the previous session", async () => {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -86,7 +86,12 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
     createdAt: raw["createdAt"],
     runtimeHandle: raw["runtimeHandle"],
     restoredAt: raw["restoredAt"],
-    role: raw["role"],
+    role:
+      raw["role"] === "orchestrator"
+        ? "orchestrator"
+        : raw["role"] === "worker"
+          ? "worker"
+          : undefined,
     dashboardPort: raw["dashboardPort"] ? Number(raw["dashboardPort"]) : undefined,
     terminalWsPort: raw["terminalWsPort"] ? Number(raw["terminalWsPort"]) : undefined,
     directTerminalWsPort: raw["directTerminalWsPort"]

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1233,6 +1233,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         worktree: workspacePath,
         branch,
         status: "spawning",
+        role: "worker", // Consistent with spawnOrchestrator writing role: "orchestrator"
         tmuxName, // Store tmux name for mapping
         issue: spawnConfig.issueId,
         project: spawnConfig.projectId,
@@ -2415,7 +2416,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         worktree: raw["worktree"] ?? "",
         branch: raw["branch"] ?? "",
         status: raw["status"] ?? "killed",
-        role: raw["role"],
+        role:
+          raw["role"] === "orchestrator"
+            ? "orchestrator"
+            : raw["role"] === "worker"
+              ? "worker"
+              : undefined,
         tmuxName: raw["tmuxName"],
         issue: raw["issue"],
         pr: raw["pr"],

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -2265,7 +2265,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       pr: pr.url,
       status: "pr_open",
       branch: pr.branch,
-      prAutoDetect: "",
+      prAutoDetect: "off", // Disable auto-detect since PR is explicitly claimed
     });
 
     for (const previousSessionId of takenOverFrom) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1420,7 +1420,7 @@ export interface SessionMetadata {
   createdAt?: string;
   runtimeHandle?: string;
   restoredAt?: string;
-  role?: string; // "orchestrator" for orchestrator sessions
+  role?: "orchestrator" | "worker"; // Session role: "orchestrator" or "worker"
   dashboardPort?: number;
   terminalWsPort?: number;
   directTerminalWsPort?: number;


### PR DESCRIPTION
## Summary
- Add `role: "worker"` in `spawn()` to match the existing `spawnOrchestrator()` pattern that writes `role: "orchestrator"`
- Add explicit validation for `role` field in the restore function, matching the validation pattern already used for `prAutoDetect`

## Test plan
- [x] Typecheck passes: `pnpm --filter @composio/ao-core typecheck`
- [x] All 626 core tests pass: `pnpm --filter @composio/ao-core test`

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)