### PR TITLE
fix: clear stale dashboard PR ownership

### DIFF
--- a/.changeset/stale-pr-dashboard-fix.md
+++ b/.changeset/stale-pr-dashboard-fix.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-core": patch
+---
+
+Fix worker session PR tracking so the dashboard clears closed pull requests and picks up replacement PRs instead of showing a stale PR number.

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1059,9 +1059,46 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("idle");
     const meta = readMetadataRaw(env.sessionsDir, "app-1");
     expect(meta?.["status"]).toBe("idle");
+    expect(meta?.["pr"]).toBeUndefined();
     expect(meta?.["statePayload"]).toContain('"state":"closed"');
     expect(meta?.["statePayload"]).toContain('"reason":"pr_closed_waiting_decision"');
+    expect(meta?.["statePayload"]).toContain('"number":null');
+    expect(meta?.["statePayload"]).toContain('"url":null');
     expect(notifier.notify).toHaveBeenCalledWith(expect.objectContaining({ type: "pr.closed" }));
+  });
+
+  it("replaces a closed PR with a newly detected PR on the same branch", async () => {
+    const oldPr = makePR();
+    const newPr = makePR({
+      number: 77,
+      url: "https://github.com/org/my-app/pull/77",
+      title: "Replacement PR",
+    });
+    const mockSCM = createMockSCM({
+      getPRState: vi.fn().mockImplementation(async (pr) => (pr.number === oldPr.number ? "closed" : "open")),
+      detectPR: vi.fn().mockResolvedValue(newPr),
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: oldPr }),
+      registry,
+      metaOverrides: { pr: oldPr.url },
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("pr_open");
+    const meta = readMetadataRaw(env.sessionsDir, "app-1");
+    expect(meta?.["status"]).toBe("pr_open");
+    expect(meta?.["pr"]).toBe(newPr.url);
+    expect(meta?.["statePayload"]).toContain('"state":"open"');
+    expect(meta?.["statePayload"]).toContain('"number":77');
+    expect(meta?.["statePayload"]).toContain(`"url":"${newPr.url}"`);
   });
 
   it("routes closed PR transitions through the pr-closed reaction key", async () => {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -505,6 +505,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const currentDetectingAttempts = parseAttemptCount(session.metadata["detectingAttempts"]);
     const currentDetectingStartedAt = session.metadata["detectingStartedAt"] || undefined;
     const currentDetectingEvidenceHash = session.metadata["detectingEvidenceHash"] || undefined;
+    const canAutoDetectPR =
+      Boolean(scm) &&
+      Boolean(session.branch) &&
+      session.metadata["prAutoDetect"] !== "off" &&
+      session.metadata["role"] !== "orchestrator" &&
+      !session.id.endsWith("-orchestrator");
 
     const commit = (
       decision: LifecycleDecision = {
@@ -554,6 +560,23 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     let activitySignal = createActivitySignal("unavailable");
     let processProbe: ProbeResult = { state: "unknown", failed: false };
     let activityEvidence = formatActivitySignalEvidence(activitySignal);
+
+    const attachDetectedPR = async (excludeUrl?: string): Promise<boolean> => {
+      if (!scm || !canAutoDetectPR) return false;
+
+      const detectedPR = await scm.detectPR(session, project);
+      if (!detectedPR || detectedPR.url === excludeUrl) {
+        return false;
+      }
+
+      session.pr = detectedPR;
+      lifecycle.pr.state = "open";
+      lifecycle.pr.reason = "in_progress";
+      lifecycle.pr.number = detectedPR.number;
+      lifecycle.pr.url = detectedPR.url;
+      lifecycle.pr.lastObservedAt = nowIso;
+      return true;
+    };
 
     if (agent && (session.runtimeHandle || session.workspacePath)) {
       try {
@@ -706,25 +729,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       return commit(probeDecision);
     }
 
-    if (
-      !session.pr &&
-      scm &&
-      session.branch &&
-      session.metadata["prAutoDetect"] !== "off" &&
-      session.metadata["role"] !== "orchestrator" &&
-      !session.id.endsWith("-orchestrator")
-    ) {
+    if (!session.pr) {
       try {
-        const detectedPR = await scm.detectPR(session, project);
-        if (detectedPR) {
-          session.pr = detectedPR;
-          lifecycle.pr.state = "open";
-          lifecycle.pr.reason = "in_progress";
-          lifecycle.pr.number = detectedPR.number;
-          lifecycle.pr.url = detectedPR.url;
-          lifecycle.pr.lastObservedAt = nowIso;
+        if (await attachDetectedPR()) {
           const sessionsDir = getSessionsDir(config.configPath, project.path);
-          updateMetadata(sessionsDir, session.id, { pr: detectedPR.url });
+          updateMetadata(sessionsDir, session.id, { pr: lifecycle.pr.url ?? "" });
           sessionManager.invalidateCache();
         }
       } catch (error) {
@@ -743,27 +752,28 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     if (session.pr && scm) {
       try {
-        const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
-        const cachedData = prEnrichmentCache.get(prKey);
-        lifecycle.pr.number = session.pr.number;
-        lifecycle.pr.url = session.pr.url;
+        let activePr = session.pr;
+        lifecycle.pr.number = activePr.number;
+        lifecycle.pr.url = activePr.url;
         lifecycle.pr.lastObservedAt = nowIso;
         const shouldEscalateIdleToStuck =
           detectedIdleTimestamp !== null && hasPositiveIdleEvidence(activitySignal)
             ? isIdleBeyondThreshold(session, detectedIdleTimestamp)
             : false;
 
-        if (cachedData) {
-          return commit(
-            resolvePREnrichmentDecision(cachedData, {
-              shouldEscalateIdleToStuck,
-              idleWasBlocked,
-              activityEvidence,
-            }),
-          );
+        let prState = await scm.getPRState(activePr);
+        if (prState === PR_STATE.CLOSED) {
+          const replaced = await attachDetectedPR(activePr.url);
+          if (replaced && session.pr) {
+            activePr = session.pr;
+            prState = await scm.getPRState(activePr);
+          } else {
+            session.pr = null;
+            lifecycle.pr.number = null;
+            lifecycle.pr.url = null;
+            lifecycle.pr.lastObservedAt = nowIso;
+          }
         }
-
-        const prState = await scm.getPRState(session.pr);
         if (prState === PR_STATE.MERGED || prState === PR_STATE.CLOSED) {
           return commit(
             resolvePRLiveDecision({
@@ -778,7 +788,20 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           );
         }
 
-        const ciStatus = await scm.getCISummary(session.pr);
+        const prKey = `${activePr.owner}/${activePr.repo}#${activePr.number}`;
+        const cachedData = prEnrichmentCache.get(prKey);
+
+        if (cachedData) {
+          return commit(
+            resolvePREnrichmentDecision(cachedData, {
+              shouldEscalateIdleToStuck,
+              idleWasBlocked,
+              activityEvidence,
+            }),
+          );
+        }
+
+        const ciStatus = await scm.getCISummary(activePr);
         if (ciStatus === CI_STATUS.FAILING) {
           return commit(
             resolvePRLiveDecision({
@@ -793,10 +816,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           );
         }
 
-        const reviewDecision = await scm.getReviewDecision(session.pr);
+        const reviewDecision = await scm.getReviewDecision(activePr);
         const mergeReady =
           reviewDecision === "approved" || reviewDecision === "none"
-            ? await scm.getMergeability(session.pr)
+            ? await scm.getMergeability(activePr)
             : { mergeable: false };
         return commit(
           resolvePRLiveDecision({

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -509,8 +509,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       Boolean(scm) &&
       Boolean(session.branch) &&
       session.metadata["prAutoDetect"] !== "off" &&
-      session.metadata["role"] !== "orchestrator" &&
-      !session.id.endsWith("-orchestrator");
+      lifecycle.session.kind !== "orchestrator";
 
     const commit = (
       decision: LifecycleDecision = {


### PR DESCRIPTION
## Summary
- clear closed-unmerged PR references from canonical lifecycle metadata so sessions stop carrying a stale PR URL/number
- re-run branch-based PR detection when a tracked PR closes and immediately attach a replacement PR if one already exists
- add regression tests for closed PR cleanup and replacement PR detection, plus a changeset entry

## Root Cause Analysis
The stale dashboard PR number came from a mismatch between raw session metadata and canonical lifecycle state:

1. PR ownership was persisted in two places:
   - legacy/raw metadata via `pr=<url>`
   - canonical lifecycle payload via `statePayload.pr.url` / `statePayload.pr.number`
2. The dashboard read path reconstructed `session.pr` from canonical lifecycle first, then fell back to raw metadata.
3. When lifecycle polling saw a PR become `closed`, it changed only the PR state/reason. It did **not** clear the stored PR URL/number.
4. Because `session.pr` stayed non-null, the poller never re-entered the `scm.detectPR()` path, so a replacement PR on the same branch was never discovered.
5. Even if a new PR was opened and the `gh pr create` wrapper updated raw metadata, the dashboard still preferred the stale canonical lifecycle PR reference.

That combination left the UI pinned to the first PR number indefinitely.

## Fix
- On `closed` PRs, clear the canonical PR URL/number when no replacement PR exists.
- On `closed` PRs, attempt `scm.detectPR()` for the session branch and attach the new PR immediately when found.
- Preserve merged PR identity; only closed-unmerged PRs are cleared/replaced.

## Validation
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

Fixes ComposioHQ/agent-orchestrator#1361.
