### PR TITLE
fix: close remaining PR #1300 lifecycle regressions

### DIFF
--- a/.changeset/late-lions-share.md
+++ b/.changeset/late-lions-share.md
@@ -4,3 +4,8 @@
 ---
 
 Allow workers to report non-terminal PR workflow events like `pr-created`, `draft-pr-created`, and `ready-for-review` with optional PR URL/number metadata, while keeping merged and closed PR state SCM-owned.
+
+**Migration:** `Session` now carries canonical lifecycle truth in `session.lifecycle`
+and explicit activity-evidence metadata in `session.activitySignal`. Third-party
+callers that construct `Session` objects directly must populate those fields or
+route through the core session helpers that synthesize them.

--- a/.changeset/pr1300-review-followups.md
+++ b/.changeset/pr1300-review-followups.md
@@ -4,4 +4,4 @@
 "@aoagents/ao-web": patch
 ---
 
-Tighten the session lifecycle review follow-ups by debouncing report-watcher reactions, restoring the shared Geist/JetBrains font setup, wiring recovery validation to real agent activity probes, and adding direct coverage for `ao report`, activity-signal classification, and dashboard lifecycle audit panels.
+Tighten the session lifecycle review follow-ups by debouncing report-watcher reactions, restoring the shared Geist/JetBrains font setup, wiring recovery validation to real agent activity probes, adding direct coverage for `ao report`, activity-signal classification, and dashboard lifecycle audit panels, and fixing the remaining lifecycle-state regressions around legacy merged-session rehydration and malformed canonical payload parsing.

--- a/.changeset/pr1300-review-followups.md
+++ b/.changeset/pr1300-review-followups.md
@@ -4,4 +4,4 @@
 "@aoagents/ao-web": patch
 ---
 
-Tighten the session lifecycle review follow-ups by debouncing report-watcher reactions, restoring the shared Geist/JetBrains font setup, wiring recovery validation to real agent activity probes, adding direct coverage for `ao report`, activity-signal classification, and dashboard lifecycle audit panels, and fixing the remaining lifecycle-state regressions around legacy merged-session rehydration and malformed canonical payload parsing.
+Tighten the session lifecycle review follow-ups by debouncing report-watcher reactions, restoring the shared Geist/JetBrains font setup, wiring recovery validation to real agent activity probes, adding direct coverage for `ao report`, activity-signal classification, and dashboard lifecycle audit panels, fixing the remaining lifecycle-state regressions around legacy merged-session rehydration and malformed canonical payload parsing, making agent-report metadata writes atomic, persisting canonical payloads for legacy sessions on read, stabilizing detecting evidence hashes, and removing the remaining inline-style cleanup debt from the session detail view.

--- a/packages/core/src/__tests__/lifecycle-state.test.ts
+++ b/packages/core/src/__tests__/lifecycle-state.test.ts
@@ -123,4 +123,51 @@ describe("parseCanonicalLifecycle", () => {
     expect(parsed.pr.reason).toBe("in_progress");
     expect(parsed.pr.number).toBe(42);
   });
+
+  it("preserves valid partial v2 payload fields while synthesizing missing sections", () => {
+    const parsed = parseCanonicalLifecycle({
+      status: "review_pending",
+      pr: "https://github.com/org/repo/pull/42",
+      stateVersion: "2",
+      statePayload: JSON.stringify({
+        version: 2,
+        session: {
+          kind: "orchestrator",
+          state: "idle",
+          reason: "awaiting_external_review",
+        },
+      }),
+    });
+
+    expect(parsed.session.kind).toBe("orchestrator");
+    expect(parsed.session.state).toBe("idle");
+    expect(parsed.session.reason).toBe("awaiting_external_review");
+    expect(parsed.pr.state).toBe("open");
+    expect(parsed.pr.reason).toBe("in_progress");
+    expect(parsed.pr.number).toBe(42);
+  });
+
+  it("normalizes runtime handles without data instead of discarding the payload", () => {
+    const parsed = parseCanonicalLifecycle({
+      status: "working",
+      stateVersion: "2",
+      statePayload: JSON.stringify({
+        version: 2,
+        runtime: {
+          handle: {
+            id: "rt-1",
+            runtimeName: "tmux",
+          },
+        },
+      }),
+    });
+
+    expect(parsed.runtime.handle).toEqual({
+      id: "rt-1",
+      runtimeName: "tmux",
+      data: {},
+    });
+    expect(parsed.runtime.state).toBe("unknown");
+    expect(parsed.runtime.reason).toBe("spawn_incomplete");
+  });
 });

