### PR TITLE
fix(agent): Remove --dangerously-skip-permissions from worker agents

### DIFF
--- a/packages/core/src/agent-selection.ts
+++ b/packages/core/src/agent-selection.ts
@@ -73,12 +73,36 @@ export function resolveAgentSelection(params: {
     agentConfig.model = model;
   }
 
-  const permissions = normalizeAgentPermissionMode(
-    typeof agentConfig.permissions === "string" ? agentConfig.permissions : undefined,
+  // Resolve permissions with role-based safety check:
+  // Workers should NOT inherit "permissionless" from shared config — it's too dangerous.
+  // Only allow permissionless for workers if explicitly set in worker.agentConfig.permissions.
+  const rolePermissions = normalizeAgentPermissionMode(
+    typeof roleAgentConfig.permissions === "string" ? roleAgentConfig.permissions : undefined,
   );
+  const sharedPermissions = normalizeAgentPermissionMode(
+    typeof sharedConfig.permissions === "string" ? sharedConfig.permissions : undefined,
+  );
+
+  let permissions: AgentPermissionMode | undefined;
+  if (role === "worker") {
+    // Workers: only use role-specific permissions, or safe fallback from shared config
+    if (rolePermissions !== undefined) {
+      permissions = rolePermissions;
+    } else if (sharedPermissions !== undefined && sharedPermissions !== "permissionless") {
+      // Safe to inherit non-permissionless modes from shared config
+      permissions = sharedPermissions;
+    }
+    // If sharedPermissions is "permissionless" and rolePermissions is undefined,
+    // permissions stays undefined (no skip-permissions flag)
+  } else {
+    // Orchestrators: can use any permission mode
+    permissions = rolePermissions ?? sharedPermissions;
+  }
+
   if (permissions !== undefined) {
     agentConfig.permissions = permissions;
   }
+
   const subagent =
     typeof agentConfig["subagent"] === "string" ? agentConfig["subagent"] : undefined;
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1291,6 +1291,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       permissions: selection.permissions,
       model: selection.model,
       subagent: spawnConfig.subagent ?? selection.subagent,
+      isOrchestrator: false, // Worker sessions should not skip permissions
     };
 
     let handle: RuntimeHandle;
@@ -1674,6 +1675,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       model: selection.model,
       systemPromptFile,
       subagent: selection.subagent,
+      isOrchestrator: true, // Orchestrator sessions may skip permissions
     };
 
     const launchCommand = plugins.agent.getLaunchCommand(agentLaunchConfig);
@@ -2698,22 +2700,24 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     // 7. Get launch command — try restore command first, fall back to fresh launch
     let launchCommand: string;
