### PR TITLE
Split orchestrator detail, add report audit trail, and stop respond/working oscillation

### DIFF
--- a/.changeset/session-ui-audit-oscillation.md
+++ b/.changeset/session-ui-audit-oscillation.md
@@ -1,0 +1,7 @@
+---
+"@aoagents/ao-core": patch
+"@aoagents/ao-cli": patch
+"@aoagents/ao-web": patch
+---
+
+Split orchestrator-only detail views from worker detail views, add an auditable history for `ao acknowledge` / `ao report`, and preserve canonical `needs_input` / `stuck` lifecycle states when polling only has weak or unchanged evidence.

--- a/changelog/session-ui-audit-oscillation.md
+++ b/changelog/session-ui-audit-oscillation.md
@@ -1,0 +1,9 @@
+# Session UI, Report Audit, and Lifecycle Stability
+
+## What Changed
+
+- Split worker session detail from orchestrator detail so orchestrator pages no longer show worker-only PR and lifecycle detail panels.
+- Added a persistent audit trail for `ao acknowledge` and `ao report`, including actor, command, note, acceptance/rejection, and before/after lifecycle state.
+- Exposed that audit trail on worker session detail pages in the dashboard.
+- Fixed lifecycle fallback so `needs_input` and `stuck` do not bounce back to `working` when the poll cycle only has weak or unchanged evidence.
+- Removed the web app's runtime dependency on Google Fonts during `next build` by using local CSS font variables instead of `next/font/google`.

--- a/changelog/session-ui-audit-oscillation.md
+++ b/changelog/session-ui-audit-oscillation.md
@@ -1,9 +1,0 @@
-# Session UI, Report Audit, and Lifecycle Stability
-
-## What Changed
-
-- Split worker session detail from orchestrator detail so orchestrator pages no longer show worker-only PR and lifecycle detail panels.
-- Added a persistent audit trail for `ao acknowledge` and `ao report`, including actor, command, note, acceptance/rejection, and before/after lifecycle state.
-- Exposed that audit trail on worker session detail pages in the dashboard.
-- Fixed lifecycle fallback so `needs_input` and `stuck` do not bounce back to `working` when the poll cycle only has weak or unchanged evidence.
-- Removed the web app's runtime dependency on Google Fonts during `next build` by using local CSS font variables instead of `next/font/google`.

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -43,6 +43,7 @@ async function writeReport(
   sessionName: string,
   state: AgentReportedState,
   note: string | undefined,
+  source: "acknowledge" | "report",
 ): Promise<void> {
   const config = loadConfig();
   const sm = await getSessionManager(config);
@@ -58,7 +59,12 @@ async function writeReport(
   }
   const sessionsDir = getSessionsDir(config.configPath, project.path);
   try {
-    const result = applyAgentReport(sessionsDir, sessionName, { state, note });
+    const result = applyAgentReport(sessionsDir, sessionName, {
+      state,
+      note,
+      source,
+      actor: process.env["USER"] ?? process.env["LOGNAME"] ?? process.env["USERNAME"],
+    });
     const label =
       result.previousState === result.nextState
         ? chalk.dim(`(${result.nextState})`)
@@ -86,7 +92,7 @@ export function registerAcknowledge(program: Command): void {
     .option("--note <text>", "Optional brief note to include with the acknowledgment")
     .action(async (session: string | undefined, opts: { note?: string }) => {
       const sessionId = resolveSessionId(session);
-      await writeReport(sessionId, "started", opts.note);
+      await writeReport(sessionId, "started", opts.note, "acknowledge");
     });
 }
 
@@ -111,6 +117,6 @@ export function registerReport(program: Command): void {
         process.exit(1);
       }
       const sessionId = resolveSessionId(opts.session);
-      await writeReport(sessionId, canonical, opts.note);
+      await writeReport(sessionId, canonical, opts.note, "report");
     });
 }

--- a/packages/core/src/__tests__/agent-report.test.ts
+++ b/packages/core/src/__tests__/agent-report.test.ts
@@ -12,6 +12,7 @@ import {
   mapAgentReportToLifecycle,
   normalizeAgentReportedState,
   readAgentReport,
+  readAgentReportAuditTrail,
   validateAgentReportTransition,
 } from "../agent-report.js";
 import { writeMetadata, writeCanonicalLifecycle, readMetadataRaw } from "../metadata.js";
