### PR TITLE
fix(atlas): commit pending flows instead of gitignoring them

### DIFF
--- a/code-atlas/.pending/.gitignore
+++ b/code-atlas/.pending/.gitignore
@@ -1,3 +1,0 @@
-# Pending flows are not committed until approved
-*
-!.gitignore

--- a/code-atlas/.pending/aa-9-agent-plugin-implementation.md
+++ b/code-atlas/.pending/aa-9-agent-plugin-implementation.md
@@ -1,0 +1,127 @@
+---
+title: "Implementing an Agent Plugin"
+discoveredIn: aa-9
+updated: "2025-04-12"
+relatedFlows: []
+---
+
+## Overview
+
+Agent plugins define how AO interacts with AI coding tools (Claude Code, Codex, Aider, OpenCode). This flow covers the required interface and common patterns.
+
+## Directory Structure
+
+```
+packages/plugins/agent-{name}/
+├── package.json          # @aoagents/ao-plugin-agent-{name}
+├── tsconfig.json
+└── src/
+    ├── index.ts          # Plugin implementation
+    └── __tests__/
+        └── index.test.ts
+```
+
+## Required Exports
+
+```typescript
+// index.ts
+import type { PluginModule, Agent } from "@aoagents/ao-core";
+
+export const manifest = {
+  name: "my-agent",           // Must match package suffix
+  slot: "agent" as const,     // Literal type required
+  description: "My AI agent",
+  version: "0.1.0",
+};
+
+export function create(config?: Record<string, unknown>): Agent {
+  return { /* Agent interface methods */ };
+}
+
+export function detect(): boolean {
+  // Check if agent binary is available
+  return existsSync("/path/to/agent");
+}
+
+export default { manifest, create, detect } satisfies PluginModule<Agent>;
+```
+
+## Critical Methods
+
+### getLaunchCommand(config)
+
+Returns the shell command to start the agent:
+```typescript
+getLaunchCommand(config: AgentLaunchConfig): string {
+  const args = ["--dangerously-skip-permissions"];
+  if (config.prompt) args.push("-p", shellEscape(config.prompt));
+  return `my-agent ${args.join(" ")}`;
+}
+```
+
+### isProcessRunning(handle)
+
+**CRITICAL:** Must correctly identify the agent process.
+
+```typescript
+async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+  // For tmux: get TTY, search ps output
+  // Regex must match ALL variants of the binary name!
+  const patterns = [
+    /\bmy-agent\b/i,
+    /\.my-agent\b/i,      // Dot-prefixed wrappers
+    /my-agent-cli/i,      // Alternative names
+  ];
+  // ...
+}
+```
+
+**Common mistake:** Regex too strict, doesn't match actual binary.
+
+### getActivityState(session)
+
+Returns current activity with required state progression:
+
+```
+spawning → active ↔ ready → idle → exited
+                ↘ waiting_input / blocked ↗
+```
+
+Implementation pattern:
+```typescript
+async getActivityState(session, thresholdMs?): Promise<ActivityDetection | null> {
+  // 1. Check process (but see #95 for why this should change)
+  if (!await this.isProcessRunning(handle)) return { state: "exited" };
+
+  // 2. Check for actionable states (waiting_input, blocked)
+  const activity = await checkActivityLogState(session.workspacePath);
+  if (activity) return activity;
+
+  // 3. Check native signal (agent's own JSONL/API)
+  // 4. Fallback to AO activity JSONL
+  return getActivityFallbackState(activityResult, activeWindowMs, thresholdMs);
+}
+```
+
+### setupWorkspaceHooks(workspacePath, sessionId)
+
+**CRITICAL for dashboard PR tracking.** Two patterns:
+
+1. **Agent-native hooks** (Claude Code): Write to `.claude/settings.json`
+2. **PATH wrappers** (others): Call `setupPathWrapperWorkspace(workspacePath)`
+
+Without this, PRs created by agents won't appear in dashboard.
+
+## Environment Requirements
+
+All agents must set in `getEnvironment()`:
+- `AO_SESSION_ID` — Required
+- `AO_ISSUE_ID` — Optional
+- Prepend `~/.ao/bin` to PATH (for wrapper agents)
+
+## Testing Checklist
+
+- [ ] `isProcessRunning` matches real binary names
+- [ ] `getActivityState` returns all 6 states over lifecycle
+- [ ] `setupWorkspaceHooks` enables PR tracking
+- [ ] Tests cover regex patterns with real binary paths

