### PR TITLE
refactor(cli): extract preflight + shutdown from start.ts (PR A)

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -35,9 +35,7 @@ import {
   registerProjectInGlobalConfig,
   detectScmPlatform,
   sanitizeProjectId,
-  getAoBaseDir,
   getGlobalConfigPath,
-  inventoryHashDirs,
   type OrchestratorConfig,
   type LocalProjectConfig,
   type ProjectConfig,
@@ -74,7 +72,6 @@ import {
   readLastStop,
   clearLastStop,
 } from "../lib/running-state.js";
-import { preventIdleSleep } from "../lib/prevent-sleep.js";
 import { startProjectSupervisor, stopProjectSupervisor } from "../lib/project-supervisor.js";
 import { isHumanCaller } from "../lib/caller-context.js";
 import { detectEnvironment } from "../lib/detect-env.js";
@@ -92,9 +89,16 @@ import {
   formatProjectTypeForDisplay,
 } from "../lib/project-detection.js";
 import { formatCommandError } from "../lib/cli-errors.js";
-import { detectOpenClawInstallation } from "../lib/openclaw-probe.js";
-import { applyOpenClawCredentials } from "../lib/credential-resolver.js";
 import { findProjectForDirectory } from "../lib/project-resolution.js";
+import {
+  type InstallAttempt,
+  canPromptForInstall,
+  genericInstallHints,
+  askYesNo,
+  runInteractiveCommand,
+  tryInstallWithAttempts,
+} from "../lib/install-helpers.js";
+import { ensureGit, runtimePreflight } from "../lib/startup-preflight.js";
 
 import { DEFAULT_PORT } from "../lib/constants.js";
 import { projectSessionUrl } from "../lib/routes.js";
@@ -278,30 +282,6 @@ async function resolveProjectByRepo(
   return await resolveProject(config);
 }
 
-interface InstallAttempt {
-  cmd: string;
-  args: string[];
-  label: string;
-}
-
-function canPromptForInstall(): boolean {
-  return isHumanCaller() && Boolean(process.stdin.isTTY && process.stdout.isTTY);
-}
-
-function genericInstallHints(command: string): string[] {
-  switch (command) {
-    case "node":
-    case "npm":
-      return ["Install Node.js/npm from https://nodejs.org/"];
-    case "pnpm":
-      return ["corepack enable && corepack prepare pnpm@latest --activate", "npm install -g pnpm"];
-    case "pipx":
-      return ["python3 -m pip install --user pipx", "python3 -m pipx ensurepath"];
-    default:
-      return [];
-  }
-}
-
 /**
  * Prompt the user to optionally switch orchestrator/worker agents at startup.
  * Shows only agents detected on the current system (reuses detectAvailableAgents).
@@ -329,47 +309,6 @@ async function promptAgentSelection(): Promise<{
   }
 }
 
-async function askYesNo(
-  question: string,
-  defaultYes = true,
-  nonInteractiveDefault = defaultYes,
-): Promise<boolean> {
-  if (!canPromptForInstall()) return nonInteractiveDefault;
-  return await promptConfirm(question, defaultYes);
-}
-
-function gitInstallAttempts(): InstallAttempt[] {
-  if (process.platform === "darwin") {
-    return [{ cmd: "brew", args: ["install", "git"], label: "brew install git" }];
-  }
-  if (process.platform === "linux") {
-    return [
-      {
-        cmd: "sudo",
-        args: ["apt-get", "install", "-y", "git"],
-        label: "sudo apt-get install -y git",
-      },
-      { cmd: "sudo", args: ["dnf", "install", "-y", "git"], label: "sudo dnf install -y git" },
-    ];
-  }
-  if (process.platform === "win32") {
-    return [
-      {
-        cmd: "winget",
-        args: ["install", "--id", "Git.Git", "-e", "--source", "winget"],
-        label: "winget install --id Git.Git -e --source winget",
-      },
-    ];
-  }
-  return [];
-}
-
-function gitInstallHints(): string[] {
-  if (process.platform === "darwin") return ["brew install git"];
-  if (process.platform === "win32") return ["winget install --id Git.Git -e --source winget"];
-  return ["sudo apt install git      # Debian/Ubuntu", "sudo dnf install git      # Fedora/RHEL"];
-}
-
 function ghInstallAttempts(): InstallAttempt[] {
   if (process.platform === "darwin") {
     return [{ cmd: "brew", args: ["install", "gh"], label: "brew install gh" }];
@@ -394,87 +333,6 @@ function ghInstallAttempts(): InstallAttempt[] {
     ];
   }
   return [];
-}
-
-async function runInteractiveCommand(
-  cmd: string,
-  args: string[],
-  options?: {
-    cwd?: string;
-    env?: Record<string, string>;
-    action?: string;
-    installHints?: string[];
-  },
-): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn(cmd, args, {
-      cwd: options?.cwd,
-      env: options?.env ? { ...process.env, ...options.env } : process.env,
-      stdio: "inherit",
-    });
-    child.once("error", (err) => {
-      reject(
-        formatCommandError(err, {
-          cmd,
-          args,
-          action: options?.action ?? "run an interactive command",
-          installHints: options?.installHints ?? genericInstallHints(cmd),
-        }),
-      );
-    });
-    child.once("close", (code) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      reject(new Error(`Command failed (${code ?? "unknown"}): ${cmd} ${args.join(" ")}`));
-    });
-  });
-}
-
-async function tryInstallWithAttempts(
-  attempts: InstallAttempt[],
-  verify: () => Promise<boolean>,
-): Promise<boolean> {
-  for (const attempt of attempts) {
-    try {
-      console.log(chalk.dim(`  Running: ${attempt.label}`));
-      await runInteractiveCommand(attempt.cmd, attempt.args, {
-        action: "run an interactive installer",
-        installHints: genericInstallHints(attempt.cmd),
-      });
-      if (await verify()) return true;
-    } catch {
-      // Try next installer
-    }
-  }
-  return verify();
-}
-
-async function ensureGit(context: string): Promise<void> {
-  const hasGit = (await execSilent("git", ["--version"])) !== null;
-  if (hasGit) return;
-
-  console.log(chalk.yellow(`⚠ Git is required for ${context}.`));
-  const shouldInstall = await askYesNo("Install Git now?", true, false);
-  if (shouldInstall) {
-    const installed = await tryInstallWithAttempts(
-      gitInstallAttempts(),
-      async () => (await execSilent("git", ["--version"])) !== null,
-    );
-    if (installed) {
-      console.log(chalk.green("  ✓ Git installed successfully"));
-      return;
-    }
-  }
-
-  console.error(chalk.red("\n✗ Git is required but is not installed.\n"));
-  console.log(chalk.bold("  Install Git manually, then re-run ao start:\n"));
-  for (const hint of gitInstallHints()) {
-    console.log(chalk.cyan(`    ${hint}`));
-  }
-  console.log();
-  process.exit(1);
 }
 
 interface AgentInstallOption {
@@ -1077,122 +935,6 @@ async function startDashboard(
 /* c8 ignore stop */
 
 /**
- * Ensure tmux is available — interactive install with user consent if missing.
- * Called from runStartup() so ALL ao start
- * paths (normal, URL, retry with existing config) are covered.
- */
-function tmuxInstallAttempts(): InstallAttempt[] {
-  if (process.platform === "darwin") {
-    return [{ cmd: "brew", args: ["install", "tmux"], label: "brew install tmux" }];
-  }
-  if (process.platform === "linux") {
-    return [
-      {
-        cmd: "sudo",
-        args: ["apt-get", "install", "-y", "tmux"],
-        label: "sudo apt-get install -y tmux",
-      },
-      { cmd: "sudo", args: ["dnf", "install", "-y", "tmux"], label: "sudo dnf install -y tmux" },
-    ];
-  }
-  return [];
-}
-
-function tmuxInstallHints(): string[] {
-  if (process.platform === "darwin") return ["brew install tmux"];
-  if (process.platform === "win32")
-    return ["# Install WSL first, then inside WSL:", "sudo apt install tmux"];
-  return ["sudo apt install tmux      # Debian/Ubuntu", "sudo dnf install tmux      # Fedora/RHEL"];
-}
-
-async function ensureTmux(): Promise<void> {
-  const hasTmux = (await execSilent("tmux", ["-V"])) !== null;
-  if (hasTmux) return;
-
-  console.log(chalk.yellow('⚠ tmux is required for runtime "tmux".'));
-  const shouldInstall = await askYesNo("Install tmux now?", true, false);
-  if (shouldInstall) {
-    const installed = await tryInstallWithAttempts(
-      tmuxInstallAttempts(),
-      async () => (await execSilent("tmux", ["-V"])) !== null,
-    );
-    if (installed) {
-      console.log(chalk.green("  ✓ tmux installed successfully"));
-      return;
-    }
-  }
-
-  console.error(chalk.red("\n✗ tmux is required but is not installed.\n"));
-  console.log(chalk.bold("  Install tmux manually, then re-run ao start:\n"));
-  for (const hint of tmuxInstallHints()) {
-    console.log(chalk.cyan(`    ${hint}`));
-  }
-  console.log();
-  process.exit(1);
-}
-
-function warnAboutLegacyStorage(): void {
-  try {
-    const hashDirs = inventoryHashDirs(getAoBaseDir(), getGlobalConfigPath());
-    if (hashDirs.length === 0) return;
-
-    const sessionCount = hashDirs.reduce((sum, d) => {
-      if (d.empty) return sum;
-      return sum + 1;
-    }, 0);
-    if (sessionCount === 0) return;
-
-    console.log(
-      chalk.yellow(
-        `\n  ⚠ Found ${hashDirs.length} legacy storage director${hashDirs.length === 1 ? "y" : "ies"} that need${hashDirs.length === 1 ? "s" : ""} migration.\n` +
-          `    Sessions stored in the old format won't appear until migrated.\n` +
-          `    Run ${chalk.bold("ao migrate-storage")} to upgrade (use ${chalk.bold("--dry-run")} to preview).\n`,
-      ),
-    );
-  } catch {
-    // Non-critical — don't block startup
-  }
-}
-
-async function warnAboutOpenClawStatus(config: OrchestratorConfig): Promise<void> {
-  const openclawConfig = config.notifiers?.["openclaw"];
-  const openclawConfigured =
-    openclawConfig !== null &&
-    openclawConfig !== undefined &&
-    typeof openclawConfig === "object" &&
-    openclawConfig.plugin === "openclaw";
-  const configuredUrl =
-    openclawConfigured && typeof openclawConfig.url === "string" ? openclawConfig.url : undefined;
-
-  try {
-    const installation = configuredUrl
-      ? await detectOpenClawInstallation(configuredUrl)
-      : await detectOpenClawInstallation();
-
-    if (openclawConfigured) {
-      if (installation.state !== "running") {
-        console.log(
-          chalk.yellow(
-            `⚠ OpenClaw is configured but the gateway is not reachable at ${installation.gatewayUrl}. Notifications may fail until it is running.`,
-          ),
-        );
-      }
-      return;
-    }
-
-    if (installation.state === "running") {
-      console.log(
-        chalk.yellow(
-          `⚠ OpenClaw is running at ${installation.gatewayUrl} but AO is not configured to use it. Run \`ao setup openclaw\` if you want OpenClaw notifications.`,
-        ),
-      );
-    }
-  } catch {
-    // OpenClaw probing is advisory for `ao start`; never block startup on it.
-  }
-}
-
-/**
  * Shared startup logic: launch dashboard + orchestrator session, print summary.
  * Used by both normal and URL-based start flows.
  */
@@ -1202,40 +944,7 @@ async function runStartup(
   project: ProjectConfig,
   opts?: { dashboard?: boolean; orchestrator?: boolean; rebuild?: boolean; dev?: boolean },
 ): Promise<number> {
-  // Ensure tmux is available before doing anything — covers all entry paths
-  // (normal start, URL start, retry with existing config)
-  const runtime = config.defaults?.runtime ?? "tmux";
-  if (runtime === "tmux") {
-    await ensureTmux();
-  }
-  warnAboutLegacyStorage();
-  await warnAboutOpenClawStatus(config);
-
-  // Prevent macOS idle sleep while AO is running (if enabled in config)
-  // Uses caffeinate -i -w <pid> to hold an assertion tied to this process lifetime.
-  // No-op on non-macOS platforms.
-  if (config.power?.preventIdleSleep !== false) {
-    const sleepHandle = preventIdleSleep();
-    if (sleepHandle) {
-      console.log(chalk.dim("  Preventing macOS idle sleep while AO is running"));
-    }
-  }
-
-  // Only inject OpenClaw credentials when the project actually uses OpenClaw.
-  // This avoids exposing API keys to projects/plugins that don't need them.
-  const openclawNotifier = config.notifiers?.["openclaw"];
-  const hasOpenClaw =
-    openclawNotifier !== null &&
-    openclawNotifier !== undefined &&
-    typeof openclawNotifier === "object" &&
-    openclawNotifier.plugin === "openclaw";
-  if (hasOpenClaw) {
-    const injectedKeys = applyOpenClawCredentials();
-    if (injectedKeys.length > 0) {
-      const names = injectedKeys.map((k) => k.key).join(", ");
-      console.log(chalk.dim(`  Resolved from OpenClaw config: ${names}`));
-    }
-  }
+  await runtimePreflight(config);
 
   const shouldStartLifecycle = opts?.dashboard !== false || opts?.orchestrator !== false;
   let port = config.port ?? DEFAULT_PORT;

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -45,8 +45,8 @@ import {
 import { parse as yamlParse, stringify as yamlStringify } from "yaml";
 import { exec, execSilent, git } from "../lib/shell.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
-import { stopAllLifecycleWorkers, listLifecycleWorkers } from "../lib/lifecycle-service.js";
-import { startBunTmpJanitor, stopBunTmpJanitor } from "../lib/bun-tmp-janitor.js";
+import { listLifecycleWorkers } from "../lib/lifecycle-service.js";
+import { startBunTmpJanitor } from "../lib/bun-tmp-janitor.js";
 import {
   findWebDir,
   buildDashboardEnv,
@@ -72,7 +72,7 @@ import {
   readLastStop,
   clearLastStop,
 } from "../lib/running-state.js";
-import { startProjectSupervisor, stopProjectSupervisor } from "../lib/project-supervisor.js";
+import { startProjectSupervisor } from "../lib/project-supervisor.js";
 import { isHumanCaller } from "../lib/caller-context.js";
 import { detectEnvironment } from "../lib/detect-env.js";
 import {
@@ -99,6 +99,7 @@ import {
   tryInstallWithAttempts,
 } from "../lib/install-helpers.js";
 import { ensureGit, runtimePreflight } from "../lib/startup-preflight.js";
+import { installShutdownHandlers } from "../lib/shutdown.js";
 
 import { DEFAULT_PORT } from "../lib/constants.js";
 import { projectSessionUrl } from "../lib/routes.js";
@@ -1952,92 +1953,10 @@ export function registerStart(program: Command): void {
             },
           });
 
-          // Install shutdown handlers so Ctrl+C and `ao stop` (which sends
-          // SIGTERM) perform a full graceful shutdown: kill sessions, record
-          // last-stop state for restore, unregister, then exit.
-          // Installing a SIGINT/SIGTERM listener removes Node's default exit
-          // behavior, so we MUST call process.exit() explicitly.
-          let shuttingDown = false;
-          const shutdown = (signal: NodeJS.Signals): void => {
-            if (shuttingDown) return;
-            shuttingDown = true;
-
-            const exitCode = signal === "SIGINT" ? 130 : 0;
-
-            try {
-              stopProjectSupervisor();
-              stopAllLifecycleWorkers();
-            } catch {
-              // Best-effort — never block shutdown on observability.
-            }
-
-            const SHUTDOWN_TIMEOUT_MS = 10_000;
-            const forceExit = setTimeout(() => process.exit(exitCode), SHUTDOWN_TIMEOUT_MS);
-            forceExit.unref();
-
-            (async () => {
-              try {
-                const shutdownConfig = loadConfig(config.configPath);
-                const sm = await getSessionManager(shutdownConfig);
-                const allSessions = await sm.list();
-                const activeSessions = allSessions.filter((s) => !isTerminalSession(s));
-
-                const killedSessionIds: string[] = [];
-                for (const session of activeSessions) {
-                  try {
-                    const result = await sm.kill(session.id);
-                    if (result.cleaned || result.alreadyTerminated) {
-                      killedSessionIds.push(session.id);
-                    }
-                  } catch {
-                    // Best-effort per session
-                  }
-                }
-
-                if (killedSessionIds.length > 0) {
-                  const targetIds = killedSessionIds.filter((id) =>
-                    activeSessions.some((s) => s.id === id && s.projectId === projectId),
-                  );
-                  const otherProjects: Array<{ projectId: string; sessionIds: string[] }> = [];
-                  const otherByProject = new Map<string, string[]>();
-                  for (const s of activeSessions) {
-                    if (s.projectId === projectId) continue;
-                    if (!killedSessionIds.includes(s.id)) continue;
-                    const list = otherByProject.get(s.projectId ?? "unknown") ?? [];
-                    list.push(s.id);
-                    otherByProject.set(s.projectId ?? "unknown", list);
-                  }
-                  for (const [pid, ids] of otherByProject) {
-                    otherProjects.push({ projectId: pid, sessionIds: ids });
-                  }
-                  await writeLastStop({
-                    stoppedAt: new Date().toISOString(),
-                    projectId,
-                    sessionIds: targetIds,
-                    otherProjects: otherProjects.length > 0 ? otherProjects : undefined,
-                  });
-                }
-
-                await unregister();
-              } catch {
-                // Best-effort — always exit even if cleanup fails
-              }
-              try {
-                // Await any in-flight sweep so shutdown does not exit while
-                // unlink() calls are still mid-flight against the filesystem.
-                await stopBunTmpJanitor();
-              } catch {
-                // Best-effort cleanup.
-              }
-              process.exit(exitCode);
-            })();
-          };
-          process.once("SIGINT", (sig) => {
-            void shutdown(sig);
-          });
-          process.once("SIGTERM", (sig) => {
-            void shutdown(sig);
-          });
+          // Ctrl+C and `ao stop` (which sends SIGTERM) perform a full
+          // graceful shutdown: kill sessions, record last-stop state for
+          // restore, unregister, then exit. See lib/shutdown.ts.
+          installShutdownHandlers({ configPath: config.configPath, projectId });
         } catch (err) {
           if (err instanceof Error) {
             console.error(chalk.red("\nError:"), err.message);

--- a/packages/cli/src/lib/install-helpers.ts
+++ b/packages/cli/src/lib/install-helpers.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared primitives for interactively installing missing CLI tools.
+ *
+ * Used by `startup-preflight.ts` (ensureGit, ensureTmux), the agent runtime
+ * installer, and the optional gh install path in autoCreateConfig. Lives in
+ * its own module so the preflight code can be moved out of `start.ts`
+ * without re-extracting these helpers later.
+ */
+
+import { spawn } from "node:child_process";
+import chalk from "chalk";
+import { formatCommandError } from "./cli-errors.js";
+import { isHumanCaller } from "./caller-context.js";
+import { promptConfirm } from "./prompts.js";
+
+export interface InstallAttempt {
+  cmd: string;
+  args: string[];
+  label: string;
+}
+
+export function canPromptForInstall(): boolean {
+  return isHumanCaller() && Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+export function genericInstallHints(command: string): string[] {
+  switch (command) {
+    case "node":
+    case "npm":
+      return ["Install Node.js/npm from https://nodejs.org/"];
+    case "pnpm":
+      return ["corepack enable && corepack prepare pnpm@latest --activate", "npm install -g pnpm"];
+    case "pipx":
+      return ["python3 -m pip install --user pipx", "python3 -m pipx ensurepath"];
+    default:
+      return [];
+  }
+}
+
+export async function askYesNo(
+  question: string,
+  defaultYes = true,
+  nonInteractiveDefault = defaultYes,
+): Promise<boolean> {
+  if (!canPromptForInstall()) return nonInteractiveDefault;
+  return await promptConfirm(question, defaultYes);
+}
+
+export async function runInteractiveCommand(
+  cmd: string,
+  args: string[],
+  options?: {
+    cwd?: string;
+    env?: Record<string, string>;
+    action?: string;
+    installHints?: string[];
+  },
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: options?.cwd,
+      env: options?.env ? { ...process.env, ...options.env } : process.env,
+      stdio: "inherit",
+    });
+    child.once("error", (err) => {
+      reject(
+        formatCommandError(err, {
+          cmd,
+          args,
+          action: options?.action ?? "run an interactive command",
+          installHints: options?.installHints ?? genericInstallHints(cmd),
+        }),
+      );
+    });
+    child.once("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`Command failed (${code ?? "unknown"}): ${cmd} ${args.join(" ")}`));
+    });
+  });
+}
+
+export async function tryInstallWithAttempts(
+  attempts: InstallAttempt[],
+  verify: () => Promise<boolean>,
+): Promise<boolean> {
+  for (const attempt of attempts) {
+    try {
+      console.log(chalk.dim(`  Running: ${attempt.label}`));
+      await runInteractiveCommand(attempt.cmd, attempt.args, {
+        action: "run an interactive installer",
+        installHints: genericInstallHints(attempt.cmd),
+      });
+      if (await verify()) return true;
+    } catch {
+      // Try next installer
+    }
+  }
+  return verify();
+}

