### PR TITLE
fix(cli): require explicit user action for orchestrator spawn (#52)

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -30,6 +30,7 @@ import {
   normalizeOrchestratorSessionStrategy,
   isOrchestratorSession,
   isTerminalSession,
+  isRestorable,
   ConfigNotFoundError,
   type OrchestratorConfig,
   type ProjectConfig,
@@ -1033,56 +1034,149 @@ async function runStartup(
     const allSessionPrefixes = Object.entries(config.projects).map(
       ([, p]) => p.sessionPrefix ?? generateSessionPrefix(p.name ?? ""),
     );
-    const existingOrchestrators = allSessions.filter(
-      (s) =>
-        isOrchestratorSession(s, project.sessionPrefix ?? projectId, allSessionPrefixes) &&
-        !isTerminalSession(s),
+    // Separate running orchestrators from restorable (killed) ones
+    const allOrchestrators = allSessions.filter(
+      (s) => isOrchestratorSession(s, project.sessionPrefix ?? projectId, allSessionPrefixes),
+    );
+    const runningOrchestrators = allOrchestrators.filter((s) => !isTerminalSession(s));
+    const restorableOrchestrators = allOrchestrators.filter(
+      (s) => isTerminalSession(s) && isRestorable(s),
     );
 
-    if (existingOrchestrators.length > 0) {
-      // Existing orchestrators found — always auto-select the most recently active one.
+    if (runningOrchestrators.length > 0) {
+      // Running orchestrators found — always auto-select the most recently active one.
       // With a single orchestrator, navigate directly to its session page.
       // With multiple orchestrators, keep the selection page so the user can choose or spawn a
       // new one — the dashboard only links to one orchestrator per project, so the selection page
       // is the only startup path for multi-orchestrator projects.
-      const sortedOrchestrators = [...existingOrchestrators].sort(
+      const sortedOrchestrators = [...runningOrchestrators].sort(
         (a, b) => (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0),
       );
       const selected = sortedOrchestrators[0];
       selectedOrchestratorId = selected.id;
       // Use runtimeHandle.id if available, otherwise fall back to the session ID
       tmuxTarget = selected.runtimeHandle?.id ?? selected.id;
-      if (opts?.dashboard !== false && existingOrchestrators.length > 1) {
+      if (opts?.dashboard !== false && runningOrchestrators.length > 1) {
         hasExistingOrchestrators = true;
       }
       spinner.succeed(
         `Using existing orchestrator session: ${selected.id}` +
-          (existingOrchestrators.length > 1
-            ? ` (${existingOrchestrators.length - 1} other session(s) available)` : ""),
+          (runningOrchestrators.length > 1
+            ? ` (${runningOrchestrators.length - 1} other session(s) available)` : ""),
       );
-    } else {
-      // No existing orchestrators — spawn a new one
-      try {
-        spinner.start("Creating orchestrator session");
-        const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
-        const session = await sm.spawnOrchestrator({ projectId, systemPrompt });
-        selectedOrchestratorId = session.id;
-        if (session.runtimeHandle?.id) {
-          tmuxTarget = session.runtimeHandle.id;
-        }
-        reused =
-          orchestratorSessionStrategy === "reuse" &&
-          session.metadata?.["orchestratorSessionReused"] === "true";
-        spinner.succeed(reused ? "Orchestrator session reused" : "Orchestrator session created");
-      } catch (err) {
-        spinner.fail("Orchestrator setup failed");
-        if (dashboardProcess) {
-          dashboardProcess.kill();
-        }
-        throw new Error(
-          `Failed to setup orchestrator: ${err instanceof Error ? err.message : String(err)}`,
-          { cause: err },
+    } else if (restorableOrchestrators.length > 0) {
+      // No running orchestrators, but found restorable (killed) ones — prompt to resume
+      const sortedRestorable = [...restorableOrchestrators].sort(
+        (a, b) => (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0),
+      );
+      const lastSession = sortedRestorable[0];
+
+      if (!isHumanCaller()) {
+        // Non-interactive context — inform user about restorable session
+        console.log(chalk.yellow(`Found last orchestrator session: ${lastSession.id}`));
+        console.log(chalk.dim("  Run 'ao start' interactively to resume it."));
+      } else {
+        // Interactive context — prompt user to resume the last session
+        const shouldResume = await promptConfirm(
+          `Found last orchestrator session: ${lastSession.id}. Resume it?`,
+          true,
         );
+
+        if (shouldResume) {
+          try {
+            spinner.start(`Resuming orchestrator session: ${lastSession.id}`);
+            const restored = await sm.restore(lastSession.id);
+            selectedOrchestratorId = restored.id;
+            if (restored.runtimeHandle?.id) {
+              tmuxTarget = restored.runtimeHandle.id;
+            }
+            spinner.succeed(`Orchestrator session resumed: ${restored.id}`);
+          } catch (err) {
+            spinner.fail("Failed to resume orchestrator session");
+            if (dashboardProcess) {
+              dashboardProcess.kill();
+            }
+            throw new Error(
+              `Failed to resume orchestrator: ${err instanceof Error ? err.message : String(err)}`,
+              { cause: err },
+            );
+          }
+        } else {
+          // User declined to resume — prompt to create new
+          const shouldSpawn = await promptConfirm(
+            "Create a new orchestrator session instead?",
+            true,
+          );
+
+          if (shouldSpawn) {
+            try {
+              spinner.start("Creating orchestrator session");
+              const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
+              const session = await sm.spawnOrchestrator({ projectId, systemPrompt });
+              selectedOrchestratorId = session.id;
+              if (session.runtimeHandle?.id) {
+                tmuxTarget = session.runtimeHandle.id;
+              }
+              reused =
+                orchestratorSessionStrategy === "reuse" &&
+                session.metadata?.["orchestratorSessionReused"] === "true";
+              spinner.succeed(reused ? "Orchestrator session reused" : "Orchestrator session created");
+            } catch (err) {
+              spinner.fail("Orchestrator setup failed");
+              if (dashboardProcess) {
+                dashboardProcess.kill();
+              }
+              throw new Error(
+                `Failed to setup orchestrator: ${err instanceof Error ? err.message : String(err)}`,
+                { cause: err },
+              );
+            }
+          } else {
+            console.log(chalk.yellow("Skipped orchestrator session."));
+            console.log(chalk.dim("  You can create or resume one via the dashboard."));
+          }
+        }
+      }
+    } else {
+      // No orchestrators at all — prompt user before spawning (never auto-spawn)
+      if (!isHumanCaller()) {
+        // Non-interactive context — inform user and skip orchestrator spawn
+        console.log(chalk.yellow("No orchestrator session found."));
+        console.log(chalk.dim("  Run 'ao start' interactively to create one."));
+      } else {
+        // Interactive context — prompt user to confirm spawning
+        const shouldSpawn = await promptConfirm(
+          "No orchestrator session found. Create a new orchestrator session?",
+          true,
+        );
+
+        if (shouldSpawn) {
+          try {
+            spinner.start("Creating orchestrator session");
+            const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
+            const session = await sm.spawnOrchestrator({ projectId, systemPrompt });
+            selectedOrchestratorId = session.id;
+            if (session.runtimeHandle?.id) {
+              tmuxTarget = session.runtimeHandle.id;
+            }
+            reused =
+              orchestratorSessionStrategy === "reuse" &&
+              session.metadata?.["orchestratorSessionReused"] === "true";
+            spinner.succeed(reused ? "Orchestrator session reused" : "Orchestrator session created");
+          } catch (err) {
+            spinner.fail("Orchestrator setup failed");
+            if (dashboardProcess) {
+              dashboardProcess.kill();
+            }
+            throw new Error(
+              `Failed to setup orchestrator: ${err instanceof Error ? err.message : String(err)}`,
+              { cause: err },
+            );
+          }
+        } else {
+          console.log(chalk.yellow("Skipped orchestrator session creation."));
+          console.log(chalk.dim("  You can create one later via the dashboard."));
+        }
       }
     }
   }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1013,6 +1013,7 @@ async function runStartup(
   let tmuxTarget = sessionId;
   let hasExistingOrchestrators = false;
   let selectedOrchestratorId: string | null = null;
+  let orchestratorSkipped = false;
 
   if (opts?.orchestrator !== false) {
     const sm = await getSessionManager(config);
@@ -1071,10 +1072,11 @@ async function runStartup(
       );
       const lastSession = sortedRestorable[0];
 
-      if (!isHumanCaller()) {
+      if (!canPromptForInstall()) {
         // Non-interactive context — inform user about restorable session
         console.log(chalk.yellow(`Found last orchestrator session: ${lastSession.id}`));
         console.log(chalk.dim("  Run 'ao start' interactively to resume it."));
+        orchestratorSkipped = true;
       } else {
         // Interactive context — prompt user to resume the last session
         const shouldResume = await promptConfirm(
@@ -1134,15 +1136,17 @@ async function runStartup(
           } else {
             console.log(chalk.yellow("Skipped orchestrator session."));
             console.log(chalk.dim("  You can create or resume one via the dashboard."));
+            orchestratorSkipped = true;
           }
         }
       }
     } else {
       // No orchestrators at all — prompt user before spawning (never auto-spawn)
-      if (!isHumanCaller()) {
+      if (!canPromptForInstall()) {
         // Non-interactive context — inform user and skip orchestrator spawn
         console.log(chalk.yellow("No orchestrator session found."));
         console.log(chalk.dim("  Run 'ao start' interactively to create one."));
+        orchestratorSkipped = true;
       } else {
         // Interactive context — prompt user to confirm spawning
         const shouldSpawn = await promptConfirm(
@@ -1176,6 +1180,7 @@ async function runStartup(
         } else {
           console.log(chalk.yellow("Skipped orchestrator session creation."));
           console.log(chalk.dim("  You can create one later via the dashboard."));
+          orchestratorSkipped = true;
         }
       }
     }
@@ -1196,7 +1201,12 @@ async function runStartup(
     console.log(chalk.cyan("Lifecycle:"), lifecycleTarget);
   }
 
-  if (hasExistingOrchestrators) {
+  if (orchestratorSkipped) {
+    console.log(
+      chalk.cyan("Orchestrator:"),
+      chalk.yellow("skipped — create or resume one via the dashboard"),
+    );
+  } else if (hasExistingOrchestrators) {
     console.log(
       chalk.cyan("Orchestrator:"),
       "multiple sessions found — select one in the dashboard",
@@ -1221,16 +1231,17 @@ async function runStartup(
 
   // Auto-open browser once the server is ready.
   // With a single orchestrator (or a newly created one), navigate directly to the session page.
-  // With multiple existing orchestrators, open the selection page so the user can choose or
-  // spawn a new one — the dashboard only links one orchestrator per project.
+  // With multiple existing orchestrators or when skipped, open the selection page so the user
+  // can choose or spawn a new one — the dashboard only links one orchestrator per project.
   // Polls the port instead of using a fixed delay — deterministic and works regardless of
   // how long Next.js takes to compile. AbortController cancels polling on early exit.
   let openAbort: AbortController | undefined;
   if (opts?.dashboard !== false) {
     openAbort = new AbortController();
-    const orchestratorUrl = hasExistingOrchestrators
-      ? `http://localhost:${port}/orchestrators?project=${projectId}`
-      : `http://localhost:${port}/sessions/${selectedOrchestratorId ?? sessionId}`;
+    const orchestratorUrl =
+      hasExistingOrchestrators || orchestratorSkipped
+        ? `http://localhost:${port}/orchestrators?project=${projectId}`
+        : `http://localhost:${port}/sessions/${selectedOrchestratorId ?? sessionId}`;
     void waitForPortAndOpen(port, orchestratorUrl, openAbort.signal);
   }
 


### PR DESCRIPTION
## Summary

- Never auto-spawn orchestrators on `ao start` - always require explicit user confirmation
- When a killed (but restorable) orchestrator session exists, prompt user to resume it
- Only prompt to create new orchestrator if user declines resume or no sessions exist
- In non-interactive mode, inform user to run `ao start` interactively

## Behavior Changes

| Scenario | Before | After |
|----------|--------|-------|
| Running orchestrator exists | Use it (unchanged) | Use it (unchanged) |
| Killed orchestrator exists | Auto-spawn new | Prompt: "Resume last session?" |
| No orchestrators | Auto-spawn new | Prompt: "Create new session?" |
| Non-interactive mode | Auto-spawn | Skip with message |

## Test plan

- [ ] Run `ao start` with a running orchestrator - should use existing
- [ ] Kill orchestrator, run `ao start` - should prompt to resume
- [ ] Confirm resume - should restore the session
- [ ] Decline resume - should prompt to create new
- [ ] Run with no orchestrators - should prompt to create new
- [ ] Run in non-interactive mode (piped) - should skip with message

🤖 Generated with [Claude Code](https://claude.com/claude-code)