### PR TITLE
fix: reduce false direct-terminal tmux misses

### DIFF
--- a/.changeset/fix-direct-terminal-mux-session-races.md
+++ b/.changeset/fix-direct-terminal-mux-session-races.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-web": patch
+---
+
+Reduce direct-terminal mux noise by suppressing expected tmux session lookup misses, de-duplicating concurrent terminal opens, and retrying brief attach races before reporting a real terminal-open failure.

--- a/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
@@ -282,6 +282,35 @@ describe("mux terminal I/O", () => {
     ws.close();
   });
 
+  it("serializes immediate input sent right after open", async () => {
+    const ws = await connectMux();
+    const marker = `MUX_RACE_${Date.now()}`;
+
+    ws.send(JSON.stringify({ ch: "terminal", id: TEST_SESSION, type: "open" }));
+    ws.send(JSON.stringify({ ch: "terminal", id: TEST_SESSION, type: "data", data: `echo ${marker}\n` }));
+
+    let received = "";
+    await new Promise<void>((resolve) => {
+      const handler = (raw: Buffer | string) => {
+        try {
+          const msg = JSON.parse(raw.toString()) as MuxMessage;
+          if (msg.ch === "terminal" && msg.type === "data") {
+            received += msg.data as string;
+            if (received.includes(marker)) {
+              ws.off("message", handler);
+              resolve();
+            }
+          }
+        } catch { /* */ }
+      };
+      ws.on("message", handler);
+      setTimeout(() => { ws.off("message", handler); resolve(); }, 5000);
+    });
+
+    expect(received).toContain(marker);
+    ws.close();
+  });
+
   it("handles resize without error", async () => {
     const ws = await connectMux();
 

--- a/packages/web/server/__tests__/terminal-manager.test.ts
+++ b/packages/web/server/__tests__/terminal-manager.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockResolveTmuxSession = vi.fn();
+const mockValidateSessionId = vi.fn();
+const mockPtySpawn = vi.fn();
+const mockChildSpawn = vi.fn(() => ({ on: vi.fn() }));
+
+vi.mock("../tmux-utils.js", () => ({
+  findTmux: vi.fn(() => "/usr/bin/tmux"),
+  resolveTmuxSession: mockResolveTmuxSession,
+  validateSessionId: mockValidateSessionId,
+}));
+
+vi.mock("node-pty", () => ({
+  spawn: mockPtySpawn,
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual("node:child_process");
+  return {
+    ...actual,
+    spawn: mockChildSpawn,
+  };
+});
+
+class FakePty {
+  private dataHandlers: Array<(data: string) => void> = [];
+  private exitHandlers: Array<(event: { exitCode: number; signal?: number }) => void> = [];
+
+  onData(handler: (data: string) => void): void {
+    this.dataHandlers.push(handler);
+  }
+
+  onExit(handler: (event: { exitCode: number; signal?: number }) => void): void {
+    this.exitHandlers.push(handler);
+  }
+
+  write(): void {}
+
+  resize(): void {}
+
+  kill(): void {}
+
+  emitData(data: string): void {
+    for (const handler of this.dataHandlers) {
+      handler(data);
+    }
+  }
+
+  emitExit(exitCode: number): void {
+    for (const handler of this.exitHandlers) {
+      handler({ exitCode });
+    }
+  }
+}
+
+describe("TerminalManager", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    mockResolveTmuxSession.mockReset();
+    mockValidateSessionId.mockReset();
+    mockPtySpawn.mockReset();
+    mockChildSpawn.mockClear();
+    mockResolveTmuxSession.mockReturnValue("606634cae37f-aa-33");
+    mockValidateSessionId.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("deduplicates concurrent open requests onto a single attach", async () => {
+    const pty = new FakePty();
+    mockPtySpawn.mockReturnValue(pty);
+
+    const { TerminalManager } = await import("../mux-websocket.js");
+    const manager = new TerminalManager("/usr/bin/tmux");
+
+    const firstOpen = manager.open("aa-33");
+    const secondOpen = manager.open("aa-33");
+
+    expect(mockPtySpawn).toHaveBeenCalledTimes(1);
+
+    pty.emitData("\u001b[?2004h");
+
+    await expect(Promise.all([firstOpen, secondOpen])).resolves.toEqual([
+      "606634cae37f-aa-33",
+      "606634cae37f-aa-33",
+    ]);
+  });
+
+  it("retries early tmux missing-session output before reporting opened", async () => {
+    const firstPty = new FakePty();
+    const secondPty = new FakePty();
+    mockPtySpawn.mockReturnValueOnce(firstPty).mockReturnValueOnce(secondPty);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { TerminalManager } = await import("../mux-websocket.js");
+    const manager = new TerminalManager("/usr/bin/tmux");
+
+    const openPromise = manager.open("aa-33");
+
+    firstPty.emitData("can't find session: aa-33\r\n");
+    firstPty.emitExit(1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const openedLogsBeforeRetry = logSpy.mock.calls.filter(([message]) =>
+      String(message).includes("Opened terminal aa-33"),
+    );
+    expect(openedLogsBeforeRetry).toHaveLength(0);
+
+    secondPty.emitData("\u001b[?2004h");
+
+    await expect(openPromise).resolves.toBe("606634cae37f-aa-33");
+    expect(mockPtySpawn).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("attach raced tmux availability; retrying"),
+    );
+
+    const openedLogs = logSpy.mock.calls.filter(([message]) =>
+      String(message).includes("Opened terminal aa-33"),
+    );
+    expect(openedLogs).toHaveLength(1);
+  });
+});

--- a/packages/web/server/__tests__/tmux-utils.test.ts
+++ b/packages/web/server/__tests__/tmux-utils.test.ts
@@ -370,7 +370,7 @@ describe("resolveTmuxSession", () => {
       expect(mockExec).toHaveBeenCalledWith(
         TMUX,
         ["has-session", "-t", "=ao-1"],
-        { timeout: 5000 },
+        { timeout: 5000, stdio: "ignore" },
       );
     });
 
@@ -383,7 +383,7 @@ describe("resolveTmuxSession", () => {
       expect(mockExec).toHaveBeenCalledWith(
         customTmux,
         ["has-session", "-t", "=my-session"],
-        { timeout: 5000 },
+        { timeout: 5000, stdio: "ignore" },
       );
     });
 
@@ -407,7 +407,7 @@ describe("resolveTmuxSession", () => {
       expect(mockExec).toHaveBeenCalledWith(
         TMUX,
         ["has-session", "-t", "=ao-15"],
-        { timeout: 5000 },
+        { timeout: 5000, stdio: "ignore" },
       );
     });
   });
