### PR TITLE
test: fix stale codex gh wrapper assertion

### DIFF
--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -2074,7 +2074,9 @@ describe("shell wrapper content", () => {
 
     it("extracts PR URL from gh pr create output", async () => {
       const content = await getWrapperContent("gh");
-      expect(content).toContain("https://github");
+      expect(content).toContain(
+        "grep -Eo 'https?://[^/]+/[^/]+/[^/]+/pull/[0-9]+'",
+      );
       expect(content).toContain("update_ao_metadata pr");
     });
 


### PR DESCRIPTION
## Summary
- update the codex gh wrapper test to assert the current regex-based PR URL extraction
- keep the metadata assertion so the wrapper contract stays covered
- unblock the failing CI test job for PR #1300

## Root cause
The shared gh wrapper stopped embedding a literal GitHub PR URL string and now extracts PR URLs dynamically with a regex. The codex test still expected the old hardcoded https://github text, so CI failed even though the wrapper behavior was correct.

## Validation
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" pnpm build`
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" pnpm typecheck`
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" pnpm lint`
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" pnpm test`

Related to PR #1300.
