### PR TITLE
feat(ux): move orchestrator creation from CLI to dashboard

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -757,7 +757,7 @@ describe("start command — non-interactive install safety", () => {
 // ---------------------------------------------------------------------------
 
 describe("start command — browser open waits for port", () => {
-  it("calls waitForPortAndOpen with orchestrator URL and AbortSignal", async () => {
+  it("calls waitForPortAndOpen with orchestrators URL when no orchestrators exist", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
 
     // Mock findWebDir to return tmpDir and create package.json for existsSync
@@ -765,15 +765,24 @@ describe("start command — browser open waits for port", () => {
     vi.mocked(findWebDir).mockReturnValue(tmpDir);
     writeFileSync(join(tmpDir, "package.json"), "{}");
 
+    const fakeDashboard = {
+      on: vi.fn(),
+      kill: vi.fn(),
+      emit: vi.fn(),
+    };
+    mockSpawn.mockReturnValue(fakeDashboard);
+
     mockSessionManager.get.mockResolvedValue(null);
-    mockSessionManager.spawnOrchestrator.mockResolvedValue({ id: "app-orchestrator" });
+    mockSessionManager.list.mockResolvedValue([]);
 
-    await program.parseAsync(["node", "test", "start", "--no-orchestrator"]);
+    // Run without --no-orchestrator to test the dashboard URL logic
+    await program.parseAsync(["node", "test", "start"]);
 
-    // waitForPortAndOpen should have been called with orchestrator URL and AbortSignal
+    // waitForPortAndOpen should have been called with orchestrators selection page URL
+    // since no orchestrator was created (creation moved to dashboard)
     expect(mockWaitForPortAndOpen).toHaveBeenCalledTimes(1);
     const args = mockWaitForPortAndOpen.mock.calls[0];
-    expect(args[1]).toContain("/sessions/app-orchestrator");
+    expect(args[1]).toContain("/orchestrators?project=my-app");
     expect(args[2]).toBeInstanceOf(AbortSignal);
     expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
       expect.objectContaining({ configPath: expect.any(String) }),
@@ -794,7 +803,7 @@ describe("start command — browser open waits for port", () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
 
     mockSessionManager.get.mockResolvedValue(null);
-    mockSessionManager.spawnOrchestrator.mockResolvedValue({ id: "app-orchestrator" });
+    mockSessionManager.list.mockResolvedValue([]);
 
     await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
 
@@ -803,10 +812,12 @@ describe("start command — browser open waits for port", () => {
       expect.objectContaining({ configPath: expect.any(String) }),
       "my-app",
     );
+    // No orchestrators exist and creation is now done via dashboard
+    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
   });
 });
 
-describe("start command — orchestrator session strategy display", () => {
+describe("start command — orchestrator session behavior", () => {
   function getLoggedOutput(): string {
     return vi
       .mocked(console.log)
@@ -814,73 +825,19 @@ describe("start command — orchestrator session strategy display", () => {
       .join("\n");
   }
 
-  it("shows reused messaging when strategy is reuse and metadata marks the session reused", async () => {
-    mockConfigRef.current = makeConfig({
-      "my-app": makeProject({ orchestratorSessionStrategy: "reuse" }),
-    });
+  it("skips orchestrator creation when none exist and shows dashboard prompt", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
 
-    mockSessionManager.get.mockResolvedValue({
-      id: "app-orchestrator",
-      runtimeHandle: { id: "tmux-session-1" },
-    });
-    mockSessionManager.spawnOrchestrator.mockResolvedValue({
-      id: "app-orchestrator",
-      runtimeHandle: { id: "tmux-session-1" },
-      metadata: { orchestratorSessionReused: "true" },
-    });
+    mockSessionManager.list.mockResolvedValue([]);
 
     await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
 
     const output = getLoggedOutput();
-    expect(output).toContain("reused existing session (app-orchestrator)");
-    expect(output).not.toContain("tmux attach -t tmux-session-1");
+    // No orchestrators exist - orchestrator creation moved to dashboard
+    expect(output).toContain("No orchestrator session found");
+    expect(output).toContain("via the dashboard");
+    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
   });
-
-  it("falls back to attach messaging when strategy is reuse but metadata is missing", async () => {
-    mockConfigRef.current = makeConfig({
-      "my-app": makeProject({ orchestratorSessionStrategy: "reuse" }),
-    });
-
-    mockSessionManager.get.mockResolvedValue({
-      id: "app-orchestrator",
-      runtimeHandle: { id: "tmux-session-1" },
-    });
-    mockSessionManager.spawnOrchestrator.mockResolvedValue({
-      id: "app-orchestrator",
-      runtimeHandle: { id: "tmux-session-1" },
-    });
-
-    await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
-
-    const output = getLoggedOutput();
-    expect(output).toContain("ao session attach app-orchestrator");
-    expect(output).not.toContain("reused existing session");
-  });
-
-  it.each(["delete", "ignore", "delete-new", "ignore-new", "kill-previous"] as const)(
-    "uses ao session attach when strategy is %s and --no-dashboard",
-    async (orchestratorSessionStrategy) => {
-      mockConfigRef.current = makeConfig({
-        "my-app": makeProject({ orchestratorSessionStrategy }),
-      });
-
-      mockSessionManager.get.mockResolvedValue({
-        id: "app-orchestrator",
-        runtimeHandle: { id: "tmux-session-1" },
-      });
-      mockSessionManager.spawnOrchestrator.mockResolvedValue({
-        id: "app-orchestrator",
-        runtimeHandle: { id: "tmux-session-1" },
-        metadata: { orchestratorSessionReused: "true" },
-      });
-
-      await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
-
-      const output = getLoggedOutput();
-      expect(output).toContain("ao session attach app-orchestrator");
-      expect(output).not.toContain("reused existing session");
-    },
-  );
 
   it("handles existing orchestrator sessions by auto-selecting when --no-dashboard", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
@@ -900,8 +857,8 @@ describe("start command — orchestrator session strategy display", () => {
 
     const output = getLoggedOutput();
     // When --no-dashboard is used, auto-selects the most recent orchestrator
-    // and shows ao session attach (not the dashboard selection message)
-    expect(output).toContain("ao session attach app-orchestrator");
+    // and shows tmux attach command (not the dashboard selection message)
+    expect(output).toContain("tmux attach -t tmux-session-existing");
     expect(output).not.toContain("existing sessions found — select one in the dashboard");
 
     // Should NOT spawn a new orchestrator when existing ones exist
@@ -938,11 +895,15 @@ describe("start command — orchestrator session strategy display", () => {
     await program.parseAsync(["node", "test", "start"]);
 
     const output = getLoggedOutput();
-    // With one orchestrator and dashboard enabled, shows the session URL instead of tmux attach
-    expect(output).toContain("http://localhost:3000/sessions/app-orchestrator");
-    expect(output).not.toContain("tmux attach");
+    // With one orchestrator and dashboard enabled, shows tmux attach command
+    expect(output).toContain("tmux attach -t tmux-session-existing");
     expect(output).not.toContain("multiple sessions found");
     expect(output).not.toContain("select one in the dashboard");
+
+    // waitForPortAndOpen should have been called with session URL for the existing orchestrator
+    expect(mockWaitForPortAndOpen).toHaveBeenCalledTimes(1);
+    const args = mockWaitForPortAndOpen.mock.calls[0];
+    expect(args[1]).toContain("/sessions/app-orchestrator");
 
     // Should NOT spawn a new orchestrator when existing one exists
     expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
@@ -992,7 +953,7 @@ describe("start command — orchestrator session strategy display", () => {
     expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
   });
 
-  it("fails and cleans up dashboard when orchestrator setup throws", async () => {
+  it("completes startup when no orchestrators exist and directs user to dashboard", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
 
     // Mock findWebDir
@@ -1008,18 +969,21 @@ describe("start command — orchestrator session strategy display", () => {
     mockSpawn.mockReturnValue(fakeDashboard);
 
     mockSessionManager.list.mockResolvedValue([]);
-    mockSessionManager.spawnOrchestrator.mockRejectedValue(new Error("Spawn failed"));
 
-    await expect(program.parseAsync(["node", "test", "start"])).rejects.toThrow("process.exit(1)");
+    // With no orchestrators, command should complete successfully
+    await program.parseAsync(["node", "test", "start"]);
 
-    const errors = vi
-      .mocked(console.error)
-      .mock.calls.map((c) => c.join(" "))
-      .join("\n");
-    expect(errors).toContain("Failed to setup orchestrator: Spawn failed");
+    const output = getLoggedOutput();
+    // Should indicate no orchestrator and direct user to dashboard
+    expect(output).toContain("No orchestrator session found");
+    expect(output).toContain("via the dashboard");
+    expect(output).toContain("Startup complete");
 
-    // Should have killed the dashboard
-    expect(fakeDashboard.kill).toHaveBeenCalled();
+    // Should NOT spawn an orchestrator - creation moved to dashboard
+    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+
+    // Dashboard should NOT be killed (command completed successfully)
+    expect(fakeDashboard.kill).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -18,7 +18,6 @@ import ora from "ora";
 import type { Command } from "commander";
 import {
   loadConfig,
-  generateOrchestratorPrompt,
   generateSessionPrefix,
   findConfigFile,
   isRepoUrl,
@@ -27,7 +26,6 @@ import {
   isRepoAlreadyCloned,
   generateConfigFromUrl,
   configToYaml,
-  normalizeOrchestratorSessionStrategy,
   isOrchestratorSession,
   isTerminalSession,
   isRestorable,
@@ -941,15 +939,11 @@ async function runStartup(
   const shouldStartLifecycle = opts?.dashboard !== false || opts?.orchestrator !== false;
   let lifecycleStatus: Awaited<ReturnType<typeof ensureLifecycleWorker>> | null = null;
   let port = config.port ?? DEFAULT_PORT;
-  const orchestratorSessionStrategy = normalizeOrchestratorSessionStrategy(
-    project.orchestratorSessionStrategy,
-  );
 
   console.log(chalk.bold(`\nStarting orchestrator for ${chalk.cyan(project.name)}\n`));
 
   const spinner = ora();
   let dashboardProcess: ChildProcess | null = null;
-  let reused = false;
 
   // Start dashboard (unless --no-dashboard)
   if (opts?.dashboard !== false) {
@@ -1104,85 +1098,19 @@ async function runStartup(
             );
           }
         } else {
-          // User declined to resume — prompt to create new
-          const shouldSpawn = await promptConfirm(
-            "Create a new orchestrator session instead?",
-            true,
-          );
-
-          if (shouldSpawn) {
-            try {
-              spinner.start("Creating orchestrator session");
-              const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
-              const session = await sm.spawnOrchestrator({ projectId, systemPrompt });
-              selectedOrchestratorId = session.id;
-              if (session.runtimeHandle?.id) {
-                tmuxTarget = session.runtimeHandle.id;
-              }
-              reused =
-                orchestratorSessionStrategy === "reuse" &&
-                session.metadata?.["orchestratorSessionReused"] === "true";
-              spinner.succeed(reused ? "Orchestrator session reused" : "Orchestrator session created");
-            } catch (err) {
-              spinner.fail("Orchestrator setup failed");
-              if (dashboardProcess) {
-                dashboardProcess.kill();
-              }
-              throw new Error(
-                `Failed to setup orchestrator: ${err instanceof Error ? err.message : String(err)}`,
-                { cause: err },
-              );
-            }
-          } else {
-            console.log(chalk.yellow("Skipped orchestrator session."));
-            console.log(chalk.dim("  You can create or resume one via the dashboard."));
-            orchestratorSkipped = true;
-          }
-        }
-      }
-    } else {
-      // No orchestrators at all — prompt user before spawning (never auto-spawn)
-      if (!canPromptForInstall()) {
-        // Non-interactive context — inform user and skip orchestrator spawn
-        console.log(chalk.yellow("No orchestrator session found."));
-        console.log(chalk.dim("  Run 'ao start' interactively to create one."));
-        orchestratorSkipped = true;
-      } else {
-        // Interactive context — prompt user to confirm spawning
-        const shouldSpawn = await promptConfirm(
-          "No orchestrator session found. Create a new orchestrator session?",
-          true,
-        );
-
-        if (shouldSpawn) {
-          try {
-            spinner.start("Creating orchestrator session");
-            const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
-            const session = await sm.spawnOrchestrator({ projectId, systemPrompt });
-            selectedOrchestratorId = session.id;
-            if (session.runtimeHandle?.id) {
-              tmuxTarget = session.runtimeHandle.id;
-            }
-            reused =
-              orchestratorSessionStrategy === "reuse" &&
-              session.metadata?.["orchestratorSessionReused"] === "true";
-            spinner.succeed(reused ? "Orchestrator session reused" : "Orchestrator session created");
-          } catch (err) {
-            spinner.fail("Orchestrator setup failed");
-            if (dashboardProcess) {
-              dashboardProcess.kill();
-            }
-            throw new Error(
-              `Failed to setup orchestrator: ${err instanceof Error ? err.message : String(err)}`,
-              { cause: err },
-            );
-          }
-        } else {
-          console.log(chalk.yellow("Skipped orchestrator session creation."));
-          console.log(chalk.dim("  You can create one later via the dashboard."));
+          // User declined to resume — skip orchestrator creation
+          // Users can create a new orchestrator via the dashboard
+          console.log(chalk.yellow("Skipped orchestrator session."));
+          console.log(chalk.dim("  You can create a new one via the dashboard."));
           orchestratorSkipped = true;
         }
       }
+    } else {
+      // No orchestrators at all — skip orchestrator creation
+      // Users can create one via the dashboard (deliberate UX decision)
+      console.log(chalk.yellow("No orchestrator session found."));
+      console.log(chalk.dim("  You can create one via the dashboard."));
+      orchestratorSkipped = true;
     }
   }
 
@@ -1211,10 +1139,8 @@ async function runStartup(
       chalk.cyan("Orchestrator:"),
       "multiple sessions found — select one in the dashboard",
     );
-  } else if (opts?.orchestrator !== false && !reused) {
+  } else if (opts?.orchestrator !== false) {
     console.log(chalk.cyan("Orchestrator:"), `tmux attach -t ${tmuxTarget}`);
-  } else if (reused) {
-    console.log(chalk.cyan("Orchestrator:"), `reused existing session (${sessionId})`);
   }
 
   console.log(chalk.dim(`Config: ${config.configPath}`));

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -940,7 +940,7 @@ async function runStartup(
   let lifecycleStatus: Awaited<ReturnType<typeof ensureLifecycleWorker>> | null = null;
   let port = config.port ?? DEFAULT_PORT;
 
-  console.log(chalk.bold(`\nStarting orchestrator for ${chalk.cyan(project.name)}\n`));
+  console.log(chalk.bold(`\nStarting AO for ${chalk.cyan(project.name)}\n`));
 
   const spinner = ora();
   let dashboardProcess: ChildProcess | null = null;

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -776,14 +776,12 @@ function OrchestratorControl({
   const orchestratorsHref = `/orchestrators?project=${encodeURIComponent(projectId)}`;
 
   if (orchestrators.length === 0) {
-    // Show "Orchestrators" button that links to picker even when no orchestrators running
+    // Show prominent "Create Orchestrator" button when no orchestrators running
     return (
       <a
         href={orchestratorsHref}
         className="orchestrator-btn flex items-center gap-2 px-4 py-2 text-[12px] font-semibold hover:no-underline"
       >
-        <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-text-tertiary)] opacity-80" />
-        orchestrators
         <svg
           aria-hidden="true"
           className="h-3 w-3 opacity-70"
@@ -792,8 +790,9 @@ function OrchestratorControl({
           strokeWidth="2"
           viewBox="0 0 24 24"
         >
-          <path d="m9 18 6-6-6-6" />
+          <path d="M12 4.5v15m7.5-7.5h-15" />
         </svg>
+        Create Orchestrator
       </a>
     );
   }

--- a/packages/web/src/components/OrchestratorSelector.tsx
+++ b/packages/web/src/components/OrchestratorSelector.tsx
@@ -172,6 +172,7 @@ export function OrchestratorSelector({
             <div className="text-center py-12">
               <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-[var(--color-bg-surface)] border border-[var(--color-border-subtle)]">
                 <svg
+                  aria-hidden="true"
                   className="h-8 w-8 text-[var(--color-text-tertiary)]"
                   fill="none"
                   stroke="currentColor"
@@ -200,6 +201,7 @@ export function OrchestratorSelector({
                 {isSpawning ? (
                   <span className="flex items-center justify-center gap-2">
                     <svg
+                      aria-hidden="true"
                       className="h-4 w-4 animate-spin"
                       viewBox="0 0 24 24"
                       fill="none"
@@ -305,6 +307,7 @@ export function OrchestratorSelector({
                   {isSpawning ? (
                     <span className="flex items-center justify-center gap-2">
                       <svg
+                        aria-hidden="true"
                         className="h-4 w-4 animate-spin"
                         viewBox="0 0 24 24"
                         fill="none"

--- a/packages/web/src/components/OrchestratorSelector.tsx
+++ b/packages/web/src/components/OrchestratorSelector.tsx
@@ -167,108 +167,175 @@ export function OrchestratorSelector({
       {/* Content */}
       <main className="flex-1 px-6 py-8">
         <div className="mx-auto max-w-3xl">
-          {/* Info banner */}
-          <div className="mb-6 rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4">
-            <p className="text-sm text-[var(--color-text-secondary)]">
-              Found{" "}
-              <span className="font-medium text-[var(--color-text-primary)]">
-                {orchestrators.length}
-              </span>{" "}
-              existing orchestrator session{orchestrators.length !== 1 ? "s" : ""}. You can resume
-              an existing session or start a new one.
-            </p>
-          </div>
-
-          {/* Existing orchestrators */}
-          <div className="mb-6">
-            <h2 className="mb-3 text-sm font-medium text-[var(--color-text-secondary)]">
-              Existing Sessions
-            </h2>
-            <div className="space-y-2">
-              {orchestrators.map((orch) => (
-                <Link
-                  key={orch.id}
-                  href={`/sessions/${orch.id}`}
-                  className={cn(
-                    "flex items-center justify-between rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4",
-                    "transition-all hover:border-[var(--color-border-default)] hover:shadow-sm",
-                  )}
+          {orchestrators.length === 0 ? (
+            /* Empty state - no orchestrators exist */
+            <div className="text-center py-12">
+              <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-[var(--color-bg-surface)] border border-[var(--color-border-subtle)]">
+                <svg
+                  className="h-8 w-8 text-[var(--color-text-tertiary)]"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  viewBox="0 0 24 24"
                 >
-                  <div className="flex items-center gap-3">
-                    <div
-                      className="h-2.5 w-2.5 rounded-full"
-                      style={{ backgroundColor: getStatusColor(orch.status) }}
-                    />
-                    <div>
-                      <div className="font-medium text-[var(--color-text-primary)]">{orch.id}</div>
-                      <div className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
-                        <span className="capitalize">{orch.status.replace(/_/g, " ")}</span>
-                        {orch.activity && (
-                          <>
-                            <span className="text-[var(--color-text-tertiary)]">&middot;</span>
-                            <span>{getActivityLabel(orch.activity)}</span>
-                          </>
+                  <path d="M12 4.5v15m7.5-7.5h-15" />
+                </svg>
+              </div>
+              <h2 className="text-lg font-semibold text-[var(--color-text-primary)] mb-2">
+                No Orchestrator Session
+              </h2>
+              <p className="text-sm text-[var(--color-text-secondary)] mb-8 max-w-md mx-auto">
+                An orchestrator manages your AI agents, coordinates tasks, and handles issue
+                assignments. Create one to get started.
+              </p>
+              <button
+                type="button"
+                onClick={handleSpawnNew}
+                disabled={isSpawning}
+                className={cn(
+                  "orchestrator-btn px-6 py-3 text-sm font-medium",
+                  "disabled:cursor-wait disabled:opacity-70",
+                )}
+              >
+                {isSpawning ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <svg
+                      className="h-4 w-4 animate-spin"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      />
+                    </svg>
+                    Creating orchestrator...
+                  </span>
+                ) : (
+                  "Create Orchestrator"
+                )}
+              </button>
+              {spawnError && (
+                <p className="mt-4 text-sm text-[var(--color-status-error)]">{spawnError}</p>
+              )}
+            </div>
+          ) : (
+            /* Has orchestrators - show list and option to create new */
+            <>
+              {/* Info banner */}
+              <div className="mb-6 rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4">
+                <p className="text-sm text-[var(--color-text-secondary)]">
+                  Found{" "}
+                  <span className="font-medium text-[var(--color-text-primary)]">
+                    {orchestrators.length}
+                  </span>{" "}
+                  existing orchestrator session{orchestrators.length !== 1 ? "s" : ""}. You can resume
+                  an existing session or start a new one.
+                </p>
+              </div>
+
+              {/* Existing orchestrators */}
+              <div className="mb-6">
+                <h2 className="mb-3 text-sm font-medium text-[var(--color-text-secondary)]">
+                  Existing Sessions
+                </h2>
+                <div className="space-y-2">
+                  {orchestrators.map((orch) => (
+                    <Link
+                      key={orch.id}
+                      href={`/sessions/${orch.id}`}
+                      className={cn(
+                        "flex items-center justify-between rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4",
+                        "transition-all hover:border-[var(--color-border-default)] hover:shadow-sm",
+                      )}
+                    >
+                      <div className="flex items-center gap-3">
+                        <div
+                          className="h-2.5 w-2.5 rounded-full"
+                          style={{ backgroundColor: getStatusColor(orch.status) }}
+                        />
+                        <div>
+                          <div className="font-medium text-[var(--color-text-primary)]">{orch.id}</div>
+                          <div className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
+                            <span className="capitalize">{orch.status.replace(/_/g, " ")}</span>
+                            {orch.activity && (
+                              <>
+                                <span className="text-[var(--color-text-tertiary)]">&middot;</span>
+                                <span>{getActivityLabel(orch.activity)}</span>
+                              </>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                      <div className="text-right text-xs text-[var(--color-text-tertiary)]">
+                        <div>Created {formatRelativeTime(orch.createdAt)}</div>
+                        {orch.lastActivityAt && (
+                          <div>Active {formatRelativeTime(orch.lastActivityAt)}</div>
                         )}
                       </div>
-                    </div>
-                  </div>
-                  <div className="text-right text-xs text-[var(--color-text-tertiary)]">
-                    <div>Created {formatRelativeTime(orch.createdAt)}</div>
-                    {orch.lastActivityAt && (
-                      <div>Active {formatRelativeTime(orch.lastActivityAt)}</div>
-                    )}
-                  </div>
-                </Link>
-              ))}
-            </div>
-          </div>
+                    </Link>
+                  ))}
+                </div>
+              </div>
 
-          {/* Start new section */}
-          <div className="border-t border-[var(--color-border-subtle)] pt-6">
-            <h2 className="mb-3 text-sm font-medium text-[var(--color-text-secondary)]">
-              Or Start Fresh
-            </h2>
-            <button
-              type="button"
-              onClick={handleSpawnNew}
-              disabled={isSpawning}
-              className={cn(
-                "orchestrator-btn w-full px-4 py-3 text-sm font-medium",
-                "disabled:cursor-wait disabled:opacity-70",
-              )}
-            >
-              {isSpawning ? (
-                <span className="flex items-center justify-center gap-2">
-                  <svg
-                    className="h-4 w-4 animate-spin"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    />
-                  </svg>
-                  Creating new orchestrator...
-                </span>
-              ) : (
-                "Start New Orchestrator"
-              )}
-            </button>
-            {spawnError && (
-              <p className="mt-2 text-sm text-[var(--color-status-error)]">{spawnError}</p>
-            )}
-          </div>
+              {/* Start new section */}
+              <div className="border-t border-[var(--color-border-subtle)] pt-6">
+                <h2 className="mb-3 text-sm font-medium text-[var(--color-text-secondary)]">
+                  Or Start Fresh
+                </h2>
+                <button
+                  type="button"
+                  onClick={handleSpawnNew}
+                  disabled={isSpawning}
+                  className={cn(
+                    "orchestrator-btn w-full px-4 py-3 text-sm font-medium",
+                    "disabled:cursor-wait disabled:opacity-70",
+                  )}
+                >
+                  {isSpawning ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <svg
+                        className="h-4 w-4 animate-spin"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        />
+                      </svg>
+                      Creating new orchestrator...
+                    </span>
+                  ) : (
+                    "Start New Orchestrator"
+                  )}
+                </button>
+                {spawnError && (
+                  <p className="mt-2 text-sm text-[var(--color-status-error)]">{spawnError}</p>
+                )}
+              </div>
+            </>
+          )}
         </div>
       </main>
     </div>

--- a/packages/web/src/components/__tests__/Dashboard.projectOverview.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.projectOverview.test.tsx
@@ -213,7 +213,8 @@ describe("Dashboard OrchestratorControl in single-project view", () => {
       />,
     );
 
-    const orchestratorsLink = screen.getByRole("link", { name: /orchestrators/i });
+    // Changed from "orchestrators" to "Create Orchestrator" to be more prominent
+    const orchestratorsLink = screen.getByRole("link", { name: /create orchestrator/i });
     expect(orchestratorsLink).toHaveAttribute("href", "/orchestrators?project=my-app");
   });
 


### PR DESCRIPTION
## Summary
- Remove orchestrator creation prompt from `ao start` CLI command
- Add prominent "Create Orchestrator" button to dashboard when no orchestrators exist
- Add empty state UI in OrchestratorSelector page

Closes #83

## Changes

### CLI (`packages/cli/src/commands/start.ts`)
- Remove prompt "No orchestrator session found. Create a new orchestrator session?"
- Remove prompt "Create a new orchestrator session instead?" when user declines to resume
- When no orchestrators exist, show message directing user to dashboard instead
- Clean up unused imports (`generateOrchestratorPrompt`, `normalizeOrchestratorSessionStrategy`)

### Dashboard (`packages/web/src/components/Dashboard.tsx`)
- Update `OrchestratorControl` to show "Create Orchestrator" button with plus icon when no orchestrators exist
- Changed from neutral "orchestrators" text to prominent "Create Orchestrator" call-to-action

### OrchestratorSelector (`packages/web/src/components/OrchestratorSelector.tsx`)
- Add empty state UI when no orchestrators exist:
  - Centered layout with icon, heading, and description
  - Prominent "Create Orchestrator" button
  - Explains what an orchestrator does
- Existing orchestrator list shown only when orchestrators exist

## Test plan
- [x] Run `ao start` with no orchestrators - verify no creation prompt, shows dashboard message
- [x] Run `ao start` with existing orchestrators - verify resume prompt still works
- [x] Dashboard shows "Create Orchestrator" button when no orchestrators exist
- [x] OrchestratorSelector page shows empty state with create button
- [x] All tests pass (`pnpm test`)
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)