--- a/packages/cli/src/lib/shutdown.ts
+++ b/packages/cli/src/lib/shutdown.ts
@@ -1,0 +1,121 @@
+/**
+ * SIGINT/SIGTERM shutdown handler for the long-running `ao start` process.
+ *
+ * Installs `process.once` listeners that perform a full graceful shutdown:
+ * stop lifecycle workers, kill all active sessions, record last-stop state
+ * for restore on next `ao start`, unregister from running.json, await the
+ * bun-tmp janitor's final sweep, then exit.
+ *
+ * Lives in its own module so the orchestration is testable in isolation
+ * and so the equivalent kill-and-record logic in `ao stop` can converge
+ * here in a later refactor (today the two paths duplicate the core loop;
+ * see ao-118 plan PR B).
+ */
+
+import { isTerminalSession, loadConfig } from "@aoagents/ao-core";
+import { stopBunTmpJanitor } from "./bun-tmp-janitor.js";
+import { getSessionManager } from "./create-session-manager.js";
+import { stopAllLifecycleWorkers } from "./lifecycle-service.js";
+import { stopProjectSupervisor } from "./project-supervisor.js";
+import { unregister, writeLastStop } from "./running-state.js";
+
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+
+export interface ShutdownContext {
+  /** Path to the orchestrator config; re-read at shutdown time so any
+   *  config edits since startup are honored. */
+  configPath: string;
+  /** Project this `ao start` invocation owns; used to scope last-stop's
+   *  primary `sessionIds` field (other projects go to `otherProjects`). */
+  projectId: string;
+}
+
+/**
+ * Install SIGINT/SIGTERM handlers. Idempotent within a process — only the
+ * first signal triggers cleanup; subsequent signals are ignored until the
+ * 10-second force-exit timer fires.
+ */
+export function installShutdownHandlers(ctx: ShutdownContext): void {
+  let shuttingDown = false;
+
+  const shutdown = (signal: NodeJS.Signals): void => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+
+    const exitCode = signal === "SIGINT" ? 130 : 0;
+
+    try {
+      stopProjectSupervisor();
+      stopAllLifecycleWorkers();
+    } catch {
+      // Best-effort — never block shutdown on observability.
+    }
+
+    const forceExit = setTimeout(() => process.exit(exitCode), SHUTDOWN_TIMEOUT_MS);
+    forceExit.unref();
+
+    void (async () => {
+      try {
+        const shutdownConfig = loadConfig(ctx.configPath);
+        const sm = await getSessionManager(shutdownConfig);
+        const allSessions = await sm.list();
+        const activeSessions = allSessions.filter((s) => !isTerminalSession(s));
+
+        const killedSessionIds: string[] = [];
+        for (const session of activeSessions) {
+          try {
+            const result = await sm.kill(session.id);
+            if (result.cleaned || result.alreadyTerminated) {
+              killedSessionIds.push(session.id);
+            }
+          } catch {
+            // Best-effort per session
+          }
+        }
+
+        if (killedSessionIds.length > 0) {
+          const targetIds = killedSessionIds.filter((id) =>
+            activeSessions.some((s) => s.id === id && s.projectId === ctx.projectId),
+          );
+          const otherProjects: Array<{ projectId: string; sessionIds: string[] }> = [];
+          const otherByProject = new Map<string, string[]>();
+          for (const s of activeSessions) {
+            if (s.projectId === ctx.projectId) continue;
+            if (!killedSessionIds.includes(s.id)) continue;
+            const list = otherByProject.get(s.projectId ?? "unknown") ?? [];
+            list.push(s.id);
+            otherByProject.set(s.projectId ?? "unknown", list);
+          }
+          for (const [pid, ids] of otherByProject) {
+            otherProjects.push({ projectId: pid, sessionIds: ids });
+          }
+          await writeLastStop({
+            stoppedAt: new Date().toISOString(),
+            projectId: ctx.projectId,
+            sessionIds: targetIds,
+            otherProjects: otherProjects.length > 0 ? otherProjects : undefined,
+          });
+        }
+
+        await unregister();
+      } catch {
+        // Best-effort — always exit even if cleanup fails
+      }
+      try {
+        // Await any in-flight sweep so shutdown does not exit while
+        // unlink() calls are still mid-flight against the filesystem.
+        await stopBunTmpJanitor();
+      } catch {
+        // Best-effort cleanup.
+      }
+      process.exit(exitCode);
+    })();
+  };
+
+  process.once("SIGINT", (sig) => {
+    shutdown(sig);
+  });
+  process.once("SIGTERM", (sig) => {
+    shutdown(sig);
+  });
+}