@@ -197,6 +198,23 @@ describe("applyAgentReport", () => {
     expect(meta![AGENT_REPORT_METADATA_KEYS.STATE]).toBe("needs_input");
     expect(meta![AGENT_REPORT_METADATA_KEYS.AT]).toBe(now.toISOString());
     expect(meta![AGENT_REPORT_METADATA_KEYS.NOTE]).toBe("please clarify the spec");
+    const audit = readAgentReportAuditTrail(dataDir, sessionId);
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({
+      accepted: true,
+      source: "report",
+      actor: "unknown",
+      reportState: "needs_input",
+      note: "please clarify the spec",
+      before: {
+        legacyStatus: "working",
+        sessionState: "working",
+      },
+      after: {
+        legacyStatus: "needs_input",
+        sessionState: "needs_input",
+      },
+    });
   });
 
   it("sets startedAt on the first working transition", () => {
@@ -244,6 +262,18 @@ describe("applyAgentReport", () => {
         now: new Date(),
       }),
     ).toThrow(/terminated/);
+    const audit = readAgentReportAuditTrail(dataDir, sessionId);
+    expect(audit[0]).toMatchObject({
+      accepted: false,
+      reportState: "working",
+      rejectionReason: "session is terminated",
+      before: {
+        sessionState: "terminated",
+      },
+      after: {
+        sessionState: "terminated",
+      },
+    });
   });
 
   it("throws when the session does not exist", () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -717,6 +717,27 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("needs_input");
   });
 
