### PR TITLE
feat(atlas): add code-atlas system for capturing project-specific knowledge

### DIFF
--- a/packages/cli/src/commands/atlas.ts
+++ b/packages/cli/src/commands/atlas.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import chalk from "chalk";
 import type { Command } from "commander";
 import {
@@ -14,32 +15,79 @@ import {
   loadConfig,
 } from "@aoagents/ao-core";
 
-function resolveRepoPath(): string {
+/**
+ * Resolve the repository path for atlas operations.
+ *
+ * Resolution order:
+ * 1. If --project is specified, use that project's path
+ * 2. If cwd is within a configured project's path, use that project
+ * 3. If only one project is configured, use it
+ * 4. Fall back to cwd (for repos without AO config)
+ */
+function resolveRepoPath(projectOption?: string): string {
   const configPath = findConfigFile();
-  if (configPath) {
-    try {
-      const config = loadConfig(configPath);
-      const firstProjectId = Object.keys(config.projects)[0];
-      if (firstProjectId) {
-        return config.projects[firstProjectId]?.path ?? process.cwd();
-      }
-    } catch {
-      // Fall back to cwd if config is invalid
+
+  if (!configPath) {
+    // No AO config - use cwd (atlas can work standalone)
+    return process.cwd();
+  }
+
+  let config;
+  try {
+    config = loadConfig(configPath);
+  } catch {
+    // Invalid config - fall back to cwd
+    return process.cwd();
+  }
+
+  const projectIds = Object.keys(config.projects);
+
+  if (projectIds.length === 0) {
+    return process.cwd();
+  }
+
+  // If --project is specified, use that project
+  if (projectOption) {
+    const project = config.projects[projectOption];
+    if (!project) {
+      throw new Error(
+        `Unknown project: ${projectOption}\nAvailable: ${projectIds.join(", ")}`,
+      );
+    }
+    return project.path;
+  }
+
+  // Try to match cwd to a configured project
+  const cwd = resolve(process.cwd());
+  for (const projectId of projectIds) {
+    const projectPath = resolve(config.projects[projectId]?.path ?? "");
+    if (cwd === projectPath || cwd.startsWith(projectPath + "/")) {
+      return projectPath;
     }
   }
+
+  // If only one project, use it
+  if (projectIds.length === 1) {
+    return config.projects[projectIds[0]]?.path ?? process.cwd();
+  }
+
+  // Multiple projects and cwd doesn't match any - use cwd
+  // This allows atlas to work in subdirectories or standalone repos
   return process.cwd();
 }
 
 export function registerAtlas(program: Command): void {
   const atlas = program
     .command("atlas")
-    .description("Manage codebase knowledge flows");
+    .description("Manage codebase knowledge flows")
+    .option("-p, --project <id>", "Project ID (for multi-project configs)");
 
   atlas
     .command("init")
     .description("Initialize code-atlas folder structure")
     .action(() => {
-      const repoPath = resolveRepoPath();
+      const opts = atlas.opts<{ project?: string }>();
+      const repoPath = resolveRepoPath(opts.project);
 
       if (atlasExists(repoPath)) {
         console.log(chalk.dim("Atlas already initialized at this location."));
@@ -58,8 +106,9 @@ export function registerAtlas(program: Command): void {
     .command("list")
     .description("List all approved flows")
     .option("--json", "Output as JSON")
-    .action((opts: { json?: boolean }) => {
-      const repoPath = resolveRepoPath();
+    .action((cmdOpts: { json?: boolean }) => {
+      const opts = atlas.opts<{ project?: string }>();
+      const repoPath = resolveRepoPath(opts.project);
 
       if (!atlasExists(repoPath)) {
         console.log(chalk.yellow("No atlas found. Run 'ao atlas init' first."));
@@ -68,7 +117,7 @@ export function registerAtlas(program: Command): void {
 
       const flows = listFlows(repoPath);
 
-      if (opts.json) {
+      if (cmdOpts.json) {
         console.log(JSON.stringify(flows, null, 2));
         return;
       }
@@ -94,8 +143,9 @@ export function registerAtlas(program: Command): void {
     .command("pending")
     .description("List pending flow changes from agents")
     .option("--json", "Output as JSON")
-    .action((opts: { json?: boolean }) => {
-      const repoPath = resolveRepoPath();
+    .action((cmdOpts: { json?: boolean }) => {
+      const opts = atlas.opts<{ project?: string }>();
+      const repoPath = resolveRepoPath(opts.project);
 
       if (!atlasExists(repoPath)) {
         console.log(chalk.yellow("No atlas found. Run 'ao atlas init' first."));
@@ -104,7 +154,7 @@ export function registerAtlas(program: Command): void {
 
       const pending = listPending(repoPath);
 
-      if (opts.json) {
+      if (cmdOpts.json) {
         console.log(JSON.stringify(pending.map((p) => ({
           id: p.id,
           title: p.frontmatter.title,
@@ -135,14 +185,15 @@ export function registerAtlas(program: Command): void {
     .command("approve")
     .description("Approve a pending flow change")
     .argument("<id>", "Pending flow ID")
-    .action((id: string) => {
-      const repoPath = resolveRepoPath();
+    .action(async (id: string) => {
+      const opts = atlas.opts<{ project?: string }>();
+      const repoPath = resolveRepoPath(opts.project);
 
       if (!atlasExists(repoPath)) {
         throw new Error("No atlas found. Run 'ao atlas init' first.");
       }
 
-      const flow = approvePending(repoPath, id);
+      const flow = await approvePending(repoPath, id);
 
       console.log(chalk.green(`Approved: ${id} → ${flow.id}`));
       console.log(chalk.dim(`  Title: ${flow.frontmatter.title}`));
@@ -155,7 +206,8 @@ export function registerAtlas(program: Command): void {
     .description("Reject a pending flow change")
     .argument("<id>", "Pending flow ID")
     .action((id: string) => {
-      const repoPath = resolveRepoPath();
+      const opts = atlas.opts<{ project?: string }>();
+      const repoPath = resolveRepoPath(opts.project);
 
       if (!atlasExists(repoPath)) {
         throw new Error("No atlas found. Run 'ao atlas init' first.");
@@ -170,7 +222,8 @@ export function registerAtlas(program: Command): void {
     .description("Output a flow's content")
     .argument("<id>", "Flow ID")
     .action((id: string) => {
-      const repoPath = resolveRepoPath();
+      const opts = atlas.opts<{ project?: string }>();
+      const repoPath = resolveRepoPath(opts.project);
 
       if (!atlasExists(repoPath)) {
         throw new Error("No atlas found. Run 'ao atlas init' first.");
@@ -190,7 +243,8 @@ export function registerAtlas(program: Command): void {
     .description("Output multiple flows for agent consumption")
     .argument("<ids...>", "Flow IDs to include")
     .action((ids: string[]) => {
-      const repoPath = resolveRepoPath();
+      const opts = atlas.opts<{ project?: string }>();
+      const repoPath = resolveRepoPath(opts.project);
 
       if (!atlasExists(repoPath)) {
         throw new Error("No atlas found. Run 'ao atlas init' first.");
@@ -210,7 +264,8 @@ export function registerAtlas(program: Command): void {
     .description("Show detailed information about a flow")
     .argument("<id>", "Flow ID")
     .action((id: string) => {
-      const repoPath = resolveRepoPath();
+      const opts = atlas.opts<{ project?: string }>();
+      const repoPath = resolveRepoPath(opts.project);
 
       if (!atlasExists(repoPath)) {
         throw new Error("No atlas found. Run 'ao atlas init' first.");

--- a/packages/cli/src/commands/atlas.ts
+++ b/packages/cli/src/commands/atlas.ts
@@ -1,0 +1,239 @@
+import chalk from "chalk";
+import type { Command } from "commander";
+import {
+  atlasExists,
+  initAtlas,
+  listFlows,
+  listPending,
+  getFlow,
+  getFlowContent,
+  getMultipleFlowContents,
+  approvePending,
+  rejectPending,
+  findConfigFile,
+  loadConfig,
+} from "@aoagents/ao-core";
+
+function resolveRepoPath(): string {
+  const configPath = findConfigFile();
+  if (configPath) {
+    try {
+      const config = loadConfig(configPath);
+      const firstProjectId = Object.keys(config.projects)[0];
+      if (firstProjectId) {
+        return config.projects[firstProjectId]?.path ?? process.cwd();
+      }
+    } catch {
+      // Fall back to cwd if config is invalid
+    }
+  }
+  return process.cwd();
+}
+
+export function registerAtlas(program: Command): void {
+  const atlas = program
+    .command("atlas")
+    .description("Manage codebase knowledge flows");
+
+  atlas
+    .command("init")
+    .description("Initialize code-atlas folder structure")
+    .action(() => {
+      const repoPath = resolveRepoPath();
+
+      if (atlasExists(repoPath)) {
+        console.log(chalk.dim("Atlas already initialized at this location."));
+        return;
+      }
+
+      initAtlas(repoPath);
+      console.log(chalk.green(`Initialized code-atlas in ${repoPath}`));
+      console.log(chalk.dim("  code-atlas/"));
+      console.log(chalk.dim("  ├── atlas.json"));
+      console.log(chalk.dim("  ├── flows/"));
+      console.log(chalk.dim("  └── .pending/"));
+    });
+
+  atlas
+    .command("list")
+    .description("List all approved flows")
+    .option("--json", "Output as JSON")
+    .action((opts: { json?: boolean }) => {
+      const repoPath = resolveRepoPath();
+
+      if (!atlasExists(repoPath)) {
+        console.log(chalk.yellow("No atlas found. Run 'ao atlas init' first."));
+        return;
+      }
+
+      const flows = listFlows(repoPath);
+
+      if (opts.json) {
+        console.log(JSON.stringify(flows, null, 2));
+        return;
+      }
+
+      if (flows.length === 0) {
+        console.log(chalk.dim("No flows in the atlas yet."));
+        return;
+      }
+
+      console.log(chalk.cyan(`${flows.length} flow(s) in atlas:\n`));
+
+      for (const flow of flows) {
+        console.log(`${chalk.green(flow.id)} ${chalk.dim(`(${flow.successCount} uses)`)}`);
+        console.log(`  ${flow.title}`);
+        if (flow.description) {
+          console.log(chalk.dim(`  ${flow.description.slice(0, 80)}${flow.description.length > 80 ? "..." : ""}`));
+        }
+        console.log();
+      }
+    });
+
+  atlas
+    .command("pending")
+    .description("List pending flow changes from agents")
+    .option("--json", "Output as JSON")
+    .action((opts: { json?: boolean }) => {
+      const repoPath = resolveRepoPath();
+
+      if (!atlasExists(repoPath)) {
+        console.log(chalk.yellow("No atlas found. Run 'ao atlas init' first."));
+        return;
+      }
+
+      const pending = listPending(repoPath);
+
+      if (opts.json) {
+        console.log(JSON.stringify(pending.map((p) => ({
+          id: p.id,
+          title: p.frontmatter.title,
+          discoveredIn: p.frontmatter.discoveredIn,
+          updated: p.frontmatter.updated,
+        })), null, 2));
+        return;
+      }
+
+      if (pending.length === 0) {
+        console.log(chalk.dim("No pending flows."));
+        return;
+      }
+
+      console.log(chalk.cyan(`${pending.length} pending flow(s):\n`));
+
+      for (const flow of pending) {
+        console.log(`${chalk.yellow(flow.id)}`);
+        console.log(`  Title: ${flow.frontmatter.title}`);
+        console.log(`  Discovered in: ${flow.frontmatter.discoveredIn}`);
+        console.log();
+      }
+
+      console.log(chalk.dim("Use 'ao atlas approve <id>' to approve or 'ao atlas reject <id>' to reject."));
+    });
+
+  atlas
+    .command("approve")
+    .description("Approve a pending flow change")
+    .argument("<id>", "Pending flow ID")
+    .action((id: string) => {
+      const repoPath = resolveRepoPath();
+
+      if (!atlasExists(repoPath)) {
+        throw new Error("No atlas found. Run 'ao atlas init' first.");
+      }
+
+      const flow = approvePending(repoPath, id);
+
+      console.log(chalk.green(`Approved: ${id} → ${flow.id}`));
+      console.log(chalk.dim(`  Title: ${flow.frontmatter.title}`));
+      console.log(chalk.dim(`  Success count: ${flow.metadata.successCount}`));
+      console.log(chalk.dim(`  Sessions: ${flow.metadata.sourceAOSession.join(", ")}`));
+    });
+
+  atlas
+    .command("reject")
+    .description("Reject a pending flow change")
+    .argument("<id>", "Pending flow ID")
+    .action((id: string) => {
+      const repoPath = resolveRepoPath();
+
+      if (!atlasExists(repoPath)) {
+        throw new Error("No atlas found. Run 'ao atlas init' first.");
+      }
+
+      rejectPending(repoPath, id);
+      console.log(chalk.green(`Rejected: ${id}`));
+    });
+
+  atlas
+    .command("read")
+    .description("Output a flow's content")
+    .argument("<id>", "Flow ID")
+    .action((id: string) => {
+      const repoPath = resolveRepoPath();
+
+      if (!atlasExists(repoPath)) {
+        throw new Error("No atlas found. Run 'ao atlas init' first.");
+      }
+
+      const content = getFlowContent(repoPath, id);
+
+      if (content === null) {
+        throw new Error(`Flow not found: ${id}`);
+      }
+
+      console.log(content);
+    });
+
+  atlas
+    .command("use")
+    .description("Output multiple flows for agent consumption")
+    .argument("<ids...>", "Flow IDs to include")
+    .action((ids: string[]) => {
+      const repoPath = resolveRepoPath();
+
+      if (!atlasExists(repoPath)) {
+        throw new Error("No atlas found. Run 'ao atlas init' first.");
+      }
+
+      const content = getMultipleFlowContents(repoPath, ids);
+
+      if (!content) {
+        throw new Error(`No flows found for: ${ids.join(", ")}`);
+      }
+
+      console.log(content);
+    });
+
+  atlas
+    .command("show")
+    .description("Show detailed information about a flow")
+    .argument("<id>", "Flow ID")
+    .action((id: string) => {
+      const repoPath = resolveRepoPath();
+
+      if (!atlasExists(repoPath)) {
+        throw new Error("No atlas found. Run 'ao atlas init' first.");
+      }
+
+      const flow = getFlow(repoPath, id);
+
+      if (flow === null) {
+        throw new Error(`Flow not found: ${id}`);
+      }
+
+      console.log(chalk.cyan(`Flow: ${flow.id}\n`));
+      console.log(`Title: ${flow.frontmatter.title}`);
+      console.log(`Discovered in: ${flow.frontmatter.discoveredIn}`);
+      console.log(`Last updated: ${flow.metadata.lastUpdated}`);
+      console.log(`Success count: ${flow.metadata.successCount}`);
+      console.log(`Source sessions: ${flow.metadata.sourceAOSession.join(", ")}`);
+
+      if (flow.frontmatter.relatedFlows && flow.frontmatter.relatedFlows.length > 0) {
+        console.log(`Related flows: ${flow.frontmatter.relatedFlows.join(", ")}`);
+      }
+
+      console.log(chalk.dim("\n--- Content ---\n"));
+      console.log(flow.body);
+    });
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -15,6 +15,7 @@ import { registerUpdate } from "./commands/update.js";
 import { registerSetup } from "./commands/setup.js";
 import { registerPlugin } from "./commands/plugin.js";
 import { registerCleanup } from "./commands/cleanup.js";
+import { registerAtlas } from "./commands/atlas.js";
 import { getConfigInstruction } from "./lib/config-instruction.js";
 import { getCliVersion } from "./options/version.js";
 
@@ -44,6 +45,7 @@ export function createProgram(): Command {
   registerSetup(program);
   registerPlugin(program);
   registerCleanup(program);
+  registerAtlas(program);
 
   program
     .command("config-help")

--- a/packages/core/src/__tests__/atlas.test.ts
+++ b/packages/core/src/__tests__/atlas.test.ts
@@ -1,0 +1,492 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import {
+  atlasExists,
+  initAtlas,
+  loadAtlasIndex,
+  saveAtlasIndex,
+  listFlows,
+  getFlow,
+  getFlowContent,
+  getMultipleFlowContents,
+  listPending,
+  approvePending,
+  rejectPending,
+  parseFrontmatter,
+  slugify,
+  getAtlasDir,
+  getFlowsDir,
+  getPendingDir,
+  getAtlasIndexPath,
+  ATLAS_DIR,
+  FLOWS_DIR,
+  PENDING_DIR,
+  ATLAS_INDEX_FILE,
+} from "../atlas.js";
+
+describe("atlas path utilities", () => {
+  it("constructs correct paths", () => {
+    const repoPath = "/my/repo";
+    expect(getAtlasDir(repoPath)).toBe("/my/repo/code-atlas");
+    expect(getFlowsDir(repoPath)).toBe("/my/repo/code-atlas/flows");
+    expect(getPendingDir(repoPath)).toBe("/my/repo/code-atlas/.pending");
+    expect(getAtlasIndexPath(repoPath)).toBe("/my/repo/code-atlas/atlas.json");
+  });
+
+  it("exports directory constants", () => {
+    expect(ATLAS_DIR).toBe("code-atlas");
+    expect(FLOWS_DIR).toBe("flows");
+    expect(PENDING_DIR).toBe(".pending");
+    expect(ATLAS_INDEX_FILE).toBe("atlas.json");
+  });
+});
+
+describe("slugify", () => {
+  it("converts title to lowercase slug", () => {
+    expect(slugify("Hello World")).toBe("hello-world");
+    expect(slugify("Agent Spawning Process")).toBe("agent-spawning-process");
+  });
+
+  it("removes special characters", () => {
+    expect(slugify("Hello, World!")).toBe("hello-world");
+    expect(slugify("Test: Something (Important)")).toBe("test-something-important");
+  });
+
+  it("handles multiple spaces and dashes", () => {
+    expect(slugify("Hello   World")).toBe("hello-world");
+    expect(slugify("Hello---World")).toBe("hello-world");
+  });
+
+  it("trims leading/trailing dashes", () => {
+    expect(slugify("  Hello World  ")).toBe("hello-world");
+    expect(slugify("-Hello World-")).toBe("hello-world");
+  });
+});
+
+describe("parseFrontmatter", () => {
+  it("parses valid frontmatter", () => {
+    const content = `---
+title: Test Flow
+discoveredIn: aa-1
+updated: 2026-04-11
+relatedFlows:
+  - other-flow
+---
+
+## Body Content
+
+This is the body.`;
+
+    const { frontmatter, body } = parseFrontmatter(content);
+
+    expect(frontmatter.title).toBe("Test Flow");
+    expect(frontmatter.discoveredIn).toBe("aa-1");
+    expect(frontmatter.updated).toBe("2026-04-11");
+    expect(frontmatter.relatedFlows).toEqual(["other-flow"]);
+    expect(body).toContain("## Body Content");
+    expect(body).toContain("This is the body.");
+  });
+
+  it("parses frontmatter without optional fields", () => {
+    const content = `---
+title: Minimal Flow
+discoveredIn: aa-2
+updated: 2026-04-11
+---
+
+Body here.`;
+
+    const { frontmatter, body } = parseFrontmatter(content);
+
+    expect(frontmatter.title).toBe("Minimal Flow");
+    expect(frontmatter.relatedFlows).toBeUndefined();
+    expect(body.trim()).toBe("Body here.");
+  });
+
+  it("throws on missing frontmatter", () => {
+    const content = "Just content, no frontmatter.";
+    expect(() => parseFrontmatter(content)).toThrow("missing YAML frontmatter");
+  });
+
+  it("throws on invalid frontmatter structure", () => {
+    const content = `---
+notTitle: Something
+---
+
+Body.`;
+
+    expect(() => parseFrontmatter(content)).toThrow();
+  });
+});
+
+describe("atlas initialization", () => {
+  let repoPath: string;
+
+  beforeEach(() => {
+    repoPath = join(tmpdir(), `ao-atlas-${randomUUID()}`);
+    mkdirSync(repoPath, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  it("atlasExists returns false when no atlas", () => {
+    expect(atlasExists(repoPath)).toBe(false);
+  });
+
+  it("initAtlas creates correct folder structure", () => {
+    initAtlas(repoPath);
+
+    expect(existsSync(getAtlasDir(repoPath))).toBe(true);
+    expect(existsSync(getFlowsDir(repoPath))).toBe(true);
+    expect(existsSync(getPendingDir(repoPath))).toBe(true);
+    expect(existsSync(getAtlasIndexPath(repoPath))).toBe(true);
+    expect(existsSync(join(getPendingDir(repoPath), ".gitignore"))).toBe(true);
+  });
+
+  it("atlasExists returns true after init", () => {
+    initAtlas(repoPath);
+    expect(atlasExists(repoPath)).toBe(true);
+  });
+
+  it("loadAtlasIndex returns empty flows for new atlas", () => {
+    initAtlas(repoPath);
+    const atlas = loadAtlasIndex(repoPath);
+
+    expect(atlas.flows).toEqual({});
+  });
+
+  it("initAtlas is idempotent", () => {
+    initAtlas(repoPath);
+    initAtlas(repoPath);
+
+    expect(atlasExists(repoPath)).toBe(true);
+  });
+});
+
+describe("flow management", () => {
+  let repoPath: string;
+
+  beforeEach(() => {
+    repoPath = join(tmpdir(), `ao-atlas-${randomUUID()}`);
+    mkdirSync(repoPath, { recursive: true });
+    initAtlas(repoPath);
+  });
+
+  afterEach(() => {
+    rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  it("listFlows returns empty array when no flows", () => {
+    const flows = listFlows(repoPath);
+    expect(flows).toEqual([]);
+  });
+
+  it("getFlow returns null for non-existent flow", () => {
+    const flow = getFlow(repoPath, "non-existent");
+    expect(flow).toBeNull();
+  });
+
+  it("getFlowContent returns null for non-existent flow", () => {
+    const content = getFlowContent(repoPath, "non-existent");
+    expect(content).toBeNull();
+  });
+
+  it("getMultipleFlowContents returns empty string for non-existent flows", () => {
+    const content = getMultipleFlowContents(repoPath, ["non-existent"]);
+    expect(content).toBe("");
+  });
+
+  describe("with existing flows", () => {
+    beforeEach(() => {
+      // Create a flow file
+      const flowContent = `---
+title: Agent Spawning
+discoveredIn: aa-1
+updated: 2026-04-11
+---
+
+## How to spawn agents
+
+This is the process for spawning agents.`;
+
+      writeFileSync(join(getFlowsDir(repoPath), "agent-spawning.md"), flowContent);
+
+      // Update the atlas index
+      const atlas = loadAtlasIndex(repoPath);
+      atlas.flows["agent-spawning"] = {
+        id: "agent-spawning",
+        title: "Agent Spawning",
+        description: "This is the process for spawning agents.",
+        lastUpdated: "2026-04-11T00:00:00.000Z",
+        sourceAOSession: ["aa-1"],
+        successCount: 1,
+      };
+      saveAtlasIndex(repoPath, atlas);
+    });
+
+    it("listFlows returns flow summaries", () => {
+      const flows = listFlows(repoPath);
+
+      expect(flows).toHaveLength(1);
+      expect(flows[0]?.id).toBe("agent-spawning");
+      expect(flows[0]?.title).toBe("Agent Spawning");
+      expect(flows[0]?.successCount).toBe(1);
+    });
+
+    it("getFlow returns flow with parsed frontmatter", () => {
+      const flow = getFlow(repoPath, "agent-spawning");
+
+      expect(flow).not.toBeNull();
+      expect(flow?.id).toBe("agent-spawning");
+      expect(flow?.frontmatter.title).toBe("Agent Spawning");
+      expect(flow?.frontmatter.discoveredIn).toBe("aa-1");
+      expect(flow?.body).toContain("## How to spawn agents");
+      expect(flow?.metadata.successCount).toBe(1);
+    });
+
+    it("getFlowContent returns raw content", () => {
+      const content = getFlowContent(repoPath, "agent-spawning");
+
+      expect(content).toContain("---");
+      expect(content).toContain("title: Agent Spawning");
+      expect(content).toContain("## How to spawn agents");
+    });
+
+    it("getMultipleFlowContents combines flows with headers", () => {
+      // Add another flow
+      const secondContent = `---
+title: Error Handling
+discoveredIn: aa-2
+updated: 2026-04-11
+---
+
+## Error handling patterns`;
+
+      writeFileSync(join(getFlowsDir(repoPath), "error-handling.md"), secondContent);
+
+      const atlas = loadAtlasIndex(repoPath);
+      atlas.flows["error-handling"] = {
+        id: "error-handling",
+        title: "Error Handling",
+        description: "Error handling patterns",
+        lastUpdated: "2026-04-11T00:00:00.000Z",
+        sourceAOSession: ["aa-2"],
+        successCount: 1,
+      };
+      saveAtlasIndex(repoPath, atlas);
+
+      const combined = getMultipleFlowContents(repoPath, ["agent-spawning", "error-handling"]);
+
+      expect(combined).toContain("# Flow: agent-spawning");
+      expect(combined).toContain("# Flow: error-handling");
+      expect(combined).toContain("---");
+      expect(combined).toContain("## How to spawn agents");
+      expect(combined).toContain("## Error handling patterns");
+    });
+  });
+});
+
+describe("pending flow workflow", () => {
+  let repoPath: string;
+
+  beforeEach(() => {
+    repoPath = join(tmpdir(), `ao-atlas-${randomUUID()}`);
+    mkdirSync(repoPath, { recursive: true });
+    initAtlas(repoPath);
+  });
+
+  afterEach(() => {
+    rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  it("listPending returns empty array when no pending flows", () => {
+    const pending = listPending(repoPath);
+    expect(pending).toEqual([]);
+  });
+
+  it("listPending returns pending flows", () => {
+    const pendingContent = `---
+title: New Flow
+discoveredIn: aa-3
+updated: 2026-04-11
+---
+
+## New flow content`;
+
+    writeFileSync(join(getPendingDir(repoPath), "aa-3-new-flow.md"), pendingContent);
+
+    const pending = listPending(repoPath);
+
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.id).toBe("aa-3-new-flow");
+    expect(pending[0]?.frontmatter.title).toBe("New Flow");
+    expect(pending[0]?.frontmatter.discoveredIn).toBe("aa-3");
+  });
+
+  it("approvePending moves file and updates index", () => {
+    const pendingContent = `---
+title: Test Flow
+discoveredIn: aa-4
+updated: 2026-04-11
+---
+
+## Test content`;
+
+    writeFileSync(join(getPendingDir(repoPath), "aa-4-test-flow.md"), pendingContent);
+
+    const flow = approvePending(repoPath, "aa-4-test-flow");
+
+    // Check returned flow
+    expect(flow.id).toBe("test-flow");
+    expect(flow.frontmatter.title).toBe("Test Flow");
+    expect(flow.metadata.successCount).toBe(1);
+    expect(flow.metadata.sourceAOSession).toEqual(["aa-4"]);
+
+    // Check pending file is removed
+    expect(existsSync(join(getPendingDir(repoPath), "aa-4-test-flow.md"))).toBe(false);
+
+    // Check flow file exists
+    expect(existsSync(join(getFlowsDir(repoPath), "test-flow.md"))).toBe(true);
+
+    // Check atlas index is updated
+    const atlas = loadAtlasIndex(repoPath);
+    expect(atlas.flows["test-flow"]).toBeDefined();
+    expect(atlas.flows["test-flow"]?.title).toBe("Test Flow");
+    expect(atlas.flows["test-flow"]?.successCount).toBe(1);
+  });
+
+  it("approvePending increments successCount for existing flow", () => {
+    // Create an existing flow
+    const existingContent = `---
+title: Existing Flow
+discoveredIn: aa-1
+updated: 2026-04-10
+---
+
+## Original content`;
+
+    writeFileSync(join(getFlowsDir(repoPath), "existing-flow.md"), existingContent);
+
+    const atlas = loadAtlasIndex(repoPath);
+    atlas.flows["existing-flow"] = {
+      id: "existing-flow",
+      title: "Existing Flow",
+      description: "Original content",
+      lastUpdated: "2026-04-10T00:00:00.000Z",
+      sourceAOSession: ["aa-1"],
+      successCount: 3,
+    };
+    saveAtlasIndex(repoPath, atlas);
+
+    // Create pending update with same title slug
+    const pendingContent = `---
+title: Existing Flow
+discoveredIn: aa-5
+updated: 2026-04-11
+---
+
+## Updated content`;
+
+    writeFileSync(join(getPendingDir(repoPath), "aa-5-existing-flow.md"), pendingContent);
+
+    const flow = approvePending(repoPath, "aa-5-existing-flow");
+
+    expect(flow.metadata.successCount).toBe(4);
+    expect(flow.metadata.sourceAOSession).toContain("aa-1");
+    expect(flow.metadata.sourceAOSession).toContain("aa-5");
+  });
+
+  it("rejectPending deletes pending file", () => {
+    const pendingContent = `---
+title: Rejected Flow
+discoveredIn: aa-6
+updated: 2026-04-11
+---
+
+## Content to reject`;
+
+    const pendingPath = join(getPendingDir(repoPath), "aa-6-rejected-flow.md");
+    writeFileSync(pendingPath, pendingContent);
+
+    expect(existsSync(pendingPath)).toBe(true);
+
+    rejectPending(repoPath, "aa-6-rejected-flow");
+
+    expect(existsSync(pendingPath)).toBe(false);
+  });
+
+  it("approvePending throws for non-existent pending", () => {
+    expect(() => approvePending(repoPath, "non-existent")).toThrow("Pending flow not found");
+  });
+
+  it("rejectPending throws for non-existent pending", () => {
+    expect(() => rejectPending(repoPath, "non-existent")).toThrow("Pending flow not found");
+  });
+});
+
+describe("validation", () => {
+  let repoPath: string;
+
+  beforeEach(() => {
+    repoPath = join(tmpdir(), `ao-atlas-${randomUUID()}`);
+    mkdirSync(repoPath, { recursive: true });
+    initAtlas(repoPath);
+  });
+
+  afterEach(() => {
+    rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  it("rejects invalid atlas.json", () => {
+    writeFileSync(getAtlasIndexPath(repoPath), "not valid json", "utf-8");
+    expect(() => loadAtlasIndex(repoPath)).toThrow();
+  });
+
+  it("rejects atlas.json with invalid schema", () => {
+    writeFileSync(getAtlasIndexPath(repoPath), '{"invalid": "schema"}', "utf-8");
+    expect(() => loadAtlasIndex(repoPath)).toThrow();
+  });
+
+  it("handles missing flow gracefully", () => {
+    // Add metadata but no file
+    const atlas = loadAtlasIndex(repoPath);
+    atlas.flows["missing-flow"] = {
+      id: "missing-flow",
+      title: "Missing Flow",
+      description: "This flow file does not exist",
+      lastUpdated: "2026-04-11T00:00:00.000Z",
+      sourceAOSession: ["aa-1"],
+      successCount: 1,
+    };
+    saveAtlasIndex(repoPath, atlas);
+
+    // getFlow should return null when file is missing
+    const flow = getFlow(repoPath, "missing-flow");
+    expect(flow).toBeNull();
+  });
+
+  it("skips invalid pending files", () => {
+    // Create an invalid pending file
+    writeFileSync(join(getPendingDir(repoPath), "bad-file.md"), "no frontmatter here");
+
+    // Create a valid pending file
+    const validContent = `---
+title: Valid Flow
+discoveredIn: aa-1
+updated: 2026-04-11
+---
+
+Content`;
+    writeFileSync(join(getPendingDir(repoPath), "valid-flow.md"), validContent);
+
+    const pending = listPending(repoPath);
+
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.id).toBe("valid-flow");
+  });
+});

--- a/packages/core/src/__tests__/atlas.test.ts
+++ b/packages/core/src/__tests__/atlas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
@@ -148,6 +148,14 @@ describe("atlas initialization", () => {
     expect(existsSync(join(getPendingDir(repoPath), ".gitignore"))).toBe(true);
   });
 
+  it("initAtlas creates .gitignore that ignores pending md files", () => {
+    initAtlas(repoPath);
+
+    const gitignoreContent = readFileSync(join(getPendingDir(repoPath), ".gitignore"), "utf-8");
+    expect(gitignoreContent).toContain("*");
+    expect(gitignoreContent).toContain("!.gitignore");
+  });
+
   it("atlasExists returns true after init", () => {
     initAtlas(repoPath);
     expect(atlasExists(repoPath)).toBe(true);
@@ -199,6 +207,17 @@ describe("flow management", () => {
   it("getMultipleFlowContents returns empty string for non-existent flows", () => {
     const content = getMultipleFlowContents(repoPath, ["non-existent"]);
     expect(content).toBe("");
+  });
+
+  it("getFlow rejects invalid flow IDs", () => {
+    expect(() => getFlow(repoPath, "../etc/passwd")).toThrow("Invalid flow ID");
+    expect(() => getFlow(repoPath, "..")).toThrow("Invalid flow ID");
+    expect(() => getFlow(repoPath, "UPPERCASE")).toThrow("Invalid flow ID");
+  });
+
+  it("getFlowContent rejects invalid flow IDs", () => {
+    expect(() => getFlowContent(repoPath, "../secret")).toThrow("Invalid flow ID");
+    expect(() => getFlowContent(repoPath, "has spaces")).toThrow("Invalid flow ID");
   });
 
   describe("with existing flows", () => {
@@ -328,7 +347,7 @@ updated: 2026-04-11
     expect(pending[0]?.frontmatter.discoveredIn).toBe("aa-3");
   });
 
-  it("approvePending moves file and updates index", () => {
+  it("approvePending moves file and updates index", async () => {
     const pendingContent = `---
 title: Test Flow
 discoveredIn: aa-4
@@ -339,7 +358,7 @@ updated: 2026-04-11
 
     writeFileSync(join(getPendingDir(repoPath), "aa-4-test-flow.md"), pendingContent);
 
-    const flow = approvePending(repoPath, "aa-4-test-flow");
+    const flow = await approvePending(repoPath, "aa-4-test-flow");
 
     // Check returned flow
     expect(flow.id).toBe("test-flow");
@@ -360,7 +379,7 @@ updated: 2026-04-11
     expect(atlas.flows["test-flow"]?.successCount).toBe(1);
   });
 
-  it("approvePending increments successCount for existing flow", () => {
+  it("approvePending increments successCount for existing flow", async () => {
     // Create an existing flow
     const existingContent = `---
 title: Existing Flow
@@ -394,7 +413,7 @@ updated: 2026-04-11
 
     writeFileSync(join(getPendingDir(repoPath), "aa-5-existing-flow.md"), pendingContent);
 
-    const flow = approvePending(repoPath, "aa-5-existing-flow");
+    const flow = await approvePending(repoPath, "aa-5-existing-flow");
 
     expect(flow.metadata.successCount).toBe(4);
     expect(flow.metadata.sourceAOSession).toContain("aa-1");
@@ -420,12 +439,23 @@ updated: 2026-04-11
     expect(existsSync(pendingPath)).toBe(false);
   });
 
-  it("approvePending throws for non-existent pending", () => {
-    expect(() => approvePending(repoPath, "non-existent")).toThrow("Pending flow not found");
+  it("approvePending throws for non-existent pending", async () => {
+    await expect(approvePending(repoPath, "non-existent")).rejects.toThrow("Pending flow not found");
   });
 
   it("rejectPending throws for non-existent pending", () => {
     expect(() => rejectPending(repoPath, "non-existent")).toThrow("Pending flow not found");
+  });
+
+  it("approvePending rejects path traversal attempts", async () => {
+    await expect(approvePending(repoPath, "../etc/passwd")).rejects.toThrow("Invalid pending flow ID");
+    await expect(approvePending(repoPath, "..")).rejects.toThrow("Invalid pending flow ID");
+    await expect(approvePending(repoPath, "foo/bar")).rejects.toThrow("Invalid pending flow ID");
+  });
+
+  it("rejectPending rejects path traversal attempts", () => {
+    expect(() => rejectPending(repoPath, "../secret")).toThrow("Invalid pending flow ID");
+    expect(() => rejectPending(repoPath, "..")).toThrow("Invalid pending flow ID");
   });
 });
 
@@ -488,5 +518,39 @@ Content`;
 
     expect(pending).toHaveLength(1);
     expect(pending[0]?.id).toBe("valid-flow");
+  });
+});
+
+describe("YAML escaping", () => {
+  let repoPath: string;
+
+  beforeEach(() => {
+    repoPath = join(tmpdir(), `ao-atlas-${randomUUID()}`);
+    mkdirSync(repoPath, { recursive: true });
+    initAtlas(repoPath);
+  });
+
+  afterEach(() => {
+    rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  it("properly escapes special characters in frontmatter", async () => {
+    const pendingContent = `---
+title: "Flow with: colons and 'quotes'"
+discoveredIn: aa-7
+updated: 2026-04-11
+---
+
+## Content with special chars`;
+
+    writeFileSync(join(getPendingDir(repoPath), "aa-7-special.md"), pendingContent);
+
+    const flow = await approvePending(repoPath, "aa-7-special");
+
+    // Read the saved flow and verify it's valid YAML
+    const savedContent = readFileSync(join(getFlowsDir(repoPath), `${flow.id}.md`), "utf-8");
+    const { frontmatter } = parseFrontmatter(savedContent);
+
+    expect(frontmatter.title).toBe("Flow with: colons and 'quotes'");
   });
 });

--- a/packages/core/src/atlas.ts
+++ b/packages/core/src/atlas.ts
@@ -14,16 +14,22 @@ import {
   statSync,
   unlinkSync,
 } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { z } from "zod";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { atomicWriteFileSync } from "./atomic-write.js";
+import { withFileLock } from "./file-lock.js";
 
 // Directory structure constants
 export const ATLAS_DIR = "code-atlas";
 export const ATLAS_INDEX_FILE = "atlas.json";
 export const FLOWS_DIR = "flows";
 export const PENDING_DIR = ".pending";
+
+// ID validation regex - must be a simple slug (lowercase alphanumeric with hyphens)
+const FLOW_ID_REGEX = /^[a-z0-9-]+$/;
+// Pending ID validation - more permissive but still safe (alphanumeric, dots, underscores, hyphens)
+const PENDING_ID_REGEX = /^[A-Za-z0-9._-]+$/;
 
 // Zod schemas for validation
 export const FlowMetadataSchema = z.object({
@@ -90,6 +96,36 @@ export function getAtlasIndexPath(repoPath: string): string {
   return join(getAtlasDir(repoPath), ATLAS_INDEX_FILE);
 }
 
+// ID validation to prevent path traversal
+function validateFlowId(flowId: string): string {
+  if (!flowId || flowId === "." || flowId === "..") {
+    throw new Error(`Invalid flow ID: ${flowId}`);
+  }
+  if (!FLOW_ID_REGEX.test(flowId)) {
+    throw new Error(`Invalid flow ID format: ${flowId}. Must be lowercase alphanumeric with hyphens.`);
+  }
+  return flowId;
+}
+
+function validatePendingId(pendingId: string): string {
+  if (!pendingId || pendingId === "." || pendingId === "..") {
+    throw new Error(`Invalid pending flow ID: ${pendingId}`);
+  }
+  if (!PENDING_ID_REGEX.test(pendingId)) {
+    throw new Error(`Invalid pending flow ID format: ${pendingId}`);
+  }
+  return pendingId;
+}
+
+// Ensure a resolved path is within the expected directory (defense in depth)
+function assertPathWithinDir(filePath: string, expectedDir: string): void {
+  const resolvedPath = resolve(filePath);
+  const resolvedDir = resolve(expectedDir);
+  if (!resolvedPath.startsWith(resolvedDir + "/") && resolvedPath !== resolvedDir) {
+    throw new Error(`Path traversal detected: ${filePath}`);
+  }
+}
+
 // Initialization
 export function atlasExists(repoPath: string): boolean {
   return existsSync(getAtlasIndexPath(repoPath));
@@ -112,10 +148,13 @@ export function initAtlas(repoPath: string): void {
     atomicWriteFileSync(indexPath, JSON.stringify(emptyIndex, null, 2) + "\n");
   }
 
-  // Create .gitignore for pending directory (but allow atlas itself to be tracked)
+  // Create .gitignore for pending directory to ignore pending flows until approved
   const gitignorePath = join(pendingDir, ".gitignore");
   if (!existsSync(gitignorePath)) {
-    atomicWriteFileSync(gitignorePath, "# Pending flows are not committed until approved\n");
+    atomicWriteFileSync(
+      gitignorePath,
+      "# Pending flows are not committed until approved\n*\n!.gitignore\n",
+    );
   }
 }
 
@@ -188,14 +227,21 @@ export function listFlows(repoPath: string): FlowSummary[] {
 }
 
 export function getFlow(repoPath: string, flowId: string): Flow | null {
+  // Validate flowId to prevent path traversal
+  const safeFlowId = validateFlowId(flowId);
+
   const atlas = loadAtlasIndex(repoPath);
-  const metadata = atlas.flows[flowId];
+  const metadata = atlas.flows[safeFlowId];
 
   if (!metadata) {
     return null;
   }
 
-  const flowPath = join(getFlowsDir(repoPath), `${flowId}.md`);
+  const flowsDir = getFlowsDir(repoPath);
+  const flowPath = join(flowsDir, `${safeFlowId}.md`);
+
+  // Defense in depth: verify path is within flows directory
+  assertPathWithinDir(flowPath, flowsDir);
 
   if (!existsSync(flowPath)) {
     return null;
@@ -206,18 +252,25 @@ export function getFlow(repoPath: string, flowId: string): Flow | null {
     const { frontmatter, body } = parseFrontmatter(content);
 
     return {
-      id: flowId,
+      id: safeFlowId,
       metadata,
       frontmatter,
       body,
     };
   } catch (err) {
-    throw new Error(`Failed to read flow ${flowId}`, { cause: err });
+    throw new Error(`Failed to read flow ${safeFlowId}`, { cause: err });
   }
 }
 
 export function getFlowContent(repoPath: string, flowId: string): string | null {
-  const flowPath = join(getFlowsDir(repoPath), `${flowId}.md`);
+  // Validate flowId to prevent path traversal
+  const safeFlowId = validateFlowId(flowId);
+
+  const flowsDir = getFlowsDir(repoPath);
+  const flowPath = join(flowsDir, `${safeFlowId}.md`);
+
+  // Defense in depth: verify path is within flows directory
+  assertPathWithinDir(flowPath, flowsDir);
 
   if (!existsSync(flowPath)) {
     return null;
@@ -280,12 +333,18 @@ export function listPending(repoPath: string): PendingFlow[] {
   return pending.sort((a, b) => a.id.localeCompare(b.id));
 }
 
-export function approvePending(repoPath: string, pendingId: string): Flow {
+export async function approvePending(repoPath: string, pendingId: string): Promise<Flow> {
+  // Validate pendingId to prevent path traversal
+  const safePendingId = validatePendingId(pendingId);
+
   const pendingDir = getPendingDir(repoPath);
-  const pendingPath = join(pendingDir, `${pendingId}.md`);
+  const pendingPath = join(pendingDir, `${safePendingId}.md`);
+
+  // Defense in depth: verify path is within pending directory
+  assertPathWithinDir(pendingPath, pendingDir);
 
   if (!existsSync(pendingPath)) {
-    throw new Error(`Pending flow not found: ${pendingId}`);
+    throw new Error(`Pending flow not found: ${safePendingId}`);
   }
 
   // Parse the pending file
@@ -299,79 +358,93 @@ export function approvePending(repoPath: string, pendingId: string): Flow {
     throw new Error(`Cannot generate valid flow ID from title: ${frontmatter.title}`);
   }
 
-  // Load current atlas index
-  const atlas = loadAtlasIndex(repoPath);
-  const existingMetadata = atlas.flows[flowId];
+  // Use file lock to prevent concurrent modifications to atlas.json
+  const indexPath = getAtlasIndexPath(repoPath);
+  const lockPath = `${indexPath}.lock`;
 
-  // Create or update metadata
-  const now = new Date().toISOString();
-  const metadata: FlowMetadata = {
-    id: flowId,
-    title: frontmatter.title,
-    description: body.split("\n").find((line) => line.trim().length > 0)?.trim().slice(0, 200) ?? "",
-    lastUpdated: now,
-    sourceAOSession: existingMetadata
-      ? [...new Set([...existingMetadata.sourceAOSession, frontmatter.discoveredIn])]
-      : [frontmatter.discoveredIn],
-    successCount: existingMetadata ? existingMetadata.successCount + 1 : 1,
-  };
+  return withFileLock(lockPath, async () => {
+    // Load current atlas index
+    const atlas = loadAtlasIndex(repoPath);
+    const existingMetadata = atlas.flows[flowId];
 
-  // Update frontmatter with current timestamp
-  const updatedFrontmatter: FlowFrontmatter = {
-    ...frontmatter,
-    updated: now,
-  };
+    // Create or update metadata
+    const now = new Date().toISOString();
+    const metadata: FlowMetadata = {
+      id: flowId,
+      title: frontmatter.title,
+      description: body.split("\n").find((line) => line.trim().length > 0)?.trim().slice(0, 200) ?? "",
+      lastUpdated: now,
+      sourceAOSession: existingMetadata
+        ? [...new Set([...existingMetadata.sourceAOSession, frontmatter.discoveredIn])]
+        : [frontmatter.discoveredIn],
+      successCount: existingMetadata ? existingMetadata.successCount + 1 : 1,
+    };
 
-  // Build updated file content
-  const updatedContent = formatFlowContent(updatedFrontmatter, body);
+    // Update frontmatter with current timestamp
+    const updatedFrontmatter: FlowFrontmatter = {
+      ...frontmatter,
+      updated: now,
+    };
 
-  // Ensure flows directory exists
-  const flowsDir = getFlowsDir(repoPath);
-  mkdirSync(flowsDir, { recursive: true });
+    // Build updated file content using yaml stringify for proper escaping
+    const updatedContent = formatFlowContent(updatedFrontmatter, body);
 
-  // Move file to flows directory
-  const flowPath = join(flowsDir, `${flowId}.md`);
-  atomicWriteFileSync(flowPath, updatedContent);
+    // Ensure flows directory exists
+    const flowsDir = getFlowsDir(repoPath);
+    mkdirSync(flowsDir, { recursive: true });
 
-  // Remove pending file
-  unlinkSync(pendingPath);
+    // Write the approved flow file
+    const flowPath = join(flowsDir, `${flowId}.md`);
+    atomicWriteFileSync(flowPath, updatedContent);
 
-  // Update atlas index
-  atlas.flows[flowId] = metadata;
-  saveAtlasIndex(repoPath, atlas);
+    // Update atlas index BEFORE removing pending file
+    // This ensures we don't lose the pending change if save fails
+    atlas.flows[flowId] = metadata;
+    saveAtlasIndex(repoPath, atlas);
 
-  return {
-    id: flowId,
-    metadata,
-    frontmatter: updatedFrontmatter,
-    body,
-  };
+    // Remove pending file only after flow and index are persisted
+    unlinkSync(pendingPath);
+
+    return {
+      id: flowId,
+      metadata,
+      frontmatter: updatedFrontmatter,
+      body,
+    };
+  });
 }
 
 export function rejectPending(repoPath: string, pendingId: string): void {
-  const pendingPath = join(getPendingDir(repoPath), `${pendingId}.md`);
+  // Validate pendingId to prevent path traversal
+  const safePendingId = validatePendingId(pendingId);
+
+  const pendingDir = getPendingDir(repoPath);
+  const pendingPath = join(pendingDir, `${safePendingId}.md`);
+
+  // Defense in depth: verify path is within pending directory
+  assertPathWithinDir(pendingPath, pendingDir);
 
   if (!existsSync(pendingPath)) {
-    throw new Error(`Pending flow not found: ${pendingId}`);
+    throw new Error(`Pending flow not found: ${safePendingId}`);
   }
 
   unlinkSync(pendingPath);
 }
 
-// Helper to format flow content with frontmatter
+// Helper to format flow content with frontmatter using yaml stringify for proper escaping
 function formatFlowContent(frontmatter: FlowFrontmatter, body: string): string {
-  const yamlLines = [
-    `title: "${frontmatter.title.replace(/"/g, '\\"')}"`,
-    `discoveredIn: "${frontmatter.discoveredIn}"`,
-    `updated: "${frontmatter.updated}"`,
-  ];
+  // Use yaml stringify to properly handle escaping of all values
+  const frontmatterObj: Record<string, unknown> = {
+    title: frontmatter.title,
+    discoveredIn: frontmatter.discoveredIn,
+    updated: frontmatter.updated,
+  };
 
   if (frontmatter.relatedFlows && frontmatter.relatedFlows.length > 0) {
-    yamlLines.push(`relatedFlows:`);
-    for (const related of frontmatter.relatedFlows) {
-      yamlLines.push(`  - "${related}"`);
-    }
+    frontmatterObj.relatedFlows = frontmatter.relatedFlows;
   }
 
-  return `---\n${yamlLines.join("\n")}\n---\n${body}`;
+  const yamlContent = stringifyYaml(frontmatterObj, { lineWidth: 0 }).trim();
+
+  return `---\n${yamlContent}\n---\n${body}`;
 }

--- a/packages/core/src/atlas.ts
+++ b/packages/core/src/atlas.ts
@@ -1,0 +1,377 @@
+/**
+ * Code Atlas — codebase knowledge flows
+ *
+ * Atlas lives in the REPO (`code-atlas/`), NOT in `~/.agent-orchestrator/`.
+ * It's committed to git as living documentation of project-specific knowledge
+ * discovered by agents.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+import { z } from "zod";
+import { parse as parseYaml } from "yaml";
+import { atomicWriteFileSync } from "./atomic-write.js";
+
+// Directory structure constants
+export const ATLAS_DIR = "code-atlas";
+export const ATLAS_INDEX_FILE = "atlas.json";
+export const FLOWS_DIR = "flows";
+export const PENDING_DIR = ".pending";
+
+// Zod schemas for validation
+export const FlowMetadataSchema = z.object({
+  id: z.string().regex(/^[a-z0-9-]+$/),
+  title: z.string().min(1),
+  description: z.string(),
+  lastUpdated: z.string().datetime({ offset: true }),
+  sourceAOSession: z.array(z.string()),
+  successCount: z.number().int().nonnegative(),
+});
+
+export const AtlasIndexSchema = z.object({
+  flows: z.record(z.string(), FlowMetadataSchema),
+});
+
+export const FlowFrontmatterSchema = z.object({
+  title: z.string().min(1),
+  discoveredIn: z.string().min(1),
+  updated: z.string().min(1),
+  relatedFlows: z.array(z.string()).optional(),
+});
+
+// Types
+export type FlowMetadata = z.infer<typeof FlowMetadataSchema>;
+export type AtlasIndex = z.infer<typeof AtlasIndexSchema>;
+export type FlowFrontmatter = z.infer<typeof FlowFrontmatterSchema>;
+
+export interface Flow {
+  id: string;
+  metadata: FlowMetadata;
+  frontmatter: FlowFrontmatter;
+  body: string;
+}
+
+export interface PendingFlow {
+  id: string;
+  frontmatter: FlowFrontmatter;
+  body: string;
+  filePath: string;
+}
+
+export interface FlowSummary {
+  id: string;
+  title: string;
+  description: string;
+  lastUpdated: string;
+  successCount: number;
+}
+
+// Path utilities
+export function getAtlasDir(repoPath: string): string {
+  return join(repoPath, ATLAS_DIR);
+}
+
+export function getFlowsDir(repoPath: string): string {
+  return join(getAtlasDir(repoPath), FLOWS_DIR);
+}
+
+export function getPendingDir(repoPath: string): string {
+  return join(getAtlasDir(repoPath), PENDING_DIR);
+}
+
+export function getAtlasIndexPath(repoPath: string): string {
+  return join(getAtlasDir(repoPath), ATLAS_INDEX_FILE);
+}
+
+// Initialization
+export function atlasExists(repoPath: string): boolean {
+  return existsSync(getAtlasIndexPath(repoPath));
+}
+
+export function initAtlas(repoPath: string): void {
+  const atlasDir = getAtlasDir(repoPath);
+  const flowsDir = getFlowsDir(repoPath);
+  const pendingDir = getPendingDir(repoPath);
+  const indexPath = getAtlasIndexPath(repoPath);
+
+  // Create directories
+  mkdirSync(atlasDir, { recursive: true });
+  mkdirSync(flowsDir, { recursive: true });
+  mkdirSync(pendingDir, { recursive: true });
+
+  // Create empty index if it doesn't exist
+  if (!existsSync(indexPath)) {
+    const emptyIndex: AtlasIndex = { flows: {} };
+    atomicWriteFileSync(indexPath, JSON.stringify(emptyIndex, null, 2) + "\n");
+  }
+
+  // Create .gitignore for pending directory (but allow atlas itself to be tracked)
+  const gitignorePath = join(pendingDir, ".gitignore");
+  if (!existsSync(gitignorePath)) {
+    atomicWriteFileSync(gitignorePath, "# Pending flows are not committed until approved\n");
+  }
+}
+
+// Index operations
+export function loadAtlasIndex(repoPath: string): AtlasIndex {
+  const indexPath = getAtlasIndexPath(repoPath);
+
+  if (!existsSync(indexPath)) {
+    return { flows: {} };
+  }
+
+  try {
+    const content = readFileSync(indexPath, "utf-8");
+    const parsed = JSON.parse(content);
+    return AtlasIndexSchema.parse(parsed);
+  } catch (err) {
+    throw new Error(`Failed to load atlas index: ${indexPath}`, { cause: err });
+  }
+}
+
+export function saveAtlasIndex(repoPath: string, atlas: AtlasIndex): void {
+  const indexPath = getAtlasIndexPath(repoPath);
+  const validated = AtlasIndexSchema.parse(atlas);
+  atomicWriteFileSync(indexPath, JSON.stringify(validated, null, 2) + "\n");
+}
+
+// Frontmatter parsing
+export function parseFrontmatter(content: string): { frontmatter: FlowFrontmatter; body: string } {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+
+  if (!match) {
+    throw new Error("Invalid flow file: missing YAML frontmatter");
+  }
+
+  const [, yamlContent, body] = match;
+
+  try {
+    const parsed = parseYaml(yamlContent ?? "");
+    const frontmatter = FlowFrontmatterSchema.parse(parsed);
+    return { frontmatter, body: body ?? "" };
+  } catch (err) {
+    throw new Error("Invalid flow frontmatter", { cause: err });
+  }
+}
+
+// Slug generation
+export function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+// Flow operations
+export function listFlows(repoPath: string): FlowSummary[] {
+  const atlas = loadAtlasIndex(repoPath);
+
+  return Object.values(atlas.flows)
+    .map((metadata) => ({
+      id: metadata.id,
+      title: metadata.title,
+      description: metadata.description,
+      lastUpdated: metadata.lastUpdated,
+      successCount: metadata.successCount,
+    }))
+    .sort((a, b) => b.lastUpdated.localeCompare(a.lastUpdated));
+}
+
+export function getFlow(repoPath: string, flowId: string): Flow | null {
+  const atlas = loadAtlasIndex(repoPath);
+  const metadata = atlas.flows[flowId];
+
+  if (!metadata) {
+    return null;
+  }
+
+  const flowPath = join(getFlowsDir(repoPath), `${flowId}.md`);
+
+  if (!existsSync(flowPath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(flowPath, "utf-8");
+    const { frontmatter, body } = parseFrontmatter(content);
+
+    return {
+      id: flowId,
+      metadata,
+      frontmatter,
+      body,
+    };
+  } catch (err) {
+    throw new Error(`Failed to read flow ${flowId}`, { cause: err });
+  }
+}
+
+export function getFlowContent(repoPath: string, flowId: string): string | null {
+  const flowPath = join(getFlowsDir(repoPath), `${flowId}.md`);
+
+  if (!existsSync(flowPath)) {
+    return null;
+  }
+
+  return readFileSync(flowPath, "utf-8");
+}
+
+export function getMultipleFlowContents(repoPath: string, flowIds: string[]): string {
+  const sections: string[] = [];
+
+  for (const flowId of flowIds) {
+    const content = getFlowContent(repoPath, flowId);
+    if (content) {
+      sections.push(`# Flow: ${flowId}\n\n${content}`);
+    }
+  }
+
+  return sections.join("\n\n---\n\n");
+}
+
+// Pending flow operations
+export function listPending(repoPath: string): PendingFlow[] {
+  const pendingDir = getPendingDir(repoPath);
+
+  if (!existsSync(pendingDir)) {
+    return [];
+  }
+
+  const pending: PendingFlow[] = [];
+
+  for (const fileName of readdirSync(pendingDir)) {
+    if (!fileName.endsWith(".md")) continue;
+
+    const filePath = join(pendingDir, fileName);
+
+    try {
+      if (!statSync(filePath).isFile()) continue;
+    } catch {
+      continue;
+    }
+
+    try {
+      const content = readFileSync(filePath, "utf-8");
+      const { frontmatter, body } = parseFrontmatter(content);
+      const id = fileName.replace(/\.md$/, "");
+
+      pending.push({
+        id,
+        frontmatter,
+        body,
+        filePath,
+      });
+    } catch {
+      // Skip invalid files
+      continue;
+    }
+  }
+
+  return pending.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function approvePending(repoPath: string, pendingId: string): Flow {
+  const pendingDir = getPendingDir(repoPath);
+  const pendingPath = join(pendingDir, `${pendingId}.md`);
+
+  if (!existsSync(pendingPath)) {
+    throw new Error(`Pending flow not found: ${pendingId}`);
+  }
+
+  // Parse the pending file
+  const content = readFileSync(pendingPath, "utf-8");
+  const { frontmatter, body } = parseFrontmatter(content);
+
+  // Generate flow ID from title
+  const flowId = slugify(frontmatter.title);
+
+  if (!flowId) {
+    throw new Error(`Cannot generate valid flow ID from title: ${frontmatter.title}`);
+  }
+
+  // Load current atlas index
+  const atlas = loadAtlasIndex(repoPath);
+  const existingMetadata = atlas.flows[flowId];
+
+  // Create or update metadata
+  const now = new Date().toISOString();
+  const metadata: FlowMetadata = {
+    id: flowId,
+    title: frontmatter.title,
+    description: body.split("\n").find((line) => line.trim().length > 0)?.trim().slice(0, 200) ?? "",
+    lastUpdated: now,
+    sourceAOSession: existingMetadata
+      ? [...new Set([...existingMetadata.sourceAOSession, frontmatter.discoveredIn])]
+      : [frontmatter.discoveredIn],
+    successCount: existingMetadata ? existingMetadata.successCount + 1 : 1,
+  };
+
+  // Update frontmatter with current timestamp
+  const updatedFrontmatter: FlowFrontmatter = {
+    ...frontmatter,
+    updated: now,
+  };
+
+  // Build updated file content
+  const updatedContent = formatFlowContent(updatedFrontmatter, body);
+
+  // Ensure flows directory exists
+  const flowsDir = getFlowsDir(repoPath);
+  mkdirSync(flowsDir, { recursive: true });
+
+  // Move file to flows directory
+  const flowPath = join(flowsDir, `${flowId}.md`);
+  atomicWriteFileSync(flowPath, updatedContent);
+
+  // Remove pending file
+  unlinkSync(pendingPath);
+
+  // Update atlas index
+  atlas.flows[flowId] = metadata;
+  saveAtlasIndex(repoPath, atlas);
+
+  return {
+    id: flowId,
+    metadata,
+    frontmatter: updatedFrontmatter,
+    body,
+  };
+}
+
+export function rejectPending(repoPath: string, pendingId: string): void {
+  const pendingPath = join(getPendingDir(repoPath), `${pendingId}.md`);
+
+  if (!existsSync(pendingPath)) {
+    throw new Error(`Pending flow not found: ${pendingId}`);
+  }
+
+  unlinkSync(pendingPath);
+}
+
+// Helper to format flow content with frontmatter
+function formatFlowContent(frontmatter: FlowFrontmatter, body: string): string {
+  const yamlLines = [
+    `title: "${frontmatter.title.replace(/"/g, '\\"')}"`,
+    `discoveredIn: "${frontmatter.discoveredIn}"`,
+    `updated: "${frontmatter.updated}"`,
+  ];
+
+  if (frontmatter.relatedFlows && frontmatter.relatedFlows.length > 0) {
+    yamlLines.push(`relatedFlows:`);
+    for (const related of frontmatter.relatedFlows) {
+      yamlLines.push(`  - "${related}"`);
+    }
+  }
+
+  return `---\n${yamlLines.join("\n")}\n---\n${body}`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -204,3 +204,39 @@ export type {
   DetectedProjectInfo,
   GenerateConfigOptions,
 } from "./config-generator.js";
+
+// Atlas — codebase knowledge flows
+export {
+  atlasExists,
+  initAtlas,
+  loadAtlasIndex,
+  saveAtlasIndex,
+  listFlows,
+  listPending,
+  getFlow,
+  getFlowContent,
+  getMultipleFlowContents,
+  approvePending,
+  rejectPending,
+  parseFrontmatter,
+  slugify,
+  getAtlasDir,
+  getFlowsDir,
+  getPendingDir,
+  getAtlasIndexPath,
+  FlowMetadataSchema,
+  AtlasIndexSchema,
+  FlowFrontmatterSchema,
+  ATLAS_DIR,
+  FLOWS_DIR,
+  PENDING_DIR,
+  ATLAS_INDEX_FILE,
+} from "./atlas.js";
+export type {
+  AtlasIndex,
+  FlowMetadata,
+  FlowFrontmatter,
+  Flow,
+  PendingFlow,
+  FlowSummary,
+} from "./atlas.js";

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1050,7 +1050,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         if (!alive) {
           // Process is confirmed dead — set activity to exited.
           // Only update status to "killed" if not already in a terminal state.
-          if (!TERMINAL_SESSION_STATUSES.has(session.status)) {
+          if (!TERMINAL_STATUSES.has(session.status)) {
             session.status = "killed";
           }
           session.activity = "exited";

--- a/packages/web/server/voice-server.ts
+++ b/packages/web/server/voice-server.ts
@@ -453,6 +453,7 @@ function orchestratorToSession(orchestrator: DashboardOrchestratorLink): Dashboa
     createdAt: new Date().toISOString(),
     lastActivityAt: new Date().toISOString(),
     pr: null,
+    userPrompt: null,
     metadata: { role: "orchestrator" },
   };
 }

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -794,7 +794,7 @@ function getFooterStatusLabel(
 
 interface Alert {
   key: string;
-  type: "ci" | "changes" | "review" | "conflict" | "comment";
+  type: "ci" | "changes" | "review" | "conflict" | "comment" | "truncation";
   icon: React.ReactNode;
   label: string;
   url: string;
@@ -816,9 +816,9 @@ function getAlerts(session: DashboardSession): Alert[] {
   if (meta["promptTruncationReport"]) {
     alerts.push({
       key: "truncation",
+      type: "truncation",
+      icon: "⚠",
       label: "prompt truncated",
-      className: "border-yellow-500/40 bg-yellow-500/10",
-      color: "var(--color-status-attention)",
       url: `/sessions/${encodeURIComponent(session.id)}`,
     });
   }


### PR DESCRIPTION
## Summary

- Implement code-atlas feature for storing codebase knowledge flows discovered by agents
- Atlas lives in repo as `code-atlas/` (committed to git as living documentation)
- Full CLI commands for managing flows with pending approval workflow

## Changes

**Core module (`packages/core/src/atlas.ts`):**
- Zod schemas for validation (`FlowMetadataSchema`, `AtlasIndexSchema`, `FlowFrontmatterSchema`)
- Type definitions for `Flow`, `PendingFlow`, `FlowSummary`, etc.
- CRUD operations for flows and pending flows
- Frontmatter parsing with yaml package
- Atomic writes for index updates

**CLI commands (`packages/cli/src/commands/atlas.ts`):**
- `ao atlas init` - Initialize code-atlas folder structure
- `ao atlas list [--json]` - List all approved flows
- `ao atlas pending [--json]` - List pending flow changes
- `ao atlas approve <id>` - Approve a pending flow
- `ao atlas reject <id>` - Reject a pending flow
- `ao atlas read <id>` - Output a flow's content
- `ao atlas use <ids...>` - Output multiple flows for agent consumption
- `ao atlas show <id>` - Show detailed flow information

**Directory structure created:**
```
code-atlas/
├── atlas.json        # Index of all flows with metadata
├── flows/            # Approved flow files (*.md)
└── .pending/         # Pending flows from agents (*.md)
```

## Test plan

- [x] 34 unit tests covering all functionality pass
- [x] Build succeeds (`pnpm build`)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] Lint passes (no errors in new files)
- [x] Manual CLI testing:
  - `ao atlas init` creates correct folder structure
  - `ao atlas pending` lists pending flows
  - `ao atlas approve` moves pending to flows and updates index
  - `ao atlas list` shows approved flows
  - `ao atlas read` outputs flow content
  - `ao atlas show` shows detailed flow information

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)