### PR TITLE
fix: isolate lifecycle logs from user terminal output

### DIFF
--- a/.changeset/isolate-lifecycle-terminal-logs.md
+++ b/.changeset/isolate-lifecycle-terminal-logs.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-core": patch
+---
+
+Keep lifecycle observability and batch diagnostic logs out of user-visible terminal stderr by routing them into AO's observability audit files instead, while preserving structured traces for debugging and regression coverage.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @composio/ao-core
 
-## Unreleased
-
-### Fixed
-
-- Keep lifecycle observability traces out of terminal-visible stderr by writing them to observability audit files instead.
-
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @composio/ao-core
 
+## Unreleased
+
+### Fixed
+
+- Keep lifecycle observability traces out of terminal-visible stderr by writing them to observability audit files instead.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -145,15 +145,27 @@ describe("check (single session)", () => {
   });
 
   it("does not mirror lifecycle transition observability logs to stderr during polling", async () => {
+    const originalAoObservabilityStderr = process.env["AO_OBSERVABILITY_STDERR"];
+    delete process.env["AO_OBSERVABILITY_STDERR"];
+
     const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
-    const lm = setupCheck("app-1", {
-      session: makeSession({ status: "spawning" }),
-    });
 
-    await lm.check("app-1");
+    try {
+      const lm = setupCheck("app-1", {
+        session: makeSession({ status: "spawning" }),
+      });
 
-    expect(stderrSpy).not.toHaveBeenCalled();
-    stderrSpy.mockRestore();
+      await lm.check("app-1");
+
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      stderrSpy.mockRestore();
+      if (originalAoObservabilityStderr === undefined) {
+        delete process.env["AO_OBSERVABILITY_STDERR"];
+      } else {
+        process.env["AO_OBSERVABILITY_STDERR"] = originalAoObservabilityStderr;
+      }
+    }
   });
 
   it("clears stale lifecycle compatibility metadata in memory and on disk", async () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -144,6 +144,18 @@ describe("check (single session)", () => {
     });
   });
 
