### PR TITLE
feat(lifecycle): bounded detecting state + centralized transitions + report watcher

### DIFF
--- a/.changeset/lifecycle-transitions-report-watcher.md
+++ b/.changeset/lifecycle-transitions-report-watcher.md
@@ -1,0 +1,14 @@
+---
+"@aoagents/ao-core": minor
+---
+
+Add centralized lifecycle transitions and report watcher for agent monitoring.
+
+- **Lifecycle transitions (#137)**: Centralize all lifecycle state mutations through `applyLifecycleDecision()` for consistent timestamp handling, atomic metadata persistence, and observability.
+- **Detecting bounds (#138)**: Add time-based (5 min) and attempt-based (3 attempts) bounds to detecting state with evidence hashing to prevent counter reset on unchanged probe results.
+- **Report watcher (#140)**: Background trigger system that audits agent reports for anomalies (no_acknowledge, stale_report, agent_needs_input) and integrates with the reaction engine.
+
+New exports:
+- `applyLifecycleDecision`, `applyDecisionToLifecycle`, `buildTransitionMetadataPatch`, `createStateTransitionDecision`
+- `DETECTING_MAX_ATTEMPTS`, `DETECTING_MAX_DURATION_MS`, `hashEvidence`, `isDetectingTimedOut`
+- `auditAgentReports`, `checkAcknowledgeTimeout`, `checkStaleReport`, `checkBlockedAgent`, `shouldAuditSession`, `getReactionKeyForTrigger`, `DEFAULT_REPORT_WATCHER_CONFIG`, `REPORT_WATCHER_METADATA_KEYS`

--- a/packages/core/src/__tests__/lifecycle-status-decisions.test.ts
+++ b/packages/core/src/__tests__/lifecycle-status-decisions.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from "vitest";
+import {
+  createDetectingDecision,
+  hashEvidence,
+  isDetectingTimedOut,
+  DETECTING_MAX_ATTEMPTS,
+  DETECTING_MAX_DURATION_MS,
+} from "../lifecycle-status-decisions.js";
+
+describe("hashEvidence", () => {
+  it("returns a 12-character hex string", () => {
+    const hash = hashEvidence("some evidence string");
+    expect(hash).toMatch(/^[a-f0-9]{12}$/);
+  });
+
+  it("returns the same hash for the same input", () => {
+    const hash1 = hashEvidence("test evidence");
+    const hash2 = hashEvidence("test evidence");
+    expect(hash1).toBe(hash2);
+  });
+
+  it("returns different hashes for different inputs", () => {
+    const hash1 = hashEvidence("evidence A");
+    const hash2 = hashEvidence("evidence B");
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+describe("isDetectingTimedOut", () => {
+  it("returns false when detectingStartedAt is undefined", () => {
+    expect(isDetectingTimedOut(undefined)).toBe(false);
+  });
+
+  it("returns false when detectingStartedAt is invalid", () => {
+    expect(isDetectingTimedOut("invalid-date")).toBe(false);
+  });
+
+  it("returns false when within time budget", () => {
+    const now = new Date();
+    const startedAt = new Date(now.getTime() - 60_000).toISOString(); // 1 minute ago
+    expect(isDetectingTimedOut(startedAt, now)).toBe(false);
+  });
+
+  it("returns true when time budget exceeded", () => {
+    const now = new Date();
+    const startedAt = new Date(now.getTime() - DETECTING_MAX_DURATION_MS - 1000).toISOString();
+    expect(isDetectingTimedOut(startedAt, now)).toBe(true);
+  });
+
+  it("returns false at exactly the time limit", () => {
+    const now = new Date();
+    const startedAt = new Date(now.getTime() - DETECTING_MAX_DURATION_MS).toISOString();
+    expect(isDetectingTimedOut(startedAt, now)).toBe(false);
+  });
+});
+
+describe("createDetectingDecision", () => {
+  const baseInput = {
+    currentAttempts: 0,
+    idleWasBlocked: false,
+    evidence: "test evidence",
+  };
+
+  describe("attempt counting", () => {
+    it("increments attempts when no previous evidence hash exists", () => {
+      const result = createDetectingDecision({
+        ...baseInput,
+        currentAttempts: 1,
+      });
+      expect(result.detectingAttempts).toBe(2);
+      expect(result.status).toBe("detecting");
+    });
+
+    it("increments attempts when evidence is unchanged", () => {
+      const evidenceHash = hashEvidence("same evidence");
+      const result = createDetectingDecision({
+        ...baseInput,
+        currentAttempts: 2,
+        evidence: "same evidence",
+        previousEvidenceHash: evidenceHash,
+      });
+      expect(result.detectingAttempts).toBe(3);
+    });
+
+    it("resets attempts to 1 when evidence changes", () => {
+      const oldEvidenceHash = hashEvidence("old evidence");
+      const result = createDetectingDecision({
+        ...baseInput,
+        currentAttempts: 5,
+        evidence: "new evidence",
+        previousEvidenceHash: oldEvidenceHash,
+      });
+      expect(result.detectingAttempts).toBe(1);
+      expect(result.status).toBe("detecting");
+    });
+  });
+
+  describe("attempt-based escalation", () => {
+    it("escalates to stuck after exceeding max attempts", () => {
+      const evidenceHash = hashEvidence("test evidence");
+      const result = createDetectingDecision({
+        ...baseInput,
+        currentAttempts: DETECTING_MAX_ATTEMPTS,
+        previousEvidenceHash: evidenceHash,
+      });
+      expect(result.status).toBe("stuck");
+      expect(result.detectingAttempts).toBe(DETECTING_MAX_ATTEMPTS + 1);
+      expect(result.sessionState).toBe("stuck");
+      expect(result.sessionReason).toBe("probe_failure");
+    });
+
+    it("uses error_in_process reason when idleWasBlocked", () => {
+      const evidenceHash = hashEvidence("test evidence");
+      const result = createDetectingDecision({
+        ...baseInput,
+        currentAttempts: DETECTING_MAX_ATTEMPTS,
+        idleWasBlocked: true,
+        previousEvidenceHash: evidenceHash,
+      });
+      expect(result.status).toBe("stuck");
+      expect(result.sessionReason).toBe("error_in_process");
+    });
+  });
+
+  describe("time-based escalation", () => {
+    it("escalates to stuck when time budget is exceeded", () => {
+      const now = new Date();
+      const oldStartedAt = new Date(now.getTime() - DETECTING_MAX_DURATION_MS - 1000).toISOString();
+      const evidenceHash = hashEvidence("test evidence");
+
+      const result = createDetectingDecision({
+        ...baseInput,
+        currentAttempts: 1, // Well under attempt limit
+        detectingStartedAt: oldStartedAt,
+        previousEvidenceHash: evidenceHash,
+        now,
+      });
+
+      expect(result.status).toBe("stuck");
+      expect(result.sessionState).toBe("stuck");
+    });
+
+    it("does not escalate when both time and attempts are within limits", () => {
+      const now = new Date();
+      const recentStartedAt = new Date(now.getTime() - 60_000).toISOString(); // 1 minute ago
+      const evidenceHash = hashEvidence("test evidence");
+
+      const result = createDetectingDecision({
+        ...baseInput,
+        currentAttempts: 1,
+        detectingStartedAt: recentStartedAt,
+        previousEvidenceHash: evidenceHash,
+        now,
+      });
+
+      expect(result.status).toBe("detecting");
+    });
+
+    it("resets detectingStartedAt when evidence changes", () => {
+      const now = new Date();
+      const oldStartedAt = new Date(now.getTime() - DETECTING_MAX_DURATION_MS - 1000).toISOString();
+      const oldEvidenceHash = hashEvidence("old evidence");
+
+      const result = createDetectingDecision({
+        ...baseInput,
+        currentAttempts: 1,
+        evidence: "new evidence", // Different from old
+        detectingStartedAt: oldStartedAt,
+        previousEvidenceHash: oldEvidenceHash,
+        now,
+      });
+
+      // Should NOT escalate because evidence changed, resetting the timer
+      expect(result.status).toBe("detecting");
+      expect(result.detectingAttempts).toBe(1);
+      expect(result.detectingStartedAt).not.toBe(oldStartedAt);
+    });
+  });
+
+  describe("metadata tracking", () => {
+    it("includes detectingEvidenceHash in the result", () => {
+      const result = createDetectingDecision(baseInput);
+      expect(result.detectingEvidenceHash).toBe(hashEvidence("test evidence"));
+    });
+
+    it("includes detectingStartedAt in the result", () => {
+      const result = createDetectingDecision(baseInput);
+      expect(result.detectingStartedAt).toBeDefined();
+      expect(Date.parse(result.detectingStartedAt!)).not.toBeNaN();
+    });
+
+    it("preserves detectingStartedAt when evidence is unchanged", () => {
+      const now = new Date();
+      const previousStartedAt = new Date(now.getTime() - 30_000).toISOString();
+      const evidenceHash = hashEvidence("test evidence");
+
+      const result = createDetectingDecision({
+        ...baseInput,
+        detectingStartedAt: previousStartedAt,
+        previousEvidenceHash: evidenceHash,
+        now,
+      });
+
+      expect(result.detectingStartedAt).toBe(previousStartedAt);
+    });
+  });
+});

--- a/packages/core/src/__tests__/lifecycle-transition.test.ts
+++ b/packages/core/src/__tests__/lifecycle-transition.test.ts
@@ -97,6 +97,38 @@ describe("applyDecisionToLifecycle", () => {
     expect(lifecycle.session.terminatedAt).toBe(nowIso);
   });
 
+  it("does not overwrite completedAt if already set", () => {
+    lifecycle.session.completedAt = "2026-04-16T12:00:00.000Z";
+
+    const decision: LifecycleDecision = {
+      status: "done",
+      evidence: "test",
+      detectingAttempts: 0,
+      sessionState: "done",
+      sessionReason: "research_complete",
+    };
+
+    applyDecisionToLifecycle(lifecycle, decision, nowIso);
+
+    expect(lifecycle.session.completedAt).toBe("2026-04-16T12:00:00.000Z");
+  });
+
+  it("does not overwrite terminatedAt if already set", () => {
+    lifecycle.session.terminatedAt = "2026-04-16T12:00:00.000Z";
+
+    const decision: LifecycleDecision = {
+      status: "terminated",
+      evidence: "test",
+      detectingAttempts: 0,
+      sessionState: "terminated",
+      sessionReason: "manually_killed",
+    };
+
+    applyDecisionToLifecycle(lifecycle, decision, nowIso);
+
+    expect(lifecycle.session.terminatedAt).toBe("2026-04-16T12:00:00.000Z");
+  });
+
   it("applies PR state and reason", () => {
     const decision: LifecycleDecision = {
       status: "pr_open",

--- a/packages/core/src/__tests__/lifecycle-transition.test.ts
+++ b/packages/core/src/__tests__/lifecycle-transition.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  applyLifecycleDecision,
+  applyDecisionToLifecycle,
+  buildTransitionMetadataPatch,
+  createStateTransitionDecision,
+} from "../lifecycle-transition.js";
+import { createInitialCanonicalLifecycle } from "../lifecycle-state.js";
+import { readMetadataRaw } from "../metadata.js";
+import type { LifecycleDecision } from "../lifecycle-status-decisions.js";
+import type { CanonicalSessionLifecycle } from "../types.js";
+
+describe("applyDecisionToLifecycle", () => {
+  let lifecycle: CanonicalSessionLifecycle;
+  const nowIso = "2026-04-17T12:00:00.000Z";
+
+  beforeEach(() => {
+    lifecycle = createInitialCanonicalLifecycle("worker");
+  });
+
+  it("applies session state and reason", () => {
+    const decision: LifecycleDecision = {
+      status: "working",
+      evidence: "test",
+      detectingAttempts: 0,
+      sessionState: "working",
+      sessionReason: "task_in_progress",
+    };
+
+    applyDecisionToLifecycle(lifecycle, decision, nowIso);
+
+    expect(lifecycle.session.state).toBe("working");
+    expect(lifecycle.session.reason).toBe("task_in_progress");
+    expect(lifecycle.session.lastTransitionAt).toBe(nowIso);
+  });
+
+  it("sets startedAt when transitioning to working", () => {
+    expect(lifecycle.session.startedAt).toBeNull();
+
+    const decision: LifecycleDecision = {
+      status: "working",
+      evidence: "test",
+      detectingAttempts: 0,
+      sessionState: "working",
+      sessionReason: "task_in_progress",
+    };
+
+    applyDecisionToLifecycle(lifecycle, decision, nowIso);
+
+    expect(lifecycle.session.startedAt).toBe(nowIso);
+  });
+
+  it("does not overwrite startedAt if already set", () => {
+    lifecycle.session.startedAt = "2026-04-16T12:00:00.000Z";
+
+    const decision: LifecycleDecision = {
+      status: "working",
+      evidence: "test",
+      detectingAttempts: 0,
+      sessionState: "working",
+      sessionReason: "task_in_progress",
+    };
+
+    applyDecisionToLifecycle(lifecycle, decision, nowIso);
+
+    expect(lifecycle.session.startedAt).toBe("2026-04-16T12:00:00.000Z");
+  });
+
+  it("sets completedAt when transitioning to done", () => {
+    const decision: LifecycleDecision = {
+      status: "done",
+      evidence: "test",
+      detectingAttempts: 0,
+      sessionState: "done",
+      sessionReason: "research_complete",
+    };
+
+    applyDecisionToLifecycle(lifecycle, decision, nowIso);
+
+    expect(lifecycle.session.completedAt).toBe(nowIso);
+  });
+
+  it("sets terminatedAt when transitioning to terminated", () => {
+    const decision: LifecycleDecision = {
+      status: "terminated",
+      evidence: "test",
+      detectingAttempts: 0,
+      sessionState: "terminated",
+      sessionReason: "manually_killed",
+    };
+
+    applyDecisionToLifecycle(lifecycle, decision, nowIso);
+
+    expect(lifecycle.session.terminatedAt).toBe(nowIso);
+  });
+
+  it("applies PR state and reason", () => {
+    const decision: LifecycleDecision = {
+      status: "pr_open",
+      evidence: "test",
+      detectingAttempts: 0,
+      prState: "open",
+      prReason: "in_progress",
+    };
+
+    applyDecisionToLifecycle(lifecycle, decision, nowIso);
+
+    expect(lifecycle.pr.state).toBe("open");
+    expect(lifecycle.pr.reason).toBe("in_progress");
+    expect(lifecycle.pr.lastObservedAt).toBe(nowIso);
+  });
+});
+
+describe("buildTransitionMetadataPatch", () => {
+  it("includes lifecycle evidence and detecting metadata", () => {
+    const lifecycle = createInitialCanonicalLifecycle("worker");
+    const decision: LifecycleDecision = {
+      status: "detecting",
+      evidence: "probe_failed",
+      detectingAttempts: 2,
+      detectingStartedAt: "2026-04-17T11:55:00.000Z",
+      detectingEvidenceHash: "abc123def456",
+      sessionState: "detecting",
+      sessionReason: "probe_failure",
+    };
+
+    const patch = buildTransitionMetadataPatch(lifecycle, decision, "working");
+
+    expect(patch["lifecycleEvidence"]).toBe("probe_failed");
+    expect(patch["detectingAttempts"]).toBe("2");
+    expect(patch["detectingStartedAt"]).toBe("2026-04-17T11:55:00.000Z");
+    expect(patch["detectingEvidenceHash"]).toBe("abc123def456");
+  });
+
+  it("clears detecting metadata when not detecting", () => {
+    const lifecycle = createInitialCanonicalLifecycle("worker");
+    const decision: LifecycleDecision = {
+      status: "working",
+      evidence: "active",
+      detectingAttempts: 0,
+      sessionState: "working",
+      sessionReason: "task_in_progress",
+    };
+
+    const patch = buildTransitionMetadataPatch(lifecycle, decision, "detecting");
+
+    expect(patch["detectingAttempts"]).toBe("");
+    expect(patch["detectingStartedAt"]).toBe("");
+    expect(patch["detectingEvidenceHash"]).toBe("");
+  });
+
+  it("includes stateVersion and statePayload", () => {
+    const lifecycle = createInitialCanonicalLifecycle("worker");
+    const decision: LifecycleDecision = {
+      status: "working",
+      evidence: "test",
+      detectingAttempts: 0,
+    };
+
+    const patch = buildTransitionMetadataPatch(lifecycle, decision, "working");
+
+    expect(patch["stateVersion"]).toBe("2");
+    expect(patch["statePayload"]).toBeDefined();
+    expect(JSON.parse(patch["statePayload"])).toHaveProperty("version", 2);
+  });
+});
+
+describe("applyLifecycleDecision (integration)", () => {
+  let testDir: string;
+  let dataDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `lifecycle-transition-test-${Date.now()}`);
+    dataDir = join(testDir, "sessions");
+    mkdirSync(dataDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function writeTestSession(sessionId: string, metadata: Record<string, string>) {
+    const content = Object.entries(metadata)
+      .map(([k, v]) => `${k}=${v}`)
+      .join("\n");
+    writeFileSync(join(dataDir, sessionId), content);
+  }
+
+  it("returns failure when session not found", () => {
+    const result = applyLifecycleDecision({
+      dataDir,
+      sessionId: "nonexistent",
+      decision: {
+        status: "working",
+        evidence: "test",
+        detectingAttempts: 0,
+      },
+      source: "poll",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.rejectionReason).toContain("Session not found");
+  });
+
+  it("applies decision and persists metadata", () => {
+    writeTestSession("test-1", {
+      status: "spawning",
+      worktree: "/tmp/test",
+      branch: "main",
+    });
+
+    const result = applyLifecycleDecision({
+      dataDir,
+      sessionId: "test-1",
+      decision: {
+        status: "working",
+        evidence: "agent_started",
+        detectingAttempts: 0,
+        sessionState: "working",
+        sessionReason: "task_in_progress",
+      },
+      source: "poll",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.previousStatus).toBe("spawning");
+    expect(result.nextStatus).toBe("working");
+    expect(result.statusChanged).toBe(true);
+
+    const meta = readMetadataRaw(dataDir, "test-1");
+    expect(meta?.["status"]).toBe("working");
+    expect(meta?.["lifecycleEvidence"]).toBe("agent_started");
+  });
+
+  it("merges additional metadata", () => {
+    writeTestSession("test-2", {
+      status: "working",
+      worktree: "/tmp/test",
+      branch: "main",
+    });
+
+    const result = applyLifecycleDecision({
+      dataDir,
+      sessionId: "test-2",
+      decision: {
+        status: "pr_open",
+        evidence: "pr_created",
+        detectingAttempts: 0,
+        prState: "open",
+        prReason: "in_progress",
+      },
+      source: "agent_report",
+      additionalMetadata: {
+        pr: "https://github.com/test/repo/pull/123",
+      },
+    });
+
+    expect(result.success).toBe(true);
+
+    const meta = readMetadataRaw(dataDir, "test-2");
+    expect(meta?.["pr"]).toBe("https://github.com/test/repo/pull/123");
+  });
+});
+
+describe("createStateTransitionDecision", () => {
+  it("creates a minimal decision for direct state updates", () => {
+    const decision = createStateTransitionDecision(
+      "stuck",
+      "stuck",
+      "probe_failure",
+      "runtime dead after 3 attempts",
+    );
+
+    expect(decision.status).toBe("stuck");
+    expect(decision.sessionState).toBe("stuck");
+    expect(decision.sessionReason).toBe("probe_failure");
+    expect(decision.evidence).toBe("runtime dead after 3 attempts");
+    expect(decision.detectingAttempts).toBe(0);
+  });
+});

--- a/packages/core/src/__tests__/report-watcher.test.ts
+++ b/packages/core/src/__tests__/report-watcher.test.ts
@@ -52,9 +52,9 @@ describe("shouldAuditSession", () => {
     }
   });
 
-  it("returns false for spawning sessions", () => {
+  it("returns true for spawning sessions (allows acknowledge timeout check)", () => {
     const session = createMockSession({ status: "spawning" });
-    expect(shouldAuditSession(session)).toBe(false);
+    expect(shouldAuditSession(session)).toBe(true);
   });
 
   it("returns false for orchestrator sessions", () => {
@@ -214,8 +214,8 @@ describe("checkBlockedAgent", () => {
 });
 
 describe("auditAgentReports", () => {
-  it("returns null for sessions that should not be audited", () => {
-    const session = createMockSession({ status: "spawning" });
+  it("returns null for terminal sessions", () => {
+    const session = createMockSession({ status: "done" });
     expect(auditAgentReports(session)).toBeNull();
   });
 
@@ -254,7 +254,6 @@ describe("getReactionKeyForTrigger", () => {
   it("maps triggers to reaction keys", () => {
     expect(getReactionKeyForTrigger("no_acknowledge")).toBe("report-no-acknowledge");
     expect(getReactionKeyForTrigger("stale_report")).toBe("report-stale");
-    expect(getReactionKeyForTrigger("agent_blocked")).toBe("report-blocked");
     expect(getReactionKeyForTrigger("agent_needs_input")).toBe("report-needs-input");
   });
 });

--- a/packages/core/src/__tests__/report-watcher.test.ts
+++ b/packages/core/src/__tests__/report-watcher.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from "vitest";
+import {
+  auditAgentReports,
+  checkAcknowledgeTimeout,
+  checkStaleReport,
+  checkBlockedAgent,
+  shouldAuditSession,
+  getReactionKeyForTrigger,
+  DEFAULT_REPORT_WATCHER_CONFIG,
+  type ReportWatcherConfig,
+} from "../report-watcher.js";
+import { createInitialCanonicalLifecycle } from "../lifecycle-state.js";
+import type { Session, SessionStatus } from "../types.js";
+import type { AgentReport } from "../agent-report.js";
+
+function createMockSession(overrides: Partial<Session> = {}): Session {
+  const lifecycle = createInitialCanonicalLifecycle("worker");
+  lifecycle.session.state = "working";
+  lifecycle.session.reason = "task_in_progress";
+
+  return {
+    id: "test-session",
+    projectId: "test-project",
+    status: "working" as SessionStatus,
+    branch: "main",
+    createdAt: new Date(),
+    lifecycle,
+    metadata: {},
+    ...overrides,
+  } as Session;
+}
+
+describe("shouldAuditSession", () => {
+  it("returns true for active working sessions", () => {
+    const session = createMockSession({ status: "working" });
+    expect(shouldAuditSession(session)).toBe(true);
+  });
+
+  it("returns false for terminal sessions", () => {
+    const terminalStatuses: SessionStatus[] = [
+      "done",
+      "terminated",
+      "killed",
+      "cleanup",
+      "merged",
+      "errored",
+    ];
+
+    for (const status of terminalStatuses) {
+      const session = createMockSession({ status });
+      expect(shouldAuditSession(session)).toBe(false);
+    }
+  });
+
+  it("returns false for spawning sessions", () => {
+    const session = createMockSession({ status: "spawning" });
+    expect(shouldAuditSession(session)).toBe(false);
+  });
+
+  it("returns false for orchestrator sessions", () => {
+    const lifecycle = createInitialCanonicalLifecycle("orchestrator");
+    const session = createMockSession({ lifecycle });
+    expect(shouldAuditSession(session)).toBe(false);
+  });
+});
+
+describe("checkAcknowledgeTimeout", () => {
+  const config = DEFAULT_REPORT_WATCHER_CONFIG;
+
+  it("returns null when report exists", () => {
+    const session = createMockSession();
+    const report: AgentReport = {
+      state: "started",
+      timestamp: new Date().toISOString(),
+    };
+    const now = new Date();
+
+    const result = checkAcknowledgeTimeout(session, report, now, config);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when within timeout window", () => {
+    const now = new Date();
+    const spawnTime = new Date(now.getTime() - 5 * 60 * 1000); // 5 minutes ago
+    const session = createMockSession({
+      createdAt: spawnTime,
+      metadata: { createdAt: spawnTime.toISOString() },
+    });
+
+    const result = checkAcknowledgeTimeout(session, null, now, config);
+    expect(result).toBeNull();
+  });
+
+  it("returns trigger when timeout exceeded", () => {
+    const now = new Date();
+    const spawnTime = new Date(now.getTime() - 15 * 60 * 1000); // 15 minutes ago
+    const session = createMockSession({
+      createdAt: spawnTime,
+      metadata: { createdAt: spawnTime.toISOString() },
+    });
+
+    const result = checkAcknowledgeTimeout(session, null, now, config);
+    expect(result).not.toBeNull();
+    expect(result?.trigger).toBe("no_acknowledge");
+    expect(result?.timeSinceSpawnMs).toBeGreaterThan(config.acknowledgeTimeoutMs);
+  });
+
+  it("respects checkAcknowledge config flag", () => {
+    const now = new Date();
+    const spawnTime = new Date(now.getTime() - 15 * 60 * 1000);
+    const session = createMockSession({
+      createdAt: spawnTime,
+      metadata: { createdAt: spawnTime.toISOString() },
+    });
+    const disabledConfig: ReportWatcherConfig = {
+      ...config,
+      checkAcknowledge: false,
+    };
+
+    const result = checkAcknowledgeTimeout(session, null, now, disabledConfig);
+    expect(result).toBeNull();
+  });
+});
+
+describe("checkStaleReport", () => {
+  const config = DEFAULT_REPORT_WATCHER_CONFIG;
+
+  it("returns null when no report exists", () => {
+    const session = createMockSession();
+    const result = checkStaleReport(session, null, new Date(), config);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when report is fresh", () => {
+    const now = new Date();
+    const reportTime = new Date(now.getTime() - 5 * 60 * 1000); // 5 minutes ago
+    const session = createMockSession();
+    const report: AgentReport = {
+      state: "working",
+      timestamp: reportTime.toISOString(),
+    };
+
+    const result = checkStaleReport(session, report, now, config);
+    expect(result).toBeNull();
+  });
+
+  it("returns trigger when report is stale", () => {
+    const now = new Date();
+    const reportTime = new Date(now.getTime() - 45 * 60 * 1000); // 45 minutes ago
+    const session = createMockSession();
+    const report: AgentReport = {
+      state: "working",
+      timestamp: reportTime.toISOString(),
+    };
+
+    const result = checkStaleReport(session, report, now, config);
+    expect(result).not.toBeNull();
+    expect(result?.trigger).toBe("stale_report");
+    expect(result?.timeSinceReportMs).toBeGreaterThan(config.staleReportTimeoutMs);
+  });
+
+  it("does not flag waiting states as stale", () => {
+    const now = new Date();
+    const reportTime = new Date(now.getTime() - 45 * 60 * 1000); // 45 minutes ago
+    const session = createMockSession();
+
+    for (const waitingState of ["waiting", "needs_input"] as const) {
+      const report: AgentReport = {
+        state: waitingState,
+        timestamp: reportTime.toISOString(),
+      };
+      const result = checkStaleReport(session, report, now, config);
+      expect(result).toBeNull();
+    }
+  });
+});
+
+describe("checkBlockedAgent", () => {
+  const config = DEFAULT_REPORT_WATCHER_CONFIG;
+
+  it("returns null when no report exists", () => {
+    const session = createMockSession();
+    const result = checkBlockedAgent(session, null, new Date(), config);
+    expect(result).toBeNull();
+  });
+
+  it("returns trigger for needs_input state", () => {
+    const now = new Date();
+    const session = createMockSession();
+    const report: AgentReport = {
+      state: "needs_input",
+      timestamp: now.toISOString(),
+      note: "Need API key",
+    };
+
+    const result = checkBlockedAgent(session, report, now, config);
+    expect(result).not.toBeNull();
+    expect(result?.trigger).toBe("agent_needs_input");
+    expect(result?.message).toContain("Need API key");
+  });
+
+  it("ignores stale reports", () => {
+    const now = new Date();
+    const oldReportTime = new Date(now.getTime() - 10 * 60 * 1000); // 10 minutes ago
+    const session = createMockSession();
+    const report: AgentReport = {
+      state: "needs_input",
+      timestamp: oldReportTime.toISOString(),
+    };
+
+    const result = checkBlockedAgent(session, report, now, config);
+    expect(result).toBeNull();
+  });
+});
+
+describe("auditAgentReports", () => {
+  it("returns null for sessions that should not be audited", () => {
+    const session = createMockSession({ status: "spawning" });
+    expect(auditAgentReports(session)).toBeNull();
+  });
+
+  it("returns null when no issues found", () => {
+    const now = new Date();
+    const session = createMockSession({
+      createdAt: now,
+      metadata: {
+        createdAt: now.toISOString(),
+        agentReportedState: "working",
+        agentReportedAt: now.toISOString(),
+      },
+    });
+
+    expect(auditAgentReports(session, {}, now)).toBeNull();
+  });
+
+  it("prioritizes blocked over acknowledge timeout", () => {
+    const now = new Date();
+    const spawnTime = new Date(now.getTime() - 15 * 60 * 1000); // Would trigger no_acknowledge
+    const session = createMockSession({
+      createdAt: spawnTime,
+      metadata: {
+        createdAt: spawnTime.toISOString(),
+        agentReportedState: "needs_input",
+        agentReportedAt: now.toISOString(), // Fresh needs_input
+      },
+    });
+
+    const result = auditAgentReports(session, {}, now);
+    expect(result?.trigger).toBe("agent_needs_input");
+  });
+});
+
+describe("getReactionKeyForTrigger", () => {
+  it("maps triggers to reaction keys", () => {
+    expect(getReactionKeyForTrigger("no_acknowledge")).toBe("report-no-acknowledge");
+    expect(getReactionKeyForTrigger("stale_report")).toBe("report-stale");
+    expect(getReactionKeyForTrigger("agent_blocked")).toBe("report-blocked");
+    expect(getReactionKeyForTrigger("agent_needs_input")).toBe("report-needs-input");
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,44 @@ export {
 } from "./metadata.js";
 export { createInitialCanonicalLifecycle, deriveLegacyStatus } from "./lifecycle-state.js";
 
+// Lifecycle transitions — centralized transition boundary (#137)
+export {
+  applyLifecycleDecision,
+  applyDecisionToLifecycle,
+  buildTransitionMetadataPatch,
+  createStateTransitionDecision,
+} from "./lifecycle-transition.js";
+export type {
+  TransitionSource,
+  TransitionResult,
+  ApplyDecisionInput,
+} from "./lifecycle-transition.js";
+
+// Lifecycle status decisions — pure decision helpers (#136)
+export {
+  DETECTING_MAX_ATTEMPTS,
+  DETECTING_MAX_DURATION_MS,
+  hashEvidence,
+  isDetectingTimedOut,
+} from "./lifecycle-status-decisions.js";
+
+// Report watcher — background trigger system for agent reports (#140)
+export {
+  auditAgentReports,
+  checkAcknowledgeTimeout,
+  checkStaleReport,
+  checkBlockedAgent,
+  shouldAuditSession,
+  getReactionKeyForTrigger,
+  DEFAULT_REPORT_WATCHER_CONFIG,
+  REPORT_WATCHER_METADATA_KEYS,
+} from "./report-watcher.js";
+export type {
+  ReportWatcherTrigger,
+  ReportAuditResult,
+  ReportWatcherConfig,
+} from "./report-watcher.js";
+
 // Agent reports — explicit workflow transitions declared by worker agents (Stage 3)
 export {
   AGENT_REPORTED_STATES,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1787,13 +1787,26 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
    */
   async function auditAndReactToReports(session: Session): Promise<void> {
     const auditResult = auditAgentReports(session);
-    if (!auditResult || !auditResult.trigger) return;
+    const now = new Date().toISOString();
+
+    // If no trigger, clear any active trigger metadata
+    if (!auditResult || !auditResult.trigger) {
+      const hadActiveTrigger = session.metadata[REPORT_WATCHER_METADATA_KEYS.ACTIVE_TRIGGER];
+      if (hadActiveTrigger) {
+        updateSessionMetadata(session, {
+          [REPORT_WATCHER_METADATA_KEYS.LAST_AUDITED_AT]: now,
+          [REPORT_WATCHER_METADATA_KEYS.ACTIVE_TRIGGER]: "",
+          [REPORT_WATCHER_METADATA_KEYS.TRIGGER_ACTIVATED_AT]: "",
+          [REPORT_WATCHER_METADATA_KEYS.TRIGGER_COUNT]: "",
+        });
+      }
+      return;
+    }
 
     const reactionKey = getReactionKeyForTrigger(auditResult.trigger);
     const reactionConfig = getReactionConfigForSession(session, reactionKey);
 
     // Update audit metadata
-    const now = new Date().toISOString();
     const currentTriggerCount = parseInt(
       session.metadata[REPORT_WATCHER_METADATA_KEYS.TRIGGER_COUNT] ?? "0",
       10,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -52,6 +52,11 @@ import {
   mapAgentReportToLifecycle,
   readAgentReport,
 } from "./agent-report.js";
+import {
+  auditAgentReports,
+  getReactionKeyForTrigger,
+  REPORT_WATCHER_METADATA_KEYS,
+} from "./report-watcher.js";
 import { createCorrelationId, createProjectObserver } from "./observability.js";
 import { resolveNotifierTarget } from "./notifier-resolution.js";
 import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
@@ -219,6 +224,10 @@ interface DeterminedStatus {
   status: SessionStatus;
   evidence: string;
   detectingAttempts: number;
+  /** ISO timestamp when detecting first started. */
+  detectingStartedAt?: string;
+  /** Hash of evidence for unchanged-evidence detection. */
+  detectingEvidenceHash?: string;
 }
 
 interface ProbeResult {
@@ -516,6 +525,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     let idleWasBlocked = false;
     const canProbeRuntimeIdentity = session.status !== SESSION_STATUS.SPAWNING;
     const currentDetectingAttempts = parseAttemptCount(session.metadata["detectingAttempts"]);
+    const currentDetectingStartedAt = session.metadata["detectingStartedAt"] || undefined;
+    const currentDetectingEvidenceHash = session.metadata["detectingEvidenceHash"] || undefined;
 
     const commit = (
       decision: LifecycleDecision = {
@@ -532,6 +543,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         status: decision.status,
         evidence: decision.evidence,
         detectingAttempts: decision.detectingAttempts,
+        detectingStartedAt: decision.detectingStartedAt,
+        detectingEvidenceHash: decision.detectingEvidenceHash,
       };
     };
 
@@ -665,6 +678,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             currentAttempts: currentDetectingAttempts,
             idleWasBlocked,
             evidence: activityEvidence,
+            detectingStartedAt: currentDetectingStartedAt,
+            previousEvidenceHash: currentDetectingEvidenceHash,
           }),
         );
       }
@@ -697,6 +712,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       activitySignal,
       activityEvidence,
       idleWasBlocked,
+      detectingStartedAt: currentDetectingStartedAt,
+      previousEvidenceHash: currentDetectingEvidenceHash,
     });
     if (probeDecision) {
       return commit(probeDecision);
@@ -1550,6 +1567,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const nextLifecycleEvidence = assessment.evidence;
     const nextDetectingAttempts =
       assessment.detectingAttempts > 0 ? String(assessment.detectingAttempts) : "";
+    const nextDetectingStartedAt = assessment.detectingStartedAt ?? "";
+    const nextDetectingEvidenceHash = assessment.detectingEvidenceHash ?? "";
     const isDetectingEscalated =
       newStatus === SESSION_STATUS.STUCK &&
       assessment.detectingAttempts > DETECTING_MAX_ATTEMPTS;
@@ -1563,6 +1582,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
     if ((session.metadata["detectingAttempts"] || "") !== nextDetectingAttempts) {
       metadataUpdates["detectingAttempts"] = nextDetectingAttempts;
+    }
+    if ((session.metadata["detectingStartedAt"] || "") !== nextDetectingStartedAt) {
+      metadataUpdates["detectingStartedAt"] = nextDetectingStartedAt;
+    }
+    if ((session.metadata["detectingEvidenceHash"] || "") !== nextDetectingEvidenceHash) {
+      metadataUpdates["detectingEvidenceHash"] = nextDetectingEvidenceHash;
     }
     if ((session.metadata["detectingEscalatedAt"] || "") !== nextDetectingEscalatedAt) {
       metadataUpdates["detectingEscalatedAt"] = nextDetectingEscalatedAt;
@@ -1751,6 +1776,65 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       maybeDispatchCIFailureDetails(session, oldStatus, newStatus, transitionReaction),
       maybeDispatchMergeConflicts(session, newStatus),
     ]);
+
+    // Report watcher: audit agent reports for issues (#140)
+    await auditAndReactToReports(session);
+  }
+
+  /**
+   * Audit agent reports and trigger reactions when issues are detected.
+   * Called at the end of each checkSession cycle.
+   */
+  async function auditAndReactToReports(session: Session): Promise<void> {
+    const auditResult = auditAgentReports(session);
+    if (!auditResult || !auditResult.trigger) return;
+
+    const reactionKey = getReactionKeyForTrigger(auditResult.trigger);
+    const reactionConfig = getReactionConfigForSession(session, reactionKey);
+
+    // Update audit metadata
+    const now = new Date().toISOString();
+    const currentTriggerCount = parseInt(
+      session.metadata[REPORT_WATCHER_METADATA_KEYS.TRIGGER_COUNT] ?? "0",
+      10,
+    );
+    const isNewTrigger =
+      session.metadata[REPORT_WATCHER_METADATA_KEYS.ACTIVE_TRIGGER] !== auditResult.trigger;
+
+    updateSessionMetadata(session, {
+      [REPORT_WATCHER_METADATA_KEYS.LAST_AUDITED_AT]: now,
+      [REPORT_WATCHER_METADATA_KEYS.ACTIVE_TRIGGER]: auditResult.trigger,
+      [REPORT_WATCHER_METADATA_KEYS.TRIGGER_ACTIVATED_AT]: isNewTrigger
+        ? now
+        : (session.metadata[REPORT_WATCHER_METADATA_KEYS.TRIGGER_ACTIVATED_AT] ?? now),
+      [REPORT_WATCHER_METADATA_KEYS.TRIGGER_COUNT]: String(
+        isNewTrigger ? 1 : currentTriggerCount + 1,
+      ),
+    });
+
+    // Log the audit finding
+    observer.recordOperation({
+      metric: "lifecycle_poll",
+      operation: "report_watcher.audit",
+      outcome: "success",
+      correlationId: createCorrelationId("report-watcher"),
+      projectId: session.projectId,
+      sessionId: session.id,
+      reason: auditResult.trigger,
+      data: {
+        trigger: auditResult.trigger,
+        message: auditResult.message,
+        timeSinceSpawnMs: auditResult.timeSinceSpawnMs,
+        timeSinceReportMs: auditResult.timeSinceReportMs,
+        reportState: auditResult.report?.state,
+      },
+      level: "warn",
+    });
+
+    // Execute reaction if configured
+    if (reactionConfig && reactionConfig.auto !== false) {
+      await executeReaction(session.id, session.projectId, reactionKey, reactionConfig);
+    }
   }
 
   /** Run one polling cycle across all sessions. */

--- a/packages/core/src/lifecycle-status-decisions.ts
+++ b/packages/core/src/lifecycle-status-decisions.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   CI_STATUS,
   PR_STATE,
@@ -14,6 +15,8 @@ import {
 import { supportsRecentLiveness } from "./activity-signal.js";
 
 export const DETECTING_MAX_ATTEMPTS = 3;
+/** Hard time cap for detecting state — escalate after this regardless of attempts. */
+export const DETECTING_MAX_DURATION_MS = 5 * 60 * 1000; // 5 minutes
 
 type ProbeState = "alive" | "dead" | "unknown";
 type PRReviewDecision = PREnrichmentData["reviewDecision"];
@@ -26,10 +29,22 @@ interface LifecycleDecision {
   status: SessionStatus;
   evidence: string;
   detectingAttempts: number;
+  /** ISO timestamp when detecting state was first entered (for time-based escalation). */
+  detectingStartedAt?: string;
+  /** Hash of evidence to detect unchanged evidence across polls. */
+  detectingEvidenceHash?: string;
   sessionState?: LifecycleSessionState;
   sessionReason?: LifecycleSessionReason;
   prState?: LifecyclePRState;
   prReason?: LifecyclePRReason;
+}
+
+/**
+ * Create a short hash of evidence string for detecting unchanged evidence.
+ * Used to prevent counter reset when the same weak evidence re-presents.
+ */
+export function hashEvidence(evidence: string): string {
+  return createHash("sha256").update(evidence).digest("hex").slice(0, 12);
 }
 
 interface OpenPRDecisionInput {
@@ -54,24 +69,78 @@ interface ProbeDecisionInput {
   activitySignal: ActivitySignal;
   activityEvidence: string;
   idleWasBlocked: boolean;
+  /** ISO timestamp when detecting first started (from metadata). */
+  detectingStartedAt?: string;
+  /** Previous evidence hash (from metadata). */
+  previousEvidenceHash?: string;
 }
 
 function createLifecycleDecision(decision: LifecycleDecision): LifecycleDecision {
   return decision;
 }
 
+export interface DetectingDecisionInput {
+  currentAttempts: number;
+  idleWasBlocked: boolean;
+  evidence: string;
+  reason?: LifecycleSessionReason;
+  /** ISO timestamp when detecting first started (from metadata). */
+  detectingStartedAt?: string;
+  /** Previous evidence hash (from metadata). */
+  previousEvidenceHash?: string;
+  /** Current time for time-based escalation check. */
+  now?: Date;
+}
+
+/**
+ * Check if detecting has exceeded its time budget.
+ */
+export function isDetectingTimedOut(
+  detectingStartedAt: string | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!detectingStartedAt) return false;
+  const startedAt = Date.parse(detectingStartedAt);
+  if (Number.isNaN(startedAt)) return false;
+  return now.getTime() - startedAt > DETECTING_MAX_DURATION_MS;
+}
+
 export function createDetectingDecision(
-  input: Pick<ProbeDecisionInput, "currentAttempts" | "idleWasBlocked"> & {
+  input: DetectingDecisionInput | (Pick<ProbeDecisionInput, "currentAttempts" | "idleWasBlocked"> & {
     evidence: string;
     reason?: LifecycleSessionReason;
-  },
+  }),
 ): LifecycleDecision {
-  const attempts = input.currentAttempts + 1;
-  if (attempts > DETECTING_MAX_ATTEMPTS) {
+  const now = "now" in input && input.now ? input.now : new Date();
+  const nowIso = now.toISOString();
+  const evidenceHash = hashEvidence(input.evidence);
+
+  // Determine the starting time for detecting
+  // If we have a previous startedAt AND evidence is unchanged, preserve it
+  // Otherwise, start fresh
+  const previousEvidenceHash = "previousEvidenceHash" in input ? input.previousEvidenceHash : undefined;
+  const previousStartedAt = "detectingStartedAt" in input ? input.detectingStartedAt : undefined;
+
+  // Evidence is considered unchanged if:
+  // 1. We have a previous hash AND it matches, OR
+  // 2. We have no previous hash (first time entering detecting)
+  const evidenceChanged = previousEvidenceHash !== undefined && previousEvidenceHash !== evidenceHash;
+  const detectingStartedAt = evidenceChanged ? nowIso : (previousStartedAt ?? nowIso);
+
+  // Calculate attempts: reset if evidence changed, otherwise increment
+  const attempts = evidenceChanged ? 1 : input.currentAttempts + 1;
+
+  // Check escalation conditions: attempt limit OR time limit
+  const attemptLimitExceeded = attempts > DETECTING_MAX_ATTEMPTS;
+  const timeLimitExceeded = isDetectingTimedOut(detectingStartedAt, now);
+
+  if (attemptLimitExceeded || timeLimitExceeded) {
     return createLifecycleDecision({
       status: SESSION_STATUS.STUCK,
       evidence: input.evidence,
       detectingAttempts: attempts,
+      detectingStartedAt,
+      detectingEvidenceHash: evidenceHash,
       sessionState: "stuck",
       sessionReason: input.idleWasBlocked ? "error_in_process" : "probe_failure",
     });
@@ -81,6 +150,8 @@ export function createDetectingDecision(
     status: SESSION_STATUS.DETECTING,
     evidence: input.evidence,
     detectingAttempts: attempts,
+    detectingStartedAt,
+    detectingEvidenceHash: evidenceHash,
     sessionState: "detecting",
     sessionReason: input.reason ?? "probe_failure",
   });
@@ -216,6 +287,8 @@ export function resolveProbeDecision(input: ProbeDecisionInput): LifecycleDecisi
       currentAttempts: input.currentAttempts,
       idleWasBlocked: input.idleWasBlocked,
       evidence: `probe_failed runtime=${input.runtimeProbe.state} process=${input.processProbe.state} ${input.activityEvidence}`,
+      detectingStartedAt: input.detectingStartedAt,
+      previousEvidenceHash: input.previousEvidenceHash,
     });
   }
 
@@ -229,6 +302,8 @@ export function resolveProbeDecision(input: ProbeDecisionInput): LifecycleDecisi
       idleWasBlocked: input.idleWasBlocked,
       evidence: `signal_disagreement runtime=${input.runtimeProbe.state} process=${input.processProbe.state} ${input.activityEvidence}`,
       reason: input.runtimeProbe.state === "dead" ? "runtime_lost" : "agent_process_exited",
+      detectingStartedAt: input.detectingStartedAt,
+      previousEvidenceHash: input.previousEvidenceHash,
     });
   }
 
@@ -242,6 +317,8 @@ export function resolveProbeDecision(input: ProbeDecisionInput): LifecycleDecisi
       idleWasBlocked: input.idleWasBlocked,
       evidence: `runtime_dead process_unknown ${input.activityEvidence}`,
       reason: "runtime_lost",
+      detectingStartedAt: input.detectingStartedAt,
+      previousEvidenceHash: input.previousEvidenceHash,
     });
   }
 

--- a/packages/core/src/lifecycle-transition.ts
+++ b/packages/core/src/lifecycle-transition.ts
@@ -95,14 +95,14 @@ export function applyDecisionToLifecycle(
     lifecycle.session.reason = decision.sessionReason;
     lifecycle.session.lastTransitionAt = nowIso;
 
-    // Handle special timestamp fields
+    // Handle special timestamp fields (only set if not already set)
     if (decision.sessionState === "working" && lifecycle.session.startedAt === null) {
       lifecycle.session.startedAt = nowIso;
     }
-    if (decision.sessionState === "done") {
+    if (decision.sessionState === "done" && lifecycle.session.completedAt === null) {
       lifecycle.session.completedAt = nowIso;
     }
-    if (decision.sessionState === "terminated") {
+    if (decision.sessionState === "terminated" && lifecycle.session.terminatedAt === null) {
       lifecycle.session.terminatedAt = nowIso;
     }
   }
@@ -227,18 +227,24 @@ export function applyLifecycleDecision(
   const nextStatus = deriveLegacyStatus(nextLifecycle, previousStatus);
   const statusChanged = nextStatus !== previousStatus;
 
-  // Build and apply metadata patch
-  const metadataPatch = buildTransitionMetadataPatch(
-    nextLifecycle,
-    input.decision,
-    previousStatus,
-  );
+  // Build metadata patch, starting with additional metadata (so lifecycle keys take precedence)
+  const metadataPatch: Record<string, string> = {};
 
-  // Merge additional metadata
+  // Apply additional metadata first
   if (input.additionalMetadata) {
     for (const [key, value] of Object.entries(input.additionalMetadata)) {
       metadataPatch[key] = value;
     }
+  }
+
+  // Apply lifecycle patch second (overwrites any conflicting keys from additionalMetadata)
+  const lifecyclePatch = buildTransitionMetadataPatch(
+    nextLifecycle,
+    input.decision,
+    previousStatus,
+  );
+  for (const [key, value] of Object.entries(lifecyclePatch)) {
+    metadataPatch[key] = value;
   }
 
   // Persist

--- a/packages/core/src/lifecycle-transition.ts
+++ b/packages/core/src/lifecycle-transition.ts
@@ -1,0 +1,306 @@
+/**
+ * Lifecycle Transition Service
+ *
+ * Centralizes all lifecycle state mutations behind a single boundary.
+ * This module ensures:
+ * - Consistent timestamp handling
+ * - Before/after state capture for observability
+ * - Atomic metadata persistence
+ * - Validation before mutation
+ *
+ * All lifecycle changes (from polling, agent reports, spawn, kill) should
+ * flow through this module.
+ */
+
+import type {
+  CanonicalSessionLifecycle,
+  CanonicalSessionReason,
+  CanonicalSessionState,
+  SessionId,
+  SessionStatus,
+} from "./types.js";
+import { cloneLifecycle, deriveLegacyStatus } from "./lifecycle-state.js";
+import { updateMetadata, readMetadataRaw, readCanonicalLifecycle } from "./metadata.js";
+import type { LifecycleDecision } from "./lifecycle-status-decisions.js";
+
+/**
+ * Source of the lifecycle transition — used for audit and observability.
+ */
+export type TransitionSource =
+  | "poll" // Lifecycle manager polling
+  | "agent_report" // Agent self-report (ao acknowledge, ao report)
+  | "spawn" // Session spawn
+  | "restore" // Session restore
+  | "kill" // Manual kill
+  | "cleanup" // Session cleanup
+  | "claim_pr"; // PR claim
+
+/**
+ * Result of a lifecycle transition attempt.
+ */
+export interface TransitionResult {
+  success: boolean;
+  /** The previous lifecycle state (before mutation). */
+  previousLifecycle: CanonicalSessionLifecycle;
+  /** The new lifecycle state (after mutation). */
+  nextLifecycle: CanonicalSessionLifecycle;
+  /** The previous legacy status. */
+  previousStatus: SessionStatus;
+  /** The new legacy status. */
+  nextStatus: SessionStatus;
+  /** ISO timestamp when the transition occurred. */
+  transitionedAt: string;
+  /** Whether the status actually changed. */
+  statusChanged: boolean;
+  /** Reason if transition was rejected. */
+  rejectionReason?: string;
+}
+
+/**
+ * Input for applying a lifecycle decision.
+ */
+export interface ApplyDecisionInput {
+  dataDir: string;
+  sessionId: SessionId;
+  decision: LifecycleDecision;
+  /** Additional metadata to persist alongside the lifecycle. */
+  additionalMetadata?: Record<string, string>;
+  /** Source of the transition for observability. */
+  source: TransitionSource;
+  /** Override the current time (for testing). */
+  now?: Date;
+}
+
+/**
+ * Apply a lifecycle decision to the in-memory lifecycle object.
+ * This mutates the lifecycle in place.
+ */
+export function applyDecisionToLifecycle(
+  lifecycle: CanonicalSessionLifecycle,
+  decision: LifecycleDecision,
+  nowIso: string,
+): void {
+  // Apply PR state if present
+  if (decision.prState) {
+    lifecycle.pr.state = decision.prState;
+    lifecycle.pr.lastObservedAt = nowIso;
+  }
+  if (decision.prReason) {
+    lifecycle.pr.reason = decision.prReason;
+  }
+
+  // Apply session state if present
+  if (decision.sessionState && decision.sessionReason) {
+    lifecycle.session.state = decision.sessionState;
+    lifecycle.session.reason = decision.sessionReason;
+    lifecycle.session.lastTransitionAt = nowIso;
+
+    // Handle special timestamp fields
+    if (decision.sessionState === "working" && lifecycle.session.startedAt === null) {
+      lifecycle.session.startedAt = nowIso;
+    }
+    if (decision.sessionState === "done") {
+      lifecycle.session.completedAt = nowIso;
+    }
+    if (decision.sessionState === "terminated") {
+      lifecycle.session.terminatedAt = nowIso;
+    }
+  }
+}
+
+/**
+ * Build the metadata patch for persisting a lifecycle transition.
+ */
+export function buildTransitionMetadataPatch(
+  lifecycle: CanonicalSessionLifecycle,
+  decision: LifecycleDecision,
+  previousStatus: SessionStatus,
+): Record<string, string> {
+  const patch: Record<string, string> = {
+    stateVersion: "2",
+    statePayload: JSON.stringify(lifecycle),
+    status: deriveLegacyStatus(lifecycle, previousStatus),
+  };
+
+  // Include lifecycle evidence
+  if (decision.evidence) {
+    patch["lifecycleEvidence"] = decision.evidence;
+  }
+
+  // Include detecting metadata
+  if (decision.detectingAttempts > 0) {
+    patch["detectingAttempts"] = String(decision.detectingAttempts);
+  } else {
+    patch["detectingAttempts"] = "";
+  }
+
+  if (decision.detectingStartedAt) {
+    patch["detectingStartedAt"] = decision.detectingStartedAt;
+  } else {
+    patch["detectingStartedAt"] = "";
+  }
+
+  if (decision.detectingEvidenceHash) {
+    patch["detectingEvidenceHash"] = decision.detectingEvidenceHash;
+  } else {
+    patch["detectingEvidenceHash"] = "";
+  }
+
+  // Include PR URL if present in lifecycle
+  if (lifecycle.pr.url) {
+    patch["pr"] = lifecycle.pr.url;
+  }
+
+  // Include runtime handle if present
+  if (lifecycle.runtime.handle) {
+    patch["runtimeHandle"] = JSON.stringify(lifecycle.runtime.handle);
+  }
+  if (lifecycle.runtime.tmuxName) {
+    patch["tmuxName"] = lifecycle.runtime.tmuxName;
+  }
+
+  // Include role if orchestrator
+  if (lifecycle.session.kind === "orchestrator") {
+    patch["role"] = "orchestrator";
+  }
+
+  return patch;
+}
+
+/**
+ * Apply a lifecycle decision and persist to metadata.
+ *
+ * This is the primary entry point for lifecycle mutations. It:
+ * 1. Reads the current lifecycle state
+ * 2. Validates the transition (if applicable)
+ * 3. Applies the decision to the lifecycle
+ * 4. Persists the updated lifecycle and metadata
+ * 5. Returns before/after state for observability
+ */
+export function applyLifecycleDecision(
+  input: ApplyDecisionInput,
+): TransitionResult {
+  const now = input.now ?? new Date();
+  const nowIso = now.toISOString();
+
+  // Read current state
+  const rawMeta = readMetadataRaw(input.dataDir, input.sessionId);
+  if (!rawMeta) {
+    const emptyLifecycle = createEmptyLifecycle();
+    return {
+      success: false,
+      previousLifecycle: emptyLifecycle,
+      nextLifecycle: emptyLifecycle,
+      previousStatus: "working",
+      nextStatus: "working",
+      transitionedAt: nowIso,
+      statusChanged: false,
+      rejectionReason: `Session not found: ${input.sessionId}`,
+    };
+  }
+
+  const currentLifecycle = readCanonicalLifecycle(input.dataDir, input.sessionId);
+  if (!currentLifecycle) {
+    const emptyLifecycle = createEmptyLifecycle();
+    return {
+      success: false,
+      previousLifecycle: emptyLifecycle,
+      nextLifecycle: emptyLifecycle,
+      previousStatus: "working",
+      nextStatus: "working",
+      transitionedAt: nowIso,
+      statusChanged: false,
+      rejectionReason: `Failed to read lifecycle for session: ${input.sessionId}`,
+    };
+  }
+
+  const previousLifecycle = cloneLifecycle(currentLifecycle);
+  const previousStatus = deriveLegacyStatus(
+    previousLifecycle,
+    (rawMeta["status"] as SessionStatus) ?? "working",
+  );
+
+  // Apply the decision to the lifecycle
+  const nextLifecycle = cloneLifecycle(currentLifecycle);
+  applyDecisionToLifecycle(nextLifecycle, input.decision, nowIso);
+
+  const nextStatus = deriveLegacyStatus(nextLifecycle, previousStatus);
+  const statusChanged = nextStatus !== previousStatus;
+
+  // Build and apply metadata patch
+  const metadataPatch = buildTransitionMetadataPatch(
+    nextLifecycle,
+    input.decision,
+    previousStatus,
+  );
+
+  // Merge additional metadata
+  if (input.additionalMetadata) {
+    for (const [key, value] of Object.entries(input.additionalMetadata)) {
+      metadataPatch[key] = value;
+    }
+  }
+
+  // Persist
+  updateMetadata(input.dataDir, input.sessionId, metadataPatch);
+
+  return {
+    success: true,
+    previousLifecycle,
+    nextLifecycle,
+    previousStatus,
+    nextStatus,
+    transitionedAt: nowIso,
+    statusChanged,
+  };
+}
+
+/**
+ * Create an empty lifecycle for error cases.
+ */
+function createEmptyLifecycle(): CanonicalSessionLifecycle {
+  return {
+    version: 2,
+    session: {
+      kind: "worker",
+      state: "not_started",
+      reason: "spawn_requested",
+      startedAt: null,
+      completedAt: null,
+      terminatedAt: null,
+      lastTransitionAt: new Date().toISOString(),
+    },
+    pr: {
+      state: "none",
+      reason: "not_created",
+      number: null,
+      url: null,
+      lastObservedAt: null,
+    },
+    runtime: {
+      state: "unknown",
+      reason: "spawn_incomplete",
+      lastObservedAt: null,
+      handle: null,
+      tmuxName: null,
+    },
+  };
+}
+
+/**
+ * Helper to create a minimal lifecycle decision for direct state updates.
+ */
+export function createStateTransitionDecision(
+  status: SessionStatus,
+  state: CanonicalSessionState,
+  reason: CanonicalSessionReason,
+  evidence: string,
+): LifecycleDecision {
+  return {
+    status,
+    evidence,
+    detectingAttempts: 0,
+    sessionState: state,
+    sessionReason: reason,
+  };
+}

--- a/packages/core/src/report-watcher.ts
+++ b/packages/core/src/report-watcher.ts
@@ -18,7 +18,6 @@ import { readAgentReport, isAgentReportFresh, type AgentReport } from "./agent-r
 export type ReportWatcherTrigger =
   | "no_acknowledge"
   | "stale_report"
-  | "agent_blocked"
   | "agent_needs_input";
 
 /**
@@ -80,6 +79,7 @@ const TERMINAL_STATUSES: Set<SessionStatus> = new Set([
 
 /**
  * Check if a session should be audited for report issues.
+ * Note: spawning sessions are included so acknowledge timeout can fire.
  */
 export function shouldAuditSession(session: Session): boolean {
   // Skip terminal sessions
@@ -90,10 +90,7 @@ export function shouldAuditSession(session: Session): boolean {
   if (session.lifecycle?.session.kind === "orchestrator") {
     return false;
   }
-  // Skip sessions still spawning (give them time to start)
-  if (session.status === "spawning") {
-    return false;
-  }
+  // Note: spawning sessions are NOT skipped — they need acknowledge timeout checks
   return true;
 }
 
@@ -237,8 +234,6 @@ export function getReactionKeyForTrigger(trigger: ReportWatcherTrigger): string 
       return "report-no-acknowledge";
     case "stale_report":
       return "report-stale";
-    case "agent_blocked":
-      return "report-blocked";
     case "agent_needs_input":
       return "report-needs-input";
   }

--- a/packages/core/src/report-watcher.ts
+++ b/packages/core/src/report-watcher.ts
@@ -1,0 +1,259 @@
+/**
+ * Report Watcher — Background trigger system for agent reports (#140)
+ *
+ * Monitors agent reports and triggers actions when anomalies are detected:
+ * - No acknowledge timeout: agent didn't acknowledge task after spawn
+ * - Stale report: agent hasn't reported in a while
+ * - Agent blocked: agent reported blocked/needs_input state
+ *
+ * This module is designed to be called from the lifecycle-manager polling loop.
+ */
+
+import type { Session, SessionStatus } from "./types.js";
+import { readAgentReport, isAgentReportFresh, type AgentReport } from "./agent-report.js";
+
+/**
+ * Report watcher trigger types.
+ */
+export type ReportWatcherTrigger =
+  | "no_acknowledge"
+  | "stale_report"
+  | "agent_blocked"
+  | "agent_needs_input";
+
+/**
+ * Result of a report audit check.
+ */
+export interface ReportAuditResult {
+  /** Which trigger was activated, if any. */
+  trigger: ReportWatcherTrigger | null;
+  /** Human-readable description of the finding. */
+  message: string;
+  /** ISO timestamp when the check was performed. */
+  checkedAt: string;
+  /** The agent report that was checked (if available). */
+  report: AgentReport | null;
+  /** Time since spawn in milliseconds. */
+  timeSinceSpawnMs?: number;
+  /** Time since last report in milliseconds. */
+  timeSinceReportMs?: number;
+}
+
+/**
+ * Configuration for report watcher thresholds.
+ */
+export interface ReportWatcherConfig {
+  /** Time after spawn before triggering no-acknowledge (default: 10 minutes). */
+  acknowledgeTimeoutMs: number;
+  /** Time without reports before triggering stale report (default: 30 minutes). */
+  staleReportTimeoutMs: number;
+  /** Whether to check for acknowledge timeout. */
+  checkAcknowledge: boolean;
+  /** Whether to check for stale reports. */
+  checkStale: boolean;
+  /** Whether to check for blocked agents. */
+  checkBlocked: boolean;
+}
+
+/**
+ * Default report watcher configuration.
+ */
+export const DEFAULT_REPORT_WATCHER_CONFIG: ReportWatcherConfig = {
+  acknowledgeTimeoutMs: 10 * 60 * 1000, // 10 minutes
+  staleReportTimeoutMs: 30 * 60 * 1000, // 30 minutes
+  checkAcknowledge: true,
+  checkStale: true,
+  checkBlocked: true,
+};
+
+/**
+ * Terminal statuses that should not be audited.
+ */
+const TERMINAL_STATUSES: Set<SessionStatus> = new Set([
+  "done",
+  "terminated",
+  "killed",
+  "cleanup",
+  "merged",
+  "errored",
+]);
+
+/**
+ * Check if a session should be audited for report issues.
+ */
+export function shouldAuditSession(session: Session): boolean {
+  // Skip terminal sessions
+  if (TERMINAL_STATUSES.has(session.status)) {
+    return false;
+  }
+  // Skip orchestrator sessions
+  if (session.lifecycle?.session.kind === "orchestrator") {
+    return false;
+  }
+  // Skip sessions still spawning (give them time to start)
+  if (session.status === "spawning") {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Check for acknowledge timeout: agent didn't acknowledge task within threshold.
+ */
+export function checkAcknowledgeTimeout(
+  session: Session,
+  report: AgentReport | null,
+  now: Date,
+  config: ReportWatcherConfig,
+): ReportAuditResult | null {
+  if (!config.checkAcknowledge) return null;
+
+  // If we have any report (acknowledge or otherwise), the agent responded
+  if (report) return null;
+
+  // Check time since spawn
+  const createdAt = session.createdAt ?? session.metadata["createdAt"];
+  if (!createdAt) return null;
+
+  const spawnTime = typeof createdAt === "string" ? Date.parse(createdAt) : createdAt.getTime();
+  if (Number.isNaN(spawnTime)) return null;
+
+  const timeSinceSpawn = now.getTime() - spawnTime;
+  if (timeSinceSpawn < config.acknowledgeTimeoutMs) return null;
+
+  return {
+    trigger: "no_acknowledge",
+    message: `Agent has not acknowledged task after ${Math.round(timeSinceSpawn / 60000)} minutes`,
+    checkedAt: now.toISOString(),
+    report: null,
+    timeSinceSpawnMs: timeSinceSpawn,
+  };
+}
+
+/**
+ * Check for stale report: agent hasn't reported in a while.
+ */
+export function checkStaleReport(
+  session: Session,
+  report: AgentReport | null,
+  now: Date,
+  config: ReportWatcherConfig,
+): ReportAuditResult | null {
+  if (!config.checkStale) return null;
+
+  // If no report, the acknowledge check handles it
+  if (!report) return null;
+
+  // Check if the report is stale
+  const reportTime = Date.parse(report.timestamp);
+  if (Number.isNaN(reportTime)) return null;
+
+  const timeSinceReport = now.getTime() - reportTime;
+  if (timeSinceReport < config.staleReportTimeoutMs) return null;
+
+  // Don't flag as stale if agent is in a waiting state (that's expected)
+  if (report.state === "waiting" || report.state === "needs_input") return null;
+
+  return {
+    trigger: "stale_report",
+    message: `Agent report is stale (${Math.round(timeSinceReport / 60000)} minutes since last report)`,
+    checkedAt: now.toISOString(),
+    report,
+    timeSinceReportMs: timeSinceReport,
+  };
+}
+
+/**
+ * Check for blocked agent: agent reported blocked or needs_input state.
+ */
+export function checkBlockedAgent(
+  _session: Session,
+  report: AgentReport | null,
+  now: Date,
+  config: ReportWatcherConfig,
+): ReportAuditResult | null {
+  if (!config.checkBlocked) return null;
+
+  // If no report, nothing to check
+  if (!report) return null;
+
+  // Only check fresh reports (don't re-trigger on old blocked states)
+  if (!isAgentReportFresh(report, now)) return null;
+
+  if (report.state === "needs_input") {
+    return {
+      trigger: "agent_needs_input",
+      message: `Agent needs input: ${report.note ?? "waiting for user decision"}`,
+      checkedAt: now.toISOString(),
+      report,
+    };
+  }
+
+  // Note: "blocked" is not in the current AGENT_REPORTED_STATES but we check for it
+  // in case it gets added or for forward compatibility
+  return null;
+}
+
+/**
+ * Audit a session's agent reports for issues.
+ * Returns the first triggered audit result, or null if no issues found.
+ */
+export function auditAgentReports(
+  session: Session,
+  config: Partial<ReportWatcherConfig> = {},
+  now: Date = new Date(),
+): ReportAuditResult | null {
+  if (!shouldAuditSession(session)) {
+    return null;
+  }
+
+  const fullConfig: ReportWatcherConfig = {
+    ...DEFAULT_REPORT_WATCHER_CONFIG,
+    ...config,
+  };
+
+  const report = readAgentReport(session.metadata);
+
+  // Check in priority order: blocked > no_acknowledge > stale
+  const blockedResult = checkBlockedAgent(session, report, now, fullConfig);
+  if (blockedResult) return blockedResult;
+
+  const acknowledgeResult = checkAcknowledgeTimeout(session, report, now, fullConfig);
+  if (acknowledgeResult) return acknowledgeResult;
+
+  const staleResult = checkStaleReport(session, report, now, fullConfig);
+  if (staleResult) return staleResult;
+
+  return null;
+}
+
+/**
+ * Get the reaction key for a report watcher trigger.
+ * Used to look up the reaction configuration.
+ */
+export function getReactionKeyForTrigger(trigger: ReportWatcherTrigger): string {
+  switch (trigger) {
+    case "no_acknowledge":
+      return "report-no-acknowledge";
+    case "stale_report":
+      return "report-stale";
+    case "agent_blocked":
+      return "report-blocked";
+    case "agent_needs_input":
+      return "report-needs-input";
+  }
+}
+
+/**
+ * Metadata keys for storing report watcher flags.
+ */
+export const REPORT_WATCHER_METADATA_KEYS = {
+  /** ISO timestamp of last audit */
+  LAST_AUDITED_AT: "reportWatcherLastAuditedAt",
+  /** Current active trigger (if any) */
+  ACTIVE_TRIGGER: "reportWatcherActiveTrigger",
+  /** ISO timestamp when trigger was first activated */
+  TRIGGER_ACTIVATED_AT: "reportWatcherTriggerActivatedAt",
+  /** Number of times this trigger has fired */
+  TRIGGER_COUNT: "reportWatcherTriggerCount",
+} as const;


### PR DESCRIPTION
## Summary

This PR implements three related lifecycle improvements:

### Issue #137: Centralize lifecycle transitions
- Create `lifecycle-transition.ts` with `applyLifecycleDecision` function
- Provide consistent mutation boundary for lifecycle state changes  
- Export `buildTransitionMetadataPatch` and `createStateTransitionDecision` helpers

### Issue #138: Make detecting a real bounded transition state
- Add time-based escalation (5 min hard cap) in addition to attempt-based (3 attempts)
- Add evidence hashing to prevent counter reset on unchanged evidence
- Track `detectingStartedAt` and `detectingEvidenceHash` in metadata
- Escalate to `stuck` when either limit is exceeded

### Issue #140: Report Watcher for agent reports
- Create `report-watcher.ts` with audit functions
- `checkAcknowledgeTimeout` (10 min default) - triggers when agent doesn't acknowledge
- `checkStaleReport` (30 min default) - triggers when agent stops reporting
- `checkBlockedAgent` - triggers when agent reports `needs_input` state
- Integrate `auditAndReactToReports` into lifecycle polling loop
- Surface triggers as reactions: `report-no-acknowledge`, `report-stale`, `report-needs-input`

## Test plan
- [x] 19 tests for lifecycle-status-decisions (detecting bounds, evidence hashing)
- [x] 13 tests for lifecycle-transition (decision application, metadata persistence)
- [x] 19 tests for report-watcher (audit triggers, priority ordering)
- [x] All 746 core package tests pass
- [x] Full monorepo build succeeds
- [x] TypeScript strict mode passes
- [x] Lint passes (0 errors)

## Files Changed
| File | Change |
|------|--------|
| `lifecycle-status-decisions.ts` | Add time-based escalation, evidence hashing |
| `lifecycle-transition.ts` | **NEW** - centralized transition service |
| `report-watcher.ts` | **NEW** - report audit functions |
| `lifecycle-manager.ts` | Integrate report watcher, pass detecting metadata |
| `index.ts` | Export new modules |
| `**/tests` | 51 new tests |

Closes #137, #138, #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)