--- a/packages/cli/src/lib/startup-preflight.ts
+++ b/packages/cli/src/lib/startup-preflight.ts
@@ -1,0 +1,244 @@
+/**
+ * Runtime preflight checks for `ao start`.
+ *
+ * Distinct from `lib/preflight.ts` (which validates dashboard build
+ * artifacts). This module verifies system tools (git, tmux), warns about
+ * legacy storage and OpenClaw status, and applies side effects like idle
+ * sleep prevention and credential injection.
+ *
+ * Each check is exported individually for callers that need it at a
+ * specific point in the flow (e.g. `ensureGit` before clone). The
+ * top-level `runtimePreflight(config)` orchestrates the checks that
+ * `runStartup` runs once at process start.
+ */
+
+import chalk from "chalk";
+import {
+  getAoBaseDir,
+  getGlobalConfigPath,
+  inventoryHashDirs,
+  type OrchestratorConfig,
+} from "@aoagents/ao-core";
+import { execSilent } from "./shell.js";
+import { detectOpenClawInstallation } from "./openclaw-probe.js";
+import { applyOpenClawCredentials } from "./credential-resolver.js";
+import { preventIdleSleep } from "./prevent-sleep.js";
+import {
+  askYesNo,
+  tryInstallWithAttempts,
+  type InstallAttempt,
+} from "./install-helpers.js";
+
+function gitInstallAttempts(): InstallAttempt[] {
+  if (process.platform === "darwin") {
+    return [{ cmd: "brew", args: ["install", "git"], label: "brew install git" }];
+  }
+  if (process.platform === "linux") {
+    return [
+      {
+        cmd: "sudo",
+        args: ["apt-get", "install", "-y", "git"],
+        label: "sudo apt-get install -y git",
+      },
+      { cmd: "sudo", args: ["dnf", "install", "-y", "git"], label: "sudo dnf install -y git" },
+    ];
+  }
+  if (process.platform === "win32") {
+    return [
+      {
+        cmd: "winget",
+        args: ["install", "--id", "Git.Git", "-e", "--source", "winget"],
+        label: "winget install --id Git.Git -e --source winget",
+      },
+    ];
+  }
+  return [];
+}
+
+function gitInstallHints(): string[] {
+  if (process.platform === "darwin") return ["brew install git"];
+  if (process.platform === "win32") return ["winget install --id Git.Git -e --source winget"];
+  return ["sudo apt install git      # Debian/Ubuntu", "sudo dnf install git      # Fedora/RHEL"];
+}
+
+function tmuxInstallAttempts(): InstallAttempt[] {
+  if (process.platform === "darwin") {
+    return [{ cmd: "brew", args: ["install", "tmux"], label: "brew install tmux" }];
+  }
+  if (process.platform === "linux") {
+    return [
+      {
+        cmd: "sudo",
+        args: ["apt-get", "install", "-y", "tmux"],
+        label: "sudo apt-get install -y tmux",
+      },
+      { cmd: "sudo", args: ["dnf", "install", "-y", "tmux"], label: "sudo dnf install -y tmux" },
+    ];
+  }
+  return [];
+}
+
+function tmuxInstallHints(): string[] {
+  if (process.platform === "darwin") return ["brew install tmux"];
+  if (process.platform === "win32")
+    return ["# Install WSL first, then inside WSL:", "sudo apt install tmux"];
+  return ["sudo apt install tmux      # Debian/Ubuntu", "sudo dnf install tmux      # Fedora/RHEL"];
+}
+
+export async function ensureGit(context: string): Promise<void> {
+  const hasGit = (await execSilent("git", ["--version"])) !== null;
+  if (hasGit) return;
+
+  console.log(chalk.yellow(`⚠ Git is required for ${context}.`));
+  const shouldInstall = await askYesNo("Install Git now?", true, false);
+  if (shouldInstall) {
+    const installed = await tryInstallWithAttempts(
+      gitInstallAttempts(),
+      async () => (await execSilent("git", ["--version"])) !== null,
+    );
+    if (installed) {
+      console.log(chalk.green("  ✓ Git installed successfully"));
+      return;
+    }
+  }
+
+  console.error(chalk.red("\n✗ Git is required but is not installed.\n"));
+  console.log(chalk.bold("  Install Git manually, then re-run ao start:\n"));
+  for (const hint of gitInstallHints()) {
+    console.log(chalk.cyan(`    ${hint}`));
+  }
+  console.log();
+  process.exit(1);
+}
+
+/**
+ * Ensure tmux is available — interactive install with user consent if missing.
+ * Called from runtimePreflight() so all `ao start` paths are covered.
+ */
+export async function ensureTmux(): Promise<void> {
+  const hasTmux = (await execSilent("tmux", ["-V"])) !== null;
+  if (hasTmux) return;
+
+  console.log(chalk.yellow('⚠ tmux is required for runtime "tmux".'));
+  const shouldInstall = await askYesNo("Install tmux now?", true, false);
+  if (shouldInstall) {
+    const installed = await tryInstallWithAttempts(
+      tmuxInstallAttempts(),
+      async () => (await execSilent("tmux", ["-V"])) !== null,
+    );
+    if (installed) {
+      console.log(chalk.green("  ✓ tmux installed successfully"));
+      return;
+    }
+  }
+
+  console.error(chalk.red("\n✗ tmux is required but is not installed.\n"));
+  console.log(chalk.bold("  Install tmux manually, then re-run ao start:\n"));
+  for (const hint of tmuxInstallHints()) {
+    console.log(chalk.cyan(`    ${hint}`));
+  }
+  console.log();
+  process.exit(1);
+}
+
+export function warnAboutLegacyStorage(): void {
+  try {
+    const hashDirs = inventoryHashDirs(getAoBaseDir(), getGlobalConfigPath());
+    if (hashDirs.length === 0) return;
+
+    const sessionCount = hashDirs.reduce((sum, d) => {
+      if (d.empty) return sum;
+      return sum + 1;
+    }, 0);
+    if (sessionCount === 0) return;
+
+    console.log(
+      chalk.yellow(
+        `\n  ⚠ Found ${hashDirs.length} legacy storage director${hashDirs.length === 1 ? "y" : "ies"} that need${hashDirs.length === 1 ? "s" : ""} migration.\n` +
+          `    Sessions stored in the old format won't appear until migrated.\n` +
+          `    Run ${chalk.bold("ao migrate-storage")} to upgrade (use ${chalk.bold("--dry-run")} to preview).\n`,
+      ),
+    );
+  } catch {
+    // Non-critical — don't block startup
+  }
+}
+
+export async function warnAboutOpenClawStatus(config: OrchestratorConfig): Promise<void> {
+  const openclawConfig = config.notifiers?.["openclaw"];
+  const openclawConfigured =
+    openclawConfig !== null &&
+    openclawConfig !== undefined &&
+    typeof openclawConfig === "object" &&
+    openclawConfig.plugin === "openclaw";
+  const configuredUrl =
+    openclawConfigured && typeof openclawConfig.url === "string" ? openclawConfig.url : undefined;
+
+  try {
+    const installation = configuredUrl
+      ? await detectOpenClawInstallation(configuredUrl)
+      : await detectOpenClawInstallation();
+
+    if (openclawConfigured) {
+      if (installation.state !== "running") {
+        console.log(
+          chalk.yellow(
+            `⚠ OpenClaw is configured but the gateway is not reachable at ${installation.gatewayUrl}. Notifications may fail until it is running.`,
+          ),
+        );
+      }
+      return;
+    }
+
+    if (installation.state === "running") {
+      console.log(
+        chalk.yellow(
+          `⚠ OpenClaw is running at ${installation.gatewayUrl} but AO is not configured to use it. Run \`ao setup openclaw\` if you want OpenClaw notifications.`,
+        ),
+      );
+    }
+  } catch {
+    // OpenClaw probing is advisory for `ao start`; never block startup on it.
+  }
+}
+
+/**
+ * Top-level orchestrator: tools + state warnings + idle-sleep + credentials.
+ * Replaces the inline preflight block in `runStartup`. Idempotent within a
+ * single process — the side effects (caffeinate spawn, env injection) latch
+ * for the lifetime of the process.
+ */
+export async function runtimePreflight(config: OrchestratorConfig): Promise<void> {
+  const runtime = config.defaults?.runtime ?? "tmux";
+  if (runtime === "tmux") {
+    await ensureTmux();
+  }
+  warnAboutLegacyStorage();
+  await warnAboutOpenClawStatus(config);
+
+  // Prevent macOS idle sleep while AO is running (if enabled in config).
+  // Uses caffeinate -i -w <pid> to hold an assertion tied to this process
+  // lifetime. No-op on non-macOS platforms.
+  if (config.power?.preventIdleSleep !== false) {
+    const sleepHandle = preventIdleSleep();
+    if (sleepHandle) {
+      console.log(chalk.dim("  Preventing macOS idle sleep while AO is running"));
+    }
+  }
+
+  // Only inject OpenClaw credentials when the project actually uses OpenClaw.
+  // Avoids exposing API keys to projects/plugins that don't need them.
+  const openclawNotifier = config.notifiers?.["openclaw"];
+  const hasOpenClaw =
+    openclawNotifier !== null &&
+    openclawNotifier !== undefined &&
+    typeof openclawNotifier === "object" &&
+    openclawNotifier.plugin === "openclaw";
+  if (hasOpenClaw) {
+    const injectedKeys = applyOpenClawCredentials();
+    if (injectedKeys.length > 0) {
+      const names = injectedKeys.map((k) => k.key).join(", ");
+      console.log(chalk.dim(`  Resolved from OpenClaw config: ${names}`));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

PR A of the `start.ts` cleanup plan (`~/.ao/agent-orchestrator/ao-118/plan.md`) — pure mechanical extractions, **zero behavior change**.

`packages/cli/src/commands/start.ts` shrinks from 2532 → ~2140 lines. The 408 lines that come out are redistributed to three focused, single-responsibility modules.

## What's in this PR

### 1. `lib/install-helpers.ts` (new — 102 lines)

Shared install primitives used by ensureGit, ensureTmux, the agent-runtime installer, and the optional gh install path:

- `InstallAttempt`, `canPromptForInstall`, `askYesNo`
- `runInteractiveCommand`, `tryInstallWithAttempts`, `genericInstallHints`

### 2. `lib/startup-preflight.ts` (new — 244 lines)

Runtime preflight checks (distinct from `lib/preflight.ts`, which validates dashboard build artifacts):

- `ensureGit(context)` — interactive install on missing
- `ensureTmux()` — interactive install on missing
- `warnAboutLegacyStorage()`, `warnAboutOpenClawStatus(config)`
- `runtimePreflight(config)` — top-level orchestrator: tools + state warnings + idle-sleep + OpenClaw credentials, called once from `runStartup`

This collapses ~32 lines of inline orchestration in `runStartup` into a single `await runtimePreflight(config)` call.

### 3. `lib/shutdown.ts` (new — 121 lines)

`installShutdownHandlers({ configPath, projectId })` extracts the SIGINT/SIGTERM handler block (85 lines) from `runStartup`'s closure into its own module. The handler logic is identical: stop lifecycle workers → kill active sessions → record last-stop → unregister → await janitor sweep → exit with code 130/0.

## What's NOT in this PR (intentional)

- The duplicated kill-and-record loop in `ao stop` is left as-is. It has different verbosity (spinner, warnings, per-project output) and different options (`--purge-session`) than the signal handler. Unifying the two paths is a behavior-shaping change that belongs with the daemon/stop restructure planned for PR B.
- No `Prompter` abstraction yet. Of the 7 `isHumanCaller()` callsites, only 2 are the "prompt-or-skip" pattern that benefits from a wrapper; the other 5 are behavioral branches that gain leverage only when PR B restructures the §3.x menu. Deferred to PR B.

## Cumulative diff

```
 packages/cli/src/commands/start.ts        | 408 ++--------------------
 packages/cli/src/lib/install-helpers.ts   | 102 ++++++++
 packages/cli/src/lib/shutdown.ts          | 121 +++++++++
 packages/cli/src/lib/startup-preflight.ts | 244 ++++++++++++++++++
 4 files changed, 485 insertions(+), 390 deletions(-)
```

Net core LOC: +95 (interface overhead). The win is organization, not raw deletion — that comes in PR B.

## Test plan

- [x] `pnpm build` — green
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — 0 errors (46 pre-existing warnings, all in unmodified files)
- [x] `pnpm --filter @aoagents/ao-cli test` — 594 passing, 8 failing
  - The 8 failures are **pre-existing on `upstream/main`** (verified by stashing my changes and re-running). All in `stop command` tests, all fail with the same `process.exit(1)` from the catch handler in `ao stop`. Not regressions from this PR.

## Plan reference

This is PR A of the 3-PR plan. Full document at `~/.ao/agent-orchestrator/ao-118/plan.md`.

- **PR A (this one):** mechanical extractions — preflight, install-helpers, shutdown
- **PR B (next):** reshape main flow — `ensureDaemon` + `resolveOrCreateProject` + `Prompter`, collapse the running/not-running fork
- **PR C (after B):** drop `startNewOrchestrator` YAML mutation, prune the multi-choice menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)