### PR TITLE
fix(voice): add WebSocket connection retry logic for voice mode

### DIFF
--- a/packages/web/src/hooks/__tests__/useVoiceCopilot.test.ts
+++ b/packages/web/src/hooks/__tests__/useVoiceCopilot.test.ts
@@ -75,14 +75,19 @@ describe("useVoiceCopilot", () => {
     lastWebSocketInstance = null;
     lastAudioContextInstance = null;
 
-    // Mock WebSocket constructor
-    vi.stubGlobal(
-      "WebSocket",
-      vi.fn(() => {
-        lastWebSocketInstance = new MockWebSocket();
-        return lastWebSocketInstance;
-      }),
-    );
+    // Mock WebSocket constructor with static constants
+    const mockWebSocketConstructor = vi.fn(() => {
+      lastWebSocketInstance = new MockWebSocket();
+      return lastWebSocketInstance;
+    });
+    // Add static constants that the real WebSocket has
+    Object.assign(mockWebSocketConstructor, {
+      CONNECTING: 0,
+      OPEN: 1,
+      CLOSING: 2,
+      CLOSED: 3,
+    });
+    vi.stubGlobal("WebSocket", mockWebSocketConstructor);
 
     // Mock AudioContext constructor
     vi.stubGlobal(
@@ -216,6 +221,168 @@ describe("useVoiceCopilot", () => {
       // Calling disconnect after unmount should be safe
       // (though in practice React prevents this)
       expect(disconnect).toBeDefined();
+    });
+  });
+
+  describe("connection retry logic", () => {
+    it("retries connection on WebSocket error with exponential backoff", async () => {
+      const { result } = renderHook(() =>
+        useVoiceCopilot({ maxRetries: 2, retryDelayMs: 100 }),
+      );
+
+      // Start connection - need to flush all microtasks for async connect
+      await act(async () => {
+        result.current.connect();
+        // Flush microtasks for the async token fetch
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(0);
+        await Promise.resolve();
+      });
+
+      expect(result.current.status).toBe("connecting");
+
+      // Simulate WebSocket error
+      await act(async () => {
+        if (lastWebSocketInstance?.onerror) {
+          lastWebSocketInstance.onerror(new Event("error"));
+        }
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // Should show retry message
+      expect(result.current.error).toContain("Connecting to voice server");
+      expect(result.current.error).toContain("attempt 2/3");
+
+      // Advance timer for first retry (100ms)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+        await Promise.resolve();
+      });
+
+      // Should have created a new WebSocket
+      expect(WebSocket).toHaveBeenCalledTimes(2);
+    });
+
+    it("stops retrying after max attempts and shows error message", async () => {
+      const { result } = renderHook(() =>
+        useVoiceCopilot({ maxRetries: 1, retryDelayMs: 100 }),
+      );
+
+      // Start connection
+      await act(async () => {
+        result.current.connect();
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(0);
+        await Promise.resolve();
+      });
+
+      // First error - should retry
+      await act(async () => {
+        if (lastWebSocketInstance?.onerror) {
+          lastWebSocketInstance.onerror(new Event("error"));
+        }
+        await vi.advanceTimersByTimeAsync(100);
+        await Promise.resolve();
+      });
+
+      // Second error - should give up
+      await act(async () => {
+        if (lastWebSocketInstance?.onerror) {
+          lastWebSocketInstance.onerror(new Event("error"));
+        }
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.status).toBe("error");
+      expect(result.current.error).toContain("Voice server connection failed");
+    });
+
+    it("disconnect cancels pending retries", async () => {
+      const { result } = renderHook(() =>
+        useVoiceCopilot({ maxRetries: 3, retryDelayMs: 1000 }),
+      );
+
+      // Start connection
+      await act(async () => {
+        result.current.connect();
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(0);
+        await Promise.resolve();
+      });
+
+      // Simulate WebSocket error
+      await act(async () => {
+        if (lastWebSocketInstance?.onerror) {
+          lastWebSocketInstance.onerror(new Event("error"));
+        }
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const callCountBeforeDisconnect = (WebSocket as ReturnType<typeof vi.fn>).mock.calls.length;
+
+      // Disconnect before retry fires
+      await act(async () => {
+        result.current.disconnect();
+      });
+
+      // Advance timer past retry delay
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      // Should not have created another WebSocket
+      expect(WebSocket).toHaveBeenCalledTimes(callCountBeforeDisconnect);
+      expect(result.current.status).toBe("disconnected");
+    });
+
+    it("resets retry count on successful connection", async () => {
+      const { result } = renderHook(() =>
+        useVoiceCopilot({ maxRetries: 3, retryDelayMs: 100 }),
+      );
+
+      // Start connection
+      await act(async () => {
+        result.current.connect();
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(0);
+        await Promise.resolve();
+      });
+
+      // Simulate successful connection
+      await act(async () => {
+        if (lastWebSocketInstance) {
+          lastWebSocketInstance.readyState = MockWebSocket.OPEN;
+          lastWebSocketInstance.onopen?.();
+        }
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // Simulate connected status from server
+      await act(async () => {
+        if (lastWebSocketInstance?.onmessage) {
+          lastWebSocketInstance.onmessage({
+            data: JSON.stringify({ type: "status", status: "connected" }),
+          });
+        }
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.status).toBe("connected");
+
+      // Disconnect and reconnect - should start fresh with retries
+      await act(async () => {
+        result.current.disconnect();
+      });
+
+      await act(async () => {
+        result.current.connect();
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(0);
+        await Promise.resolve();
+      });
+
+      // Should be in connecting state, ready for new retry cycle
+      expect(result.current.status).toBe("connecting");
     });
   });
 });

--- a/packages/web/src/hooks/useVoiceCopilot.ts
+++ b/packages/web/src/hooks/useVoiceCopilot.ts
@@ -439,9 +439,9 @@ export function useVoiceCopilot(
           retryCountRef.current < maxRetries;
 
         if (shouldRetry) {
+          const delay = retryDelayMs * Math.pow(2, retryCountRef.current);
           retryCountRef.current += 1;
           setStatus("connecting");
-          const delay = retryDelayMs * Math.pow(2, retryCountRef.current - 1);
           setError(`Connecting to voice server... (attempt ${retryCountRef.current + 1}/${maxRetries + 1})`);
           retryTimeoutRef.current = setTimeout(() => {
             retryTimeoutRef.current = null;

--- a/packages/web/src/hooks/useVoiceCopilot.ts
+++ b/packages/web/src/hooks/useVoiceCopilot.ts
@@ -347,7 +347,8 @@ export function useVoiceCopilot(
       retryTimeoutRef.current = null;
     }
 
-    // Reset manual disconnect flag when user initiates connection
+    // Reset retry/manual disconnect state when user initiates a fresh connection
+    retryCountRef.current = 0;
     isManualDisconnectRef.current = false;
 
     setStatus("connecting");
@@ -406,7 +407,9 @@ export function useVoiceCopilot(
         if (retryCountRef.current < maxRetries) {
           const delay = retryDelayMs * Math.pow(2, retryCountRef.current);
           retryCountRef.current++;
-          console.log(`[voice] Connection failed, retrying in ${delay}ms (attempt ${retryCountRef.current}/${maxRetries})...`);
+          wsRef.current = null;
+          setStatus("connecting");
+          console.log(`[voice] Connection failed, retrying in ${delay}ms (attempt ${retryCountRef.current + 1}/${maxRetries + 1})...`);
           setError(`Connecting to voice server... (attempt ${retryCountRef.current + 1}/${maxRetries + 1})`);
 
           retryTimeoutRef.current = setTimeout(() => {
@@ -426,12 +429,31 @@ export function useVoiceCopilot(
 
       ws.onclose = (event) => {
         console.log(`[voice] WebSocket closed: ${event.code} ${event.reason}`);
+        wsRef.current = null;
 
-        // Don't update status if we're retrying or manually disconnected
-        if (!retryTimeoutRef.current && !isManualDisconnectRef.current) {
+        const isExpectedClose = event.code === 1000 || event.code === 1001;
+        const shouldRetry =
+          !isManualDisconnectRef.current &&
+          !retryTimeoutRef.current &&
+          !isExpectedClose &&
+          retryCountRef.current < maxRetries;
+
+        if (shouldRetry) {
+          retryCountRef.current += 1;
+          setStatus("connecting");
+          const delay = retryDelayMs * Math.pow(2, retryCountRef.current - 1);
+          setError(`Connecting to voice server... (attempt ${retryCountRef.current + 1}/${maxRetries + 1})`);
+          retryTimeoutRef.current = setTimeout(() => {
+            retryTimeoutRef.current = null;
+            attemptConnection();
+          }, delay);
+          return;
+        }
+
+        // Don't update status if we're manually disconnected or a retry is already pending
+        if (!isManualDisconnectRef.current && !retryTimeoutRef.current) {
           setStatus("disconnected");
         }
-        wsRef.current = null;
       };
     };
 
@@ -682,12 +704,6 @@ export function useVoiceCopilot(
     }
 
     return () => {
-      // Clear retry timeout on unmount
-      if (retryTimeoutRef.current) {
-        clearTimeout(retryTimeoutRef.current);
-        retryTimeoutRef.current = null;
-      }
-
       // Only disconnect on unmount if we were the one who connected
       // Actually, standard practice is to cleanup on unmount
       if (wsRef.current) {

--- a/packages/web/src/hooks/useVoiceCopilot.ts
+++ b/packages/web/src/hooks/useVoiceCopilot.ts
@@ -60,6 +60,10 @@ interface UseVoiceCopilotOptions {
   serverUrl?: string;
   /** Auto-connect on mount (default: false) */
   autoConnect?: boolean;
+  /** Maximum connection retry attempts (default: 3) */
+  maxRetries?: number;
+  /** Base delay for retry backoff in ms (default: 1000) */
+  retryDelayMs?: number;
   /** Callback when text response is received */
   onText?: (text: string) => void;
   /** Callback when error occurs */
@@ -117,6 +121,8 @@ export function useVoiceCopilot(
   const {
     serverUrl = "ws://localhost:3002",
     autoConnect = false,
+    maxRetries = 3,
+    retryDelayMs = 1000,
     onText,
     onError,
     onAction,
@@ -153,6 +159,11 @@ export function useVoiceCopilot(
   // Memory leak fix: Track active audio sources and timeouts for cleanup
   const activeSourcesRef = useRef<Set<AudioBufferSourceNode>>(new Set());
   const playbackTimeoutsRef = useRef<Set<NodeJS.Timeout>>(new Set());
+
+  // Retry logic state
+  const retryCountRef = useRef(0);
+  const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const isManualDisconnectRef = useRef(false);
 
   useEffect(() => {
     onTextRef.current = onText;
@@ -323,12 +334,21 @@ export function useVoiceCopilot(
   );
 
   /**
-   * Connect to voice server
+   * Connect to voice server with automatic retry on failure
    */
   const connect = useCallback(async () => {
     if (wsRef.current?.readyState === WebSocket.OPEN || wsRef.current?.readyState === WebSocket.CONNECTING) {
       return;
     }
+
+    // Clear any pending retry timeout
+    if (retryTimeoutRef.current) {
+      clearTimeout(retryTimeoutRef.current);
+      retryTimeoutRef.current = null;
+    }
+
+    // Reset manual disconnect flag when user initiates connection
+    isManualDisconnectRef.current = false;
 
     setStatus("connecting");
     setError(null);
@@ -360,36 +380,79 @@ export function useVoiceCopilot(
       audioContextRef.current.resume();
     }
 
-    console.log(`[voice] Connecting to ${serverUrl}...`);
-    const ws = new WebSocket(serverUrl);
-    wsRef.current = ws;
+    const attemptConnection = () => {
+      console.log(`[voice] Connecting to ${serverUrl}... (attempt ${retryCountRef.current + 1}/${maxRetries + 1})`);
+      const ws = new WebSocket(serverUrl);
+      wsRef.current = ws;
 
-    ws.onopen = () => {
-      console.log("[voice] WebSocket connected");
-      // Request Gemini connection with token
-      ws.send(JSON.stringify({ type: "connect", token }));
+      ws.onopen = () => {
+        console.log("[voice] WebSocket connected");
+        retryCountRef.current = 0; // Reset retry count on successful connection
+        // Request Gemini connection with token
+        ws.send(JSON.stringify({ type: "connect", token }));
+      };
+
+      ws.onmessage = handleMessage;
+
+      ws.onerror = (event) => {
+        console.error("[voice] WebSocket error event:", event);
+
+        // Don't retry if manually disconnected
+        if (isManualDisconnectRef.current) {
+          return;
+        }
+
+        // Check if we should retry
+        if (retryCountRef.current < maxRetries) {
+          const delay = retryDelayMs * Math.pow(2, retryCountRef.current);
+          retryCountRef.current++;
+          console.log(`[voice] Connection failed, retrying in ${delay}ms (attempt ${retryCountRef.current}/${maxRetries})...`);
+          setError(`Connecting to voice server... (attempt ${retryCountRef.current + 1}/${maxRetries + 1})`);
+
+          retryTimeoutRef.current = setTimeout(() => {
+            retryTimeoutRef.current = null;
+            if (!isManualDisconnectRef.current) {
+              attemptConnection();
+            }
+          }, delay);
+        } else {
+          setStatus("error");
+          setError(
+            "Voice server connection failed. Please check that the voice server is running (pnpm dev starts it automatically)."
+          );
+          retryCountRef.current = 0;
+        }
+      };
+
+      ws.onclose = (event) => {
+        console.log(`[voice] WebSocket closed: ${event.code} ${event.reason}`);
+
+        // Don't update status if we're retrying or manually disconnected
+        if (!retryTimeoutRef.current && !isManualDisconnectRef.current) {
+          setStatus("disconnected");
+        }
+        wsRef.current = null;
+      };
     };
 
-    ws.onmessage = handleMessage;
-
-    ws.onerror = (event) => {
-      console.error("[voice] WebSocket error event:", event);
-      setStatus("error");
-      setError("WebSocket connection failed. Ensure server is running on port 3002.");
-    };
-
-    ws.onclose = (event) => {
-      console.log(`[voice] WebSocket closed: ${event.code} ${event.reason}`);
-      setStatus("disconnected");
-      wsRef.current = null;
-    };
-  }, [serverUrl, handleMessage]);
+    attemptConnection();
+  }, [serverUrl, handleMessage, maxRetries, retryDelayMs]);
 
   /**
    * Disconnect from voice server
    * Memory leak fix: Also cleans up audio resources to prevent accumulation
    */
   const disconnect = useCallback(() => {
+    // Set manual disconnect flag to prevent retry attempts
+    isManualDisconnectRef.current = true;
+    retryCountRef.current = 0;
+
+    // Clear any pending retry timeout
+    if (retryTimeoutRef.current) {
+      clearTimeout(retryTimeoutRef.current);
+      retryTimeoutRef.current = null;
+    }
+
     if (wsRef.current) {
       const ws = wsRef.current;
       // Request graceful disconnect if open
@@ -619,6 +682,12 @@ export function useVoiceCopilot(
     }
 
     return () => {
+      // Clear retry timeout on unmount
+      if (retryTimeoutRef.current) {
+        clearTimeout(retryTimeoutRef.current);
+        retryTimeoutRef.current = null;
+      }
+
       // Only disconnect on unmount if we were the one who connected
       // Actually, standard practice is to cleanup on unmount
       if (wsRef.current) {
@@ -633,6 +702,12 @@ export function useVoiceCopilot(
   // Cleanup on unmount
   useEffect(() => {
     return () => {
+      // Clear retry timeout
+      if (retryTimeoutRef.current) {
+        clearTimeout(retryTimeoutRef.current);
+        retryTimeoutRef.current = null;
+      }
+
       // Memory leak fix: Stop and disconnect all active audio sources
       activeSourcesRef.current.forEach((source) => {
         try {


### PR DESCRIPTION
## Summary

- Add automatic WebSocket connection retry with exponential backoff (default: 3 retries)
- Fix voice mode failing with "WebSocket connection failed" when server starts slowly
- Improve error messages to guide users on how to resolve connection issues

Fixes #90

## Problem

When attempting to start voice mode, users encountered:
```
WebSocket connection failed. Ensure server is running on port 3002.
```

This happened because:
1. The voice server starts concurrently with Next.js during `pnpm dev`
2. The client might try to connect before the server is ready
3. There was no retry mechanism, so transient issues caused permanent failures
4. The error message wasn't actionable

## Solution

Added automatic retry logic with exponential backoff:
- Default: 3 retries with 1s base delay (1s -> 2s -> 4s)
- Configurable via `maxRetries` and `retryDelayMs` options
- Shows progress during retries: "Connecting to voice server... (attempt 2/4)"
- Clear final error message when all retries exhausted
- Proper cleanup of retry timeouts on disconnect/unmount

## Test plan

- [x] Run voice hook tests: `pnpm --filter @aoagents/ao-web test src/hooks/__tests__/useVoiceCopilot.test.ts`
- [x] All 14 tests pass (4 new tests for retry logic)
- [ ] Manual test: Start dashboard with `pnpm dev`, enable voice mode
- [ ] Verify retry messages appear in console if server is slow to start
- [ ] Verify connection succeeds after server becomes available

🤖 Generated with [Claude Code](https://claude.com/claude-code)