--- a/code-atlas/.pending/aa-9-liveness-detection-architecture.md
+++ b/code-atlas/.pending/aa-9-liveness-detection-architecture.md
@@ -1,0 +1,84 @@
+---
+title: "Liveness Detection Architecture"
+discoveredIn: aa-9
+updated: "2025-04-12"
+relatedFlows: []
+---
+
+## Overview
+
+Agent Orchestrator has THREE separate systems that determine if an agent is alive. Understanding their interaction is critical for debugging false 'exited' states.
+
+## The Three Systems
+
+### 1. Runtime.isAlive(handle)
+
+**Location:** `packages/plugins/runtime-tmux/src/index.ts`
+
+Checks if the tmux session exists:
+```typescript
+async isAlive(handle: RuntimeHandle): Promise<boolean> {
+  const { stdout } = await execFileAsync("tmux", ["has-session", "-t", handle.id]);
+  return true; // If command succeeds, session exists
+}
+```
+
+**What it tells you:** The tmux session exists (not that the agent process is running inside it).
+
+### 2. Agent.isProcessRunning(handle)
+
+**Location:** Each agent plugin (e.g., `packages/plugins/agent-claude-code/src/index.ts:477-533`)
+
+Checks if the agent process is running via `ps`:
+```typescript
+// Get TTY from tmux, then find process matching regex
+const processRe = /(?:^|\/)claude(?:\s|$)/;
+// Match against ps output filtered by TTY
+```
+
+**What it tells you:** A process matching the agent's name pattern is running on the tmux pane's TTY.
+
+**Common failure:** Regex doesn't match actual binary name (e.g., `.claude`, `claude-code`).
+
+### 3. Agent.getActivityState(session)
+
+**Location:** Each agent plugin (e.g., `packages/plugins/agent-claude-code/src/index.ts:733-794`)
+
+Returns activity state including `exited`:
+```typescript
+async getActivityState(session): Promise<ActivityDetection | null> {
+  const running = await this.isProcessRunning(handle);
+  if (!running) return { state: "exited" };  // Declares death!
+  // ... check JSONL for activity ...
+}
+```
+
+**What it tells you:** Combines process check with JSONL activity data.
+
+## The Problem: No Consensus
+
+Each system can independently declare death:
+
+```typescript
+// lifecycle-manager.ts:406-458
+if (!runtime.isAlive(handle)) return "killed";           // System 1
+if (activityState.state === "exited") return "killed";   // System 3 (calls System 2)
+if (!agent.isProcessRunning(handle)) return "killed";    // System 2 (fallback)
+```
+
+If ANY check fails, the session is killed. No cross-verification.
+
+## Debugging Checklist
+
+When a session is falsely marked as `exited`/`killed`:
+
+1. **Check tmux session exists:** `tmux has-session -t <session-id>`
+2. **Check process is running:** `tmux list-panes -t <session-id> -F '#{pane_tty}'` then `ps -t <tty>`
+3. **Check process name matches regex:** The regex in the agent plugin may not match the actual binary
+4. **Check JSONL has recent activity:** Look at `~/.claude/projects/*/` for recent `.jsonl` files
+
+## Related Issues
+
+- #70: Session killed immediately after spawn
+- #80: Orchestrator shows exited while working
+- #95: Unify liveness detection (proposed fix)

