### PR TITLE
docs: add pending atlas flows for state derivation

### DIFF
--- a/code-atlas/.pending/aa-1-dashboard-attention-projection.md
+++ b/code-atlas/.pending/aa-1-dashboard-attention-projection.md
@@ -1,0 +1,140 @@
+---
+title: Dashboard Attention Projection
+discoveredIn: aa-1
+updated: 2026-04-13T00:00:00.000Z
+relatedFlows:
+  - liveness-detection-architecture
+  - session-spawn-flow
+---
+
+## Overview
+
+The dashboard does not render raw lifecycle status directly. It projects sessions into human-priority buckets such as merge, respond, review, pending, working, and done. That projection lives mostly in `packages/web/src/lib/types.ts` and is tightly coupled to the current overloaded backend state model.
+
+## Primary Entry Point
+
+**Location:** `packages/web/src/lib/types.ts`
+
+`getAttentionLevel(session)` combines:
+
+- `session.status`
+- `session.activity`
+- PR state
+- CI summary
+- review decision
+- mergeability
+
+into a single attention bucket.
+
+## Current Attention Levels
+
+The current buckets are:
+
+- `merge`
+- `respond`
+- `review`
+- `pending`
+- `working`
+- `done`
+
+These are useful for the UI, but they are projections, not durable backend truth.
+
+## Current Derivation Rules
+
+### Done
+
+First priority:
+
+- terminal lifecycle statuses such as `merged`, `killed`, `cleanup`, `done`, `terminated`
+- PR state `merged` or `closed`
+
+### Merge
+
+Next priority:
+
+- lifecycle `mergeable` or `approved`
+- PR mergeability saying all requirements are satisfied
+
+### Respond
+
+Next priority:
+
+- lifecycle `errored`, `needs_input`, `stuck`
+- activity `waiting_input`, `blocked`, or `exited`
+
+### Review
+
+Next priority:
+
+- lifecycle `ci_failed`, `changes_requested`
+- PR CI failing
+- PR conflicts
+
+### Pending
+
+Next priority:
+
+- lifecycle `review_pending`
+- PR unresolved threads or pending review
+
+### Working
+
+Fallback:
+
+- anything else
+
+## Why This Is Important
+
+The dashboard is currently compensating for ambiguity in backend state:
+
+- `needs_input` is treated as both lifecycle phase and attention state
+- `stuck` is treated as a lifecycle phase even though it really means “please inspect”
+- `activity === "exited"` is treated as a respond-worthy crash even when the root cause may be false liveness detection
+
+That means UI semantics are coupled to backend modeling mistakes.
+
+## Secondary Consumers
+
+Attention-like assumptions also leak into:
+
+- `packages/web/src/components/SessionCard.tsx`
+- `packages/web/src/components/SessionDetail.tsx`
+- `packages/web/src/components/BottomSheet.tsx`
+- `packages/web/src/lib/serialize.ts`
+
+Examples:
+
+- working-session counts exclude `activity === "exited"`
+- terminal-style pills and labels are chosen partly from activity, partly from status
+- some “done” presentation paths assume terminality from mixed sources
+
+## Structural Problem
+
+The UI currently infers three separate questions from the same fields:
+
+1. Is the session alive?
+2. What workflow phase is it in?
+3. Does a human need to do something?
+
+That works only because the backend mixes all three into `status` and `activity`. Once the backend is redesigned, the dashboard should project from separate fact domains instead:
+
+- workflow phase
+- attention reasons
+- liveness result
+- termination reason
+
+## Recommended Future Split
+
+If the backend exposes richer facts, the dashboard should derive attention using this order:
+
+1. terminal outcomes with explicit reason
+2. human-input / blocked reasons
+3. review / CI / conflict reasons
+4. merge-readiness
+5. passive monitoring for healthy running work
+
+This would let the UI stay simple while depending on cleaner semantics.
+
+## Why This Flow Should Exist in Atlas
+
+Anyone changing status semantics or fixing liveness bugs will eventually run into dashboard behavior. This flow documents how the UI currently converts backend ambiguity into operator priority, which makes it easier to evaluate whether a backend change will actually improve what humans see.

