### PR TITLE
fix(runtime-tmux): send Enter immediately after paste in sendMessage

### DIFF
--- a/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
@@ -348,12 +348,12 @@ describe("runtime.sendMessage()", () => {
     const handle = makeHandle("msg-long");
     const longText = "x".repeat(250);
 
-    // 1: C-u, 2: load-buffer, 3: paste-buffer, 4: unlinkSync (sync), 5: delete-buffer, 6: Enter
+    // 1: C-u, 2: load-buffer, 3: paste-buffer, 4: Enter, 5: delete-buffer (finally)
     mockTmuxSuccess(); // C-u
     mockTmuxSuccess(); // load-buffer
     mockTmuxSuccess(); // paste-buffer
+    mockTmuxSuccess(); // Enter (sent immediately after paste, before cleanup)
     mockTmuxSuccess(); // delete-buffer (finally block)
-    mockTmuxSuccess(); // Enter
 
     await runtime.sendMessage(handle, longText);
 
@@ -388,6 +388,14 @@ describe("runtime.sendMessage()", () => {
       expectedTmuxOptions,
     );
 
+    // Call 3: Enter is sent immediately after paste (before cleanup)
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      4,
+      "tmux",
+      ["send-keys", "-t", "msg-long", "Enter"],
+      expectedTmuxOptions,
+    );
+
     // Verify writeFileSync was called with the message
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       expect.stringContaining("ao-send-test-uuid-1234.txt"),
@@ -405,11 +413,12 @@ describe("runtime.sendMessage()", () => {
     const runtime = create();
     const handle = makeHandle("msg-multi");
 
+    // 1: C-u, 2: load-buffer, 3: paste-buffer, 4: Enter, 5: delete-buffer (finally)
     mockTmuxSuccess(); // C-u
     mockTmuxSuccess(); // load-buffer
     mockTmuxSuccess(); // paste-buffer
+    mockTmuxSuccess(); // Enter (before cleanup)
     mockTmuxSuccess(); // delete-buffer (finally)
-    mockTmuxSuccess(); // Enter
 
     await runtime.sendMessage(handle, "line1\nline2\nline3");
 
@@ -423,6 +432,14 @@ describe("runtime.sendMessage()", () => {
         "ao-test-uuid-1234",
         expect.stringContaining("ao-send-test-uuid-1234.txt"),
       ],
+      expectedTmuxOptions,
+    );
+
+    // Enter is sent immediately after paste, before cleanup
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      4,
+      "tmux",
+      ["send-keys", "-t", "msg-multi", "Enter"],
       expectedTmuxOptions,
     );
 
@@ -459,6 +476,51 @@ describe("runtime.sendMessage()", () => {
       ["delete-buffer", "-b", "ao-test-uuid-1234"],
       expectedTmuxOptions,
     );
+  });
+
+  it("sends Enter immediately after pasting spawn prompt (long multiline)", async () => {
+    const runtime = create();
+    const handle = makeHandle("spawn-prompt");
+    // Simulate a typical spawn prompt: long, multiline, just like buildPrompt produces
+    const spawnPrompt =
+      "You are an AI coding agent managed by the Agent Orchestrator (ao).\n\n" +
+      "## Session Lifecycle\n" +
+      "- You are running inside a managed session.\n\n" +
+      "## Additional Instructions\n" +
+      "Fix the login bug in auth.ts";
+
+    // 1: C-u, 2: load-buffer, 3: paste-buffer, 4: Enter, 5: delete-buffer (finally)
+    mockTmuxSuccess(); // C-u
+    mockTmuxSuccess(); // load-buffer
+    mockTmuxSuccess(); // paste-buffer
+    mockTmuxSuccess(); // Enter
+    mockTmuxSuccess(); // delete-buffer
+
+    await runtime.sendMessage(handle, spawnPrompt);
+
+    // Verify Enter is the 4th tmux call — immediately after paste-buffer, before cleanup
+    const calls = mockExecFileCustom.mock.calls;
+    const enterCallIndex = calls.findIndex(
+      (call: unknown[]) =>
+        call[0] === "tmux" &&
+        Array.isArray(call[1]) &&
+        call[1][0] === "send-keys" &&
+        call[1].includes("Enter"),
+    );
+    const deleteBufferCallIndex = calls.findIndex(
+      (call: unknown[]) =>
+        call[0] === "tmux" &&
+        Array.isArray(call[1]) &&
+        call[1][0] === "delete-buffer",
+    );
+
+    // Enter MUST come before delete-buffer (cleanup)
+    expect(enterCallIndex).toBeGreaterThan(-1);
+    expect(deleteBufferCallIndex).toBeGreaterThan(-1);
+    expect(enterCallIndex).toBeLessThan(deleteBufferCallIndex);
+
+    // Verify Enter targets the correct session
+    expect(calls[enterCallIndex][1]).toEqual(["send-keys", "-t", "spawn-prompt", "Enter"]);
   });
 });
 