+    const isOrchestratorRole = selection.role === "orchestrator";
     const agentLaunchConfig = {
       sessionId,
       projectConfig: {
         ...project,
         agentConfig: {
           ...selection.agentConfig,
-          ...(selection.role === "orchestrator" ? { permissions: "permissionless" as const } : {}),
+          ...(isOrchestratorRole ? { permissions: "permissionless" as const } : {}),
           ...(session.metadata?.opencodeSessionId
             ? { opencodeSessionId: session.metadata.opencodeSessionId }
             : {}),
         },
       },
       issueId: session.issueId ?? undefined,
-      permissions: selection.role === "orchestrator" ? "permissionless" : selection.permissions,
+      permissions: isOrchestratorRole ? "permissionless" : selection.permissions,
       model: selection.model,
       subagent: selection.subagent,
+      isOrchestrator: isOrchestratorRole, // Pass role for permission enforcement in agent plugins
     };
 
     if (plugins.agent.getRestoreCommand) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -431,6 +431,17 @@ export interface AgentLaunchConfig {
   permissions?: AgentPermissionInput;
   model?: string;
   /**
+   * Whether this agent is running as an orchestrator (true) or worker (false).
+   *
+   * Agent plugins use this to enforce permission boundaries:
+   * - Orchestrators may use `--dangerously-skip-permissions` (or equivalent)
+   * - Workers should NOT skip permissions even if `permissions: "permissionless"` is set
+   *
+   * This is a safety measure: orchestrators coordinate workers and have limited blast radius,
+   * while workers write code, run tests, and create PRs — higher blast radius actions.
+   */
+  isOrchestrator?: boolean;
+  /**
    * System prompt to pass to the agent for orchestrator context.
    * - Claude Code: --append-system-prompt
    * - Codex: --system-prompt or AGENTS.md

--- a/packages/plugins/agent-aider/src/index.test.ts
+++ b/packages/plugins/agent-aider/src/index.test.ts
@@ -142,20 +142,34 @@ describe("getLaunchCommand", () => {
     expect(agent.getLaunchCommand(makeLaunchConfig())).toBe("aider");
   });
 
-  it("includes --yes when permissions=permissionless", () => {
-    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "permissionless" }));
-    expect(cmd).toContain("--yes");
-  });
-
-  it("treats legacy permissions=skip as permissionless", () => {
+  it("includes --yes when permissions=permissionless AND isOrchestrator=true", () => {
     const cmd = agent.getLaunchCommand(
-      makeLaunchConfig({ permissions: "skip" as unknown as AgentLaunchConfig["permissions"] }),
+      makeLaunchConfig({ permissions: "permissionless", isOrchestrator: true }),
     );
     expect(cmd).toContain("--yes");
   });
 
-  it("maps permissions=auto-edit to no-prompt mode on Aider", () => {
-    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "auto-edit" }));
+  it("omits --yes when permissions=permissionless but isOrchestrator=false (worker safety)", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ permissions: "permissionless", isOrchestrator: false }),
+    );
+    expect(cmd).not.toContain("--yes");
+  });
+
+  it("treats legacy permissions=skip as permissionless (orchestrator only)", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        permissions: "skip" as unknown as AgentLaunchConfig["permissions"],
+        isOrchestrator: true,
+      }),
+    );
+    expect(cmd).toContain("--yes");
+  });
+
+  it("maps permissions=auto-edit to --yes on Aider (orchestrator only)", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ permissions: "auto-edit", isOrchestrator: true }),
+    );
     expect(cmd).toContain("--yes");
   });
 
@@ -169,9 +183,14 @@ describe("getLaunchCommand", () => {
     expect(cmd).toContain("--message 'Fix the tests'");
   });
 
-  it("combines all options", () => {
+  it("combines all options (orchestrator mode)", () => {
     const cmd = agent.getLaunchCommand(
-      makeLaunchConfig({ permissions: "permissionless", model: "sonnet", prompt: "Go" }),
+      makeLaunchConfig({
+        permissions: "permissionless",
+        model: "sonnet",
+        prompt: "Go",
+        isOrchestrator: true,
+      }),
     );
     expect(cmd).toBe("aider --yes --model 'sonnet' --message 'Go'");
   });

--- a/packages/plugins/agent-aider/src/index.ts
+++ b/packages/plugins/agent-aider/src/index.ts
@@ -116,8 +116,11 @@ function createAiderAgent(): Agent {
     getLaunchCommand(config: AgentLaunchConfig): string {
       const parts: string[] = ["aider"];
 
+      // Only orchestrators may skip confirmations — workers should not use --yes
+      // even if `permissions: "permissionless"` is set in config (safety guardrail).
       const permissionMode = normalizeAgentPermissionMode(config.permissions);
-      if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
+      const canSkipConfirmations = config.isOrchestrator === true;
+      if (canSkipConfirmations && (permissionMode === "permissionless" || permissionMode === "auto-edit")) {
         parts.push("--yes");
       }
 

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -170,20 +170,34 @@ describe("getLaunchCommand", () => {
     expect(cmd).not.toContain("unset");
   });
 
-  it("includes --dangerously-skip-permissions when permissions=permissionless", () => {
-    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "permissionless" }));
-    expect(cmd).toContain("--dangerously-skip-permissions");
-  });
-
-  it("treats legacy permissions=skip as permissionless", () => {
+  it("includes --dangerously-skip-permissions when permissions=permissionless AND isOrchestrator=true", () => {
     const cmd = agent.getLaunchCommand(
-      makeLaunchConfig({ permissions: "skip" as unknown as AgentLaunchConfig["permissions"] }),
+      makeLaunchConfig({ permissions: "permissionless", isOrchestrator: true }),
     );
     expect(cmd).toContain("--dangerously-skip-permissions");
   });
 
-  it("maps permissions=auto-edit to no-prompt mode on Claude", () => {
-    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "auto-edit" }));
+  it("omits --dangerously-skip-permissions when permissions=permissionless but isOrchestrator=false (worker safety)", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ permissions: "permissionless", isOrchestrator: false }),
+    );
+    expect(cmd).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("treats legacy permissions=skip as permissionless (orchestrator only)", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        permissions: "skip" as unknown as AgentLaunchConfig["permissions"],
+        isOrchestrator: true,
+      }),
+    );
+    expect(cmd).toContain("--dangerously-skip-permissions");
+  });
+
+  it("maps permissions=auto-edit to --dangerously-skip-permissions (orchestrator only)", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ permissions: "auto-edit", isOrchestrator: true }),
+    );
     expect(cmd).toContain("--dangerously-skip-permissions");
   });
 
@@ -198,9 +212,14 @@ describe("getLaunchCommand", () => {
     expect(cmd).not.toContain("Fix the bug");
   });
 
-  it("combines all options without prompt", () => {
+  it("combines all options without prompt (orchestrator mode)", () => {
     const cmd = agent.getLaunchCommand(
-      makeLaunchConfig({ permissions: "permissionless", model: "opus", prompt: "Hello" }),
+      makeLaunchConfig({
+        permissions: "permissionless",
+        model: "opus",
+        prompt: "Hello",
+        isOrchestrator: true,
+      }),
     );
     expect(cmd).toBe("claude --dangerously-skip-permissions --model 'opus'");
   });

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -672,7 +672,10 @@ function createClaudeCodeAgent(): Agent {
       const parts: string[] = ["claude"];
 
       const permissionMode = normalizeAgentPermissionMode(config.permissions);
-      if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
+      // Only orchestrators may skip permissions — workers should never use this flag
+      // even if `permissions: "permissionless"` is set in config (safety guardrail).
+      const canSkipPermissions = config.isOrchestrator === true;
+      if (canSkipPermissions && (permissionMode === "permissionless" || permissionMode === "auto-edit")) {
         parts.push("--dangerously-skip-permissions");
       }
 
@@ -835,8 +838,11 @@ function createClaudeCodeAgent(): Agent {
       // Build resume command
       const parts: string[] = ["claude", "--resume", shellEscape(sessionUuid)];
 
+      // Only orchestrators may skip permissions — workers should never use this flag
+      // even if `permissions: "permissionless"` is set in config (safety guardrail).
+      const isOrchestrator = session.metadata?.["role"] === "orchestrator";
       const permissionMode = normalizeAgentPermissionMode(project.agentConfig?.permissions);
-      if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
+      if (isOrchestrator && (permissionMode === "permissionless" || permissionMode === "auto-edit")) {
         parts.push("--dangerously-skip-permissions");
       }
 

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -224,16 +224,30 @@ describe("getLaunchCommand", () => {
     expect(agent.getLaunchCommand(makeLaunchConfig())).toBe("'codex' -c check_for_update_on_startup=false");
   });
 
-  it("includes bypass flag when permissions=permissionless", () => {
-    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "permissionless" }));
+  it("includes bypass flag when permissions=permissionless AND isOrchestrator=true", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ permissions: "permissionless", isOrchestrator: true }),
+    );
     expect(cmd).toContain("--dangerously-bypass-approvals-and-sandbox");
     expect(cmd).not.toContain("--ask-for-approval");
     expect(cmd).not.toContain("--full-auto");
   });
 
-  it("treats legacy permissions=skip as permissionless", () => {
+  it("omits bypass flag when permissions=permissionless but isOrchestrator=false (worker safety)", () => {
     const cmd = agent.getLaunchCommand(
-      makeLaunchConfig({ permissions: "skip" as unknown as AgentLaunchConfig["permissions"] }),
+      makeLaunchConfig({ permissions: "permissionless", isOrchestrator: false }),
+    );
+    expect(cmd).not.toContain("--dangerously-bypass-approvals-and-sandbox");
+    // auto-edit is safe for workers
+    expect(cmd).toContain("--ask-for-approval never");
+  });
+
+  it("treats legacy permissions=skip as permissionless (orchestrator only)", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        permissions: "skip" as unknown as AgentLaunchConfig["permissions"],
+        isOrchestrator: true,
+      }),
     );
     expect(cmd).toContain("--dangerously-bypass-approvals-and-sandbox");
   });
@@ -265,9 +279,14 @@ describe("getLaunchCommand", () => {
     expect(cmd).toContain("-- 'Fix it'");
   });
 
-  it("combines all options", () => {
+  it("combines all options (orchestrator mode)", () => {
     const cmd = agent.getLaunchCommand(
-      makeLaunchConfig({ permissions: "permissionless", model: "o3", prompt: "Go" }),
+      makeLaunchConfig({
+        permissions: "permissionless",
+        model: "o3",
+        prompt: "Go",
+        isOrchestrator: true,
+      }),
     );
     expect(cmd).toBe("'codex' -c check_for_update_on_startup=false --dangerously-bypass-approvals-and-sandbox --model 'o3' -c model_reasoning_effort=high -- 'Go'");
   });
@@ -1075,7 +1094,7 @@ describe("getRestoreCommand", () => {
     expect(cmd).toContain("thread-abc-123");
   });
 
-  it("includes bypass flag when project config permissions=permissionless", async () => {
+  it("includes bypass flag when project config permissions=permissionless AND session role=orchestrator", async () => {
     const content = jsonl(
       { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
       { threadId: "thread-1" },
@@ -1086,7 +1105,10 @@ describe("getRestoreCommand", () => {
     mockReadFile.mockResolvedValue(content);
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
-    const session = makeSession({ workspacePath: "/workspace/test" });
+    const session = makeSession({
+      workspacePath: "/workspace/test",
+      metadata: { role: "orchestrator" },
+    });
     const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
       agentConfig: { permissions: "permissionless" },
     }));
@@ -1095,7 +1117,7 @@ describe("getRestoreCommand", () => {
     expect(cmd).not.toContain("--ask-for-approval");
   });
 
-  it("treats legacy project config permissions=skip as permissionless", async () => {
+  it("omits bypass flag when project config permissions=permissionless but session role=worker (safety)", async () => {
     const content = jsonl(
       { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
       { threadId: "thread-1" },
@@ -1106,7 +1128,34 @@ describe("getRestoreCommand", () => {
     mockReadFile.mockResolvedValue(content);
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
-    const session = makeSession({ workspacePath: "/workspace/test" });
+    const session = makeSession({
+      workspacePath: "/workspace/test",
+      metadata: { role: "worker" },
+    });
+    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
+      agentConfig: { permissions: "permissionless" },
+    }));
+
+    expect(cmd).not.toContain("--dangerously-bypass-approvals-and-sandbox");
+    // auto-edit is safe for workers
+    expect(cmd).toContain("--ask-for-approval never");
+  });
+
+  it("treats legacy project config permissions=skip as permissionless (orchestrator only)", async () => {
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
+      { threadId: "thread-1" },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockReadFile.mockResolvedValue(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const session = makeSession({
+      workspacePath: "/workspace/test",
+      metadata: { role: "orchestrator" },
+    });
     const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
       agentConfig: { permissions: "skip" as unknown as AgentSpecificConfig["permissions"] },
     }));

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -300,12 +300,25 @@ export async function resolveCodexBinary(): Promise<string> {
 // Agent Implementation
 // =============================================================================
 
-/** Append approval-policy flags to a command parts array */
-function appendApprovalFlags(parts: string[], permissions: string | undefined): void {
+/**
+ * Append approval-policy flags to a command parts array.
+ * @param parts - Command parts array to append to
+ * @param permissions - Permission mode string
+ * @param isOrchestrator - Whether this is an orchestrator session
+ */
+function appendApprovalFlags(parts: string[], permissions: string | undefined, isOrchestrator: boolean): void {
   const mode = normalizeAgentPermissionMode(permissions);
+  // Only orchestrators may skip approvals entirely — workers should never use this flag
+  // even if `permissions: "permissionless"` is set in config (safety guardrail).
   if (mode === "permissionless") {
-    parts.push("--dangerously-bypass-approvals-and-sandbox");
+    if (isOrchestrator) {
+      parts.push("--dangerously-bypass-approvals-and-sandbox");
+    } else {
+      // Workers requesting permissionless get demoted to auto-edit (safer alternative)
+      parts.push("--ask-for-approval", "never");
+    }
   } else if (mode === "auto-edit") {
+    // auto-edit is safe for workers — it allows edits but prompts for bash commands
     parts.push("--ask-for-approval", "never");
   } else if (mode === "suggest") {
     parts.push("--ask-for-approval", "untrusted");
@@ -365,7 +378,7 @@ function createCodexAgent(): Agent {
       const parts: string[] = [shellEscape(binary)];
       appendNoUpdateCheckFlag(parts);
 
-      appendApprovalFlags(parts, config.permissions);
+      appendApprovalFlags(parts, config.permissions, config.isOrchestrator === true);
       appendModelFlags(parts, config.model);
 
       if (config.systemPromptFile) {
@@ -614,7 +627,9 @@ function createCodexAgent(): Agent {
       const parts: string[] = [shellEscape(binary), "resume"];
       appendNoUpdateCheckFlag(parts);
 
-      appendApprovalFlags(parts, project.agentConfig?.permissions);
+      // Only orchestrators may skip approvals — check session role from metadata
+      const isOrchestrator = session.metadata?.["role"] === "orchestrator";
+      appendApprovalFlags(parts, project.agentConfig?.permissions, isOrchestrator);
       const effectiveModel = (project.agentConfig?.model ?? data.model) as string | undefined;
       appendModelFlags(parts, effectiveModel ?? undefined);
 

--- a/packages/plugins/agent-cursor/src/index.test.ts
+++ b/packages/plugins/agent-cursor/src/index.test.ts
@@ -162,22 +162,38 @@ describe("getLaunchCommand", () => {
     expect(agent.getLaunchCommand(makeLaunchConfig())).toBe("agent");
   });
 
-  it("includes --force --sandbox disabled --approve-mcps when permissions=permissionless", () => {
-    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "permissionless" }));
+  it("includes --force --sandbox disabled --approve-mcps when permissions=permissionless AND isOrchestrator=true", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ permissions: "permissionless", isOrchestrator: true }),
+    );
     expect(cmd).toContain("--force");
     expect(cmd).toContain("--sandbox disabled");
     expect(cmd).toContain("--approve-mcps");
   });
 
-  it("treats legacy permissions=skip as permissionless", () => {
+  it("omits --force flags when permissions=permissionless but isOrchestrator=false (worker safety)", () => {
     const cmd = agent.getLaunchCommand(
-      makeLaunchConfig({ permissions: "skip" as unknown as AgentLaunchConfig["permissions"] }),
+      makeLaunchConfig({ permissions: "permissionless", isOrchestrator: false }),
+    );
+    expect(cmd).not.toContain("--force");
+    expect(cmd).not.toContain("--sandbox");
+    expect(cmd).not.toContain("--approve-mcps");
+  });
+
+  it("treats legacy permissions=skip as permissionless (orchestrator only)", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        permissions: "skip" as unknown as AgentLaunchConfig["permissions"],
+        isOrchestrator: true,
+      }),
     );
     expect(cmd).toContain("--force");
   });
 