+  it("preserves canonical needs_input when persisted status is stale working", async () => {
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue(null);
+    vi.mocked(plugins.runtime.getOutput).mockResolvedValue("");
+
+    const session = makeSession({ status: "working" });
+    session.lifecycle.session.state = "needs_input";
+    session.lifecycle.session.reason = "awaiting_user_input";
+
+    const lm = setupCheck("app-1", {
+      session,
+      metaOverrides: {
+        status: "working",
+      },
+    });
+
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("needs_input");
+    const meta = readMetadataRaw(env.sessionsDir, "app-1");
+    expect(meta?.["status"]).toBe("needs_input");
+  });
+
   it("detects PR states from SCM", async () => {
     const mockSCM = createMockSCM({ getCISummary: vi.fn().mockResolvedValue("failing") });
     const registry = createMockRegistry({

--- a/packages/core/src/agent-report.ts
+++ b/packages/core/src/agent-report.ts
@@ -16,6 +16,8 @@
  *   6. Default to working
  */
 
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import type {
   CanonicalSessionLifecycle,
   CanonicalSessionReason,
@@ -24,7 +26,8 @@ import type {
   SessionStatus,
 } from "./types.js";
 import { updateCanonicalLifecycle, updateMetadata, readMetadataRaw } from "./metadata.js";
-import { deriveLegacyStatus } from "./lifecycle-state.js";
+import { deriveLegacyStatus, parseCanonicalLifecycle } from "./lifecycle-state.js";
+import { validateStatus } from "./utils/validation.js";
 
 /**
  * Canonical set of states an agent can self-declare.
@@ -59,6 +62,29 @@ export interface AgentReport {
   timestamp: string;
   /** Optional free-text note the agent may include (e.g. brief status line). */
   note?: string;
+  /** Local actor identity when available (e.g. $USER). */
+  actor?: string;
+  /** Which CLI surface produced this report. */
+  source?: "acknowledge" | "report";
+}
+
+export interface AgentReportAuditSnapshot {
+  legacyStatus: SessionStatus;
+  sessionState: CanonicalSessionState;
+  sessionReason: CanonicalSessionReason;
+  lastTransitionAt: string | null;
+}
+
+export interface AgentReportAuditEntry {
+  timestamp: string;
+  actor: string;
+  source: "acknowledge" | "report";
+  reportState: AgentReportedState;
+  note?: string;
+  accepted: boolean;
+  rejectionReason?: string;
+  before: AgentReportAuditSnapshot;
+  after: AgentReportAuditSnapshot;
 }
 
 /** Metadata keys written by `applyAgentReport`. Keep in sync with CLI parsing. */
@@ -171,6 +197,8 @@ export function validateAgentReportTransition(
 export interface ApplyAgentReportInput {
   state: AgentReportedState;
   note?: string;
+  actor?: string;
+  source?: "acknowledge" | "report";
   /** Override the current clock — used by tests. */
   now?: Date;
 }
@@ -180,6 +208,78 @@ export interface ApplyAgentReportResult {
   legacyStatus: SessionStatus;
   previousState: CanonicalSessionState;
   nextState: CanonicalSessionState;
+  auditEntry: AgentReportAuditEntry;
+}
+
+function buildAuditDir(dataDir: string): string {
+  return join(dataDir, ".agent-report-audit");
+}
+
+function buildAuditFilePath(dataDir: string, sessionId: SessionId): string {
+  return join(buildAuditDir(dataDir), `${sessionId}.ndjson`);
+}
+
+function normalizeActor(actor: string | undefined): string {
+  const trimmed = actor?.trim();
+  if (trimmed) return trimmed;
+  return "unknown";
+}
+
+function buildAuditSnapshot(
+  lifecycle: CanonicalSessionLifecycle,
+  legacyStatus: SessionStatus,
+): AgentReportAuditSnapshot {
+  return {
+    legacyStatus,
+    sessionState: lifecycle.session.state,
+    sessionReason: lifecycle.session.reason,
+    lastTransitionAt: lifecycle.session.lastTransitionAt,
+  };
+}
+
+function appendAgentReportAuditEntry(
+  dataDir: string,
+  sessionId: SessionId,
+  entry: AgentReportAuditEntry,
+): void {
+  const auditDir = buildAuditDir(dataDir);
+  mkdirSync(auditDir, { recursive: true });
+  appendFileSync(buildAuditFilePath(dataDir, sessionId), `${JSON.stringify(entry)}\n`, "utf8");
+}
+
+export function readAgentReportAuditTrail(
+  dataDir: string,
+  sessionId: SessionId,
+): AgentReportAuditEntry[] {
+  const auditFilePath = buildAuditFilePath(dataDir, sessionId);
+  if (!existsSync(auditFilePath)) {
+    return [];
+  }
+
+  return readFileSync(auditFilePath, "utf8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .flatMap((line) => {
+      try {
+        const parsed = JSON.parse(line) as Partial<AgentReportAuditEntry>;
+        if (
+          typeof parsed.timestamp !== "string" ||
+          typeof parsed.actor !== "string" ||
+          (parsed.source !== "acknowledge" && parsed.source !== "report") ||
+          !AGENT_REPORTED_STATES.includes(parsed.reportState as AgentReportedState) ||
+          typeof parsed.accepted !== "boolean" ||
+          !parsed.before ||
+          !parsed.after
+        ) {
+          return [];
+        }
+        return [parsed as AgentReportAuditEntry];
+      } catch {
+        return [];
+      }
+    })
+    .reverse();
 }
 
 /**
@@ -200,6 +300,31 @@ export function applyAgentReport(
   }
 
   const now = (input.now ?? new Date()).toISOString();
+  const source = input.source ?? "report";
+  const actor = normalizeActor(input.actor);
+  const trimmedNote = input.note?.trim() || undefined;
+  const currentLifecycle = parseCanonicalLifecycle(raw, {
+    sessionId,
+    status: validateStatus(raw["status"]),
+  });
+  const previousLegacyStatus = validateStatus(raw["status"]);
+  const before = buildAuditSnapshot(currentLifecycle, previousLegacyStatus);
+  const validation = validateAgentReportTransition(currentLifecycle, input.state);
+  if (!validation.ok) {
+    appendAgentReportAuditEntry(dataDir, sessionId, {
+      timestamp: now,
+      actor,
+      source,
+      reportState: input.state,
+      note: trimmedNote,
+      accepted: false,
+      rejectionReason: validation.reason ?? "transition rejected",
+      before,
+      after: before,
+    });
+    throw new Error(validation.reason ?? "transition rejected");
+  }
+
   let previousState: CanonicalSessionState | null = null;
   let nextState: CanonicalSessionState | null = null;
   let legacyStatus: SessionStatus | null = null;
@@ -208,10 +333,6 @@ export function applyAgentReport(
     dataDir,
     sessionId,
     (current) => {
-      const validation = validateAgentReportTransition(current, input.state);
-      if (!validation.ok) {
-        throw new Error(validation.reason ?? "transition rejected");
-      }
       const mapped = mapAgentReportToLifecycle(input.state);
       previousState = current.session.state;
       nextState = mapped.sessionState;
@@ -221,7 +342,7 @@ export function applyAgentReport(
       if (mapped.sessionState === "working" && current.session.startedAt === null) {
         current.session.startedAt = now;
       }
-      legacyStatus = deriveLegacyStatus(current);
+      legacyStatus = deriveLegacyStatus(current, previousLegacyStatus);
       return current;
     },
   );
@@ -235,19 +356,39 @@ export function applyAgentReport(
     [AGENT_REPORT_METADATA_KEYS.STATE]: input.state,
     [AGENT_REPORT_METADATA_KEYS.AT]: now,
   };
-  if (input.note && input.note.trim()) {
-    metadataUpdates[AGENT_REPORT_METADATA_KEYS.NOTE] = input.note.trim();
+  if (trimmedNote) {
+    metadataUpdates[AGENT_REPORT_METADATA_KEYS.NOTE] = trimmedNote;
   } else {
     // Clear stale notes from previous reports so they don't mislead humans.
     metadataUpdates[AGENT_REPORT_METADATA_KEYS.NOTE] = "";
   }
   updateMetadata(dataDir, sessionId, metadataUpdates);
 
+  const after = buildAuditSnapshot(nextLifecycle, legacyStatus);
+  const auditEntry: AgentReportAuditEntry = {
+    timestamp: now,
+    actor,
+    source,
+    reportState: input.state,
+    note: trimmedNote,
+    accepted: true,
+    before,
+    after,
+  };
+  appendAgentReportAuditEntry(dataDir, sessionId, auditEntry);
+
   return {
-    report: { state: input.state, timestamp: now, note: input.note?.trim() || undefined },
+    report: {
+      state: input.state,
+      timestamp: now,
+      note: trimmedNote,
+      actor,
+      source,
+    },
     legacyStatus,
     previousState,
     nextState,
+    auditEntry,
   };
 }
 

--- a/packages/core/src/agent-report.ts
+++ b/packages/core/src/agent-report.ts
@@ -17,6 +17,7 @@
  */
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type {
   CanonicalSessionLifecycle,
@@ -26,7 +27,7 @@ import type {
   SessionStatus,
 } from "./types.js";
 import { updateCanonicalLifecycle, updateMetadata, readMetadataRaw } from "./metadata.js";
-import { deriveLegacyStatus, parseCanonicalLifecycle } from "./lifecycle-state.js";
+import { deriveLegacyStatus } from "./lifecycle-state.js";
 import { validateStatus } from "./utils/validation.js";
 
 /**
@@ -215,7 +216,16 @@ function buildAuditDir(dataDir: string): string {
   return join(dataDir, ".agent-report-audit");
 }
 
+const VALID_AUDIT_SESSION_ID = /^[a-zA-Z0-9_-]+$/;
+
+function validateAuditSessionId(sessionId: SessionId): void {
+  if (!VALID_AUDIT_SESSION_ID.test(sessionId)) {
+    throw new Error(`Invalid session ID: ${sessionId}`);
+  }
+}
+
 function buildAuditFilePath(dataDir: string, sessionId: SessionId): string {
+  validateAuditSessionId(sessionId);
   return join(buildAuditDir(dataDir), `${sessionId}.ndjson`);
 }
 
@@ -256,7 +266,23 @@ export function readAgentReportAuditTrail(
     return [];
   }
 
-  return readFileSync(auditFilePath, "utf8")
+  return parseAgentReportAuditTrail(readFileSync(auditFilePath, "utf8"));
+}
+
+export async function readAgentReportAuditTrailAsync(
+  dataDir: string,
+  sessionId: SessionId,
+): Promise<AgentReportAuditEntry[]> {
+  const auditFilePath = buildAuditFilePath(dataDir, sessionId);
+  if (!existsSync(auditFilePath)) {
+    return [];
+  }
+
+  return parseAgentReportAuditTrail(await readFile(auditFilePath, "utf8"));
+}
+
+function parseAgentReportAuditTrail(content: string): AgentReportAuditEntry[] {
+  return content
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
@@ -299,40 +325,38 @@ export function applyAgentReport(
     throw new Error(`Session not found: ${sessionId}`);
   }
 
+  validateAuditSessionId(sessionId);
   const now = (input.now ?? new Date()).toISOString();
   const source = input.source ?? "report";
   const actor = normalizeActor(input.actor);
   const trimmedNote = input.note?.trim() || undefined;
-  const currentLifecycle = parseCanonicalLifecycle(raw, {
-    sessionId,
-    status: validateStatus(raw["status"]),
-  });
-  const previousLegacyStatus = validateStatus(raw["status"]);
-  const before = buildAuditSnapshot(currentLifecycle, previousLegacyStatus);
-  const validation = validateAgentReportTransition(currentLifecycle, input.state);
-  if (!validation.ok) {
-    appendAgentReportAuditEntry(dataDir, sessionId, {
-      timestamp: now,
-      actor,
-      source,
-      reportState: input.state,
-      note: trimmedNote,
-      accepted: false,
-      rejectionReason: validation.reason ?? "transition rejected",
-      before,
-      after: before,
-    });
-    throw new Error(validation.reason ?? "transition rejected");
-  }
-
+  let before: AgentReportAuditSnapshot | null = null;
   let previousState: CanonicalSessionState | null = null;
   let nextState: CanonicalSessionState | null = null;
   let legacyStatus: SessionStatus | null = null;
+  let previousLegacyStatus: SessionStatus | null = null;
 
   const nextLifecycle = updateCanonicalLifecycle(
     dataDir,
     sessionId,
     (current) => {
+      previousLegacyStatus = deriveLegacyStatus(current, validateStatus(raw["status"]));
+      before = buildAuditSnapshot(current, previousLegacyStatus);
+      const validation = validateAgentReportTransition(current, input.state);
+      if (!validation.ok) {
+        appendAgentReportAuditEntry(dataDir, sessionId, {
+          timestamp: now,
+          actor,
+          source,
+          reportState: input.state,
+          note: trimmedNote,
+          accepted: false,
+          rejectionReason: validation.reason ?? "transition rejected",
+          before,
+          after: before,
+        });
+        throw new Error(validation.reason ?? "transition rejected");
+      }
       const mapped = mapAgentReportToLifecycle(input.state);
       previousState = current.session.state;
       nextState = mapped.sessionState;
@@ -347,7 +371,7 @@ export function applyAgentReport(
     },
   );
 
-  if (!nextLifecycle || !previousState || !nextState || !legacyStatus) {
+  if (!nextLifecycle || !before || !previousState || !nextState || !legacyStatus) {
     throw new Error(`Failed to apply agent report for session ${sessionId}`);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,7 @@ export {
   AGENT_REPORT_FRESHNESS_MS,
   applyAgentReport,
   readAgentReport,
+  readAgentReportAuditTrail,
   isAgentReportFresh,
   mapAgentReportToLifecycle,
   normalizeAgentReportedState,
@@ -55,6 +56,8 @@ export {
 } from "./agent-report.js";
 export type {
   AgentReport,
+  AgentReportAuditEntry,
+  AgentReportAuditSnapshot,
   AgentReportedState,
   ApplyAgentReportInput,
   ApplyAgentReportResult,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,7 @@ export {
   applyAgentReport,
   readAgentReport,
   readAgentReportAuditTrail,
+  readAgentReportAuditTrailAsync,
   isAgentReportFresh,
   mapAgentReportToLifecycle,
   normalizeAgentReportedState,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -904,9 +904,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       isWeakActivityEvidence(activitySignal) &&
       (session.status === SESSION_STATUS.DETECTING ||
         session.status === SESSION_STATUS.STUCK ||
-        session.status === SESSION_STATUS.NEEDS_INPUT)
+        session.status === SESSION_STATUS.NEEDS_INPUT ||
+        lifecycle.session.state === "detecting" ||
+        lifecycle.session.state === "stuck" ||
+        lifecycle.session.state === "needs_input")
     ) {
-      return commit(session.status, activityEvidence, 0);
+      return commit(deriveLegacyStatus(lifecycle, session.status), activityEvidence, 0);
     }
 
     if (

--- a/packages/web/src/__tests__/helpers.ts
+++ b/packages/web/src/__tests__/helpers.ts
@@ -210,6 +210,7 @@ export function makeSession(overrides: Partial<DashboardSession> = {}): Dashboar
     lastActivityAt: new Date().toISOString(),
     pr: null,
     metadata: {},
+    agentReportAudit: [],
   };
 
   const session = {

--- a/packages/web/src/app/api/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest } from "next/server";
+import { getSessionsDir, readAgentReportAuditTrail } from "@aoagents/ao-core";
 import { getServices, getSCM } from "@/lib/services";
 import {
   sessionToDashboard,
@@ -21,13 +22,17 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     }
 
     const dashboardSession = sessionToDashboard(coreSession);
+    const project = resolveProject(coreSession, config.projects);
+    if (project) {
+      const sessionsDir = getSessionsDir(config.configPath, project.path);
+      dashboardSession.agentReportAudit = readAgentReportAuditTrail(sessionsDir, coreSession.id);
+    }
 
     // Enrich metadata (issue labels, agent summaries, issue titles)
     await enrichSessionsMetadata([coreSession], [dashboardSession], config, registry);
 
     // Enrich PR — serve cache immediately, refresh in background if stale
     if (coreSession.pr) {
-      const project = resolveProject(coreSession, config.projects);
       const scm = getSCM(registry, project);
       if (scm) {
         const cached = await enrichSessionPR(dashboardSession, scm, coreSession.pr, {

--- a/packages/web/src/app/api/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from "next/server";
-import { getSessionsDir, readAgentReportAuditTrail } from "@aoagents/ao-core";
+import { getSessionsDir, readAgentReportAuditTrailAsync } from "@aoagents/ao-core";
 import { getServices, getSCM } from "@/lib/services";
 import {
   sessionToDashboard,
@@ -25,7 +25,10 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     const project = resolveProject(coreSession, config.projects);
     if (project) {
       const sessionsDir = getSessionsDir(config.configPath, project.path);
-      dashboardSession.agentReportAudit = readAgentReportAuditTrail(sessionsDir, coreSession.id);
+      dashboardSession.agentReportAudit = await readAgentReportAuditTrailAsync(
+        sessionsDir,
+        coreSession.id,
+      );
     }
 
     // Enrich metadata (issue labels, agent summaries, issue titles)

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,22 +1,15 @@
+import type { CSSProperties, ReactNode } from "react";
 import type { Metadata, Viewport } from "next";
-import { Geist, JetBrains_Mono } from "next/font/google";
 import { getProjectName } from "@/lib/project-name";
 import { ServiceWorkerRegistrar } from "@/components/ServiceWorkerRegistrar";
 import { Providers } from "@/app/providers";
 import "./globals.css";
 
-const geistSans = Geist({
-  subsets: ["latin"],
-  variable: "--font-geist-sans",
-  display: "swap",
-});
-
-const jetbrainsMono = JetBrains_Mono({
-  subsets: ["latin"],
-  variable: "--font-jetbrains-mono",
-  display: "swap",
-  weight: ["400", "500"],
-});
+const rootFontVariables = {
+  "--font-geist-sans": '"SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  "--font-jetbrains-mono":
+    '"SF Mono", "JetBrains Mono", "Menlo", "Consolas", "Liberation Mono", monospace',
+} as CSSProperties;
 
 export const viewport: Viewport = {
   width: "device-width",
@@ -44,9 +37,14 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={`dark ${geistSans.variable} ${jetbrainsMono.variable}`} suppressHydrationWarning>
+    <html
+      lang="en"
+      className="dark"
+      style={rootFontVariables}
+      suppressHydrationWarning
+    >
       <body className="bg-[var(--color-bg-base)] text-[var(--color-text-primary)] antialiased">
         <Providers>{children}</Providers>
         <ServiceWorkerRegistrar />

--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -45,6 +45,7 @@ function makeWorkerSession(): DashboardSession {
     lastActivityAt: new Date().toISOString(),
     pr: null,
     metadata: {},
+    agentReportAudit: [],
   };
 }
 

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useMemo, useCallback, type ReactNode } fro
 import { useSearchParams } from "next/navigation";
 import { useMediaQuery, MOBILE_BREAKPOINT } from "@/hooks/useMediaQuery";
 import {
+  type DashboardAgentReportAuditEntry,
   type DashboardSession,
   type DashboardPR,
   NON_RESTORABLE_STATUSES,
@@ -220,6 +221,78 @@ function SessionTruthPanel({ session }: { session: DashboardSession }) {
           Evidence: {evidence}
         </p>
       ) : null}
+    </section>
+  );
+}
+
+function formatAuditTimestamp(isoDate: string): string {
+  const parsed = Date.parse(isoDate);
+  if (Number.isNaN(parsed)) return isoDate;
+  return new Date(parsed).toLocaleString();
+}
+
+function SessionReportAuditPanel({
+  entries,
+}: {
+  entries: DashboardAgentReportAuditEntry[];
+}) {
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mb-4 rounded-[20px] border border-[var(--color-border-muted)] bg-[var(--color-bg-panel)] px-4 py-3">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--color-text-muted)]">
+        Agent Report Audit
+      </p>
+      <div className="mt-3 space-y-3">
+        {entries.map((entry) => (
+          <div
+            key={`${entry.timestamp}-${entry.reportState}-${entry.actor}`}
+            className="rounded-[16px] border border-[var(--color-border-muted)] bg-[var(--color-bg-base)] px-3 py-3"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                className="rounded-full px-2 py-0.5 text-[11px] font-medium"
+                style={{
+                  background: entry.accepted
+                    ? "color-mix(in srgb, var(--color-status-ready) 14%, transparent)"
+                    : "color-mix(in srgb, var(--color-status-error) 14%, transparent)",
+                  color: entry.accepted
+                    ? "var(--color-status-ready)"
+                    : "var(--color-status-error)",
+                }}
+              >
+                {entry.accepted ? "Accepted" : "Rejected"}
+              </span>
+              <span className="text-[12px] font-medium text-[var(--color-text-primary)]">
+                {entry.source === "acknowledge" ? "ao acknowledge" : `ao report ${entry.reportState}`}
+              </span>
+              <span className="text-[12px] text-[var(--color-text-secondary)]">
+                by {entry.actor}
+              </span>
+              <span className="text-[11px] text-[var(--color-text-tertiary)]">
+                {formatAuditTimestamp(entry.timestamp)}
+              </span>
+            </div>
+            <div className="mt-2 text-[12px] text-[var(--color-text-secondary)]">
+              {entry.before.legacyStatus} / {entry.before.sessionState}
+              {" -> "}
+              {entry.after.legacyStatus} / {entry.after.sessionState}
+            </div>
+            {entry.note ? (
+              <p className="mt-2 text-[12px] text-[var(--color-text-secondary)]">
+                Note: {entry.note}
+              </p>
+            ) : null}
+            {entry.rejectionReason ? (
+              <p className="mt-2 text-[12px] text-[var(--color-status-error)]">
+                Rejection: {entry.rejectionReason}
+              </p>
+            ) : null}
+          </div>
+        ))}
+      </div>
     </section>
   );
 }
@@ -559,7 +632,7 @@ export function SessionDetail({
   const startFullscreen = searchParams.get("fullscreen") === "true";
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [showTerminal, setShowTerminal] = useState(false);
-  const pr = session.pr;
+  const pr = isOrchestrator ? null : session.pr;
   const terminalEnded = isDashboardRuntimeEnded(session);
   const isRestorable =
     !isOrchestrator &&
@@ -718,7 +791,7 @@ export function SessionDetail({
                       crumbId={session.id}
                       activityLabel={activity.label}
                       activityColor={activity.color}
-                      branch={session.branch}
+                      branch={isOrchestrator ? null : session.branch}
                       pr={pr}
                       isOrchestrator={isOrchestrator}
                       crumbHref={crumbHref}
@@ -728,7 +801,7 @@ export function SessionDetail({
                     />
                   )}
 
-                  {pr ? (
+                  {!isOrchestrator && pr ? (
                     <section id="session-pr-section" className="session-detail-pr-section">
                       <SessionDetailPRCard
                         pr={pr}
@@ -739,7 +812,10 @@ export function SessionDetail({
                     </section>
                   ) : null}
 
-                  <SessionTruthPanel session={session} />
+                  {!isOrchestrator ? <SessionTruthPanel session={session} /> : null}
+                  {!isOrchestrator ? (
+                    <SessionReportAuditPanel entries={session.agentReportAudit ?? []} />
+                  ) : null}
 
                   <section className="session-detail-terminal-wrap">
                     <div id="session-terminal-section" aria-hidden="true" />

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -246,9 +246,9 @@ function SessionReportAuditPanel({
         Agent Report Audit
       </p>
       <div className="mt-3 space-y-3">
-        {entries.map((entry) => (
+        {entries.map((entry, index) => (
           <div
-            key={`${entry.timestamp}-${entry.reportState}-${entry.actor}`}
+            key={`${entry.timestamp}-${entry.reportState}-${entry.actor}-${entry.source}-${String(entry.accepted)}-${index}`}
             className="rounded-[16px] border border-[var(--color-border-muted)] bg-[var(--color-bg-base)] px-3 py-3"
           >
             <div className="flex flex-wrap items-center gap-2">

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -60,6 +60,28 @@ describe("SessionDetail desktop layout", () => {
           projectId: "my-app",
           summary: "Desktop session detail",
           branch: "feat/desktop-detail",
+          agentReportAudit: [
+            {
+              timestamp: "2025-01-01T10:00:00.000Z",
+              actor: "codex",
+              source: "report",
+              reportState: "working",
+              note: "Running final verification",
+              accepted: true,
+              before: {
+                legacyStatus: "working",
+                sessionState: "working",
+                sessionReason: "task_in_progress",
+                lastTransitionAt: "2025-01-01T09:55:00.000Z",
+              },
+              after: {
+                legacyStatus: "working",
+                sessionState: "working",
+                sessionReason: "task_in_progress",
+                lastTransitionAt: "2025-01-01T10:00:00.000Z",
+              },
+            },
+          ],
           pr: makePR({
             number: 310,
             title: "Desktop detail coverage",
@@ -125,6 +147,9 @@ describe("SessionDetail desktop layout", () => {
     expect(screen.getByText(/Unresolved Comments/i)).toBeInTheDocument();
     expect(screen.getByText("Tighten the copy")).toBeInTheDocument();
     expect(screen.getByText("The empty state text needs to be shorter.")).toBeInTheDocument();
+    expect(screen.getByText("Agent Report Audit")).toBeInTheDocument();
+    expect(screen.getByText(/ao report working/i)).toBeInTheDocument();
+    expect(screen.getByText(/by codex/i)).toBeInTheDocument();
     expect(screen.getByText("Live Terminal")).toBeInTheDocument();
   });
 
@@ -210,5 +235,7 @@ describe("SessionDetail desktop layout", () => {
 
     expect(screen.queryByRole("link", { name: "Orchestrator" })).not.toBeInTheDocument();
     expect(screen.getByText("orchestrator")).toBeInTheDocument();
+    expect(screen.queryByText("Lifecycle Truth")).not.toBeInTheDocument();
+    expect(screen.queryByText("Agent Report Audit")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -191,6 +191,7 @@ export function sessionToDashboard(session: Session): DashboardSession {
         }
       : null,
     metadata: session.metadata,
+    agentReportAudit: [],
   });
 }
 

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -91,7 +91,27 @@ export interface DashboardSession {
   lastActivityAt: string;
   pr: DashboardPR | null;
   metadata: Record<string, string>;
+  agentReportAudit?: DashboardAgentReportAuditEntry[];
   attentionLevel?: AttentionLevel;
+}
+
+export interface DashboardAgentReportAuditSnapshot {
+  legacyStatus: SessionStatus;
+  sessionState: CanonicalSessionState;
+  sessionReason: CanonicalSessionReason;
+  lastTransitionAt: string | null;
+}
+
+export interface DashboardAgentReportAuditEntry {
+  timestamp: string;
+  actor: string;
+  source: "acknowledge" | "report";
+  reportState: string;
+  note?: string;
+  accepted: boolean;
+  rejectionReason?: string;
+  before: DashboardAgentReportAuditSnapshot;
+  after: DashboardAgentReportAuditSnapshot;
 }
 
 export interface DashboardActivitySignal {

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -47,6 +47,7 @@ import {
   type CanonicalRuntimeState,
   type CanonicalRuntimeReason,
 } from "@aoagents/ao-core/types";
+import type { AgentReportedState } from "@aoagents/ao-core";
 
 // Re-export for use in client components
 export { CI_STATUS, TERMINAL_STATUSES, TERMINAL_ACTIVITIES, NON_RESTORABLE_STATUSES };
@@ -106,7 +107,7 @@ export interface DashboardAgentReportAuditEntry {
   timestamp: string;
   actor: string;
   source: "acknowledge" | "report";
-  reportState: string;
+  reportState: AgentReportedState;
   note?: string;
   accepted: boolean;
   rejectionReason?: string;


### PR DESCRIPTION
Closes #123
Closes #124
Closes #126

## Summary
- split worker session detail from orchestrator detail and remove worker-only PR/lifecycle panels from orchestrator pages
- persist an audit trail for `ao acknowledge` and `ao report`, expose it through the session API, and render it on worker detail pages
- preserve canonical `needs_input`/`stuck` when lifecycle polling only has weak or unchanged evidence, preventing respond <-> working bounce
- remove the web layout's `next/font/google` dependency so local validation does not require Google Fonts fetches

## Validation
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

## Notes
- `pnpm build` still emits a non-fatal warning from the optional `tracker-linear` plugin because `@composio/core` is not present in this environment, but the build completes successfully.