### PR TITLE
feat(cli): add --prompt flag to ao spawn command

### DIFF
--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -369,6 +369,75 @@ describe("spawn command", () => {
     });
   });
 
+  it("passes --prompt flag to sessionManager.spawn()", async () => {
+    const fakeSession: Session = {
+      id: "app-1",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: null,
+      issueId: null,
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-app-1", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "spawn",
+      "--prompt",
+      "Focus on fixing the API layer only.",
+    ]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "my-app",
+      issueId: undefined,
+      prompt: "Focus on fixing the API layer only.",
+    });
+  });
+
+  it("passes --prompt flag with issue ID", async () => {
+    const fakeSession: Session = {
+      id: "app-1",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: "feat/INT-42",
+      issueId: "INT-42",
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-app-1", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "spawn",
+      "INT-42",
+      "--prompt",
+      "Use TypeScript strict mode.",
+    ]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "my-app",
+      issueId: "INT-42",
+      prompt: "Use TypeScript strict mode.",
+    });
+  });
+
   it("warns and exits when two positional args given (old syntax)", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -92,6 +92,7 @@ async function spawnSession(
   claimOptions?: SpawnClaimOptions,
   maxPromptTokens?: number,
   baseBranch?: string,
+  prompt?: string,
 ): Promise<string> {
   const spinner = ora("Creating session").start();
 
@@ -105,6 +106,7 @@ async function spawnSession(
       agent,
       maxPromptTokens,
       baseBranch,
+      prompt,
     });
 
     let claimedPrUrl: string | null = null;
@@ -176,6 +178,7 @@ export function registerSpawn(program: Command): void {
     .option("--max-depth <n>", "Max decomposition depth (default: 3)")
     .option("--max-prompt-tokens <n>", "Override the default prompt budget for this spawn")
     .option("--base-branch <branch>", "Base branch to create the new branch from (defaults to project's configured default branch)")
+    .option("--prompt <text>", "Custom prompt to append to the agent's system prompt")
     .action(
       async (
         first: string | undefined,
@@ -189,6 +192,7 @@ export function registerSpawn(program: Command): void {
           maxDepth?: string;
           maxPromptTokens?: string;
           baseBranch?: string;
+          prompt?: string;
         },
       ) => {
         // Catch old two-arg usage: ao spawn <project> <issue>
@@ -264,7 +268,7 @@ export function registerSpawn(program: Command): void {
 
             if (leaves.length <= 1) {
               console.log(chalk.yellow("Task is atomic — spawning directly."));
-              await spawnSession(config, projectId, issueId, opts.open, opts.agent, claimOptions, opts.maxPromptTokens ? parseInt(opts.maxPromptTokens, 10) : undefined, opts.baseBranch);
+              await spawnSession(config, projectId, issueId, opts.open, opts.agent, claimOptions, opts.maxPromptTokens ? parseInt(opts.maxPromptTokens, 10) : undefined, opts.baseBranch, opts.prompt);
             } else {
               // Create child issues and spawn sessions with lineage context
               const sm = await getSessionManager(config);
@@ -282,6 +286,7 @@ export function registerSpawn(program: Command): void {
                     agent: opts.agent,
                     maxPromptTokens: opts.maxPromptTokens ? parseInt(opts.maxPromptTokens, 10) : undefined,
                     baseBranch: opts.baseBranch,
+                    prompt: opts.prompt,
                   });
                   console.log(`  ${chalk.green("✓")} ${session.id} — ${leaf.description}`);
                 } catch (err) {
@@ -293,7 +298,7 @@ export function registerSpawn(program: Command): void {
               }
             }
           } else {
-            await spawnSession(config, projectId, issueId, opts.open, opts.agent, claimOptions, opts.maxPromptTokens ? parseInt(opts.maxPromptTokens, 10) : undefined, opts.baseBranch);
+            await spawnSession(config, projectId, issueId, opts.open, opts.agent, claimOptions, opts.maxPromptTokens ? parseInt(opts.maxPromptTokens, 10) : undefined, opts.baseBranch, opts.prompt);
           }
         } catch (err) {
           console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));

--- a/packages/core/src/__tests__/metadata.test.ts
+++ b/packages/core/src/__tests__/metadata.test.ts
@@ -109,6 +109,80 @@ describe("writeMetadata + readMetadata", () => {
     const content = readFileSync(join(dataDir, "app-5"), "utf-8");
     expect(content).toContain("pinnedSummary=First quality summary\n");
   });
+
+  it("writes and reads promptDelivered field", () => {
+    writeMetadata(dataDir, "app-6", {
+      worktree: "/tmp/w",
+      branch: "feat/test",
+      status: "spawning",
+      promptDelivered: "pending",
+    });
+
+    const meta = readMetadata(dataDir, "app-6");
+    expect(meta).not.toBeNull();
+    expect(meta!.promptDelivered).toBe("pending");
+  });
+
+  it("writes and reads customPrompt field", () => {
+    writeMetadata(dataDir, "app-7", {
+      worktree: "/tmp/w",
+      branch: "feat/test",
+      status: "working",
+      customPrompt: "Focus on the API layer only.",
+    });
+
+    const meta = readMetadata(dataDir, "app-7");
+    expect(meta).not.toBeNull();
+    expect(meta!.customPrompt).toBe("Focus on the API layer only.");
+  });
+
+  it("encodes and decodes newlines in customPrompt", () => {
+    const promptWithNewlines = "Line 1\nLine 2\nLine 3";
+    writeMetadata(dataDir, "app-8", {
+      worktree: "/tmp/w",
+      branch: "feat/test",
+      status: "working",
+      customPrompt: promptWithNewlines,
+    });
+
+    // Verify the raw file doesn't contain literal newlines in the value
+    const content = readFileSync(join(dataDir, "app-8"), "utf-8");
+    expect(content).toContain("customPrompt=Line 1\\nLine 2\\nLine 3\n");
+    expect(content.split("\n").filter((line) => line.startsWith("customPrompt="))).toHaveLength(1);
+
+    // Verify round-trip decodes correctly
+    const meta = readMetadata(dataDir, "app-8");
+    expect(meta).not.toBeNull();
+    expect(meta!.customPrompt).toBe(promptWithNewlines);
+  });
+
+  it("encodes and decodes backslashes in customPrompt", () => {
+    const promptWithBackslashes = "Use \\n for newlines and \\\\ for backslash";
+    writeMetadata(dataDir, "app-9", {
+      worktree: "/tmp/w",
+      branch: "feat/test",
+      status: "working",
+      customPrompt: promptWithBackslashes,
+    });
+
+    const meta = readMetadata(dataDir, "app-9");
+    expect(meta).not.toBeNull();
+    expect(meta!.customPrompt).toBe(promptWithBackslashes);
+  });
+
+  it("handles carriage returns in customPrompt", () => {
+    const promptWithCR = "Line 1\r\nLine 2";
+    writeMetadata(dataDir, "app-10", {
+      worktree: "/tmp/w",
+      branch: "feat/test",
+      status: "working",
+      customPrompt: promptWithCR,
+    });
+
+    const meta = readMetadata(dataDir, "app-10");
+    expect(meta).not.toBeNull();
+    expect(meta!.customPrompt).toBe(promptWithCR);
+  });
 });
 
 describe("readMetadataRaw", () => {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -37,6 +37,38 @@ import type { SessionId, SessionMetadata } from "./types.js";
 import { atomicWriteFileSync } from "./atomic-write.js";
 import { parseKeyValueContent } from "./key-value.js";
 
+/** Encode newlines and carriage returns for safe storage in key=value format. */
+function encodeMetadataValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/\r/g, "\\r");
+}
+
+/** Decode escaped newlines and carriage returns from stored metadata. */
+function decodeMetadataValue(value: string): string {
+  let result = "";
+  let i = 0;
+  while (i < value.length) {
+    if (value[i] === "\\" && i + 1 < value.length) {
+      const next = value[i + 1];
+      if (next === "n") {
+        result += "\n";
+        i += 2;
+        continue;
+      } else if (next === "r") {
+        result += "\r";
+        i += 2;
+        continue;
+      } else if (next === "\\") {
+        result += "\\";
+        i += 2;
+        continue;
+      }
+    }
+    result += value[i];
+    i++;
+  }
+  return result;
+}
+
 /** Serialize a record back to key=value format. */
 function serializeMetadata(data: Record<string, string>): string {
   return (
@@ -100,6 +132,8 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
       : undefined,
     opencodeSessionId: raw["opencodeSessionId"],
     pinnedSummary: raw["pinnedSummary"],
+    promptDelivered: raw["promptDelivered"],
+    customPrompt: raw["customPrompt"] ? decodeMetadataValue(raw["customPrompt"]) : undefined,
   };
 }
 