-  it("maps permissions=auto-edit to force mode on Cursor", () => {
-    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "auto-edit" }));
+  it("maps permissions=auto-edit to force mode on Cursor (orchestrator only)", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ permissions: "auto-edit", isOrchestrator: true }),
+    );
     expect(cmd).toContain("--force");
   });
 
@@ -192,9 +208,14 @@ describe("getLaunchCommand", () => {
     expect(cmd).not.toContain("--prompt");
   });
 
-  it("combines all options", () => {
+  it("combines all options (orchestrator mode)", () => {
     const cmd = agent.getLaunchCommand(
-      makeLaunchConfig({ permissions: "permissionless", model: "sonnet", prompt: "Go" }),
+      makeLaunchConfig({
+        permissions: "permissionless",
+        model: "sonnet",
+        prompt: "Go",
+        isOrchestrator: true,
+      }),
     );
     expect(cmd).toBe("agent --force --sandbox disabled --approve-mcps --model 'sonnet' -- 'Go'");
   });

--- a/packages/plugins/agent-cursor/src/index.ts
+++ b/packages/plugins/agent-cursor/src/index.ts
@@ -160,8 +160,11 @@ function createCursorAgent(): Agent {
     getLaunchCommand(config: AgentLaunchConfig): string {
       const parts: string[] = ["agent"];
 
+      // Only orchestrators may skip permissions — workers should not use these flags
+      // even if `permissions: "permissionless"` is set in config (safety guardrail).
       const permissionMode = normalizeAgentPermissionMode(config.permissions);
-      if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
+      const canSkipPermissions = config.isOrchestrator === true;
+      if (canSkipPermissions && (permissionMode === "permissionless" || permissionMode === "auto-edit")) {
         // Cursor uses --force (or --yolo alias) for automatic approval
         // --sandbox disabled: Skip workspace trust prompts entirely
         // --approve-mcps: Auto-approve MCP servers

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_READY_THRESHOLD_MS,
   DEFAULT_ACTIVE_WINDOW_MS,
   shellEscape,
+  normalizeAgentPermissionMode,
   buildAgentPath,
   readLastActivityEntry,
   checkActivityLogState,
@@ -211,6 +212,16 @@ function createOpenCodeAgent(): Agent {
     getLaunchCommand(config: AgentLaunchConfig): string {
       const options: string[] = [];
       const sharedOptions: string[] = [];
+
+      // NOTE: OpenCode doesn't currently have permission flags like other agents.
+      // When OpenCode adds support (e.g., --auto-approve or similar), implement:
+      //   const permissionMode = normalizeAgentPermissionMode(config.permissions);
+      //   const canSkipPermissions = config.isOrchestrator === true;
+      //   if (canSkipPermissions && permissionMode === "permissionless") {
+      //     sharedOptions.push("--auto-approve"); // or equivalent flag
+      //   }
+      // The import and isOrchestrator field are already available for this.
+      void normalizeAgentPermissionMode; // Silence unused import warning until implemented
 
       const existingSessionId = asValidOpenCodeSessionId(
         (config.projectConfig.agentConfig as OpenCodeAgentConfig | undefined)?.opencodeSessionId,


### PR DESCRIPTION
## Summary
- Only orchestrator sessions may now use `--dangerously-skip-permissions` (or equivalent)
- Worker agents are protected from using dangerous permission flags even if `permissions: "permissionless"` is set in config
- Workers requesting permissionless mode are demoted to safer alternatives (e.g., `--ask-for-approval never` for Codex)
- Added `isOrchestrator` field to `AgentLaunchConfig` for explicit role tracking

## Changes
- **Core Types**: Added `isOrchestrator` field to `AgentLaunchConfig`
- **Session Manager**: Passes `isOrchestrator` flag during spawn/restore
- **Agent Selection**: Workers no longer inherit `permissionless` from shared config
- **All Agent Plugins**: Check `isOrchestrator` before using dangerous flags:
  - Claude Code: `--dangerously-skip-permissions`
  - Codex: `--dangerously-bypass-approvals-and-sandbox`
  - Aider: `--yes`
  - Cursor: `--force --sandbox disabled --approve-mcps`
  - OpenCode: Placeholder added for future permission support

## Test plan
- [x] All agent plugin tests pass (1209 tests)
- [x] Core tests pass (656 tests)
- [x] Build succeeds
- [x] Type check passes
- [x] Lint passes
- [ ] Manual testing: spawn worker session and verify no skip-permissions flag
- [ ] Manual testing: start orchestrator session and verify skip-permissions flag is present

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)