--- a/code-atlas/.pending/aa-1-session-status-derivation.md
+++ b/code-atlas/.pending/aa-1-session-status-derivation.md
@@ -1,0 +1,129 @@
+---
+title: Session Status Derivation Pipeline
+discoveredIn: aa-1
+updated: 2026-04-13T00:00:00.000Z
+relatedFlows:
+  - session-spawn-flow
+  - liveness-detection-architecture
+---
+
+## Overview
+
+`packages/core/src/lifecycle-manager.ts` contains the real status machine for live sessions, but the logic is not a clean state table. It is an ordered derivation pipeline where unrelated fact domains can overwrite each other. This flow explains the current order of operations so future debugging and redesign work has one place to point to.
+
+## Entry Point
+
+**Location:** `packages/core/src/lifecycle-manager.ts`
+
+The polling loop calls `determineStatus(session)` for each non-terminal or recently-transitioned session. That function returns a single `SessionStatus`, which is then persisted to metadata and emitted as an event if it changed.
+
+## Current Derivation Order
+
+The current implementation is effectively:
+
+1. Resolve project + selected agent plugin
+2. Infer whether runtime identity is stable enough to probe
+3. Check `runtime.isAlive(handle)`
+4. Record terminal output into activity logs when possible
+5. Call `agent.getActivityState(session)`
+6. Fall back to terminal parsing + `agent.isProcessRunning(handle)`
+7. Auto-detect PR from branch if missing
+8. Query PR state / CI / review / mergeability
+9. Run stuck detection from idle timestamps
+10. Default to `working` or preserve some existing states on probe failure
+
+This is not a pure state transition table. It is “first decisive branch wins”.
+
+## Why This Matters
+
+Several unrelated subsystems can return a terminal answer:
+
+- runtime liveness
+- activity detection
+- process detection
+- PR closure
+
+Because they run in one ordered pipeline, the final status depends as much on ordering as on truth.
+
+## Important Decision Points
+
+### 1. Runtime Probe
+
+If `runtime.isAlive(handle)` returns false and the session is considered safe to probe, the function returns `killed` immediately.
+
+Implication:
+
+- runtime reachability is currently allowed to terminate the session before agent-native activity or PR state are consulted
+
+### 2. Activity Probe
+
+If `agent.getActivityState()` returns:
+
+- `waiting_input` => `needs_input`
+- `exited` => `killed`
+- `idle` or `blocked` with timestamp => capture timestamp for possible `stuck`
+
+Implication:
+
+- activity is not just descriptive; it can currently terminate the session
+
+### 3. Terminal Fallback
+
+If `getActivityState()` returns `null`, lifecycle falls back to:
+
+- raw terminal parsing for `waiting_input`
+- `agent.isProcessRunning(handle)` for `killed`
+
+Implication:
+
+- null does not mean “unknown”; it means “use weaker heuristics”
+
+### 4. PR Overlay
+
+If a PR is present or auto-detected, PR state can override the earlier work/liveness interpretation:
+
+- merged => `merged`
+- closed => `killed`
+- failing CI => `ci_failed`
+- changes requested => `changes_requested`
+- approved => `approved`
+- mergeable => `mergeable`
+
+Implication:
+
+- PR state is currently treated as part of the same status truth as runtime/process state
+
+### 5. Stuck Detection
+
+If earlier activity produced an idle timestamp and the configured threshold is exceeded, the result becomes `stuck`.
+
+Implication:
+
+- “stuck” is derived late from age, not from a first-class fact domain
+
+## Behavior on Probe Failure
+
+The function has several `catch` paths that preserve existing `needs_input` or `stuck` status rather than coercing back to `working`. This is a useful guardrail, but it is also a signal that the model is compensating for unreliable probes with status-specific exceptions.
+
+## Known Structural Problems
+
+1. Ordered checks are masquerading as a coherent state machine.
+2. The same status enum carries workflow phase, attention, and terminal outcome.
+3. Activity and liveness are not separated.
+4. `null` activity causes fallback to weaker probes instead of preserving uncertainty.
+5. PR closure maps directly to `killed`, which conflates policy with fact.
+
+## Debugging Checklist
+
+When a status looks wrong, inspect these in order:
+
+1. `session.metadata` for `runtimeHandle`, `tmuxName`, and persisted status
+2. runtime plugin `isAlive()` behavior for the exact handle being used
+3. agent plugin `getActivityState()` result
+4. terminal fallback path: `detectActivity()` and `isProcessRunning()`
+5. PR enrichment / `detectPR()` / `getPRState()` result
+6. stuck-threshold configuration and idle timestamp source
+
+## Why This Flow Should Exist in Atlas
+
+The spawn flow and liveness architecture docs explain pieces of the problem, but neither explains how those pieces are composed into one status answer. This flow is the missing map for anyone changing or debugging `determineStatus()`.


### PR DESCRIPTION
## Summary
- add a pending atlas item documenting the lifecycle status derivation pipeline
- add a pending atlas item documenting dashboard attention projection
- keep the PR scoped to atlas knowledge artifacts only