### PR TITLE
fix(core): session data integrity fixes (#49, #44, #42)

### DIFF
--- a/packages/core/src/__tests__/file-lock.test.ts
+++ b/packages/core/src/__tests__/file-lock.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { createFileLock, withFileLock } from "../file-lock.js";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `ao-test-file-lock-${randomUUID()}`);
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("createFileLock", () => {
+  it("creates a lock file and releases it", async () => {
+    const lockPath = join(testDir, "test.lock");
+
+    const lock = await createFileLock(lockPath);
+
+    // Lock file should exist
+    expect(existsSync(lockPath)).toBe(true);
+
+    // Lock should be held
+    expect(lock.isHeld()).toBe(true);
+
+    // Release the lock
+    lock.release();
+
+    // Lock file should be removed
+    expect(existsSync(lockPath)).toBe(false);
+
+    // isHeld should return false after release
+    expect(lock.isHeld()).toBe(false);
+  });
+
+  it("prevents concurrent lock acquisition", async () => {
+    const lockPath = join(testDir, "concurrent.lock");
+
+    // Acquire first lock
+    const lock1 = await createFileLock(lockPath, { lockTimeoutMs: 100 });
+    expect(lock1.isHeld()).toBe(true);
+
+    // Second lock should timeout
+    await expect(
+      createFileLock(lockPath, { lockTimeoutMs: 100 }),
+    ).rejects.toThrow(/Failed to acquire lock/);
+
+    // Release first lock
+    lock1.release();
+
+    // Now we should be able to acquire again
+    const lock2 = await createFileLock(lockPath);
+    expect(lock2.isHeld()).toBe(true);
+    lock2.release();
+  });
+
+  it("handles stale lock detection", async () => {
+    const lockPath = join(testDir, "stale.lock");
+
+    // Create a stale lock file (old timestamp)
+    const stalePid = 99999;
+    const staleTimestamp = Date.now() - 60_000; // 60 seconds ago
+    writeFileSync(lockPath, `${stalePid}:${staleTimestamp}`, "utf-8");
+
+    // Should be able to acquire lock despite stale file
+    const lock = await createFileLock(lockPath, { lockExpirationMs: 30_000 });
+    expect(lock.isHeld()).toBe(true);
+
+    // Verify our process owns it now
+    const content = readFileSync(lockPath, "utf-8");
+    expect(content).toMatch(new RegExp(`^${process.pid}:\\d+$`));
+
+    lock.release();
+  });
+
+  it("handles invalid lock file content as stale", async () => {
+    const lockPath = join(testDir, "invalid.lock");
+
+    // Create an invalid lock file
+    writeFileSync(lockPath, "invalid-content", "utf-8");
+
+    // Should be able to acquire lock
+    const lock = await createFileLock(lockPath, { lockExpirationMs: 1 });
+    expect(lock.isHeld()).toBe(true);
+    lock.release();
+  });
+
+  it("release is safe to call multiple times", async () => {
+    const lockPath = join(testDir, "multi-release.lock");
+
+    const lock = await createFileLock(lockPath);
+    expect(lock.isHeld()).toBe(true);
+
+    // Multiple releases should not throw
+    lock.release();
+    lock.release();
+    lock.release();
+
+    expect(lock.isHeld()).toBe(false);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("only releases if we own the lock", async () => {
+    const lockPath = join(testDir, "ownership.lock");
+
+    // Create lock owned by another process
+    const otherPid = 99999;
+    const timestamp = Date.now();
+    writeFileSync(lockPath, `${otherPid}:${timestamp}`, "utf-8");
+
+    // Create a fake lock object that thinks it owns it
+    // (simulating what would happen if another process acquired it between checks)
+    const fakeLock = {
+      release: () => {
+        // This mimics the internal release logic
+        const content = readFileSync(lockPath, "utf-8");
+        const match = content.match(/^(\d+):(\d+)$/);
+        if (match && parseInt(match[1], 10) === process.pid) {
+          unlinkSync(lockPath);
+        }
+      },
+    };
+
+    // Calling release should NOT delete the file (different owner)
+    fakeLock.release();
+    expect(existsSync(lockPath)).toBe(true);
+
+    // Clean up
+    unlinkSync(lockPath);
+  });
+});
+
+describe("withFileLock", () => {
+  it("executes function while holding lock", async () => {
+    const lockPath = join(testDir, "with-lock.lock");
+    let lockExisted = false;
+
+    const result = await withFileLock(lockPath, async () => {
+      lockExisted = existsSync(lockPath);
+      return "success";
+    });
+
+    expect(result).toBe("success");
+    expect(lockExisted).toBe(true);
+    // Lock should be released after function completes
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("releases lock even if function throws", async () => {
+    const lockPath = join(testDir, "throw.lock");
+
+    await expect(
+      withFileLock(lockPath, async () => {
+        throw new Error("Test error");
+      }),
+    ).rejects.toThrow("Test error");
+
+    // Lock should be released despite error
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("passes through function return value", async () => {
+    const lockPath = join(testDir, "return.lock");
+
+    const result = await withFileLock(lockPath, async () => {
+      return { foo: "bar", count: 42 };
+    });
+
+    expect(result).toEqual({ foo: "bar", count: 42 });
+  });
+
+  it("serializes concurrent operations", async () => {
+    const lockPath = join(testDir, "serialize.lock");
+    const results: number[] = [];
+
+    // Start multiple concurrent operations
+    const operations = [1, 2, 3].map((n) =>
+      withFileLock(lockPath, async () => {
+        // Simulate async work
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        results.push(n);
+        return n;
+      }),
+    );
+
+    await Promise.all(operations);
+
+    // All operations should complete
+    expect(results.sort()).toEqual([1, 2, 3]);
+  });
+
+  it("respects custom timeout", async () => {
+    const lockPath = join(testDir, "timeout.lock");
+
+    // Acquire lock and hold it
+    const lock = await createFileLock(lockPath);
+
+    // Second operation should timeout
+    const start = Date.now();
+    await expect(
+      withFileLock(
+        lockPath,
+        async () => "should not run",
+        { lockTimeoutMs: 100 },
+      ),
+    ).rejects.toThrow(/Failed to acquire lock/);
+    const elapsed = Date.now() - start;
+
+    // Should have waited at least the timeout duration
+    expect(elapsed).toBeGreaterThanOrEqual(90); // Allow some timing variance
+
+    lock.release();
+  });
+});
+
+describe("lock file format", () => {
+  it("writes pid:timestamp format", async () => {
+    const lockPath = join(testDir, "format.lock");
+
+    const before = Date.now();
+    const lock = await createFileLock(lockPath);
+    const after = Date.now();
+
+    const content = readFileSync(lockPath, "utf-8");
+    const match = content.match(/^(\d+):(\d+)$/);
+
+    expect(match).not.toBeNull();
+    expect(parseInt(match![1], 10)).toBe(process.pid);
+
+    const timestamp = parseInt(match![2], 10);
+    expect(timestamp).toBeGreaterThanOrEqual(before);
+    expect(timestamp).toBeLessThanOrEqual(after);
+
+    lock.release();
+  });
+});

--- a/packages/core/src/__tests__/metadata.test.ts
+++ b/packages/core/src/__tests__/metadata.test.ts
@@ -11,6 +11,7 @@ import {
   updateMetadata,
   deleteMetadata,
   listMetadata,
+  reserveSessionIdWithData,
 } from "../metadata.js";
 
 let dataDir: string;
@@ -472,5 +473,107 @@ describe("listMetadata", () => {
     const list = listMetadata(emptyDir);
     expect(list).toEqual([]);
     // no cleanup needed since dir was never created
+  });
+});
+
+describe("reserveSessionIdWithData", () => {
+  it("creates metadata file with initial data atomically", () => {
+    const initialData = {
+      status: "reserving",
+      createdAt: "2025-01-01T00:00:00.000Z",
+      role: "orchestrator",
+    };
+
+    const result = reserveSessionIdWithData(dataDir, "orch-1", initialData);
+
+    expect(result).toBe(true);
+    expect(existsSync(join(dataDir, "orch-1"))).toBe(true);
+
+    const raw = readMetadataRaw(dataDir, "orch-1");
+    expect(raw).not.toBeNull();
+    expect(raw!["status"]).toBe("reserving");
+    expect(raw!["createdAt"]).toBe("2025-01-01T00:00:00.000Z");
+    expect(raw!["role"]).toBe("orchestrator");
+  });
+
+  it("returns false if session ID already exists", () => {
+    // Create the session first
+    reserveSessionIdWithData(dataDir, "orch-2", { status: "first" });
+
+    // Try to reserve again
+    const result = reserveSessionIdWithData(dataDir, "orch-2", { status: "second" });
+
+    expect(result).toBe(false);
+
+    // Original data should be preserved
+    const raw = readMetadataRaw(dataDir, "orch-2");
+    expect(raw!["status"]).toBe("first");
+  });
+
+  it("prevents concurrent reservation", () => {
+    // This test verifies that two rapid calls don't both succeed
+    const results = [
+      reserveSessionIdWithData(dataDir, "orch-3", { status: "a" }),
+      reserveSessionIdWithData(dataDir, "orch-3", { status: "b" }),
+    ];
+
+    // Exactly one should succeed
+    expect(results.filter(Boolean).length).toBe(1);
+  });
+
+  it("leaves no temp files behind", () => {
+    reserveSessionIdWithData(dataDir, "orch-4", { status: "test" });
+
+    const files = readdirSync(dataDir);
+    const tmpFiles = files.filter((f) => f.includes(".tmp."));
+    expect(tmpFiles).toHaveLength(0);
+  });
+
+  it("creates parent directory if it does not exist", () => {
+    const nestedDir = join(dataDir, "nested", "sessions");
+
+    const result = reserveSessionIdWithData(nestedDir, "orch-5", { status: "test" });
+
+    expect(result).toBe(true);
+    expect(existsSync(join(nestedDir, "orch-5"))).toBe(true);
+  });
+});
+
+describe("readMetadataRaw with empty files", () => {
+  it("returns null for empty file (orphaned reservation)", () => {
+    // Create an empty file to simulate orphaned reservation
+    writeFileSync(join(dataDir, "orphan-1"), "", "utf-8");
+
+    const raw = readMetadataRaw(dataDir, "orphan-1");
+    expect(raw).toBeNull();
+  });
+
+  it("returns null for whitespace-only file", () => {
+    writeFileSync(join(dataDir, "orphan-2"), "  \n\t  \n", "utf-8");
+
+    const raw = readMetadataRaw(dataDir, "orphan-2");
+    expect(raw).toBeNull();
+  });
+
+  it("returns data for non-empty file", () => {
+    writeFileSync(join(dataDir, "valid-1"), "status=working\n", "utf-8");
+
+    const raw = readMetadataRaw(dataDir, "valid-1");
+    expect(raw).not.toBeNull();
+    expect(raw!["status"]).toBe("working");
+  });
+
+  it("handles the transition from empty to populated gracefully", () => {
+    // First write an empty file
+    writeFileSync(join(dataDir, "transition-1"), "", "utf-8");
+    expect(readMetadataRaw(dataDir, "transition-1")).toBeNull();
+
+    // Then update it with real data
+    updateMetadata(dataDir, "transition-1", { status: "working" });
+
+    // Now it should be readable
+    const raw = readMetadataRaw(dataDir, "transition-1");
+    expect(raw).not.toBeNull();
+    expect(raw!["status"]).toBe("working");
   });
 });

--- a/packages/core/src/file-lock.ts
+++ b/packages/core/src/file-lock.ts
@@ -1,0 +1,220 @@
+/**
+ * File-based locking utility for preventing race conditions.
+ *
+ * Uses O_EXCL (exclusive create) for atomic lock file creation.
+ * Lock files contain `pid:timestamp` for stale lock detection.
+ */
+
+import {
+  openSync,
+  closeSync,
+  writeFileSync,
+  readFileSync,
+  unlinkSync,
+  existsSync,
+  constants,
+} from "node:fs";
+
+export interface FileLockOptions {
+  /** Maximum time to wait for lock acquisition (default: 5000ms) */
+  lockTimeoutMs?: number;
+  /** Time after which a lock is considered stale (default: 30000ms) */
+  lockExpirationMs?: number;
+  /** Interval between retry attempts (default: 100ms) */
+  retryIntervalMs?: number;
+}
+
+export interface FileLock {
+  /** Release the lock. Safe to call multiple times. */
+  release(): void;
+  /** Check if this lock instance still owns the lock file. */
+  isHeld(): boolean;
+}
+
+const DEFAULT_LOCK_TIMEOUT_MS = 5000;
+const DEFAULT_LOCK_EXPIRATION_MS = 30000;
+const DEFAULT_RETRY_INTERVAL_MS = 100;
+
+/**
+ * Format lock file content: `pid:timestamp`
+ */
+function formatLockContent(): string {
+  return `${process.pid}:${Date.now()}`;
+}
+
+/**
+ * Parse lock file content to extract pid and timestamp.
+ * Returns null if content is invalid.
+ */
+function parseLockContent(content: string): { pid: number; timestamp: number } | null {
+  const match = content.trim().match(/^(\d+):(\d+)$/);
+  if (!match) return null;
+  const pid = parseInt(match[1], 10);
+  const timestamp = parseInt(match[2], 10);
+  if (Number.isNaN(pid) || Number.isNaN(timestamp)) return null;
+  return { pid, timestamp };
+}
+
+/**
+ * Check if a lock file is stale (older than expiration threshold).
+ */
+function isLockStale(lockPath: string, expirationMs: number): boolean {
+  try {
+    const content = readFileSync(lockPath, "utf-8");
+    const parsed = parseLockContent(content);
+    if (!parsed) {
+      // Invalid content - treat as stale
+      return true;
+    }
+    const age = Date.now() - parsed.timestamp;
+    return age > expirationMs;
+  } catch {
+    // Can't read file - treat as not stale (may have been released)
+    return false;
+  }
+}
+
+/**
+ * Check if this process owns the lock.
+ */
+function isOwnedByUs(lockPath: string): boolean {
+  try {
+    const content = readFileSync(lockPath, "utf-8");
+    const parsed = parseLockContent(content);
+    return parsed !== null && parsed.pid === process.pid;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Try to acquire the lock file atomically using O_EXCL.
+ * Returns true if lock was acquired, false otherwise.
+ */
+function tryAcquireLock(lockPath: string): boolean {
+  try {
+    // O_EXCL fails if file exists - atomic create
+    const fd = openSync(lockPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL);
+    const content = formatLockContent();
+    writeFileSync(lockPath, content, "utf-8");
+    closeSync(fd);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EEXIST") {
+      return false;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Remove a stale lock file if it exists and is stale.
+ * Returns true if a stale lock was removed.
+ */
+function removeStaleIfNeeded(lockPath: string, expirationMs: number): boolean {
+  if (!existsSync(lockPath)) return false;
+  if (!isLockStale(lockPath, expirationMs)) return false;
+
+  try {
+    unlinkSync(lockPath);
+    return true;
+  } catch {
+    // Another process may have removed it or acquired it
+    return false;
+  }
+}
+
+/**
+ * Sleep for a specified duration.
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Create a file-based lock.
+ *
+ * @param lockPath - Path to the lock file
+ * @param options - Lock configuration options
+ * @returns A FileLock object for releasing the lock
+ * @throws Error if lock cannot be acquired within timeout
+ */
+export async function createFileLock(
+  lockPath: string,
+  options?: FileLockOptions,
+): Promise<FileLock> {
+  const lockTimeoutMs = options?.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
+  const lockExpirationMs = options?.lockExpirationMs ?? DEFAULT_LOCK_EXPIRATION_MS;
+  const retryIntervalMs = options?.retryIntervalMs ?? DEFAULT_RETRY_INTERVAL_MS;
+
+  const startTime = Date.now();
+  let acquired = false;
+
+  while (!acquired) {
+    // Check for timeout
+    const elapsed = Date.now() - startTime;
+    if (elapsed >= lockTimeoutMs) {
+      throw new Error(
+        `Failed to acquire lock on ${lockPath} after ${lockTimeoutMs}ms`,
+      );
+    }
+
+    // Try to remove stale lock
+    removeStaleIfNeeded(lockPath, lockExpirationMs);
+
+    // Try to acquire
+    acquired = tryAcquireLock(lockPath);
+
+    if (!acquired) {
+      // Wait before retrying with slight jitter to reduce contention
+      const jitter = Math.random() * (retryIntervalMs * 0.2);
+      await sleep(retryIntervalMs + jitter);
+    }
+  }
+
+  let released = false;
+
+  return {
+    release(): void {
+      if (released) return;
+      released = true;
+
+      // Only release if we still own the lock
+      if (isOwnedByUs(lockPath)) {
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // Best effort - file may have been removed by cleanup
+        }
+      }
+    },
+
+    isHeld(): boolean {
+      if (released) return false;
+      return isOwnedByUs(lockPath);
+    },
+  };
+}
+
+/**
+ * Execute a function while holding a file lock.
+ *
+ * @param lockPath - Path to the lock file
+ * @param fn - Async function to execute while holding the lock
+ * @param options - Lock configuration options
+ * @returns The result of the function
+ * @throws Error if lock cannot be acquired or function throws
+ */
+export async function withFileLock<T>(
+  lockPath: string,
+  fn: () => Promise<T>,
+  options?: FileLockOptions,
+): Promise<T> {
+  const lock = await createFileLock(lockPath, options);
+  try {
+    return await fn();
+  } finally {
+    lock.release();
+  }
+}

--- a/packages/core/src/file-lock.ts
+++ b/packages/core/src/file-lock.ts
@@ -8,7 +8,7 @@
 import {
   openSync,
   closeSync,
-  writeFileSync,
+  writeSync,
   readFileSync,
   unlinkSync,
   existsSync,
@@ -56,7 +56,30 @@ function parseLockContent(content: string): { pid: number; timestamp: number } |
 }
 
 /**
- * Check if a lock file is stale (older than expiration threshold).
+ * Check if a process is still alive.
+ * Uses signal 0 which doesn't actually send a signal but checks if the process exists.
+ */
+function isProcessAlive(pid: number): boolean {
+  try {
+    // Signal 0 checks if process exists without sending an actual signal
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // ESRCH = process not found (dead)
+    // EPERM = process exists but we don't have permission (still alive)
+    return code === "EPERM";
+  }
+}
+
+/**
+ * Check if a lock file is stale.
+ * A lock is considered stale if:
+ * 1. Content is invalid/unparseable, OR
+ * 2. Lock is older than expiration threshold AND owning process is dead
+ *
+ * This prevents prematurely stealing locks from long-running operations
+ * while still allowing recovery from crashed processes.
  */
 function isLockStale(lockPath: string, expirationMs: number): boolean {
   try {
@@ -66,8 +89,16 @@ function isLockStale(lockPath: string, expirationMs: number): boolean {
       // Invalid content - treat as stale
       return true;
     }
+
     const age = Date.now() - parsed.timestamp;
-    return age > expirationMs;
+    if (age <= expirationMs) {
+      // Lock is fresh - not stale regardless of process state
+      return false;
+    }
+
+    // Lock is old - only consider stale if owning process is dead
+    // This prevents stealing locks from long-running critical sections
+    return !isProcessAlive(parsed.pid);
   } catch {
     // Can't read file - treat as not stale (may have been released)
     return false;
@@ -90,16 +121,32 @@ function isOwnedByUs(lockPath: string): boolean {
 /**
  * Try to acquire the lock file atomically using O_EXCL.
  * Returns true if lock was acquired, false otherwise.
+ *
+ * IMPORTANT: We write directly to the fd returned by openSync to ensure
+ * the lock content is written atomically with the file creation. Using
+ * writeFileSync(lockPath, ...) would re-open the file by path, leaving a
+ * window where the lock file exists but is empty.
  */
 function tryAcquireLock(lockPath: string): boolean {
+  let fd: number | undefined;
   try {
     // O_EXCL fails if file exists - atomic create
-    const fd = openSync(lockPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL);
+    fd = openSync(lockPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL);
     const content = formatLockContent();
-    writeFileSync(lockPath, content, "utf-8");
+    // Write directly to the fd to ensure atomicity - no window with empty file
+    writeSync(fd, content, 0, "utf-8");
     closeSync(fd);
+    fd = undefined; // Mark as closed
     return true;
   } catch (err) {
+    // Clean up fd if open but write failed
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
     const code = (err as NodeJS.ErrnoException).code;
     if (code === "EEXIST") {
       return false;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,7 +35,12 @@ export {
   updateMetadata,
   deleteMetadata,
   listMetadata,
+  reserveSessionIdWithData,
 } from "./metadata.js";
+
+// File locking — prevent race conditions in concurrent operations
+export { createFileLock, withFileLock } from "./file-lock.js";
+export type { FileLockOptions, FileLock } from "./file-lock.js";
 
 // tmux — command wrappers
 export {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -103,12 +103,17 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
   };
 }
 
-/** Threshold for considering an empty file orphaned (60 seconds) */
-const ORPHANED_FILE_THRESHOLD_MS = 60_000;
-
 /**
  * Read raw metadata as a string record (for arbitrary keys).
- * Returns null if file doesn't exist, is empty, or is an orphaned empty file.
+ * Returns null if file doesn't exist or is empty/whitespace-only.
+ *
+ * Empty files may result from:
+ * - Orphaned reservations (process crashed between reserveSessionId and writeMetadata)
+ * - Corrupted writes
+ *
+ * Callers should use reserveSessionIdWithData() instead of reserveSessionId()
+ * to prevent orphaned empty files. Cleanup of existing empty files should be
+ * handled by a separate garbage collection process.
  */
 export function readMetadataRaw(
   dataDir: string,
@@ -119,22 +124,9 @@ export function readMetadataRaw(
 
   const content = readFileSync(path, "utf-8");
 
-  // Handle empty files (orphaned from failed reservations)
+  // Treat empty/whitespace-only files as non-existent
+  // This handles orphaned reservations from crashed processes
   if (content.trim() === "") {
-    try {
-      const stats = statSync(path);
-      const ageMs = Date.now() - stats.mtimeMs;
-      if (ageMs > ORPHANED_FILE_THRESHOLD_MS) {
-        // Orphaned empty file - treat as non-existent
-        // Note: We don't delete it here to avoid race conditions;
-        // cleanup should be done separately
-        return null;
-      }
-    } catch {
-      // Can't stat file - treat as non-existent
-      return null;
-    }
-    // Recently created empty file - likely still being written
     return null;
   }
 

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -29,6 +29,7 @@ import {
   statSync,
   openSync,
   closeSync,
+  linkSync,
   constants,
 } from "node:fs";
 import { join, dirname } from "node:path";
@@ -102,8 +103,12 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
   };
 }
 
+/** Threshold for considering an empty file orphaned (60 seconds) */
+const ORPHANED_FILE_THRESHOLD_MS = 60_000;
+
 /**
  * Read raw metadata as a string record (for arbitrary keys).
+ * Returns null if file doesn't exist, is empty, or is an orphaned empty file.
  */
 export function readMetadataRaw(
   dataDir: string,
@@ -111,7 +116,29 @@ export function readMetadataRaw(
 ): Record<string, string> | null {
   const path = metadataPath(dataDir, sessionId);
   if (!existsSync(path)) return null;
-  return parseKeyValueContent(readFileSync(path, "utf-8"));
+
+  const content = readFileSync(path, "utf-8");
+
+  // Handle empty files (orphaned from failed reservations)
+  if (content.trim() === "") {
+    try {
+      const stats = statSync(path);
+      const ageMs = Date.now() - stats.mtimeMs;
+      if (ageMs > ORPHANED_FILE_THRESHOLD_MS) {
+        // Orphaned empty file - treat as non-existent
+        // Note: We don't delete it here to avoid race conditions;
+        // cleanup should be done separately
+        return null;
+      }
+    } catch {
+      // Can't stat file - treat as non-existent
+      return null;
+    }
+    // Recently created empty file - likely still being written
+    return null;
+  }
+
+  return parseKeyValueContent(content);
 }
 
 /**
@@ -303,6 +330,9 @@ export function listMetadata(dataDir: string): SessionId[] {
 /**
  * Atomically reserve a session ID by creating its metadata file with O_EXCL.
  * Returns true if the ID was successfully reserved, false if it already exists.
+ *
+ * NOTE: This creates an empty file. Prefer reserveSessionIdWithData() for new code
+ * to avoid orphaned empty files on crash.
  */
 export function reserveSessionId(dataDir: string, sessionId: SessionId): boolean {
   const path = metadataPath(dataDir, sessionId);
@@ -313,5 +343,66 @@ export function reserveSessionId(dataDir: string, sessionId: SessionId): boolean
     return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Atomically reserve a session ID with initial data, using link() for atomic creation.
+ *
+ * This prevents orphaned empty files that can occur when a process crashes
+ * between reserveSessionId() and the subsequent writeMetadata() call.
+ *
+ * The implementation:
+ * 1. Writes initial data to a temp file
+ * 2. Uses link() to atomically create the target file (fails if exists)
+ * 3. Removes the temp file
+ *
+ * @param dataDir - Session data directory
+ * @param sessionId - Session ID to reserve
+ * @param initialData - Initial metadata to write (e.g., { status: "reserving", createdAt: ... })
+ * @returns true if successfully reserved, false if already exists
+ */
+export function reserveSessionIdWithData(
+  dataDir: string,
+  sessionId: SessionId,
+  initialData: Record<string, string>,
+): boolean {
+  const path = metadataPath(dataDir, sessionId);
+  mkdirSync(dirname(path), { recursive: true });
+
+  // Create a unique temp file name
+  const tmpPath = `${path}.tmp.${process.pid}.${Date.now()}`;
+
+  try {
+    // Write initial data to temp file
+    writeFileSync(tmpPath, serializeMetadata(initialData), "utf-8");
+
+    // link() fails atomically if target already exists (EEXIST)
+    linkSync(tmpPath, path);
+
+    // Remove temp file (no longer needed)
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // Best effort - orphaned temp files are harmless
+    }
+
+    return true;
+  } catch (err) {
+    // Clean up temp file on any error
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      /* ignore */
+    }
+
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EEXIST") {
+      // Session ID already taken - return false
+      return false;
+    }
+
+    // Re-throw unexpected errors
+    throw err;
   }
 }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -55,7 +55,9 @@ import {
   deleteMetadata,
   listMetadata,
   reserveSessionId,
+  reserveSessionIdWithData,
 } from "./metadata.js";
+import { withFileLock } from "./file-lock.js";
 import { buildPromptWithMetadata, truncatePrompt } from "./prompt-builder.js";
 import {
   getSessionsDir,
@@ -435,10 +437,43 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     return repaired;
   }
 
+  /**
+   * Generate a deterministic hash for a session name.
+   * Used for stable sorting when timestamps are unavailable.
+   */
+  function hashSessionName(name: string): number {
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+      hash = ((hash << 5) - hash) + name.charCodeAt(i);
+      hash |= 0; // Convert to 32-bit integer
+    }
+    return Math.abs(hash);
+  }
+
+  /**
+   * Get a timestamp for sorting sessions, with deterministic fallback.
+   *
+   * Priority:
+   * 1. File modification time (most accurate for activity)
+   * 2. restoredAt metadata field
+   * 3. createdAt metadata field
+   * 4. Deterministic hash (negative to sort unknown timestamps last)
+   */
   function sessionMetadataTimestamp(record: ActiveSessionRecord): number {
-    const metadataTimestamp = Date.parse(record.raw["restoredAt"] ?? record.raw["createdAt"] ?? "");
+    // Prefer file mtime as it reflects actual activity
     if (record.modifiedAt) return record.modifiedAt.getTime();
-    return Number.isNaN(metadataTimestamp) ? 0 : metadataTimestamp;
+
+    // Try restoredAt first (more recent than createdAt for restored sessions)
+    const restoredAt = Date.parse(record.raw["restoredAt"] ?? "");
+    if (!Number.isNaN(restoredAt)) return restoredAt;
+
+    // Fall back to createdAt
+    const createdAt = Date.parse(record.raw["createdAt"] ?? "");
+    if (!Number.isNaN(createdAt)) return createdAt;
+
+    // Deterministic fallback: negative hash sorts unknown timestamps last
+    // but maintains stable ordering across runs
+    return -hashSessionName(record.sessionName);
   }
 
   function repairSessionMetadataOnRead(
@@ -640,6 +675,45 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     }
   }
 
+  /**
+   * List remote branch numbers for orchestrator sessions.
+   * Checks for branches matching orchestrator/{prefix}-orchestrator-N pattern.
+   */
+  async function listRemoteOrchestratorNumbers(
+    project: ProjectConfig,
+    orchestratorPrefix: string,
+  ): Promise<number[]> {
+    try {
+      const { stdout } = await execFileAsync(
+        "git",
+        ["ls-remote", "--heads", "origin", `orchestrator/${orchestratorPrefix}-*`],
+        {
+          cwd: project.path,
+          timeout: 5_000,
+        },
+      );
+
+      return stdout
+        .split("\n")
+        .flatMap((line: string) => {
+          const trimmed = line.trim();
+          if (!trimmed) return [];
+
+          const ref = trimmed.split(/\s+/)[1] ?? "";
+          const match = ref.match(
+            new RegExp(`refs/heads/orchestrator/${escapeRegex(orchestratorPrefix)}-(\\d+)$`),
+          );
+          if (!match) return [];
+
+          const parsed = Number.parseInt(match[1], 10);
+          return Number.isNaN(parsed) ? [] : [parsed];
+        })
+        .filter((num: number, index: number, values: number[]) => values.indexOf(num) === index);
+    } catch {
+      return [];
+    }
+  }
+
   async function reserveNextSessionIdentity(
     project: ProjectConfig,
     sessionsDir: string,
@@ -685,12 +759,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
   /**
    * Reserve a unique orchestrator identity ({prefix}-orchestrator-N) for a worktree-based orchestrator.
-   * Unlike worker sessions, orchestrator IDs are assigned locally without remote branch checks.
+   * Now async to support remote branch checking for collision avoidance.
    */
-  function reserveNextOrchestratorIdentity(
+  async function reserveNextOrchestratorIdentity(
     project: ProjectConfig,
     sessionsDir: string,
-  ): { num: number; sessionId: string; tmuxName: string | undefined } {
+  ): Promise<{ num: number; sessionId: string; tmuxName: string | undefined }> {
     const orchestratorPrefix = `${project.sessionPrefix}-orchestrator`;
     const usedNumbers = new Set<number>();
 
@@ -704,6 +778,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         const parsed = Number.parseInt(match[1], 10);
         if (!Number.isNaN(parsed)) usedNumbers.add(parsed);
       }
+    }
+
+    // Check remote branches for existing orchestrator worktrees
+    // This prevents collision when multiple instances spawn orchestrators concurrently
+    for (const num of await listRemoteOrchestratorNumbers(project, orchestratorPrefix)) {
+      usedNumbers.add(num);
     }
 
     // Build worker-ID patterns for all other projects. If another project has
@@ -731,7 +811,15 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         const tmuxName = config.configPath
           ? generateTmuxName(config.configPath, orchestratorPrefix, num)
           : undefined;
-        if (reserveSessionId(sessionsDir, sessionId)) {
+
+        // Use reserveSessionIdWithData to atomically create metadata with initial data,
+        // avoiding orphaned empty files if the process crashes between reservation and write
+        const initialData = {
+          status: "reserving",
+          createdAt: new Date().toISOString(),
+          role: "orchestrator",
+        };
+        if (reserveSessionIdWithData(sessionsDir, sessionId, initialData)) {
           return { num, sessionId, tmuxName };
         }
       }
@@ -1368,7 +1456,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     // Reserve a new unique orchestrator identity (e.g. {prefix}-orchestrator-1, -2, …).
     // Each spawnOrchestrator call gets its own numbered session and isolated worktree.
-    const identity = reserveNextOrchestratorIdentity(project, sessionsDir);
+    const identity = await reserveNextOrchestratorIdentity(project, sessionsDir);
     const sessionId = identity.sessionId;
     const tmuxName = identity.tmuxName;
 
@@ -2216,6 +2304,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const reference = prRef.trim();
     if (!reference) throw new Error("PR reference is required");
 
+    // Validation (no lock needed for these read-only checks)
     const { raw, sessionsDir, project, projectId } = requireSessionRecord(sessionId);
     if (isOrchestratorSessionRecord(sessionId, raw, project.sessionPrefix)) {
       throw new Error(`Session ${sessionId} is an orchestrator session and cannot claim PRs`);
@@ -2232,80 +2321,95 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       );
     }
 
+    // Save checkoutPR to preserve type narrowing inside the lock callback
+    const checkoutPR = scm.checkoutPR;
+
+    // Resolve PR and validate state (outside lock - these are remote API calls)
     const pr = await scm.resolvePR(reference, project);
     const prState = await scm.getPRState(pr);
     if (prState !== PR_STATE.OPEN) {
       throw new Error(`Cannot claim PR #${pr.number} because it is ${prState}`);
     }
 
-    const conflictingSessions = new Set<SessionId>();
-    const activeRecords = loadActiveSessionRecords(project).filter(
-      (record) => record.sessionName !== sessionId,
-    );
-
-    for (const { sessionName, raw: otherRaw } of activeRecords) {
-      if (!otherRaw || isOrchestratorSessionRecord(sessionName, otherRaw, project.sessionPrefix)) continue;
-
-      const samePr = otherRaw["pr"] === pr.url;
-      const sameBranch =
-        otherRaw["branch"] === pr.branch && (otherRaw["prAutoDetect"] ?? "on") !== "off";
-
-      if (samePr || sameBranch) {
-        conflictingSessions.add(sessionName);
-      }
-    }
-
-    const takenOverFrom = [...conflictingSessions];
-
     const workspacePath = raw["worktree"];
     if (!workspacePath) {
       throw new Error(`Session ${sessionId} has no workspace to check out PR #${pr.number}`);
     }
 
-    const branchChanged = await scm.checkoutPR(pr, workspacePath);
+    // Lock file per PR number to prevent concurrent claims of the same PR
+    const lockPath = join(sessionsDir, `.claim-pr-${pr.number}.lock`);
 
-    updateMetadata(sessionsDir, sessionId, {
-      pr: pr.url,
-      status: "pr_open",
-      branch: pr.branch,
-      prAutoDetect: "off", // Disable auto-detect since PR is explicitly claimed
-    });
+    return withFileLock(lockPath, async () => {
+      // Re-read active records under lock to get fresh state
+      const activeRecords = loadActiveSessionRecords(project).filter(
+        (record) => record.sessionName !== sessionId,
+      );
 
-    for (const previousSessionId of takenOverFrom) {
-      const previousRaw = readMetadataRaw(sessionsDir, previousSessionId);
-      if (!previousRaw) continue;
+      // Detect conflicting sessions
+      const conflictingSessions = new Set<SessionId>();
+      for (const { sessionName, raw: otherRaw } of activeRecords) {
+        if (!otherRaw || isOrchestratorSessionRecord(sessionName, otherRaw, project.sessionPrefix)) continue;
 
-      updateMetadata(sessionsDir, previousSessionId, {
-        pr: "",
-        prAutoDetect: "off",
-        ...(PR_TRACKING_STATUSES.has(previousRaw["status"] ?? "") ? { status: "working" } : {}),
-      });
-    }
+        const samePr = otherRaw["pr"] === pr.url;
+        const sameBranch =
+          otherRaw["branch"] === pr.branch && (otherRaw["prAutoDetect"] ?? "on") !== "off";
 
-    let githubAssigned = false;
-    let githubAssignmentError: string | undefined;
-    if (options?.assignOnGithub) {
-      if (!scm.assignPRToCurrentUser) {
-        githubAssignmentError = `SCM plugin "${scm.name}" does not support assigning PRs`;
-      } else {
-        try {
-          await scm.assignPRToCurrentUser(pr);
-          githubAssigned = true;
-        } catch (err) {
-          githubAssignmentError = err instanceof Error ? err.message : String(err);
+        if (samePr || sameBranch) {
+          conflictingSessions.add(sessionName);
         }
       }
-    }
 
-    return {
-      sessionId,
-      projectId,
-      pr,
-      branchChanged,
-      githubAssigned,
-      githubAssignmentError,
-      takenOverFrom,
-    };
+      const takenOverFrom = [...conflictingSessions];
+
+      // Perform checkout
+      const branchChanged = await checkoutPR(pr, workspacePath);
+
+      // Update metadata atomically within the lock
+      updateMetadata(sessionsDir, sessionId, {
+        pr: pr.url,
+        status: "pr_open",
+        branch: pr.branch,
+        prAutoDetect: "off", // Disable auto-detect since PR is explicitly claimed
+      });
+
+      // Clear previous owners
+      for (const previousSessionId of takenOverFrom) {
+        const previousRaw = readMetadataRaw(sessionsDir, previousSessionId);
+        if (!previousRaw) continue;
+
+        updateMetadata(sessionsDir, previousSessionId, {
+          pr: "",
+          prAutoDetect: "off",
+          ...(PR_TRACKING_STATUSES.has(previousRaw["status"] ?? "") ? { status: "working" } : {}),
+        });
+      }
+
+      // GitHub assignment (can be done inside or outside lock, keeping inside for simplicity)
+      let githubAssigned = false;
+      let githubAssignmentError: string | undefined;
+      if (options?.assignOnGithub) {
+        if (!scm.assignPRToCurrentUser) {
+          githubAssignmentError = `SCM plugin "${scm.name}" does not support assigning PRs`;
+        } else {
+          try {
+            await scm.assignPRToCurrentUser(pr);
+            githubAssigned = true;
+          } catch (err) {
+            githubAssignmentError = err instanceof Error ? err.message : String(err);
+          }
+        }
+      }
+
+      return {
+        sessionId,
+        projectId,
+        pr,
+        branchChanged,
+        githubAssigned,
+        githubAssignmentError,
+        takenOverFrom,
+      };
+    }, { lockTimeoutMs: 10_000 });
   }
 
   async function remap(sessionId: SessionId, force = false): Promise<string> {


### PR DESCRIPTION
## Summary

- Add file-based locking utility (`file-lock.ts`) for preventing race conditions
- Add `reserveSessionIdWithData()` for atomic metadata file creation with initial data
- Add empty file detection in `readMetadataRaw()` to handle orphaned reservations
- Add `listRemoteOrchestratorNumbers()` for remote branch collision avoidance
- Convert `reserveNextOrchestratorIdentity()` to async with remote branch checking
- Add deterministic timestamp fallback using session name hash for stable sorting
- Wrap `claimPR()` critical section with file locking to prevent metadata corruption

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] All 649 core tests pass (`pnpm --filter @composio/ao-core test`)
- [x] New file-lock tests (12 tests) pass
- [x] New metadata tests (8 tests) pass
- [x] Lint clean for modified files
- [ ] Manual testing: Spawn multiple orchestrators concurrently - verify unique IDs
- [ ] Manual testing: Create orphaned empty metadata file - verify it's detected and skipped
- [ ] Manual testing: Concurrent `claimPR()` calls - verify no corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)