+  it("does not mirror lifecycle transition observability logs to stderr during polling", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "spawning" }),
+    });
+
+    await lm.check("app-1");
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+    stderrSpy.mockRestore();
+  });
+
   it("clears stale lifecycle compatibility metadata in memory and on disk", async () => {
     const session = makeSession({
       status: "working",

--- a/packages/core/src/__tests__/observability.test.ts
+++ b/packages/core/src/__tests__/observability.test.ts
@@ -104,46 +104,58 @@ describe("observability snapshot", () => {
   });
 
   it("writes observability diagnostics to audit files without mirroring to stderr by default", () => {
+    const originalObservabilityStderr = process.env["AO_OBSERVABILITY_STDERR"];
+    delete process.env["AO_OBSERVABILITY_STDERR"];
+
     const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
-    const observer = createProjectObserver(config, "session-manager");
 
-    observer.recordOperation({
-      metric: "spawn",
-      operation: "session.spawn",
-      outcome: "success",
-      correlationId: "corr-1",
-      projectId: "my-app",
-      sessionId: "app-1",
-      level: "info",
-    });
+    try {
+      const observer = createProjectObserver(config, "session-manager");
 
-    observer.recordDiagnostic({
-      operation: "batch_enrichment.log",
-      correlationId: "corr-2",
-      projectId: "my-app",
-      message: "GraphQL batch returned cached result",
-      level: "info",
-      data: { plugin: "github" },
-    });
+      observer.recordOperation({
+        metric: "spawn",
+        operation: "session.spawn",
+        outcome: "success",
+        correlationId: "corr-1",
+        projectId: "my-app",
+        sessionId: "app-1",
+        level: "warn",
+      });
 
-    observer.setHealth({
-      surface: "lifecycle.worker",
-      status: "ok",
-      projectId: "my-app",
-      correlationId: "corr-3",
-      details: { projectId: "my-app" },
-    });
+      observer.recordDiagnostic?.({
+        operation: "batch_enrichment.log",
+        correlationId: "corr-2",
+        projectId: "my-app",
+        message: "GraphQL batch returned cached result",
+        level: "warn",
+        data: { plugin: "github" },
+      });
 
-    const auditDir = join(getObservabilityBaseDir(config.configPath), "processes");
-    const auditFiles = readdirSync(auditDir).filter((fileName) => fileName.endsWith(".ndjson"));
-    expect(auditFiles.length).toBeGreaterThan(0);
+      observer.setHealth({
+        surface: "lifecycle.worker",
+        status: "warn",
+        projectId: "my-app",
+        correlationId: "corr-3",
+        details: { projectId: "my-app" },
+      });
 
-    const auditLog = readFileSync(join(auditDir, auditFiles[0]!), "utf-8");
-    expect(auditLog).toContain('"operation":"session.spawn"');
-    expect(auditLog).toContain('"operation":"batch_enrichment.log"');
-    expect(auditLog).toContain('"message":"GraphQL batch returned cached result"');
-    expect(stderrSpy).not.toHaveBeenCalled();
+      const auditDir = join(getObservabilityBaseDir(config.configPath), "processes");
+      const auditFiles = readdirSync(auditDir).filter((fileName) => fileName.endsWith(".ndjson"));
+      expect(auditFiles.length).toBeGreaterThan(0);
 
-    stderrSpy.mockRestore();
+      const auditLog = readFileSync(join(auditDir, auditFiles[0]!), "utf-8");
+      expect(auditLog).toContain('"operation":"session.spawn"');
+      expect(auditLog).toContain('"operation":"batch_enrichment.log"');
+      expect(auditLog).toContain('"message":"GraphQL batch returned cached result"');
+      expect(auditLog).toContain('"timestamp"');
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      stderrSpy.mockRestore();
+      if (originalObservabilityStderr === undefined) {
+        delete process.env["AO_OBSERVABILITY_STDERR"];
+      } else {
+        process.env["AO_OBSERVABILITY_STDERR"] = originalObservabilityStderr;
+      }
+    }
   });
 });

--- a/packages/core/src/__tests__/observability.test.ts
+++ b/packages/core/src/__tests__/observability.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import {
   createProjectObserver,
+  getObservabilityBaseDir,
   readObservabilitySummary,
   type OrchestratorConfig,
 } from "../index.js";
@@ -100,5 +101,49 @@ describe("observability snapshot", () => {
     expect(project.recentTraces.some((trace) => trace.operation === "session.spawn")).toBe(true);
     expect(project.health["lifecycle.worker"]?.status).toBe("warn");
     expect(summary.overallStatus).toBe("warn");
+  });
+
+  it("writes observability diagnostics to audit files without mirroring to stderr by default", () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const observer = createProjectObserver(config, "session-manager");
+
+    observer.recordOperation({
+      metric: "spawn",
+      operation: "session.spawn",
+      outcome: "success",
+      correlationId: "corr-1",
+      projectId: "my-app",
+      sessionId: "app-1",
+      level: "info",
+    });
+
+    observer.recordDiagnostic({
+      operation: "batch_enrichment.log",
+      correlationId: "corr-2",
+      projectId: "my-app",
+      message: "GraphQL batch returned cached result",
+      level: "info",
+      data: { plugin: "github" },
+    });
+
+    observer.setHealth({
+      surface: "lifecycle.worker",
+      status: "ok",
+      projectId: "my-app",
+      correlationId: "corr-3",
+      details: { projectId: "my-app" },
+    });
+
+    const auditDir = join(getObservabilityBaseDir(config.configPath), "processes");
+    const auditFiles = readdirSync(auditDir).filter((fileName) => fileName.endsWith(".ndjson"));
+    expect(auditFiles.length).toBeGreaterThan(0);
+
+    const auditLog = readFileSync(join(auditDir, auditFiles[0]!), "utf-8");
+    expect(auditLog).toContain('"operation":"session.spawn"');
+    expect(auditLog).toContain('"operation":"batch_enrichment.log"');
+    expect(auditLog).toContain('"message":"GraphQL batch returned cached result"');
+    expect(stderrSpy).not.toHaveBeenCalled();
+
+    stderrSpy.mockRestore();
   });
 });

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -386,7 +386,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
               });
             },
             log(level, message) {
-              observer?.recordDiagnostic({
+              observer?.recordDiagnostic?.({
                 operation: "batch_enrichment.log",
                 correlationId: createCorrelationId("graphql-batch"),
                 projectId: scopedProjectId,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -386,16 +386,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
               });
             },
             log(level, message) {
-              // Log to stderr for observability
-              process.stderr.write(
-                JSON.stringify({
-                  source: "ao-graphql-batch",
-                  level,
-                  message,
+              observer?.recordDiagnostic({
+                operation: "batch_enrichment.log",
+                correlationId: createCorrelationId("graphql-batch"),
+                projectId: scopedProjectId,
+                message,
+                level,
+                data: {
                   plugin: pluginKey,
-                  timestamp: new Date().toISOString(),
-                }) + "\n"
-              );
+                  source: "ao-graphql-batch",
+                },
+              });
             },
           },
         );

