### PR TITLE
fix(core): improve orchestrator detection and metadata tracking

### DIFF
--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1299,6 +1299,8 @@ describe("spawn", () => {
       );
       const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
       expect(meta?.["opencodeSessionId"]).toBe("ses_existing");
+      // Verify orchestratorSessionReused is set when session is reused upfront
+      expect(meta?.["orchestratorSessionReused"]).toBe("true");
     });
 
     it("discovers OpenCode mapping by title when no archived mapping exists for new session id", async () => {
@@ -1401,6 +1403,8 @@ describe("spawn", () => {
       );
       const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
       expect(meta?.["opencodeSessionId"]).toBe("ses_title_match");
+      // Verify orchestratorSessionReused is set when session is reused
+      expect(meta?.["orchestratorSessionReused"]).toBe("true");
     });
 
     it("calls agent.setupWorkspaceHooks on worktree path", async () => {

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -74,6 +74,30 @@ describe("isOrchestratorSession", () => {
     ).toBe(true);
     expect(isOrchestratorSession({ id: "app-orchestrator", metadata: {} })).toBe(true);
   });
+
+  it("disambiguates workers from orchestrators when prefix ends with -orchestrator and allSessionPrefixes provided", () => {
+    // Edge case: "my-orchestrator-1" could be either:
+    // - A worker for prefix "my-orchestrator"
+    // - An orchestrator for prefix "my"
+    // When allSessionPrefixes is provided, we can disambiguate
+    const allPrefixes = ["my-orchestrator", "other-project"];
+
+    // Without sessionPrefix but with allSessionPrefixes, correctly identify as worker
+    expect(
+      isOrchestratorSession({ id: "my-orchestrator-1", metadata: {} }, undefined, allPrefixes),
+    ).toBe(false);
+
+    // Real orchestrators still detected
+    expect(
+      isOrchestratorSession({ id: "other-project-orchestrator-1", metadata: {} }, undefined, allPrefixes),
+    ).toBe(true);
+
+    // Without allSessionPrefixes, we can't disambiguate (known limitation)
+    // This is a false positive - documenting current behavior
+    expect(
+      isOrchestratorSession({ id: "my-orchestrator-1", metadata: {} }),
+    ).toBe(true); // False positive without allSessionPrefixes
+  });
 });
 
 describe("isIssueNotFoundError", () => {

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -59,6 +59,21 @@ describe("isOrchestratorSession", () => {
       isOrchestratorSession({ id: "app-worker-1", metadata: {} }, "app", allPrefixes),
     ).toBe(false);
   });
+
+  it("detects numbered orchestrators without sessionPrefix", () => {
+    // When sessionPrefix is unavailable (e.g., during lifecycle checks), the function
+    // should still detect IDs ending with "-orchestrator-N" pattern
+    expect(isOrchestratorSession({ id: "app-orchestrator-1", metadata: {} })).toBe(true);
+    expect(isOrchestratorSession({ id: "myproject-orchestrator-42", metadata: {} })).toBe(true);
+    // Should not match regular numbered workers
+    expect(isOrchestratorSession({ id: "app-7", metadata: {} })).toBe(false);
+    expect(isOrchestratorSession({ id: "app-worker-1", metadata: {} })).toBe(false);
+    // Should still detect role metadata and legacy suffix without prefix
+    expect(
+      isOrchestratorSession({ id: "app-control", metadata: { role: "orchestrator" } }),
+    ).toBe(true);
+    expect(isOrchestratorSession({ id: "app-orchestrator", metadata: {} })).toBe(true);
+  });
 });
 
 describe("isIssueNotFoundError", () => {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -16,6 +16,7 @@ import {
   PR_STATE,
   CI_STATUS,
   TERMINAL_STATUSES,
+  isOrchestratorSession,
   type LifecycleManager,
   type SessionManager,
   type SessionId,
@@ -472,8 +473,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       scm &&
       session.branch &&
       session.metadata["prAutoDetect"] !== "off" &&
-      session.metadata["role"] !== "orchestrator" &&
-      !session.id.endsWith("-orchestrator")
+      !isOrchestratorSession(session, project.sessionPrefix)
     ) {
       try {
         const detectedPR = await scm.detectPR(session, project);

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1535,7 +1535,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       createdAt: new Date(),
       lastActivityAt: new Date(),
       metadata: {
-        ...(reusableOpenCodeSessionId ? { opencodeSessionId: reusableOpenCodeSessionId } : {}),
+        ...(reusableOpenCodeSessionId
+          ? { opencodeSessionId: reusableOpenCodeSessionId, orchestratorSessionReused: "true" }
+          : {}),
       },
     };
 
@@ -1568,6 +1570,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         );
         if (discovered) {
           session.metadata["opencodeSessionId"] = discovered;
+          session.metadata["orchestratorSessionReused"] = "true";
         }
       }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -202,7 +202,23 @@ export function isOrchestratorSession(
   // prefix is unavailable (e.g., during lifecycle checks on individual sessions).
   if (!sessionPrefix) {
     // Match any ID ending with "-orchestrator-N" pattern
-    return /-orchestrator-\d+$/.test(session.id);
+    if (!/-orchestrator-\d+$/.test(session.id)) {
+      return false;
+    }
+    // Guard against false positives: if allSessionPrefixes is provided, check
+    // if this ID is actually a worker for a prefix ending in "-orchestrator".
+    // E.g., "my-orchestrator-1" is a worker when prefix is "my-orchestrator".
+    if (allSessionPrefixes) {
+      for (const prefix of allSessionPrefixes) {
+        if (prefix.endsWith("-orchestrator")) {
+          const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+          if (new RegExp(`^${escaped}-\\d+$`).test(session.id)) {
+            return false; // It's a worker for this prefix, not an orchestrator
+          }
+        }
+      }
+    }
+    return true;
   }
   const escaped = sessionPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   if (!new RegExp(`^${escaped}-orchestrator-\\d+$`).test(session.id)) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -197,8 +197,12 @@ export function isOrchestratorSession(
   if (session.metadata?.["role"] === "orchestrator" || session.id.endsWith("-orchestrator")) {
     return true;
   }
+  // When no prefix is provided, check for generic orchestrator patterns.
+  // This catches numbered orchestrator IDs like "app-orchestrator-1" when the
+  // prefix is unavailable (e.g., during lifecycle checks on individual sessions).
   if (!sessionPrefix) {
-    return false;
+    // Match any ID ending with "-orchestrator-N" pattern
+    return /-orchestrator-\d+$/.test(session.id);
   }
   const escaped = sessionPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   if (!new RegExp(`^${escaped}-orchestrator-\\d+$`).test(session.id)) {


### PR DESCRIPTION
## Summary

- Fix missing `orchestratorSessionReused` metadata flag when OpenCode orchestrator sessions are reused
- Fix `isOrchestratorSession()` to detect numbered orchestrators (e.g., `app-orchestrator-1`) without requiring sessionPrefix
- Use centralized `isOrchestratorSession()` in lifecycle manager for consistent PR auto-detection logic

## Test plan

- [x] Verify existing `isOrchestratorSession` tests pass (14 tests)
- [x] Verify new test for prefix-less detection passes
- [x] Verify lifecycle manager tests pass (56 tests)
- [x] Verify spawn tests pass including `orchestratorSessionReused` behavior (69 tests)
- [x] Typecheck passes
- [x] No new lint errors

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)