--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -121,6 +121,11 @@ export function create(): Runtime {
         try {
           await tmux("load-buffer", "-b", bufferName, tmpPath);
           await tmux("paste-buffer", "-b", bufferName, "-t", handle.id, "-d");
+          // Send Enter immediately after paste succeeds, before any cleanup.
+          // Placing Enter here (not after the finally block) prevents cleanup
+          // operations (delete-buffer, unlinkSync) from delaying the keypress.
+          await sleep(300);
+          await tmux("send-keys", "-t", handle.id, "Enter");
         } finally {
           // Clean up temp file and tmux buffer (in case paste-buffer failed
           // and the -d flag didn't delete it)
@@ -139,12 +144,10 @@ export function create(): Runtime {
         // Use -l (literal) so text like "Enter" or "Space" isn't interpreted
         // as tmux key names
         await tmux("send-keys", "-t", handle.id, "-l", message);
+        // Small delay to let tmux process the text before pressing Enter.
+        await sleep(300);
+        await tmux("send-keys", "-t", handle.id, "Enter");
       }
-
-      // Small delay to let tmux process the pasted text before pressing Enter.
-      // Without this, Enter can arrive before the text is fully rendered.
-      await sleep(300);
-      await tmux("send-keys", "-t", handle.id, "Enter");
     },
 
     async getOutput(handle: RuntimeHandle, lines = 50): Promise<string> {


### PR DESCRIPTION
## Summary
- Moves the Enter keypress in `sendMessage()` to fire immediately after `paste-buffer` succeeds, before the finally block runs cleanup (`delete-buffer`, `unlinkSync`)
- Previously Enter was sent after the finally block, meaning cleanup operations (which have a 5s tmux command timeout) could delay the keypress and cause it to arrive too late
- Adds test verifying Enter is sent before cleanup for spawn prompt scenarios

## Root Cause
When spawning a session with `ao spawn --prompt "..."`, the composed prompt is delivered via `runtime.sendMessage()`. For long/multiline prompts, this uses tmux's `paste-buffer` followed by Enter. However, Enter was placed **after** the finally block containing async cleanup (`delete-buffer`). If that cleanup hung or was slow, Enter arrived too late for the agent to process it.

This is the same pattern fixed in commit 13192d49 for the `create()` method (launch commands).

Fixes ComposioHQ/agent-orchestrator#1376

## Test plan
- [x] Existing `sendMessage` tests updated to verify new call ordering (Enter before delete-buffer)
- [x] New test: "sends Enter immediately after pasting spawn prompt (long multiline)" verifies Enter comes before cleanup
- [x] Paste failure test: confirms Enter is NOT sent when paste fails (exception propagates)
- [x] All 27 runtime-tmux tests pass
- [x] All 801 core tests pass
- [x] Typecheck passes for changed packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)