--- a/packages/core/src/observability.ts
+++ b/packages/core/src/observability.ts
@@ -1,10 +1,12 @@
 import {
   appendFileSync,
+  statSync,
   mkdirSync,
   existsSync,
   readFileSync,
   readdirSync,
   renameSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -130,7 +132,7 @@ export interface SetHealthInput {
 export interface ProjectObserver {
   readonly component: string;
   recordOperation(input: RecordOperationInput): void;
-  recordDiagnostic(input: {
+  recordDiagnostic?(input: {
     operation: string;
     correlationId: string;
     projectId?: string;
@@ -145,6 +147,7 @@ export interface ProjectObserver {
 
 const TRACE_LIMIT = 80;
 const SESSION_LIMIT = 200;
+const AUDIT_LOG_MAX_BYTES = 5 * 1024 * 1024;
 const LEVEL_ORDER: Record<ObservabilityLevel, number> = {
   debug: 10,
   info: 20,
@@ -209,7 +212,30 @@ function appendAuditLog(
   level: ObservabilityLevel,
 ): void {
   const filePath = getAuditLogPath(config, component);
+  const rotatedPath = `${filePath}.1`;
+  if (existsSync(filePath)) {
+    const currentSize = statSync(filePath).size;
+    if (currentSize >= AUDIT_LOG_MAX_BYTES) {
+      if (existsSync(rotatedPath)) {
+        unlinkSync(rotatedPath);
+      }
+      renameSync(filePath, rotatedPath);
+    }
+  }
   appendFileSync(filePath, `${JSON.stringify({ ...payload, level })}\n`, "utf-8");
+}
+
+function appendObservabilityFailure(
+  config: OrchestratorConfig,
+  component: string,
+  payload: Record<string, unknown>,
+): void {
+  try {
+    const filePath = join(getObservabilityDir(config), "observability-errors.ndjson");
+    appendFileSync(filePath, `${JSON.stringify(payload)}\n`, "utf-8");
+  } catch {
+    // Best effort only — avoid recursive observability failures.
+  }
 }
 
 function readSnapshot(filePath: string, component: string): ProcessObservabilitySnapshot {
@@ -344,21 +370,21 @@ export function createProjectObserver(
       const snapshot = readSnapshot(filePath, normalizedComponent);
       updater(snapshot);
       writeSnapshot(config, snapshot);
-      if (logEntry) {
+      if (logEntry && shouldLog(logEntry.level)) {
         appendAuditLog(config, normalizedComponent, logEntry.payload, logEntry.level);
         emitStructuredLog(logEntry.payload, logEntry.level);
       }
     } catch (error) {
-      emitStructuredLog(
-        {
-          source: "ao-observability",
-          component: normalizedComponent,
-          outcome: "failure",
-          operation: "observability.write",
-          reason: error instanceof Error ? error.message : String(error),
-        },
-        "error",
-      );
+      const payload = {
+        source: "ao-observability",
+        timestamp: nowIso(),
+        component: normalizedComponent,
+        outcome: "failure",
+        operation: "observability.write",
+        reason: error instanceof Error ? error.message : String(error),
+      };
+      appendObservabilityFailure(config, normalizedComponent, payload);
+      emitStructuredLog(payload, "error");
     }
   }
 
@@ -428,6 +454,7 @@ export function createProjectObserver(
           level,
           payload: {
             source: "ao-observability",
+            timestamp,
             component: normalizedComponent,
             metric: input.metric,
             operation,
@@ -489,6 +516,7 @@ export function createProjectObserver(
           level,
           payload: {
             source: "ao-observability",
+            timestamp,
             component: normalizedComponent,
             operation: input.operation,
             correlationId: input.correlationId,
@@ -523,6 +551,7 @@ export function createProjectObserver(
           level: input.status === "error" ? "error" : input.status === "warn" ? "warn" : "info",
           payload: {
             source: "ao-observability",
+            timestamp: updatedAt,
             component: normalizedComponent,
             surface: input.surface,
             status: input.status,

--- a/packages/core/src/observability.ts
+++ b/packages/core/src/observability.ts
@@ -1,4 +1,5 @@
 import {
+  appendFileSync,
   mkdirSync,
   existsSync,
   readFileSync,
@@ -129,6 +130,16 @@ export interface SetHealthInput {
 export interface ProjectObserver {
   readonly component: string;
   recordOperation(input: RecordOperationInput): void;
+  recordDiagnostic(input: {
+    operation: string;
+    correlationId: string;
+    projectId?: string;
+    sessionId?: SessionId;
+    message: string;
+    level?: ObservabilityLevel;
+    path?: string;
+    data?: Record<string, unknown>;
+  }): void;
   setHealth(input: SetHealthInput): void;
 }
 
@@ -161,8 +172,13 @@ function shouldLog(level: ObservabilityLevel): boolean {
   return LEVEL_ORDER[level] >= LEVEL_ORDER[getLogLevel()];
 }
 
+function shouldMirrorStructuredLogsToStderr(): boolean {
+  const raw = process.env["AO_OBSERVABILITY_STDERR"]?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
 function emitStructuredLog(entry: Record<string, unknown>, level: ObservabilityLevel): void {
-  if (!shouldLog(level)) return;
+  if (!shouldMirrorStructuredLogsToStderr() || !shouldLog(level)) return;
   process.stderr.write(`${JSON.stringify({ ...entry, level })}\n`);
 }
 
@@ -180,6 +196,20 @@ function getObservabilityDir(config: OrchestratorConfig): string {
 
 function getSnapshotPath(config: OrchestratorConfig, component: string): string {
   return join(getObservabilityDir(config), `${sanitizeComponent(component)}-${process.pid}.json`);
+}
+
+function getAuditLogPath(config: OrchestratorConfig, component: string): string {
+  return join(getObservabilityDir(config), `${sanitizeComponent(component)}-${process.pid}.ndjson`);
+}
+
+function appendAuditLog(
+  config: OrchestratorConfig,
+  component: string,
+  payload: Record<string, unknown>,
+  level: ObservabilityLevel,
+): void {
+  const filePath = getAuditLogPath(config, component);
+  appendFileSync(filePath, `${JSON.stringify({ ...payload, level })}\n`, "utf-8");
 }
 
 function readSnapshot(filePath: string, component: string): ProcessObservabilitySnapshot {
@@ -315,6 +345,7 @@ export function createProjectObserver(
       updater(snapshot);
       writeSnapshot(config, snapshot);
       if (logEntry) {
+        appendAuditLog(config, normalizedComponent, logEntry.payload, logEntry.level);
         emitStructuredLog(logEntry.payload, logEntry.level);
       }
     } catch (error) {
@@ -408,6 +439,66 @@ export function createProjectObserver(
             durationMs: input.durationMs,
             path: input.path,
             data: input.data,
+          },
+        },
+      );
+    },
+
+    recordDiagnostic(input) {
+      const timestamp = nowIso();
+      const level = input.level ?? "info";
+      const trace: ObservabilityTraceRecord = {
+        id: randomUUID(),
+        timestamp,
+        component: normalizedComponent,
+        operation: input.operation,
+        outcome: "success",
+        correlationId: input.correlationId,
+        projectId: input.projectId,
+        sessionId: input.sessionId,
+        path: input.path,
+        data: {
+          message: input.message,
+          ...input.data,
+        },
+      };
+
+      updateSnapshot(
+        (snapshot) => {
+          snapshot.traces = [trace, ...snapshot.traces]
+            .sort((a, b) => compareIsoDesc(a.timestamp, b.timestamp))
+            .slice(0, TRACE_LIMIT);
+
+          if (input.sessionId) {
+            snapshot.sessions[input.sessionId] = {
+              sessionId: input.sessionId,
+              projectId: input.projectId,
+              correlationId: input.correlationId,
+              operation: input.operation,
+              outcome: "success",
+              updatedAt: timestamp,
+            };
+
+            const sessionEntries = Object.entries(snapshot.sessions).sort(([, a], [, b]) =>
+              compareIsoDesc(a.updatedAt, b.updatedAt),
+            );
+            snapshot.sessions = Object.fromEntries(sessionEntries.slice(0, SESSION_LIMIT));
+          }
+        },
+        {
+          level,
+          payload: {
+            source: "ao-observability",
+            component: normalizedComponent,
+            operation: input.operation,
+            correlationId: input.correlationId,
+            projectId: input.projectId,
+            sessionId: input.sessionId,
+            path: input.path,
+            data: {
+              message: input.message,
+              ...input.data,
+            },
           },
         },
       );

--- a/packages/core/src/observability.ts
+++ b/packages/core/src/observability.ts
@@ -227,7 +227,6 @@ function appendAuditLog(
 
 function appendObservabilityFailure(
   config: OrchestratorConfig,
-  component: string,
   payload: Record<string, unknown>,
 ): void {
   try {
@@ -383,7 +382,7 @@ export function createProjectObserver(
         operation: "observability.write",
         reason: error instanceof Error ? error.message : String(error),
       };
-      appendObservabilityFailure(config, normalizedComponent, payload);
+      appendObservabilityFailure(config, payload);
       emitStructuredLog(payload, "error");
     }
   }


### PR DESCRIPTION
## Summary
- move lifecycle observability records off terminal-visible stderr and into per-process audit files
- route GraphQL batch lifecycle diagnostics through the observability audit channel instead of direct stderr writes
- add regression coverage that lifecycle polling and observability writes stay out of terminal-visible output

## Testing
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm test

Closes #121