--- a/code-atlas/.pending/aa-9-session-spawn-flow.md
+++ b/code-atlas/.pending/aa-9-session-spawn-flow.md
@@ -1,0 +1,104 @@
+---
+title: "Session Spawn Flow"
+discoveredIn: aa-9
+updated: "2025-04-12"
+relatedFlows:
+  - liveness-detection-architecture
+---
+
+## Overview
+
+Understanding the spawn flow is critical for debugging "session killed immediately after spawn" (#70) and "prompt not sent" (#91) issues.
+
+## Spawn Sequence
+
+```
+ao spawn <issue-id>
+    │
+    ├─ 1. Validate issue exists (tracker.getIssue)
+    │
+    ├─ 2. Reserve session identity (atomic file lock)
+    │      └─ Creates: ~/.agent-orchestrator/{hash}/sessions/{id}/
+    │
+    ├─ 3. Create workspace (worktree plugin)
+    │      └─ git worktree add ~/.agent-orchestrator/{hash}/worktrees/{id}/
+    │
+    ├─ 4. Setup workspace hooks (agent.setupWorkspaceHooks)
+    │      └─ Installs PATH wrappers or agent-native hooks
+    │
+    ├─ 5. Create runtime (runtime.create)
+    │      └─ tmux new-session -d -s {tmuxName} -c {workspacePath}
+    │
+    ├─ 6. Write metadata (status: "spawning")
+    │
+    ├─ 7. Post-launch setup (agent.postLaunchSetup)
+    │      └─ Agent-specific initialization
+    │
+    ├─ 8. Wait for agent ready (if promptDelivery: "post-launch")
+    │      └─ Poll terminal output for agent prompt character
+    │
+    └─ 9. Send prompt (runtime.send → tmux send-keys)
+```
+
+**Code location:** `packages/core/src/session-manager.ts:1123-1480`
+
+## Race Condition Window
+
+Between steps 5-6 and step 9, the lifecycle manager may poll:
+
+```
+Step 5: Runtime created (tmux session exists)
+Step 6: Metadata written (status: "spawning")
+    │
+    │  ← LIFECYCLE POLL HAPPENS HERE
+    │     • runtime.isAlive() → true (tmux exists)
+    │     • getActivityState() → null (no JSONL yet)
+    │     • isProcessRunning() → false (agent not started)
+    │     → Returns "killed" ← FALSE POSITIVE
+    │
+Step 9: Prompt sent (never happens, session already killed)
+```
+
+## Prompt Delivery Modes
+
+Agents declare how they receive prompts:
+
+| Mode | Behavior | Agents |
+|------|----------|--------|
+| `inline` | Prompt passed as CLI arg (`-p "..."`) | Codex |
+| `post-launch` | Prompt sent via tmux after agent starts | Claude Code, Aider |
+
+For `post-launch`, AO waits for the agent to show its prompt character before sending.
+
+## Common Failures
+
+### 1. Agent Not Ready When Prompt Sent
+
+**Symptom:** Session created but agent has no instructions.
+**Cause:** `tmux send-keys` is fire-and-forget; agent may not be listening.
+**Debug:** Check terminal output — is the prompt visible?
+
+### 2. Session Killed During Spawn
+
+**Symptom:** Session immediately shows "killed" status.
+**Cause:** Lifecycle poll during spawn window (see above).
+**Debug:** Check timing — did poll happen before agent process started?
+
+### 3. Workspace Hooks Not Installed
+
+**Symptom:** Agent works but PRs don't appear in dashboard.
+**Cause:** `setupWorkspaceHooks` failed silently.
+**Debug:** Check `.ao/AGENTS.md` exists in workspace, or `.claude/settings.json` for Claude.
+
+## Key Files
+
+- `session-manager.ts:1123` — `spawn()` function entry
+- `session-manager.ts:1298` — Runtime creation
+- `session-manager.ts:1429` — Prompt delivery for post-launch agents
+- `lifecycle-manager.ts:406` — Where false kills happen during spawn
+
+## Related Issues
+
+- #70: Session killed immediately after spawn
+- #91: Spawn doesn't always send prompt
+- #96: Add spawn confirmation loop (proposed fix)

--- a/packages/core/src/__tests__/atlas.test.ts
+++ b/packages/core/src/__tests__/atlas.test.ts
@@ -145,15 +145,7 @@ describe("atlas initialization", () => {
     expect(existsSync(getFlowsDir(repoPath))).toBe(true);
     expect(existsSync(getPendingDir(repoPath))).toBe(true);
     expect(existsSync(getAtlasIndexPath(repoPath))).toBe(true);
-    expect(existsSync(join(getPendingDir(repoPath), ".gitignore"))).toBe(true);
-  });
-
-  it("initAtlas creates .gitignore that ignores pending md files", () => {
-    initAtlas(repoPath);
-
-    const gitignoreContent = readFileSync(join(getPendingDir(repoPath), ".gitignore"), "utf-8");
-    expect(gitignoreContent).toContain("*");
-    expect(gitignoreContent).toContain("!.gitignore");
+    expect(existsSync(join(getPendingDir(repoPath), ".gitkeep"))).toBe(true);
   });
 
   it("atlasExists returns true after init", () => {

--- a/packages/core/src/atlas.ts
+++ b/packages/core/src/atlas.ts
@@ -148,13 +148,11 @@ export function initAtlas(repoPath: string): void {
     atomicWriteFileSync(indexPath, JSON.stringify(emptyIndex, null, 2) + "\n");
   }
 
-  // Create .gitignore for pending directory to ignore pending flows until approved
-  const gitignorePath = join(pendingDir, ".gitignore");
-  if (!existsSync(gitignorePath)) {
-    atomicWriteFileSync(
-      gitignorePath,
-      "# Pending flows are not committed until approved\n*\n!.gitignore\n",
-    );
+  // Create .gitkeep to ensure pending directory exists in git
+  // Pending flows ARE committed so they can be reviewed/approved from any worktree
+  const gitkeepPath = join(pendingDir, ".gitkeep");
+  if (!existsSync(gitkeepPath)) {
+    atomicWriteFileSync(gitkeepPath, "");
   }
 }
 


### PR DESCRIPTION
## Summary

- **Fix cross-worktree approval workflow**: The `.pending/` directory was gitignored, which meant pending flows discovered in one worktree couldn't be approved from another worktree or the main branch
- **Replace `.gitignore` with `.gitkeep`**: Pending flows are now committed to git so they can be reviewed and approved from anywhere
- **Add initial knowledge flows**: 3 flows documenting patterns discovered during state management audit

## Changes

| File | Change |
|------|--------|
| `packages/core/src/atlas.ts` | `initAtlas()` now creates `.gitkeep` instead of `.gitignore` |
| `packages/core/src/__tests__/atlas.test.ts` | Updated test to expect `.gitkeep` |
| `code-atlas/.pending/.gitignore` | Deleted |
| `code-atlas/.pending/.gitkeep` | Added |
| `code-atlas/.pending/aa-9-*.md` | 3 new knowledge flows |

## Knowledge Flows Added

1. **Liveness Detection Architecture** — Documents the three liveness detection systems, how they interact, why they cause false deaths, and a debugging checklist
2. **Agent Plugin Implementation** — Guide for implementing new agent plugins with required methods, critical patterns, and common mistakes
3. **Session Spawn Flow** — The full spawn sequence, race condition window, prompt delivery modes, and common failures

## Test plan

- [x] All 39 atlas tests pass
- [ ] Verify `ao atlas pending` shows flows from any worktree
- [ ] Verify `ao atlas approve <id>` works cross-worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)