@@ -168,6 +202,8 @@ export function writeMetadata(
     data["directTerminalWsPort"] = String(metadata.directTerminalWsPort);
   if (metadata.opencodeSessionId) data["opencodeSessionId"] = metadata.opencodeSessionId;
   if (metadata.pinnedSummary) data["pinnedSummary"] = metadata.pinnedSummary;
+  if (metadata.promptDelivered) data["promptDelivered"] = metadata.promptDelivered;
+  if (metadata.customPrompt) data["customPrompt"] = encodeMetadataValue(metadata.customPrompt);
 
   atomicWriteFileSync(path, serializeMetadata(data));
 }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1367,6 +1367,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         // Include promptDelivered placeholder — prevents incomplete metadata
         // if crash occurs between initial write and post-launch prompt delivery
         promptDelivered: agentLaunchConfig.prompt ? "pending" : undefined,
+        // Store custom prompt for reference (from --prompt flag)
+        customPrompt: spawnConfig.prompt,
       });
 
       if (plugins.agent.postLaunchSetup) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1451,6 +1451,7 @@ export interface SessionMetadata {
   opencodeSessionId?: string;
   pinnedSummary?: string; // First quality summary, pinned for display stability
   promptDelivered?: string; // "pending" | "true" | "false" — tracks post-launch prompt delivery
+  customPrompt?: string; // Custom prompt from --prompt flag, stored for reference
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add `--prompt` option to the `ao spawn` command that appends custom instructions to the agent's system prompt
- Store the custom prompt in session metadata as `customPrompt` for reference
- The prompt is added as "Additional Instructions" with the highest priority (10) in the prompt builder

## Usage
```bash
ao spawn 42 --prompt "Focus on the API layer only"
ao spawn --prompt "Use TypeScript strict mode"
```

## Test plan
- [x] Added tests for `--prompt` flag without issue ID
- [x] Added tests for `--prompt` flag with issue ID
- [x] All spawn command tests pass (22/22)
- [x] Prompt builder tests pass (17/17)
- [x] Build succeeds

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)