--- a/packages/core/src/__tests__/lifecycle-state.test.ts
+++ b/packages/core/src/__tests__/lifecycle-state.test.ts
@@ -63,6 +63,21 @@ describe("deriveLegacyStatus", () => {
 });
 
 describe("parseCanonicalLifecycle", () => {
+  it("rehydrates legacy merged sessions with a merged PR state", () => {
+    const parsed = parseCanonicalLifecycle({
+      status: "merged",
+      pr: "https://github.com/org/repo/pull/42",
+      createdAt: "2025-01-01T00:00:00.000Z",
+    });
+
+    expect(parsed.session.state).toBe("idle");
+    expect(parsed.session.reason).toBe("merged_waiting_decision");
+    expect(parsed.pr.state).toBe("merged");
+    expect(parsed.pr.reason).toBe("merged");
+    expect(parsed.pr.number).toBe(42);
+    expect(deriveLegacyStatus(parsed, "merged")).toBe("merged");
+  });
+
   it("preserves explicit null payload fields instead of rehydrating stale flat metadata", () => {
     const lifecycle = createInitialCanonicalLifecycle("worker", new Date("2025-01-01T00:00:00Z"));
     lifecycle.session.state = "working";
@@ -85,5 +100,27 @@ describe("parseCanonicalLifecycle", () => {
     expect(parsed.pr.url).toBeNull();
     expect(parsed.runtime.handle).toBeNull();
     expect(parsed.runtime.tmuxName).toBeNull();
+  });
+
+  it("falls back to synthesized lifecycle when a v2 payload is malformed", () => {
+    const parsed = parseCanonicalLifecycle({
+      status: "review_pending",
+      pr: "https://github.com/org/repo/pull/42",
+      stateVersion: "2",
+      statePayload: JSON.stringify({
+        version: 2,
+        session: {
+          kind: "worker",
+          state: "working",
+          reason: 123,
+        },
+      }),
+    });
+
+    expect(parsed.session.state).toBe("working");
+    expect(parsed.session.reason).toBe("task_in_progress");
+    expect(parsed.pr.state).toBe("open");
+    expect(parsed.pr.reason).toBe("in_progress");
+    expect(parsed.pr.number).toBe(42);
   });
 });

--- a/packages/core/src/__tests__/lifecycle-status-decisions.test.ts
+++ b/packages/core/src/__tests__/lifecycle-status-decisions.test.ts
@@ -24,6 +24,17 @@ describe("hashEvidence", () => {
     const hash2 = hashEvidence("evidence B");
     expect(hash1).not.toBe(hash2);
   });
+
+  it("ignores activity labels and timestamps when hashing probe evidence", () => {
+    const active = hashEvidence(
+      "signal_disagreement runtime=alive process=unknown activity_signal=valid via_native activity=active at=2026-04-18T10:00:00.000Z",
+    );
+    const blocked = hashEvidence(
+      "signal_disagreement runtime=alive process=unknown activity_signal=valid via_native activity=blocked at=2026-04-18T10:01:00.000Z",
+    );
+
+    expect(active).toBe(blocked);
+  });
 });
 
 describe("isDetectingTimedOut", () => {

--- a/packages/core/src/__tests__/metadata.test.ts
+++ b/packages/core/src/__tests__/metadata.test.ts
@@ -8,6 +8,7 @@ import {
   readMetadataRaw,
   readCanonicalLifecycle,
   readArchivedMetadataRaw,
+  mutateMetadata,
   writeMetadata,
   updateMetadata,
   deleteMetadata,
@@ -211,6 +212,29 @@ describe("updateMetadata", () => {
     const meta = readMetadata(dataDir, "upd-4");
     expect(meta!.status).toBe("pr_open");
     expect(meta!.summary).toBeUndefined();
+  });
+
+  it("returns the normalized record that is actually persisted", () => {
+    writeMetadata(dataDir, "upd-5", {
+      worktree: "/tmp/w",
+      branch: "main",
+      status: "working",
+      summary: "doing stuff",
+    });
+
+    const next = mutateMetadata(dataDir, "upd-5", (existing) => ({
+      ...existing,
+      summary: "",
+      pr: "https://github.com/org/repo/pull/5",
+    }));
+
+    expect(next).toEqual({
+      worktree: "/tmp/w",
+      branch: "main",
+      status: "working",
+      pr: "https://github.com/org/repo/pull/5",
+    });
+    expect(readMetadataRaw(dataDir, "upd-5")).toEqual(next);
   });
 });
 

--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -88,6 +88,34 @@ describe("list", () => {
     expect(repaired!["status"]).toBe("working");
   });
 
+  it("persists canonical lifecycle payloads for legacy session metadata on read", async () => {
+    writeMetadata(sessionsDir, "app-legacy", {
+      worktree: "/tmp/legacy",
+      branch: "feat/legacy",
+      status: "working",
+      project: "my-app",
+      createdAt: "2025-01-01T00:00:00.000Z",
+    });
+
+    const oldTime = new Date("2026-01-02T00:00:00.000Z");
+    utimesSync(join(sessionsDir, "app-legacy"), oldTime, oldTime);
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const sessions = await sm.list("my-app");
+    const legacy = sessions.find((session) => session.id === "app-legacy");
+
+    expect(legacy).toBeDefined();
+    expect(legacy!.lastActivityAt.getTime()).toBe(oldTime.getTime());
+
+    const repaired = readMetadataRaw(sessionsDir, "app-legacy");
+    expect(repaired?.["stateVersion"]).toBe("2");
+    expect(repaired?.["statePayload"]).toBeTruthy();
+
+    const payload = JSON.parse(repaired!["statePayload"]);
+    expect(payload.session.startedAt).toBe("2025-01-01T00:00:00.000Z");
+    expect(payload.session.lastTransitionAt).toBe("2025-01-01T00:00:00.000Z");
+  });
+
   it("filters by project ID", async () => {
     // In hash-based architecture, each project has its own directory
     // so filtering is implicit. This test verifies list(projectId) only

--- a/packages/core/src/__tests__/session-manager/restore.test.ts
+++ b/packages/core/src/__tests__/session-manager/restore.test.ts
@@ -176,6 +176,20 @@ describe("restore", () => {
     await expect(sm.restore("app-1")).rejects.toThrow(SessionNotRestorableError);
   });
 
+  it("throws SessionNotRestorableError for legacy merged sessions with a PR URL", async () => {
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "merged",
+      pr: "https://github.com/org/my-app/pull/10",
+      project: "my-app",
+      createdAt: "2025-01-01T00:00:00.000Z",
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await expect(sm.restore("app-1")).rejects.toThrow(SessionNotRestorableError);
+  });
+
   it("throws SessionNotRestorableError for working sessions", async () => {
     writeMetadata(sessionsDir, "app-1", {
       worktree: "/tmp",

--- a/packages/core/src/agent-report.ts
+++ b/packages/core/src/agent-report.ts
@@ -26,8 +26,8 @@ import type {
   SessionId,
   SessionStatus,
 } from "./types.js";
-import { updateCanonicalLifecycle, updateMetadata, readMetadataRaw } from "./metadata.js";
-import { deriveLegacyStatus } from "./lifecycle-state.js";
+import { mutateMetadata, readMetadataRaw } from "./metadata.js";
+import { buildLifecycleMetadataPatch, cloneLifecycle, deriveLegacyStatus, parseCanonicalLifecycle } from "./lifecycle-state.js";
 import { parsePrFromUrl } from "./utils/pr.js";
 import { validateStatus } from "./utils/validation.js";
 
@@ -402,7 +402,13 @@ export function applyAgentReport(
   let legacyStatus: SessionStatus | null = null;
   let previousLegacyStatus: SessionStatus | null = null;
 
-  const nextLifecycle = updateCanonicalLifecycle(dataDir, sessionId, (current) => {
+  const nextMetadata = mutateMetadata(dataDir, sessionId, (existing) => {
+    const current = cloneLifecycle(
+      parseCanonicalLifecycle(existing, {
+        sessionId,
+        status: validateStatus(existing["status"]),
+      }),
+    );
     previousLegacyStatus = deriveLegacyStatus(current, validateStatus(raw["status"]));
     before = buildAuditSnapshot(current, previousLegacyStatus);
     const validation = validateAgentReportTransition(current, input.state);
@@ -454,36 +460,42 @@ export function applyAgentReport(
       current.session.startedAt = now;
     }
     legacyStatus = deriveLegacyStatus(current, previousLegacyStatus);
-    return current;
+    const next = { ...existing };
+    Object.assign(
+      next,
+      buildLifecycleMetadataPatch(current, previousLegacyStatus),
+      {
+        [AGENT_REPORT_METADATA_KEYS.STATE]: input.state,
+        [AGENT_REPORT_METADATA_KEYS.AT]: now,
+      },
+    );
+    if (trimmedNote) {
+      next[AGENT_REPORT_METADATA_KEYS.NOTE] = trimmedNote;
+    } else {
+      next[AGENT_REPORT_METADATA_KEYS.NOTE] = "";
+    }
+    if (isPRWorkflowReport(input.state)) {
+      if (trimmedPrUrl) {
+        next[AGENT_REPORT_METADATA_KEYS.PR_URL] = trimmedPrUrl;
+      }
+      if (prNumber !== undefined) {
+        next[AGENT_REPORT_METADATA_KEYS.PR_NUMBER] = String(prNumber);
+      }
+      if (prIsDraft !== undefined) {
+        next[AGENT_REPORT_METADATA_KEYS.PR_IS_DRAFT] = prIsDraft ? "true" : "false";
+      }
+    }
+    return next;
   });
 
-  if (!nextLifecycle || !before || !previousState || !nextState || !legacyStatus) {
+  if (!nextMetadata || !before || !previousState || !nextState || !legacyStatus) {
     throw new Error(`Failed to apply agent report for session ${sessionId}`);
   }
 
-  // Persist report metadata alongside the lifecycle patch.
-  const metadataUpdates: Record<string, string> = {
-    [AGENT_REPORT_METADATA_KEYS.STATE]: input.state,
-    [AGENT_REPORT_METADATA_KEYS.AT]: now,
-  };
-  if (trimmedNote) {
-    metadataUpdates[AGENT_REPORT_METADATA_KEYS.NOTE] = trimmedNote;
-  } else {
-    // Clear stale notes from previous reports so they don't mislead humans.
-    metadataUpdates[AGENT_REPORT_METADATA_KEYS.NOTE] = "";
-  }
-  if (isPRWorkflowReport(input.state)) {
-    if (trimmedPrUrl) {
-      metadataUpdates[AGENT_REPORT_METADATA_KEYS.PR_URL] = trimmedPrUrl;
-    }
-    if (prNumber !== undefined) {
-      metadataUpdates[AGENT_REPORT_METADATA_KEYS.PR_NUMBER] = String(prNumber);
-    }
-    if (prIsDraft !== undefined) {
-      metadataUpdates[AGENT_REPORT_METADATA_KEYS.PR_IS_DRAFT] = prIsDraft ? "true" : "false";
-    }
-  }
-  updateMetadata(dataDir, sessionId, metadataUpdates);
+  const nextLifecycle = parseCanonicalLifecycle(nextMetadata, {
+    sessionId,
+    status: validateStatus(nextMetadata["status"]),
+  });
 
   const after = buildAuditSnapshot(nextLifecycle, legacyStatus);
   const auditEntry: AgentReportAuditEntry = {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -568,8 +568,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             if (terminalOutput) {
               await agent.recordActivity(session, terminalOutput);
             }
-          } catch {
-            // Best effort only.
+          } catch (error) {
+            observer?.recordOperation?.({
+              metric: "lifecycle_poll",
+              operation: "activity.record",
+              outcome: "failure",
+              correlationId: createCorrelationId("lifecycle-poll"),
+              projectId: session.projectId,
+              sessionId: session.id,
+              reason: error instanceof Error ? error.message : String(error),
+              level: "warn",
+            });
           }
         }
 
@@ -716,8 +725,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           const sessionsDir = getSessionsDir(config.configPath, project.path);
           updateMetadata(sessionsDir, session.id, { pr: detectedPR.url });
         }
-      } catch {
-        // Retry next poll.
+      } catch (error) {
+        observer?.recordOperation?.({
+          metric: "lifecycle_poll",
+          operation: "scm.detect_pr",
+          outcome: "failure",
+          correlationId: createCorrelationId("lifecycle-poll"),
+          projectId: session.projectId,
+          sessionId: session.id,
+          reason: error instanceof Error ? error.message : String(error),
+          level: "warn",
+        });
       }
     }
 
@@ -789,8 +807,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             activityEvidence,
           }),
         );
-      } catch {
-        // Keep current status on SCM failure.
+      } catch (error) {
+        observer?.recordOperation?.({
+          metric: "lifecycle_poll",
+          operation: "scm.poll_pr",
+          outcome: "failure",
+          correlationId: createCorrelationId("lifecycle-poll"),
+          projectId: session.projectId,
+          sessionId: session.id,
+          reason: error instanceof Error ? error.message : String(error),
+          level: "warn",
+        });
       }
     }
 

--- a/packages/core/src/lifecycle-state.ts
+++ b/packages/core/src/lifecycle-state.ts
@@ -26,78 +26,94 @@ const TimestampSchema = z.string().nullable();
 const RuntimeHandleSchema = z.object({
   id: z.string(),
   runtimeName: z.string(),
-  data: z.record(z.unknown()),
+  data: z.preprocess((value) => {
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      return value;
+    }
+    return {};
+  }, z.record(z.unknown())),
 });
 
 const CanonicalSessionLifecycleSchema = z.object({
   version: z.literal(2),
-  session: z.object({
-    kind: z.enum(["worker", "orchestrator"]),
-    state: z.enum([
-      "not_started",
-      "working",
-      "idle",
-      "needs_input",
-      "stuck",
-      "detecting",
-      "done",
-      "terminated",
-    ]),
-    reason: z.enum([
-      "spawn_requested",
-      "agent_acknowledged",
-      "task_in_progress",
-      "pr_created",
-      "pr_closed_waiting_decision",
-      "fixing_ci",
-      "resolving_review_comments",
-      "awaiting_user_input",
-      "awaiting_external_review",
-      "research_complete",
-      "merged_waiting_decision",
-      "manually_killed",
-      "runtime_lost",
-      "agent_process_exited",
-      "probe_failure",
-      "error_in_process",
-    ]),
-    startedAt: TimestampSchema,
-    completedAt: TimestampSchema,
-    terminatedAt: TimestampSchema,
-    lastTransitionAt: z.string(),
-  }),
-  pr: z.object({
-    state: z.enum(["none", "open", "merged", "closed"]),
-    reason: z.enum([
-      "not_created",
-      "in_progress",
-      "ci_failing",
-      "review_pending",
-      "changes_requested",
-      "approved",
-      "merge_ready",
-      "merged",
-      "closed_unmerged",
-    ]),
-    number: z.number().int().nullable(),
-    url: z.string().nullable(),
-    lastObservedAt: TimestampSchema,
-  }),
-  runtime: z.object({
-    state: z.enum(["unknown", "alive", "exited", "missing", "probe_failed"]),
-    reason: z.enum([
-      "spawn_incomplete",
-      "process_running",
-      "process_missing",
-      "tmux_missing",
-      "manual_kill_requested",
-      "probe_error",
-    ]),
-    lastObservedAt: TimestampSchema,
-    handle: RuntimeHandleSchema.nullable(),
-    tmuxName: z.string().nullable(),
-  }),
+  session: z
+    .object({
+      kind: z.enum(["worker", "orchestrator"]),
+      state: z.enum([
+        "not_started",
+        "working",
+        "idle",
+        "needs_input",
+        "stuck",
+        "detecting",
+        "done",
+        "terminated",
+      ]),
+      reason: z.enum([
+        "spawn_requested",
+        "agent_acknowledged",
+        "task_in_progress",
+        "pr_created",
+        "pr_closed_waiting_decision",
+        "fixing_ci",
+        "resolving_review_comments",
+        "awaiting_user_input",
+        "awaiting_external_review",
+        "research_complete",
+        "merged_waiting_decision",
+        "manually_killed",
+        "runtime_lost",
+        "agent_process_exited",
+        "probe_failure",
+        "error_in_process",
+      ]),
+      startedAt: TimestampSchema,
+      completedAt: TimestampSchema,
+      terminatedAt: TimestampSchema,
+      lastTransitionAt: z.string(),
+    })
+    .partial()
+    .optional(),
+  pr: z
+    .object({
+      state: z.enum(["none", "open", "merged", "closed"]),
+      reason: z.enum([
+        "not_created",
+        "in_progress",
+        "ci_failing",
+        "review_pending",
+        "changes_requested",
+        "approved",
+        "merge_ready",
+        "merged",
+        "closed_unmerged",
+      ]),
+      number: z.number().int().nullable(),
+      url: z.string().nullable(),
+      lastObservedAt: TimestampSchema,
+    })
+    .partial()
+    .optional(),
+  runtime: z
+    .object({
+      state: z.enum(["unknown", "alive", "exited", "missing", "probe_failed"]),
+      reason: z.enum([
+        "spawn_incomplete",
+        "process_running",
+        "process_missing",
+        "tmux_missing",
+        "manual_kill_requested",
+        "probe_error",
+      ]),
+      lastObservedAt: TimestampSchema,
+      handle: RuntimeHandleSchema.nullable(),
+      tmuxName: z.string().nullable(),
+    })
+    .partial()
+    .optional(),
 });
+
+type ParsedCanonicalSessionLifecycle = z.infer<typeof CanonicalSessionLifecycleSchema>;
 
 function normalizeTimestamp(value: unknown, fallback: string | null = null): string | null {
   if (typeof value !== "string") return fallback;
@@ -266,7 +282,7 @@ function synthesizeCanonicalLifecycle(
 }
 
 function normalizePayloadLifecycle(
-  payload: CanonicalSessionLifecycle,
+  payload: ParsedCanonicalSessionLifecycle,
   meta: Record<string, string>,
   options: ParseCanonicalLifecycleOptions = {},
 ): CanonicalSessionLifecycle {

--- a/packages/core/src/lifecycle-state.ts
+++ b/packages/core/src/lifecycle-state.ts
@@ -10,6 +10,7 @@ import type {
   SessionKind,
   SessionStatus,
 } from "./types.js";
+import { z } from "zod";
 import { parsePrFromUrl } from "./utils/pr.js";
 import { safeJsonParse, validateStatus } from "./utils/validation.js";
 
@@ -19,6 +20,84 @@ interface ParseCanonicalLifecycleOptions {
   runtimeHandle?: RuntimeHandle | null;
   createdAt?: Date;
 }
+
+const TimestampSchema = z.string().nullable();
+
+const RuntimeHandleSchema = z.object({
+  id: z.string(),
+  runtimeName: z.string(),
+  data: z.record(z.unknown()),
+});
+
+const CanonicalSessionLifecycleSchema = z.object({
+  version: z.literal(2),
+  session: z.object({
+    kind: z.enum(["worker", "orchestrator"]),
+    state: z.enum([
+      "not_started",
+      "working",
+      "idle",
+      "needs_input",
+      "stuck",
+      "detecting",
+      "done",
+      "terminated",
+    ]),
+    reason: z.enum([
+      "spawn_requested",
+      "agent_acknowledged",
+      "task_in_progress",
+      "pr_created",
+      "pr_closed_waiting_decision",
+      "fixing_ci",
+      "resolving_review_comments",
+      "awaiting_user_input",
+      "awaiting_external_review",
+      "research_complete",
+      "merged_waiting_decision",
+      "manually_killed",
+      "runtime_lost",
+      "agent_process_exited",
+      "probe_failure",
+      "error_in_process",
+    ]),
+    startedAt: TimestampSchema,
+    completedAt: TimestampSchema,
+    terminatedAt: TimestampSchema,
+    lastTransitionAt: z.string(),
+  }),
+  pr: z.object({
+    state: z.enum(["none", "open", "merged", "closed"]),
+    reason: z.enum([
+      "not_created",
+      "in_progress",
+      "ci_failing",
+      "review_pending",
+      "changes_requested",
+      "approved",
+      "merge_ready",
+      "merged",
+      "closed_unmerged",
+    ]),
+    number: z.number().int().nullable(),
+    url: z.string().nullable(),
+    lastObservedAt: TimestampSchema,
+  }),
+  runtime: z.object({
+    state: z.enum(["unknown", "alive", "exited", "missing", "probe_failed"]),
+    reason: z.enum([
+      "spawn_incomplete",
+      "process_running",
+      "process_missing",
+      "tmux_missing",
+      "manual_kill_requested",
+      "probe_error",
+    ]),
+    lastObservedAt: TimestampSchema,
+    handle: RuntimeHandleSchema.nullable(),
+    tmuxName: z.string().nullable(),
+  }),
+});
 
 function normalizeTimestamp(value: unknown, fallback: string | null = null): string | null {
   if (typeof value !== "string") return fallback;
@@ -98,7 +177,7 @@ function synthesizeSessionState(
   }
 }
 
-function synthesizePRState(meta: Record<string, string>): {
+function synthesizePRState(meta: Record<string, string>, status: SessionStatus): {
   state: CanonicalPRState;
   reason: CanonicalPRReason;
   number: number | null;
@@ -110,8 +189,8 @@ function synthesizePRState(meta: Record<string, string>): {
   }
   const parsed = parsePrFromUrl(prUrl);
   return {
-    state: "open",
-    reason: "in_progress",
+    state: status === "merged" ? "merged" : "open",
+    reason: status === "merged" ? "merged" : "in_progress",
     number: parsed?.number ?? null,
     url: prUrl,
   };
@@ -154,7 +233,7 @@ function synthesizeCanonicalLifecycle(
     normalizeTimestamp(meta["createdAt"], new Date().toISOString()) ??
     new Date().toISOString();
   const sessionState = synthesizeSessionState(status);
-  const pr = synthesizePRState(meta);
+  const pr = synthesizePRState(meta, status);
   const runtime = synthesizeRuntimeState(meta, options.runtimeHandle ?? null);
 
   return {
@@ -289,10 +368,11 @@ export function parseCanonicalLifecycle(
 ): CanonicalSessionLifecycle {
   const parsed =
     meta["statePayload"] && meta["stateVersion"] === "2"
-      ? safeJsonParse<CanonicalSessionLifecycle>(meta["statePayload"])
+      ? safeJsonParse<unknown>(meta["statePayload"])
       : null;
-  if (parsed?.version === 2) {
-    return normalizePayloadLifecycle(parsed, meta, options);
+  const validated = CanonicalSessionLifecycleSchema.safeParse(parsed);
+  if (validated.success) {
+    return normalizePayloadLifecycle(validated.data, meta, options);
   }
   return synthesizeCanonicalLifecycle(meta, options);
 }
@@ -345,6 +425,8 @@ export function deriveLegacyStatus(
       return "idle";
     case "working":
       return "working";
+    default:
+      return previousStatus;
   }
 }
 

--- a/packages/core/src/lifecycle-status-decisions.ts
+++ b/packages/core/src/lifecycle-status-decisions.ts
@@ -43,8 +43,18 @@ interface LifecycleDecision {
  * Create a short hash of evidence string for detecting unchanged evidence.
  * Used to prevent counter reset when the same weak evidence re-presents.
  */
+function normalizeEvidenceForHash(evidence: string): string {
+  return evidence
+    .replace(/\sactivity=[^\s]+/g, "")
+    .replace(/\sat=[^\s]+/g, "")
+    .trim();
+}
+
 export function hashEvidence(evidence: string): string {
-  return createHash("sha256").update(evidence).digest("hex").slice(0, 12);
+  return createHash("sha256")
+    .update(normalizeEvidenceForHash(evidence))
+    .digest("hex")
+    .slice(0, 12);
 }
 
 interface OpenPRDecisionInput {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -193,6 +193,12 @@ function applyMetadataUpdates(
   return next;
 }
 
+function normalizeMetadataRecord(data: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(data).filter(([, value]) => value !== undefined && value !== ""),
+  );
+}
+
 export function mutateMetadata(
   dataDir: string,
   sessionId: SessionId,
@@ -208,7 +214,7 @@ export function mutateMetadata(
     return null;
   }
 
-  const next = updater({ ...existing });
+  const next = normalizeMetadataRecord(updater({ ...existing }));
 
   mkdirSync(dirname(path), { recursive: true });
   atomicWriteFileSync(path, serializeMetadata(next));

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -169,26 +169,50 @@ export function updateMetadata(
   sessionId: SessionId,
   updates: Partial<Record<string, string>>,
 ): void {
+  mutateMetadata(dataDir, sessionId, (existing) => {
+    return applyMetadataUpdates(existing, updates);
+  }, { createIfMissing: true });
+}
+
+function applyMetadataUpdates(
+  existing: Record<string, string>,
+  updates: Partial<Record<string, string>>,
+): Record<string, string> {
+  let next = { ...existing };
+  // Merge updates — remove keys set to empty string
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) continue;
+    if (value === "") {
+      const { [key]: _removed, ...rest } = next;
+      void _removed;
+      next = rest;
+    } else {
+      next[key] = value;
+    }
+  }
+  return next;
+}
+
+export function mutateMetadata(
+  dataDir: string,
+  sessionId: SessionId,
+  updater: (existing: Record<string, string>) => Record<string, string>,
+  options: { createIfMissing?: boolean } = {},
+): Record<string, string> | null {
   const path = metadataPath(dataDir, sessionId);
   let existing: Record<string, string> = {};
 
   if (existsSync(path)) {
     existing = parseKeyValueContent(readFileSync(path, "utf-8"));
+  } else if (!options.createIfMissing) {
+    return null;
   }
 
-  // Merge updates — remove keys set to empty string
-  for (const [key, value] of Object.entries(updates)) {
-    if (value === undefined) continue;
-    if (value === "") {
-      const { [key]: _, ...rest } = existing;
-      existing = rest;
-    } else {
-      existing[key] = value;
-    }
-  }
+  const next = updater({ ...existing });
 
   mkdirSync(dirname(path), { recursive: true });
-  atomicWriteFileSync(path, serializeMetadata(existing));
+  atomicWriteFileSync(path, serializeMetadata(next));
+  return next;
 }
 
 export function readCanonicalLifecycle(

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -494,6 +494,24 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const duplicatePRAttachments = new Map<string, ActiveSessionRecord[]>();
 
     for (const record of repaired) {
+      if (record.raw["stateVersion"] !== "2" || !record.raw["statePayload"]) {
+        const lifecycle = cloneLifecycle(
+          parseCanonicalLifecycle(record.raw, {
+            sessionId: record.sessionName,
+            status: validateStatus(record.raw["status"]),
+            createdAt: record.raw["createdAt"] ? new Date(record.raw["createdAt"]) : undefined,
+          }),
+        );
+        const canonicalUpdates = lifecycleMetadataUpdates(record.raw, lifecycle);
+        updateMetadataPreservingMtime(
+          sessionsDir,
+          record.sessionName,
+          canonicalUpdates,
+          record.modifiedAt,
+        );
+        record.raw = applyMetadataUpdatesToRaw(record.raw, canonicalUpdates);
+      }
+
       if (isOrchestratorSessionRecord(record.sessionName, record.raw, sessionPrefix)) {
         record.raw = repairSingleSessionMetadataOnRead(sessionsDir, record, sessionPrefix).raw;
         continue;

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -428,6 +428,12 @@ describe("scm-github plugin", () => {
       expect(ghMock).not.toHaveBeenCalled();
     });
 
+    it("returns null when project has no repo configured", async () => {
+      const result = await scm.detectPR(makeSession(), { ...project, repo: undefined });
+      expect(result).toBeNull();
+      expect(ghMock).not.toHaveBeenCalled();
+    });
+
     it("returns null on gh CLI error", async () => {
       mockGhError("gh: not found");
       const result = await scm.detectPR(makeSession(), project);

--- a/packages/plugins/scm-gitlab/test/index.test.ts
+++ b/packages/plugins/scm-gitlab/test/index.test.ts
@@ -356,6 +356,12 @@ describe("scm-gitlab plugin", () => {
       expect(glabMock).not.toHaveBeenCalled();
     });
 
+    it("returns null when project has no repo configured", async () => {
+      const result = await scm.detectPR(makeSession(), { ...project, repo: undefined });
+      expect(result).toBeNull();
+      expect(glabMock).not.toHaveBeenCalled();
+    });
+
     it("returns null and warns on glab CLI error", async () => {
       mockGlabError("glab: not found");
       const result = await scm.detectPR(makeSession(), project);

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1854,6 +1854,11 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   background: var(--color-status-ready);
 }
 
+.session-detail-tone--idle {
+  color: var(--color-status-idle);
+  background: var(--color-status-idle);
+}
+
 .session-detail-tone--attention {
   color: var(--color-status-attention);
   background: var(--color-status-attention);

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1841,6 +1841,37 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   height: 6px;
   border-radius: 999px;
   flex-shrink: 0;
+  background: currentColor;
+}
+
+.session-detail-tone--working {
+  color: var(--color-status-working);
+  background: var(--color-status-working);
+}
+
+.session-detail-tone--ready {
+  color: var(--color-status-ready);
+  background: var(--color-status-ready);
+}
+
+.session-detail-tone--attention {
+  color: var(--color-status-attention);
+  background: var(--color-status-attention);
+}
+
+.session-detail-tone--error {
+  color: var(--color-status-error);
+  background: var(--color-status-error);
+}
+
+.session-detail-tone--muted {
+  color: var(--color-text-muted);
+  background: var(--color-text-muted);
+}
+
+.session-detail-tone--accent {
+  color: var(--color-accent);
+  background: var(--color-accent);
 }
 
 .session-detail-status-pill--active {
@@ -1937,6 +1968,69 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   border: 1px solid var(--color-border-default);
   border-radius: 6px;
   background: color-mix(in srgb, var(--color-bg-elevated) 92%, transparent);
+}
+
+.session-detail-height--worker {
+  height: clamp(380px, 48vh, 560px);
+}
+
+.session-detail-height--orchestrator {
+  height: clamp(400px, 52vh, 620px);
+}
+
+.session-detail-height--full {
+  height: 100%;
+}
+
+.session-detail-zone-pill {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+
+.session-detail-zone-pill__value {
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.session-detail-zone-pill__label {
+  font-size: 10px;
+  font-weight: 500;
+  opacity: 0.8;
+}
+
+.session-detail-zone-pill--merge {
+  color: var(--color-status-ready);
+  background: color-mix(in srgb, var(--color-status-ready) 10%, transparent);
+}
+
+.session-detail-zone-pill--respond {
+  color: var(--color-status-error);
+  background: color-mix(in srgb, var(--color-status-error) 10%, transparent);
+}
+
+.session-detail-zone-pill--review {
+  color: var(--color-accent-orange);
+  background: color-mix(in srgb, var(--color-accent-orange) 10%, transparent);
+}
+
+.session-detail-zone-pill--working {
+  color: var(--color-accent-blue);
+  background: color-mix(in srgb, var(--color-accent-blue) 10%, transparent);
+}
+
+.session-detail-zone-pill--pending {
+  color: var(--color-status-attention);
+  background: color-mix(in srgb, var(--color-status-attention) 10%, transparent);
+}
+
+.session-detail-zone-pill--done {
+  color: var(--color-text-tertiary);
+  background: color-mix(in srgb, var(--color-text-tertiary) 14%, transparent);
 }
 
 /* ── Session cards — Emil design vision ──────────────────────────────── */
@@ -5012,6 +5106,31 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
     border-radius: 10px;
   }
 
+  .session-detail__status-pill--active {
+    color: var(--color-status-working);
+    background: color-mix(in srgb, var(--color-status-working) 12%, transparent);
+  }
+
+  .session-detail__status-pill--ready {
+    color: var(--color-status-ready);
+    background: color-mix(in srgb, var(--color-status-ready) 12%, transparent);
+  }
+
+  .session-detail__status-pill--waiting {
+    color: var(--color-status-attention);
+    background: color-mix(in srgb, var(--color-status-attention) 12%, transparent);
+  }
+
+  .session-detail__status-pill--error {
+    color: var(--color-status-error);
+    background: color-mix(in srgb, var(--color-status-error) 12%, transparent);
+  }
+
+  .session-detail__status-pill--idle {
+    color: var(--color-text-muted);
+    background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  }
+
   .session-detail__time {
     margin-left: auto;
     font-family: var(--font-mono);
@@ -5092,6 +5211,22 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
     height: 6px;
     border-radius: 50%;
     flex-shrink: 0;
+  }
+
+  .session-detail-ci-tone--neutral {
+    background: var(--color-text-tertiary);
+  }
+
+  .session-detail-ci-tone--pass {
+    background: var(--color-accent-green);
+  }
+
+  .session-detail-ci-tone--fail {
+    background: var(--color-accent-red);
+  }
+
+  .session-detail-ci-tone--pending {
+    background: var(--color-status-attention);
   }
 
   /* ── Mobile PR Dense Rows enhancements ─────────────────────────────── */

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -131,6 +131,8 @@ function activityToneClass(activityColor: string): string {
       return "session-detail-tone--working";
     case "var(--color-status-ready)":
       return "session-detail-tone--ready";
+    case "var(--color-status-idle)":
+      return "session-detail-tone--idle";
     case "var(--color-status-attention)":
       return "session-detail-tone--attention";
     case "var(--color-status-error)":

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -72,13 +72,6 @@ function formatTimeCompact(isoDate: string | null): string {
   return `${Math.floor(diffHours / 24)}d ago`;
 }
 
-function getCiDotBg(pr: DashboardPR): string {
-  if (isPRRateLimited(pr) || isPRUnenriched(pr)) return "var(--color-text-tertiary)";
-  if (pr.ciStatus === "passing") return "var(--color-accent-green)";
-  if (pr.ciStatus === "failing") return "var(--color-accent-red)";
-  return "var(--color-status-attention)";
-}
-
 function getCiShortLabel(pr: DashboardPR): string {
   if (isPRRateLimited(pr) || isPRUnenriched(pr)) return "CI";
   if (pr.ciStatus === "passing") return "CI passing";
@@ -130,6 +123,39 @@ function activityStateClass(activityLabel: string): string {
     return "session-detail-status-pill--error";
   }
   return "session-detail-status-pill--neutral";
+}
+
+function activityToneClass(activityColor: string): string {
+  switch (activityColor) {
+    case "var(--color-status-working)":
+      return "session-detail-tone--working";
+    case "var(--color-status-ready)":
+      return "session-detail-tone--ready";
+    case "var(--color-status-attention)":
+      return "session-detail-tone--attention";
+    case "var(--color-status-error)":
+      return "session-detail-tone--error";
+    default:
+      return "session-detail-tone--muted";
+  }
+}
+
+function mobileStatusPillClass(activityLabel: string): string {
+  const normalized = activityLabel.toLowerCase();
+  if (normalized === "active") return "session-detail__status-pill--active";
+  if (normalized === "ready") return "session-detail__status-pill--ready";
+  if (normalized === "waiting for input") return "session-detail__status-pill--waiting";
+  if (normalized === "blocked" || normalized === "exited") {
+    return "session-detail__status-pill--error";
+  }
+  return "session-detail__status-pill--idle";
+}
+
+function ciToneClass(pr: DashboardPR): string {
+  if (isPRRateLimited(pr) || isPRUnenriched(pr)) return "session-detail-ci-tone--neutral";
+  if (pr.ciStatus === "passing") return "session-detail-ci-tone--pass";
+  if (pr.ciStatus === "failing") return "session-detail-ci-tone--fail";
+  return "session-detail-ci-tone--pending";
 }
 
 function SessionTopStrip({
@@ -199,8 +225,10 @@ function SessionTopStrip({
               )}
             >
               <span
-                className="session-detail-status-pill__dot"
-                style={{ background: activityColor }}
+                className={cn(
+                  "session-detail-status-pill__dot",
+                  activityToneClass(activityColor),
+                )}
               />
               <span className="session-detail-status-pill__label">
                 {activityLabel}
@@ -344,42 +372,36 @@ function _OrchestratorStatusStrip({
     return () => clearInterval(id);
   }, [createdAt]);
 
-  const stats: Array<{ value: number; label: string; color: string; bg: string }> = [
+  const stats: Array<{ value: number; label: string; toneClass: string }> = [
     {
       value: zones.merge,
       label: "merge-ready",
-      color: "var(--color-status-ready)",
-      bg: "color-mix(in srgb, var(--color-status-ready) 10%, transparent)",
+      toneClass: "session-detail-zone-pill--merge",
     },
     {
       value: zones.respond,
       label: "responding",
-      color: "var(--color-status-error)",
-      bg: "color-mix(in srgb, var(--color-status-error) 10%, transparent)",
+      toneClass: "session-detail-zone-pill--respond",
     },
     {
       value: zones.review,
       label: "review",
-      color: "var(--color-accent-orange)",
-      bg: "color-mix(in srgb, var(--color-accent-orange) 10%, transparent)",
+      toneClass: "session-detail-zone-pill--review",
     },
     {
       value: zones.working,
       label: "working",
-      color: "var(--color-accent-blue)",
-      bg: "color-mix(in srgb, var(--color-accent-blue) 10%, transparent)",
+      toneClass: "session-detail-zone-pill--working",
     },
     {
       value: zones.pending,
       label: "pending",
-      color: "var(--color-status-attention)",
-      bg: "color-mix(in srgb, var(--color-status-attention) 10%, transparent)",
+      toneClass: "session-detail-zone-pill--pending",
     },
     {
       value: zones.done,
       label: "done",
-      color: "var(--color-text-tertiary)",
-      bg: "color-mix(in srgb, var(--color-text-tertiary) 14%, transparent)",
+      toneClass: "session-detail-zone-pill--done",
     },
   ].filter((s) => s.value > 0);
 
@@ -414,19 +436,12 @@ function _OrchestratorStatusStrip({
               stats.map((s) => (
                 <div
                   key={s.label}
-                  className="flex items-center gap-1.5 px-2.5 py-1"
-                  style={{ background: s.bg }}
+                  className={cn("session-detail-zone-pill", s.toneClass)}
                 >
-                  <span
-                    className="text-[15px] font-bold leading-none tabular-nums"
-                    style={{ color: s.color }}
-                  >
+                  <span className="session-detail-zone-pill__value">
                     {s.value}
                   </span>
-                  <span
-                    className="text-[10px] font-medium"
-                    style={{ color: s.color, opacity: 0.8 }}
-                  >
+                  <span className="session-detail-zone-pill__label">
                     {s.label}
                   </span>
                 </div>
@@ -479,12 +494,14 @@ export function SessionDetail({
   };
   const headline = getSessionTitle(session);
 
-  const accentColor = "var(--color-accent)";
   const terminalVariant = isOrchestrator ? "orchestrator" : "agent";
 
   const terminalHeight = isOrchestrator
     ? "clamp(400px, 52vh, 620px)"
     : "clamp(380px, 48vh, 560px)";
+  const terminalHeightClass = isOrchestrator
+    ? "session-detail-height--orchestrator"
+    : "session-detail-height--worker";
   const isOpenCodeSession = session.metadata["agent"] === "opencode";
   const opencodeSessionId =
     typeof session.metadata["opencodeSessionId"] === "string" &&
@@ -659,17 +676,26 @@ export function SessionDetail({
                     <div id="session-terminal-section" aria-hidden="true" />
                     <div className="session-detail-section-label">
                       <div
-                        className="session-detail-section-label__bar"
-                        style={{ background: isOrchestrator ? accentColor : activity.color }}
+                        className={cn(
+                          "session-detail-section-label__bar",
+                          isOrchestrator
+                            ? "session-detail-tone--accent"
+                            : activityToneClass(activity.color),
+                        )}
                       />
                       <span className="session-detail-section-label__text">
                         Live Terminal
                       </span>
                     </div>
                     {!showTerminal ? (
-                      <div className="session-detail-terminal-placeholder" style={{ height: terminalHeight }} />
+                      <div
+                        className={cn(
+                          "session-detail-terminal-placeholder",
+                          terminalHeightClass,
+                        )}
+                      />
                     ) : terminalEnded ? (
-                      <div className="terminal-exited-placeholder" style={{ height: terminalHeight }}>
+                      <div className={cn("terminal-exited-placeholder", terminalHeightClass)}>
                         <span className="terminal-exited-placeholder__text">
                           Terminal session has ended
                         </span>
@@ -695,14 +721,6 @@ export function SessionDetail({
     );
   }
 
-  const statusPillBg = activity.color === "var(--color-status-working)"
-    ? "color-mix(in srgb, var(--color-status-working) 12%, transparent)"
-    : activity.color === "var(--color-status-attention)"
-      ? "color-mix(in srgb, var(--color-status-attention) 12%, transparent)"
-      : activity.color === "var(--color-status-error)"
-        ? "color-mix(in srgb, var(--color-status-error) 12%, transparent)"
-        : "color-mix(in srgb, var(--color-accent) 12%, transparent)";
-
   return (
     <div className="session-detail--terminal-first">
       {/* Floating header */}
@@ -712,11 +730,13 @@ export function SessionDetail({
             <path d="M19 12H5M12 19l-7-7 7-7" />
           </svg>
         </a>
-        <span className="session-detail__status-dot" style={{ background: activity.color }} />
+        <span className={cn("session-detail__status-dot", activityToneClass(activity.color))} />
         <span className="session-detail__session-id">{session.id}</span>
         <span
-          className="session-detail__status-pill"
-          style={{ background: statusPillBg, color: activity.color }}
+          className={cn(
+            "session-detail__status-pill",
+            mobileStatusPillClass(activity.label),
+          )}
         >
           {activity.label.toLowerCase()}
         </span>
@@ -728,9 +748,9 @@ export function SessionDetail({
       {/* Terminal fills the viewport */}
       <div className={`session-detail__terminal-full${pr ? " session-detail__terminal-full--with-sheet" : ""}`}>
         {!showTerminal ? (
-          <div className="session-detail-terminal-placeholder" style={{ height: "100%" }} />
+          <div className="session-detail-terminal-placeholder session-detail-height--full" />
         ) : terminalEnded ? (
-          <div className="terminal-exited-placeholder" style={{ height: "100%" }}>
+          <div className="terminal-exited-placeholder session-detail-height--full">
             <span className="terminal-exited-placeholder__text">
               Terminal session has ended
             </span>
@@ -764,8 +784,7 @@ export function SessionDetail({
             </a>
             <span className="session-detail__sheet-item">
               <span
-                className="session-detail__sheet-ci-dot"
-                style={{ background: getCiDotBg(pr) }}
+                className={cn("session-detail__sheet-ci-dot", ciToneClass(pr))}
               />
               {getCiShortLabel(pr)}
             </span>


### PR DESCRIPTION
## Summary
- fix legacy merged-session rehydration so merged PR metadata stays merged during canonical synthesis
- validate v2 canonical lifecycle payloads before normalization and fall back to synthesized metadata on malformed payloads
- extend the PR #1300 follow-up note and add regression coverage for merged restore behavior and malformed lifecycle payloads

## Validation
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm test

## Context
Follow-up to PR #1300 / branch `sessions-redone`. This closes the remaining high-priority core lifecycle issues I found still open during the review follow-up audit.