@@ -566,7 +566,7 @@ describe("resolveTmuxSession", () => {
       expect(mockExec).toHaveBeenNthCalledWith(2,
         TMUX,
         ["list-sessions", "-F", "#{session_name}"],
-        { timeout: 5000, encoding: "utf8" },
+        { timeout: 5000, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
       );
     });
 
@@ -787,7 +787,11 @@ describe("resolveTmuxSession", () => {
       for (const tmuxPath of paths) {
         const mockExec = vi.fn().mockReturnValue("");
         resolveTmuxSession("ao-15", tmuxPath, mockExec);
-        expect(mockExec).toHaveBeenCalledWith(tmuxPath, ["has-session", "-t", "=ao-15"], { timeout: 5000 });
+        expect(mockExec).toHaveBeenCalledWith(
+          tmuxPath,
+          ["has-session", "-t", "=ao-15"],
+          { timeout: 5000, stdio: "ignore" },
+        );
       }
     });
   });

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -251,19 +251,20 @@ export class TerminalManager {
    * If has subscribers but PTY crashed, re-attach.
    */
   async open(id: string): Promise<string> {
-    // Validate and resolve
+    // Validate first, but avoid probing tmux again if the terminal is already
+    // attached or another caller is already driving the attach flow.
     if (!validateSessionId(id)) {
       throw new Error(`Invalid session ID: ${id}`);
-    }
-
-    const tmuxSessionId = resolveTmuxSession(id, this.TMUX);
-    if (!tmuxSessionId) {
-      throw new Error(`Session not found: ${id}`);
     }
 
     // Get or create terminal entry
     let terminal = this.terminals.get(id);
     if (!terminal) {
+      const tmuxSessionId = resolveTmuxSession(id, this.TMUX);
+      if (!tmuxSessionId) {
+        throw new Error(`Session not found: ${id}`);
+      }
+
       terminal = {
         id,
         tmuxSessionId,
@@ -280,7 +281,7 @@ export class TerminalManager {
 
     // If PTY is already attached, we're done
     if (terminal.pty) {
-      return tmuxSessionId;
+      return terminal.tmuxSessionId;
     }
 
     if (terminal.openingPromise) {

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -220,6 +220,7 @@ interface ManagedTerminal {
   id: string;
   tmuxSessionId: string;
   pty: IPty | null;
+  openingPromise: Promise<string> | null;
   subscribers: Set<(data: string) => void>;
   exitCallbacks: Set<(exitCode: number) => void>;
   buffer: string[];
@@ -229,12 +230,15 @@ interface ManagedTerminal {
 
 const RING_BUFFER_MAX = 50 * 1024; // 50KB max per terminal
 const MAX_REATTACH_ATTEMPTS = 3;
+const MAX_TRANSIENT_ATTACH_RETRIES = 2;
+const ATTACH_READY_GRACE_MS = 150;
+const TRANSIENT_ATTACH_ERROR_PATTERN = /(can't find session|no sessions?|session .* not found)/i;
 
 /**
  * TerminalManager manages PTY processes independently of WebSocket connections.
  * A single manager instance is shared across all mux connections.
  */
-class TerminalManager {
+export class TerminalManager {
   private terminals = new Map<string, ManagedTerminal>();
   private TMUX: string;
 
@@ -246,7 +250,7 @@ class TerminalManager {
    * Open/attach to a terminal. If already open, just return.
    * If has subscribers but PTY crashed, re-attach.
    */
-  open(id: string): string {
+  async open(id: string): Promise<string> {
     // Validate and resolve
     if (!validateSessionId(id)) {
       throw new Error(`Invalid session ID: ${id}`);
@@ -264,6 +268,7 @@ class TerminalManager {
         id,
         tmuxSessionId,
         pty: null,
+        openingPromise: null,
         subscribers: new Set(),
         exitCallbacks: new Set(),
         buffer: [],
@@ -278,19 +283,22 @@ class TerminalManager {
       return tmuxSessionId;
     }
 
+    if (terminal.openingPromise) {
+      return terminal.openingPromise;
+    }
+
+    terminal.openingPromise = this.attachTerminal(terminal);
+    try {
+      return await terminal.openingPromise;
+    } finally {
+      if (terminal.openingPromise) {
+        terminal.openingPromise = null;
+      }
+    }
+  }
+
+  private async attachTerminal(terminal: ManagedTerminal): Promise<string> {
     // Enable mouse mode
-    const mouseProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "mouse", "on"]);
-    mouseProc.on("error", (err) => {
-      console.error(`[MuxServer] Failed to set mouse mode for ${tmuxSessionId}:`, err.message);
-    });
-
-    // Hide the status bar
-    const statusProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "status", "off"]);
-    statusProc.on("error", (err) => {
-      console.error(`[MuxServer] Failed to hide status bar for ${tmuxSessionId}:`, err.message);
-    });
-
-    // Build environment
     const homeDir = process.env.HOME || homedir();
     const currentUser = process.env.USER || userInfo().username;
     const env = {
@@ -307,70 +315,145 @@ class TerminalManager {
       throw new Error("node-pty not available");
     }
 
-    // Spawn PTY
-    const pty = ptySpawn(this.TMUX, ["attach-session", "-t", tmuxSessionId], {
-      name: "xterm-256color",
-      cols: 80,
-      rows: 24,
-      cwd: homeDir,
-      env,
-    });
+    for (let attempt = 0; attempt <= MAX_TRANSIENT_ATTACH_RETRIES; attempt += 1) {
+      const tmuxSessionId = resolveTmuxSession(terminal.id, this.TMUX);
+      if (!tmuxSessionId) {
+        throw new Error(`Session not found: ${terminal.id}`);
+      }
+      terminal.tmuxSessionId = tmuxSessionId;
 
-    terminal.pty = pty;
+      const mouseProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "mouse", "on"]);
+      mouseProc.on("error", (err) => {
+        console.error(`[MuxServer] Failed to set mouse mode for ${tmuxSessionId}:`, err.message);
+      });
 
-    // Wire up data events
-    pty.onData((data: string) => {
-      // Push to all subscribers — isolate each callback so a throw in one
-      // (e.g. a closed ws.send) doesn't abort the loop or skip the buffer.
-      for (const callback of terminal.subscribers) {
-        try {
-          callback(data);
-        } catch (err) {
-          console.error("[MuxServer] Subscriber callback threw:", err);
-        }
+      const statusProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "status", "off"]);
+      statusProc.on("error", (err) => {
+        console.error(`[MuxServer] Failed to hide status bar for ${tmuxSessionId}:`, err.message);
+      });
+
+      const attachResult = await new Promise<{
+        exitCode: number | null;
+        ready: boolean;
+        tmuxSessionId: string;
+      }>((resolve) => {
+        const pty = ptySpawn!(this.TMUX, ["attach-session", "-t", tmuxSessionId], {
+          name: "xterm-256color",
+          cols: 80,
+          rows: 24,
+          cwd: homeDir,
+          env,
+        });
+
+        terminal.pty = pty;
+        let ready = false;
+        let preReadyOutput = "";
+        const markReady = () => {
+          if (ready) {
+            return;
+          }
+          ready = true;
+          console.log(`[MuxServer] Opened terminal ${terminal.id} (tmux: ${tmuxSessionId})`);
+          resolve({ exitCode: null, ready: true, tmuxSessionId });
+        };
+        const readyTimer = setTimeout(markReady, ATTACH_READY_GRACE_MS);
+        readyTimer.unref?.();
+
+        pty.onData((data: string) => {
+          if (!ready) {
+            preReadyOutput += data;
+            if (TRANSIENT_ATTACH_ERROR_PATTERN.test(preReadyOutput)) {
+              return;
+            }
+          }
+
+          if (!ready) {
+            clearTimeout(readyTimer);
+            markReady();
+          }
+
+          // Push to all subscribers — isolate each callback so a throw in one
+          // (e.g. a closed ws.send) doesn't abort the loop or skip the buffer.
+          for (const callback of terminal.subscribers) {
+            try {
+              callback(data);
+            } catch (err) {
+              console.error("[MuxServer] Subscriber callback threw:", err);
+            }
+          }
+
+          terminal.buffer.push(data);
+          terminal.bufferBytes += Buffer.byteLength(data, "utf8");
+
+          while (terminal.bufferBytes > RING_BUFFER_MAX && terminal.buffer.length > 0) {
+            const removed = terminal.buffer.shift() ?? "";
+            terminal.bufferBytes -= Buffer.byteLength(removed, "utf8");
+          }
+        });
+
+        pty.onExit(({ exitCode }) => {
+          clearTimeout(readyTimer);
+          terminal.pty = null;
+
+          if (!ready) {
+            resolve({ exitCode, ready: false, tmuxSessionId });
+            return;
+          }
+
+          console.log(`[MuxServer] PTY exited for ${terminal.id} with code ${exitCode}`);
+
+          // Re-attach if subscribers are still present, up to MAX_REATTACH_ATTEMPTS.
+          // The cap prevents an unbounded respawn loop when the PTY crashes immediately
+          // after every attach (e.g. resource exhaustion or a broken tmux session).
+          if (terminal.subscribers.size > 0 && terminal.reattachAttempts < MAX_REATTACH_ATTEMPTS) {
+            terminal.reattachAttempts += 1;
+            console.warn(
+              `[MuxServer] Terminal ${terminal.id} detached unexpectedly, retrying attach ` +
+                `(${terminal.reattachAttempts}/${MAX_REATTACH_ATTEMPTS})`,
+            );
+            void this.open(terminal.id)
+              .then(() => {
+                terminal.reattachAttempts = 0;
+              })
+              .catch((err) => {
+                console.error(`[MuxServer] Failed to re-attach ${terminal.id}:`, err);
+                for (const cb of terminal.exitCallbacks) {
+                  cb(exitCode);
+                }
+              });
+            return;
+          }
+
+          if (terminal.reattachAttempts >= MAX_REATTACH_ATTEMPTS) {
+            console.error(`[MuxServer] Max re-attach attempts reached for ${terminal.id}, giving up`);
+          }
+
+          for (const cb of terminal.exitCallbacks) {
+            cb(exitCode);
+          }
+        });
+      });
+
+      if (attachResult.ready) {
+        terminal.reattachAttempts = 0;
+        return attachResult.tmuxSessionId;
       }
 
-      // Append to ring buffer
-      terminal.buffer.push(data);
-      terminal.bufferBytes += Buffer.byteLength(data, "utf8");
-
-      // Trim buffer if over limit
-      while (terminal.bufferBytes > RING_BUFFER_MAX && terminal.buffer.length > 0) {
-        const removed = terminal.buffer.shift() ?? "";
-        terminal.bufferBytes -= Buffer.byteLength(removed, "utf8");
-      }
-    });
-
-    // Handle PTY exit
-    pty.onExit(({ exitCode }) => {
-      console.log(`[MuxServer] PTY exited for ${id} with code ${exitCode}`);
-      terminal.pty = null;
-
-      // Re-attach if subscribers are still present, up to MAX_REATTACH_ATTEMPTS.
-      // The cap prevents an unbounded respawn loop when the PTY crashes immediately
-      // after every attach (e.g. resource exhaustion or a broken tmux session).
-      if (terminal.subscribers.size > 0 && terminal.reattachAttempts < MAX_REATTACH_ATTEMPTS) {
-        terminal.reattachAttempts += 1;
-        console.log(`[MuxServer] Re-attaching to ${id} (attempt ${terminal.reattachAttempts}/${MAX_REATTACH_ATTEMPTS})`);
-        try {
-          this.open(id);
-          terminal.reattachAttempts = 0; // reset on successful attach
-          return; // re-attached — don't notify exit
-        } catch (err) {
-          console.error(`[MuxServer] Failed to re-attach ${id}:`, err);
-        }
-      } else if (terminal.reattachAttempts >= MAX_REATTACH_ATTEMPTS) {
-        console.error(`[MuxServer] Max re-attach attempts reached for ${id}, giving up`);
+      if (attempt < MAX_TRANSIENT_ATTACH_RETRIES && attachResult.exitCode === 1) {
+        console.warn(
+          `[MuxServer] Terminal ${terminal.id} attach raced tmux availability; retrying ` +
+            `(${attempt + 1}/${MAX_TRANSIENT_ATTACH_RETRIES})`,
+        );
+        continue;
       }
 
-      // Notify subscribers that the terminal has exited (re-attach failed or no subscribers)
-      for (const cb of terminal.exitCallbacks) {
-        cb(exitCode);
-      }
-    });
+      console.warn(
+        `[MuxServer] Terminal ${terminal.id} failed before attach completed (exit ${attachResult.exitCode ?? "unknown"})`,
+      );
+      throw new Error(`Session not ready for attach: ${terminal.id}`);
+    }
 
-    console.log(`[MuxServer] Opened terminal ${id} (tmux: ${tmuxSessionId})`);
-    return tmuxSessionId;
+    throw new Error(`Session not ready for attach: ${terminal.id}`);
   }
 
   /**
@@ -395,12 +478,9 @@ class TerminalManager {
 
   /**
    * Subscribe to terminal data. Returns unsubscribe function.
-   * Automatically opens the terminal if needed.
    * @param onExit - called when the PTY exits and cannot be re-attached
    */
   subscribe(id: string, callback: (data: string) => void, onExit?: (exitCode: number) => void): () => void {
-    // Ensure terminal is open
-    this.open(id);
     const terminal = this.terminals.get(id);
     if (!terminal) {
       throw new Error(`Failed to open terminal: ${id}`);
@@ -484,109 +564,104 @@ export function createMuxWebSocket(tmuxPath?: string): WebSocketServer | null {
      * Handle incoming messages
      */
     ws.on("message", (data) => {
+      void (async () => {
+        try {
+          const msg = JSON.parse(data.toString("utf8")) as ClientMessage;
 
-      try {
-        const msg = JSON.parse(data.toString("utf8")) as ClientMessage;
+          if (msg.ch === "system") {
+            if (msg.type === "ping") {
+              const pong: ServerMessage = { ch: "system", type: "pong" };
+              ws.send(JSON.stringify(pong));
+            }
+          } else if (msg.ch === "terminal") {
+            const { id, type } = msg;
 
-        if (msg.ch === "system") {
-          if (msg.type === "ping") {
-            const pong: ServerMessage = { ch: "system", type: "pong" };
-            ws.send(JSON.stringify(pong));
-          }
-        } else if (msg.ch === "terminal") {
-          const { id, type } = msg;
+            try {
+              if (type === "open") {
+                // Validate session exists and wait for attach to survive the
+                // transient tmux race window before reporting "opened".
+                await terminalManager.open(id);
 
-          try {
-            if (type === "open") {
-              // Validate session exists
-              terminalManager.open(id);
+                const openedMsg: ServerMessage = { ch: "terminal", id, type: "opened" };
+                ws.send(JSON.stringify(openedMsg));
 
-              // Send opened confirmation (idempotent — safe to send on re-open)
-              const openedMsg: ServerMessage = { ch: "terminal", id, type: "opened" };
-              ws.send(JSON.stringify(openedMsg));
-
-              // Subscribe and send history buffer only for new subscribers.
-              // Skipping the buffer on re-open prevents duplicate output when
-              // MuxProvider re-sends open for all terminals on reconnect.
-              if (!subscriptions.has(id)) {
-                // Send buffered history to catch up the new subscriber
-                const buffer = terminalManager.getBuffer(id);
-                if (buffer) {
-                  const bufferMsg: ServerMessage = {
-                    ch: "terminal",
-                    id,
-                    type: "data",
-                    data: buffer,
-                  };
-                  ws.send(JSON.stringify(bufferMsg));
-                }
-                const unsub = terminalManager.subscribe(
-                  id,
-                  (data) => {
-                    const dataMsg: ServerMessage = {
+                if (!subscriptions.has(id)) {
+                  const buffer = terminalManager.getBuffer(id);
+                  if (buffer) {
+                    const bufferMsg: ServerMessage = {
                       ch: "terminal",
                       id,
                       type: "data",
-                      data,
+                      data: buffer,
                     };
-                    if (ws.readyState === WebSocket.OPEN) {
-                      ws.send(JSON.stringify(dataMsg));
-                    }
-                  },
-                  (exitCode) => {
-                    const exitedMsg: ServerMessage = { ch: "terminal", id, type: "exited", code: exitCode };
-                    if (ws.readyState === WebSocket.OPEN) {
-                      ws.send(JSON.stringify(exitedMsg));
-                    }
-                  },
-                );
-                subscriptions.set(id, unsub);
+                    ws.send(JSON.stringify(bufferMsg));
+                  }
+                  const unsub = terminalManager.subscribe(
+                    id,
+                    (data) => {
+                      const dataMsg: ServerMessage = {
+                        ch: "terminal",
+                        id,
+                        type: "data",
+                        data,
+                      };
+                      if (ws.readyState === WebSocket.OPEN) {
+                        ws.send(JSON.stringify(dataMsg));
+                      }
+                    },
+                    (exitCode) => {
+                      const exitedMsg: ServerMessage = { ch: "terminal", id, type: "exited", code: exitCode };
+                      if (ws.readyState === WebSocket.OPEN) {
+                        ws.send(JSON.stringify(exitedMsg));
+                      }
+                    },
+                  );
+                  subscriptions.set(id, unsub);
+                }
+              } else if (type === "data" && "data" in msg) {
+                terminalManager.write(id, msg.data);
+              } else if (type === "resize" && "cols" in msg && "rows" in msg) {
+                terminalManager.resize(id, msg.cols, msg.rows);
+              } else if (type === "close") {
+                const unsub = subscriptions.get(id);
+                if (unsub) {
+                  unsub();
+                  subscriptions.delete(id);
+                }
               }
-            } else if (type === "data" && "data" in msg) {
-              terminalManager.write(id, msg.data);
-            } else if (type === "resize" && "cols" in msg && "rows" in msg) {
-              terminalManager.resize(id, msg.cols, msg.rows);
-            } else if (type === "close") {
-              // Unsubscribe this client only — TerminalManager is shared across
-              // all mux connections so we must not kill the PTY here.
-              const unsub = subscriptions.get(id);
-              if (unsub) {
-                unsub();
-                subscriptions.delete(id);
-              }
-            }
-          } catch (err) {
-            if (ws.readyState === WebSocket.OPEN) {
-              const errorMsg: ServerMessage = {
-                ch: "terminal",
-                id,
-                type: "error",
-                message: err instanceof Error ? err.message : String(err),
-              };
-              ws.send(JSON.stringify(errorMsg));
-            }
-          }
-        } else if (msg.ch === "subscribe") {
-          if (msg.topics.includes("sessions") && !sessionUnsubscribe) {
-            sessionUnsubscribe = broadcaster.subscribe((sessions) => {
+            } catch (err) {
               if (ws.readyState === WebSocket.OPEN) {
-                const snapMsg: ServerMessage = { ch: "sessions", type: "snapshot", sessions };
-                ws.send(JSON.stringify(snapMsg));
+                const errorMsg: ServerMessage = {
+                  ch: "terminal",
+                  id,
+                  type: "error",
+                  message: err instanceof Error ? err.message : String(err),
+                };
+                ws.send(JSON.stringify(errorMsg));
               }
-            });
+            }
+          } else if (msg.ch === "subscribe") {
+            if (msg.topics.includes("sessions") && !sessionUnsubscribe) {
+              sessionUnsubscribe = broadcaster.subscribe((sessions) => {
+                if (ws.readyState === WebSocket.OPEN) {
+                  const snapMsg: ServerMessage = { ch: "sessions", type: "snapshot", sessions };
+                  ws.send(JSON.stringify(snapMsg));
+                }
+              });
+            }
+          }
+        } catch (err) {
+          console.error("[MuxServer] Failed to parse message:", err);
+          const errorMsg: ServerMessage = {
+            ch: "system",
+            type: "error",
+            message: "Invalid message format",
+          };
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify(errorMsg));
           }
         }
-      } catch (err) {
-        console.error("[MuxServer] Failed to parse message:", err);
-        const errorMsg: ServerMessage = {
-          ch: "system",
-          type: "error",
-          message: "Invalid message format",
-        };
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify(errorMsg));
-        }
-      }
+      })();
     });
 
     /**

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -538,6 +538,7 @@ export function createMuxWebSocket(tmuxPath?: string): WebSocketServer | null {
 
     const subscriptions = new Map<string, () => void>();
     let sessionUnsubscribe: (() => void) | null = null;
+    let messageQueue = Promise.resolve();
     let missedPongs = 0;
     const MAX_MISSED_PONGS = 3;
 
@@ -564,8 +565,7 @@ export function createMuxWebSocket(tmuxPath?: string): WebSocketServer | null {
     /**
      * Handle incoming messages
      */
-    ws.on("message", (data) => {
-      void (async () => {
+    const handleMessage = async (data: WebSocket.RawData): Promise<void> => {
         try {
           const msg = JSON.parse(data.toString("utf8")) as ClientMessage;
 
@@ -662,7 +662,14 @@ export function createMuxWebSocket(tmuxPath?: string): WebSocketServer | null {
             ws.send(JSON.stringify(errorMsg));
           }
         }
-      })();
+    };
+
+    ws.on("message", (data) => {
+      messageQueue = messageQueue
+        .then(() => handleMessage(data))
+        .catch((err) => {
+          console.error("[MuxServer] Message handling failed:", err);
+        });
     });
 
     /**

--- a/packages/web/server/tmux-utils.ts
+++ b/packages/web/server/tmux-utils.ts
@@ -73,7 +73,10 @@ export function resolveTmuxSession(
   // Try exact match first using = prefix for exact matching (e.g., "ao-orchestrator")
   // Without =, tmux uses prefix matching: "ao-1" would match "ao-15"
   try {
-    execFn(tmuxPath, ["has-session", "-t", `=${sessionId}`], { timeout: 5000 });
+    execFn(tmuxPath, ["has-session", "-t", `=${sessionId}`], {
+      timeout: 5000,
+      stdio: "ignore",
+    });
     return sessionId;
   } catch {
     // Not an exact match
@@ -86,6 +89,7 @@ export function resolveTmuxSession(
     const output = execFn(tmuxPath, ["list-sessions", "-F", "#{session_name}"], {
       timeout: 5000,
       encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
     }) as string;
     const sessions = output.split("\n").filter(Boolean);
     const match = sessions.find((s) =>


### PR DESCRIPTION
## Summary
- suppress expected tmux session-probe stderr in direct terminal session resolution so fallback lookups do not spam misleading missing-session logs
- de-duplicate concurrent mux terminal opens and wait through a short attach grace window before reporting opened
- retry brief attach races, add targeted server coverage, and record the patch release in changesets

Closes #143.

## Validation
- pnpm build (fails in existing unrelated web build path: Next.js prerender error for the 404 page due to Html import usage outside pages/_document)
- pnpm typecheck
- pnpm lint (passes with existing repo warnings)
- pnpm test
- pnpm --filter @aoagents/ao-web test server/__tests__/tmux-utils.test.ts server/__tests__/terminal-manager.test.ts server/__tests__/direct-terminal-ws.integration.test.ts
