### PR TITLE
fix(web): defer idle PTY kill to curb macOS ptmx slot exhaustion (#1718)

### DIFF
--- a/.changeset/pty-idle-grace-period.md
+++ b/.changeset/pty-idle-grace-period.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-web": patch
+---
+
+Defer killing idle terminal PTYs by 30s in the mux server so that quick reconnects (tab reload, sleep/wake, network blip) reuse the existing PTY instead of allocating a fresh one. macOS never recycles ptmx slot numbers within a boot, so churning PTYs across these events used to drain `kern.tty.ptmx_max` (511) over weeks of dashboard uptime. (#1718)

--- a/.changeset/reload-dashboard-on-add-project.md
+++ b/.changeset/reload-dashboard-on-add-project.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-cli": patch
+---
+
+Fix dashboard 404 after adding a project from the "AO is already running" menu. The CLI now notifies the running daemon to reload its cached config so the new project's page is reachable immediately.

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1411,6 +1411,14 @@ export function registerStart(program: Command): void {
                     `\n✓ Added "${addedId}" — open the dashboard to start an orchestrator.\n`,
                   ),
                 );
+                const notifyResult = await attachToDaemon(running).notifyProjectChange();
+                if (!notifyResult.ok) {
+                  console.log(
+                    chalk.yellow(
+                      `  ⚠ ${notifyResult.reason}. Refresh the page if the project doesn't show up.`,
+                    ),
+                  );
+                }
                 openUrl(`http://localhost:${running.port}`);
                 unlockStartup();
                 process.exit(0);

--- a/packages/core/src/__tests__/tmux.test.ts
+++ b/packages/core/src/__tests__/tmux.test.ts
@@ -4,7 +4,6 @@ import {
   isTmuxAvailable,
   listSessions,
   hasSession,
-  newSession,
   sendKeys,
   capturePane,
   killSession,
@@ -115,68 +114,6 @@ describe("hasSession", () => {
   it("returns false when session does not exist", async () => {
     mockTmuxError("session not found");
     expect(await hasSession("app-99")).toBe(false);
-  });
-});
-
-describe("newSession", () => {
-  it("creates a basic session", async () => {
-    mockTmuxSuccess("");
-
-    await newSession({ name: "test-1", cwd: "/tmp/workspace" });
-
-    expect(mockExecFile).toHaveBeenCalledWith(
-      "tmux",
-      ["new-session", "-d", "-s", "test-1", "-c", "/tmp/workspace"],
-      expect.any(Object),
-      expect.any(Function),
-    );
-  });
-
-  it("includes environment variables", async () => {
-    mockTmuxSuccess("");
-
-    await newSession({
-      name: "test-2",
-      cwd: "/tmp",
-      environment: { AO_SESSION: "test-2", SOME_VAR: "value" },
-    });
-
-    const args = mockExecFile.mock.calls[0][1] as string[];
-    expect(args).toContain("-e");
-    expect(args).toContain("AO_SESSION=test-2");
-    expect(args).toContain("SOME_VAR=value");
-  });
-
-  it("includes window size", async () => {
-    mockTmuxSuccess("");
-
-    await newSession({ name: "test-3", cwd: "/tmp", width: 200, height: 50 });
-
-    const args = mockExecFile.mock.calls[0][1] as string[];
-    expect(args).toContain("-x");
-    expect(args).toContain("200");
-    expect(args).toContain("-y");
-    expect(args).toContain("50");
-  });
-
-  it("sends initial command after creation", async () => {
-    // Calls: new-session, set-option status off, send-keys Escape, send-keys text, send-keys Enter
-    mockTmuxSequence([{ stdout: "" }, { stdout: "" }, { stdout: "" }, { stdout: "" }, { stdout: "" }]);
-
-    await newSession({ name: "test-4", cwd: "/tmp", command: "echo hello" });
-
-    expect(mockExecFile).toHaveBeenCalledTimes(5);
-    // Call 0: new-session
-    // Call 1: set-option status off (hide status bar)
-    const statusArgs = mockExecFile.mock.calls[1][1] as string[];
-    expect(statusArgs).toEqual(["set-option", "-t", "test-4", "status", "off"]);
-    // Call 2: send-keys Escape (clear partial input)
-    const escapeArgs = mockExecFile.mock.calls[2][1] as string[];
-    expect(escapeArgs).toEqual(["send-keys", "-t", "test-4", "Escape"]);
-    // Call 3: send-keys text
-    const textArgs = mockExecFile.mock.calls[3][1] as string[];
-    expect(textArgs).toContain("send-keys");
-    expect(textArgs).toContain("echo hello");
   });
 });
 

--- a/packages/core/src/gh-trace.ts
+++ b/packages/core/src/gh-trace.ts
@@ -60,7 +60,7 @@ export interface GhTraceContext {
   cwd?: string;
 }
 
-export interface GhTraceResult {
+interface GhTraceResult {
   ok: boolean;
   stdout: string;
   stderr: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,7 +110,6 @@ export {
   isTmuxAvailable,
   listSessions as listTmuxSessions,
   hasSession as hasTmuxSession,
-  newSession as newTmuxSession,
   sendKeys as tmuxSendKeys,
   capturePane as tmuxCapturePane,
   killSession as killTmuxSession,

--- a/packages/core/src/tmux.ts
+++ b/packages/core/src/tmux.ts
@@ -75,50 +75,6 @@ export async function hasSession(sessionName: string): Promise<boolean> {
   }
 }
 
-export interface NewSessionOptions {
-  /** Session name */
-  name: string;
-  /** Working directory */
-  cwd: string;
-  /** Initial command to run */
-  command?: string;
-  /** Environment variables to set */
-  environment?: Record<string, string>;
-  /** Window width/height */
-  width?: number;
-  height?: number;
-}
-
-/** Create a new tmux session (detached). */
-export async function newSession(opts: NewSessionOptions): Promise<void> {
-  const args = ["new-session", "-d", "-s", opts.name, "-c", opts.cwd];
-
-  // Add environment variables
-  if (opts.environment) {
-    for (const [key, value] of Object.entries(opts.environment)) {
-      args.push("-e", `${key}=${value}`);
-    }
-  }
-
-  // Window size
-  if (opts.width) {
-    args.push("-x", String(opts.width));
-  }
-  if (opts.height) {
-    args.push("-y", String(opts.height));
-  }
-
-  await tmux(...args);
-
-  // Hide the tmux status bar — sessions are embedded in web terminal
-  await tmux("set-option", "-t", opts.name, "status", "off");
-
-  // Send the initial command if provided
-  if (opts.command) {
-    await sendKeys(opts.name, opts.command);
-  }
-}
-
 /**
  * Send keys (text + Enter) to a tmux session.
  * For long/multiline messages, uses load-buffer + paste-buffer with

--- a/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
@@ -83,7 +83,8 @@ describe("runtime.create()", () => {
   it("calls new-session with correct args", async () => {
     const runtime = create();
 
-    // 1: new-session, 2: send-keys (launch command)
+    // 1: new-session, 2: set-option status off, 3: send-keys (launch command)
+    mockTmuxSuccess();
     mockTmuxSuccess();
     mockTmuxSuccess();
 
@@ -106,9 +107,34 @@ describe("runtime.create()", () => {
     );
   });
 
+  it("disables the tmux status bar immediately after new-session", async () => {
+    const runtime = create();
+
+    // 1: new-session, 2: set-option status off, 3: send-keys
+    mockTmuxSuccess();
+    mockTmuxSuccess();
+    mockTmuxSuccess();
+
+    await runtime.create({
+      sessionId: "status-bar-off",
+      workspacePath: "/tmp/ws",
+      launchCommand: "echo hi",
+      environment: {},
+    });
+
+    // Second call must be set-option ... status off, scoped to the session
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      2,
+      "tmux",
+      ["set-option", "-t", "status-bar-off", "status", "off"],
+      expectedTmuxOptions,
+    );
+  });
+
   it("includes -e KEY=VALUE flags for environment variables", async () => {
     const runtime = create();
 
+    mockTmuxSuccess();
     mockTmuxSuccess();
     mockTmuxSuccess();
 
@@ -132,6 +158,7 @@ describe("runtime.create()", () => {
 
     mockTmuxSuccess();
     mockTmuxSuccess();
+    mockTmuxSuccess();
 
     await runtime.create({
       sessionId: "launch-test",
@@ -140,7 +167,7 @@ describe("runtime.create()", () => {
       environment: {},
     });
 
-    // Second call: send-keys with the launch command
+    // Third call: send-keys with the launch command (after new-session and set-option)
     expect(mockExecFileCustom).toHaveBeenCalledWith(
       "tmux",
       ["send-keys", "-t", "launch-test", "claude --session abc", "Enter"],
@@ -152,6 +179,8 @@ describe("runtime.create()", () => {
     const runtime = create();
     const longCommand = "x".repeat(250);
 
+    // 1: new-session, 2: set-option, 3: send-keys -l, 4: send-keys Enter
+    mockTmuxSuccess();
     mockTmuxSuccess();
     mockTmuxSuccess();
     mockTmuxSuccess();
@@ -170,7 +199,7 @@ describe("runtime.create()", () => {
     );
 
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
-      2,
+      3,
       "tmux",
       [
         "send-keys",
@@ -183,7 +212,7 @@ describe("runtime.create()", () => {
     );
 
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
-      3,
+      4,
       "tmux",
       ["send-keys", "-t", "launch-long", "Enter"],
       expectedTmuxOptions,
@@ -195,9 +224,11 @@ describe("runtime.create()", () => {
 
     // 1: new-session succeeds
     mockTmuxSuccess();
-    // 2: send-keys fails
+    // 2: set-option succeeds
+    mockTmuxSuccess();
+    // 3: send-keys fails
     mockTmuxError("send-keys failed");
-    // 3: kill-session (cleanup attempt)
+    // 4: kill-session (cleanup attempt)
     mockTmuxSuccess();
 
     await expect(
@@ -207,12 +238,39 @@ describe("runtime.create()", () => {
         launchCommand: "bad-command",
         environment: {},
       }),
-    ).rejects.toThrow('Failed to send launch command to session "fail-session"');
+    ).rejects.toThrow('Failed to configure or launch session "fail-session"');
 
     // Verify kill-session was called for cleanup
     expect(mockExecFileCustom).toHaveBeenCalledWith(
       "tmux",
       ["kill-session", "-t", "fail-session"],
+      expectedTmuxOptions,
+    );
+  });
+
+  it("cleans up session if set-option fails", async () => {
+    const runtime = create();
+
+    // 1: new-session succeeds
+    mockTmuxSuccess();
+    // 2: set-option fails (e.g. tmux command timeout on a slow host)
+    mockTmuxError("set-option timed out");
+    // 3: kill-session (cleanup attempt)
+    mockTmuxSuccess();
+
+    await expect(
+      runtime.create({
+        sessionId: "setopt-fail",
+        workspacePath: "/tmp/ws",
+        launchCommand: "echo hi",
+        environment: {},
+      }),
+    ).rejects.toThrow('Failed to configure or launch session "setopt-fail"');
+
+    // kill-session must run so we don't leave an orphaned tmux session
+    expect(mockExecFileCustom).toHaveBeenCalledWith(
+      "tmux",
+      ["kill-session", "-t", "setopt-fail"],
       expectedTmuxOptions,
     );
   });
@@ -248,6 +306,7 @@ describe("runtime.create()", () => {
 
     mockTmuxSuccess();
     mockTmuxSuccess();
+    mockTmuxSuccess();
 
     const handle = await runtime.create({
       sessionId: "valid-session_123",
@@ -262,6 +321,7 @@ describe("runtime.create()", () => {
   it("handles no environment (undefined)", async () => {
     const runtime = create();
 
+    mockTmuxSuccess();
     mockTmuxSuccess();
     mockTmuxSuccess();
 

--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -78,10 +78,16 @@ export function create(): Runtime {
         launchCommand = `export PATH=$(printf '%s' ${JSON.stringify(pathValue)})\n${launchCommand}`;
       }
 
-      // Send the launch command — clean up the session if this fails.
-      // Use a temp script for long commands so the pane shows a short
+      // Configure the session and send the launch command — kill the session
+      // if any of these fail so we don't leave an orphaned tmux process.
+      // Use a temp script for long launch commands so the pane shows a short
       // invocation instead of a pasted wall of shell.
       try {
+        // Hide the tmux status bar — sessions are embedded in the web terminal,
+        // and the green bar at the bottom is visual noise (and racy with the
+        // web layer's own set-option call, which only fires on WebSocket connect).
+        await tmux("set-option", "-t", sessionName, "status", "off");
+
         if (launchCommand.length > 200) {
           const invocation = writeLaunchScript(launchCommand);
           await tmux("send-keys", "-t", sessionName, "-l", invocation);
@@ -97,7 +103,7 @@ export function create(): Runtime {
           // Best-effort cleanup
         }
         const msg = err instanceof Error ? err.message : String(err);
-        throw new Error(`Failed to send launch command to session "${sessionName}": ${msg}`, {
+        throw new Error(`Failed to configure or launch session "${sessionName}": ${msg}`, {
           cause: err,
         });
       }

--- a/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
@@ -283,6 +283,105 @@ describe("mux terminal open", () => {
 
     ws.close();
   });
+
+  it("retry budget recovers after PTY survives the grace period (issue #1639)", async () => {
+    // Complements the runaway-loop test below. That one proves the counter
+    // does NOT reset when the PTY crashes inside REATTACH_RESET_GRACE_MS.
+    // This one proves the counter DOES reset once the PTY survives the
+    // grace period — without which a transient blip during startup would
+    // permanently consume the retry budget and prevent any later recovery.
+    //
+    // Test shape:
+    //   1. Open a terminal against a healthy tmux session (PTY 1 attaches).
+    //   2. Wait > REATTACH_RESET_GRACE_MS so the grace timer fires and
+    //      resets reattachAttempts to 0 on the still-attached PTY 1.
+    //   3. Kill the tmux session — PTY 1 exits, the server burns the full
+    //      MAX_REATTACH_ATTEMPTS=3 budget trying to re-attach, then emits
+    //      "exited". A 2 s window is comfortably more than 3 × ~50 ms.
+    //   4. Per-test timeout raised to 15 s to accommodate the 5+ s wait.
+    //
+    // If the grace timer or its closure guard ever regresses (e.g. is
+    // unref'd in a way that prevents firing, or the wrong reference is
+    // compared, or a future change clears it too eagerly), step 3 will
+    // either time out waiting for "exited" or never reach the cap.
+    const RECOVERY_TEST_SESSION = `ao-test-recovery-${process.pid}`;
+    execFileSync(TMUX, ["new-session", "-d", "-s", RECOVERY_TEST_SESSION, "-x", "80", "-y", "24"], {
+      timeout: 5000,
+    });
+
+    try {
+      const ws = await connectMux();
+      ws.send(JSON.stringify({ ch: "terminal", id: RECOVERY_TEST_SESSION, type: "open" }));
+      await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "opened");
+
+      // Sleep past REATTACH_RESET_GRACE_MS (5 s in production).
+      await new Promise((r) => setTimeout(r, 5500));
+
+      execFileSync(TMUX, ["kill-session", "-t", RECOVERY_TEST_SESSION], { timeout: 5000 });
+
+      const exitedMsg = await waitForMessage(
+        ws,
+        (m) => m.ch === "terminal" && m.type === "exited",
+        2000,
+      );
+      expect(exitedMsg.id).toBe(RECOVERY_TEST_SESSION);
+
+      ws.close();
+    } finally {
+      try {
+        execFileSync(TMUX, ["kill-session", "-t", RECOVERY_TEST_SESSION], { timeout: 5000 });
+      } catch {
+        /* already gone */
+      }
+    }
+  }, 15_000);
+
+  it("bounds re-attach attempts when tmux session dies mid-subscription (issue #1639)", async () => {
+    // Reproduces the runaway re-attach loop that exhausts the system PTY
+    // pool in seconds when `ao stop` kills the tmux session out from
+    // under a still-subscribed dashboard.
+    //
+    // Pre-fix behaviour: each "successful" re-attach reset reattachAttempts
+    // to 0, so MAX_REATTACH_ATTEMPTS=3 never engaged; the loop ran at
+    // ~80 spawns/sec and "exited" was never emitted, so this test would
+    // hang until the 2-second timeout.
+    //
+    // Post-fix: the counter is only reset by a 5-second grace timer, so a
+    // PTY that exits in ~40 ms can never reset it. After 3 attempts the
+    // server gives up and emits "exited".
+    const RUNAWAY_TEST_SESSION = `ao-test-runaway-${process.pid}`;
+    execFileSync(TMUX, ["new-session", "-d", "-s", RUNAWAY_TEST_SESSION, "-x", "80", "-y", "24"], {
+      timeout: 5000,
+    });
+
+    try {
+      const ws = await connectMux();
+
+      ws.send(JSON.stringify({ ch: "terminal", id: RUNAWAY_TEST_SESSION, type: "open" }));
+      await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "opened");
+
+      // Kill the tmux session externally — the attached PTY now has nothing
+      // to attach to and will exit ~40 ms after each re-attach attempt.
+      execFileSync(TMUX, ["kill-session", "-t", RUNAWAY_TEST_SESSION], { timeout: 5000 });
+
+      // 3 re-attach attempts × ~50 ms each = ~150 ms; allow generous margin.
+      const exitedMsg = await waitForMessage(
+        ws,
+        (m) => m.ch === "terminal" && m.type === "exited",
+        2000,
+      );
+      expect(exitedMsg.id).toBe(RUNAWAY_TEST_SESSION);
+
+      ws.close();
+    } finally {
+      // Best-effort cleanup if test fails before kill-session ran
+      try {
+        execFileSync(TMUX, ["kill-session", "-t", RUNAWAY_TEST_SESSION], { timeout: 5000 });
+      } catch {
+        /* already gone */
+      }
+    }
+  });
 });
 
 // =============================================================================

--- a/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
@@ -392,9 +392,13 @@ describe("mux terminal I/O", () => {
   it("receives terminal data after open", async () => {
     const ws = await connectMux();
 
-    ws.send(
-      JSON.stringify({ ch: "terminal", id: "test-session", tmuxName: TEST_SESSION, type: "open" }),
-    );
+    // Use a unique terminal id so we exercise a fresh tmux attach. The shared
+    // "test-session" id used by earlier tests in this file would land in the
+    // post-#1718 PTY-grace path (PTY reused, no fresh init-data flow), and
+    // the prior test closes its WS too quickly for the buffer to populate —
+    // so a grace-path replay would deliver an empty buffer and time out.
+    const id = `test-data-flow-${Date.now()}`;
+    ws.send(JSON.stringify({ ch: "terminal", id, tmuxName: TEST_SESSION, type: "open" }));
     await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "opened");
 
     // tmux sends terminal init sequences on attach — wait for any data

--- a/packages/web/server/__tests__/mux-websocket.test.ts
+++ b/packages/web/server/__tests__/mux-websocket.test.ts
@@ -1,12 +1,48 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { SessionBroadcaster } from "../mux-websocket";
+import { EventEmitter } from "node:events";
+import type { SessionBroadcaster as SessionBroadcasterType } from "../mux-websocket";
+
+// vi.mock factories run before module-level statements. Hoist the mock
+// fns so the factories close over the same instances the tests use.
+const { mockSpawn, mockPtySpawn } = vi.hoisted(() => ({
+  mockSpawn: vi.fn(),
+  mockPtySpawn: vi.fn(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  const spawnFn = (...args: unknown[]) => mockSpawn(...args);
+  return {
+    ...actual,
+    default: { ...(actual.default as object), spawn: spawnFn },
+    spawn: spawnFn,
+  };
+});
+
+vi.mock("node-pty", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    spawn: (...args: unknown[]) => mockPtySpawn(...args),
+  };
+});
+
+// Mock tmux-utils so resolveTmuxSession returns a deterministic session id
+// and we don't shell out to a real tmux binary.
+vi.mock("../tmux-utils.js", () => ({
+  findTmux: () => "/usr/bin/tmux",
+  validateSessionId: () => true,
+  resolveTmuxSession: () => "ao-177",
+}));
+
+const { SessionBroadcaster, TerminalManager } = await import("../mux-websocket");
 
 // Mock global fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 describe("SessionBroadcaster", () => {
-  let broadcaster: SessionBroadcaster;
+  let broadcaster: SessionBroadcasterType;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -223,5 +259,55 @@ describe("SessionBroadcaster", () => {
       // Should only have 1 fetch (initial snapshot)
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+describe("TerminalManager.open — tmux target args (regression for #1714)", () => {
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    mockPtySpawn.mockReset();
+
+    // spawn() returns an object that emits "error" — we just need .on() to work.
+    mockSpawn.mockImplementation(() => new EventEmitter());
+
+    // ptySpawn() returns a minimal IPty-like stub so terminal wiring doesn't crash.
+    mockPtySpawn.mockImplementation(() => ({
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+    }));
+  });
+
+  it("invokes set-option mouse on with the bare session id (no = prefix)", () => {
+    const mgr = new TerminalManager("/usr/bin/tmux");
+    mgr.open("ao-177");
+
+    const mouseCall = mockSpawn.mock.calls.find(
+      (call) => Array.isArray(call[1]) && call[1].includes("mouse"),
+    );
+    expect(mouseCall).toBeDefined();
+    expect(mouseCall?.[1]).toEqual(["set-option", "-t", "ao-177", "mouse", "on"]);
+  });
+
+  it("invokes set-option status off with the bare session id (no = prefix)", () => {
+    const mgr = new TerminalManager("/usr/bin/tmux");
+    mgr.open("ao-177");
+
+    const statusCall = mockSpawn.mock.calls.find(
+      (call) => Array.isArray(call[1]) && call[1].includes("status"),
+    );
+    expect(statusCall).toBeDefined();
+    expect(statusCall?.[1]).toEqual(["set-option", "-t", "ao-177", "status", "off"]);
+  });
+
+  it("still uses the = exact-match prefix for attach-session", () => {
+    const mgr = new TerminalManager("/usr/bin/tmux");
+    mgr.open("ao-177");
+
+    expect(mockPtySpawn).toHaveBeenCalledTimes(1);
+    const [, args] = mockPtySpawn.mock.calls[0];
+    expect(args).toEqual(["attach-session", "-t", "=ao-177"]);
   });
 });

--- a/packages/web/server/__tests__/mux-websocket.test.ts
+++ b/packages/web/server/__tests__/mux-websocket.test.ts
@@ -311,3 +311,119 @@ describe("TerminalManager.open — tmux target args (regression for #1714)", () 
     expect(args).toEqual(["attach-session", "-t", "=ao-177"]);
   });
 });
+
+describe("TerminalManager — PTY idle grace period (issue #1718)", () => {
+  // Stable mock fns shared across spawns within a single test, reset per test.
+  // The unit under test relies on `pty.kill()` being called exactly once on
+  // grace expiry, so kill needs a stable identity to count against.
+  let ptyKill: ReturnType<typeof vi.fn>;
+  let ptyOnData: ReturnType<typeof vi.fn>;
+  let ptyOnExit: ReturnType<typeof vi.fn>;
+  let manager: InstanceType<typeof TerminalManager>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockSpawn.mockReset();
+    mockPtySpawn.mockReset();
+
+    ptyKill = vi.fn();
+    ptyOnData = vi.fn();
+    ptyOnExit = vi.fn();
+
+    mockSpawn.mockImplementation(() => new EventEmitter());
+    mockPtySpawn.mockImplementation(() => ({
+      onData: ptyOnData,
+      onExit: ptyOnExit,
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: ptyKill,
+    }));
+
+    manager = new TerminalManager("/usr/bin/tmux");
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("does not kill the PTY immediately when the last subscriber unsubscribes", () => {
+    const unsub = manager.subscribe("ao-177", undefined, vi.fn());
+    expect(mockPtySpawn).toHaveBeenCalledTimes(1);
+
+    unsub();
+
+    // PTY must remain alive during the grace window — killing here would
+    // burn a fresh ptmx slot on the next reconnect (issue #1718).
+    expect(ptyKill).not.toHaveBeenCalled();
+  });
+
+  it("kills the PTY after the grace period expires with no reconnect", () => {
+    const unsub = manager.subscribe("ao-177", undefined, vi.fn());
+    unsub();
+
+    // Just before the window closes — still alive.
+    vi.advanceTimersByTime(29_999);
+    expect(ptyKill).not.toHaveBeenCalled();
+
+    // Window closes — kill fires.
+    vi.advanceTimersByTime(1);
+    expect(ptyKill).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the PTY when a new subscriber arrives within the grace window", () => {
+    const unsub1 = manager.subscribe("ao-177", undefined, vi.fn());
+    expect(mockPtySpawn).toHaveBeenCalledTimes(1);
+    unsub1();
+
+    // A reconnect lands halfway through the grace window.
+    vi.advanceTimersByTime(15_000);
+    const unsub2 = manager.subscribe("ao-177", undefined, vi.fn());
+
+    // No new PTY allocated and the original is still alive — reconnect
+    // reused the existing slot, which is the whole point of the fix.
+    expect(mockPtySpawn).toHaveBeenCalledTimes(1);
+    expect(ptyKill).not.toHaveBeenCalled();
+
+    // After the original timer's deadline passes, the cancelled timer must
+    // not retroactively kill the still-subscribed PTY.
+    vi.advanceTimersByTime(60_000);
+    expect(ptyKill).not.toHaveBeenCalled();
+
+    unsub2();
+  });
+
+  it("only kills once when last subscriber leaves and grace expires", () => {
+    const unsub1 = manager.subscribe("ao-177", undefined, vi.fn());
+    const unsub2 = manager.subscribe("ao-177", undefined, vi.fn());
+
+    unsub1();
+    // First unsubscribe is not the last subscriber — no timer scheduled.
+    vi.advanceTimersByTime(60_000);
+    expect(ptyKill).not.toHaveBeenCalled();
+
+    unsub2();
+    // Now we are at zero subscribers — schedule the grace timer.
+    vi.advanceTimersByTime(30_000);
+    expect(ptyKill).toHaveBeenCalledTimes(1);
+  });
+
+  it("buffer is preserved across an unsubscribe/resubscribe within grace", () => {
+    const cb = vi.fn();
+    const unsub = manager.subscribe("ao-177", undefined, cb);
+
+    // Simulate the PTY emitting some output by invoking the captured handler.
+    const onDataHandler = ptyOnData.mock.calls[0]?.[0] as (data: string) => void;
+    onDataHandler("hello");
+
+    unsub();
+    vi.advanceTimersByTime(10_000);
+
+    // The terminal entry must still exist — buffered output is still there.
+    expect(manager.getBuffer("ao-177")).toBe("hello");
+
+    // After full grace expiry, the entry is cleaned up.
+    vi.advanceTimersByTime(20_001);
+    expect(manager.getBuffer("ao-177")).toBe("");
+  });
+});

--- a/packages/web/server/__tests__/mux-websocket.test.ts
+++ b/packages/web/server/__tests__/mux-websocket.test.ts
@@ -426,4 +426,20 @@ describe("TerminalManager — PTY idle grace period (issue #1718)", () => {
     vi.advanceTimersByTime(20_001);
     expect(manager.getBuffer("ao-177")).toBe("");
   });
+
+  it("double-unsub after grace eviction does not re-arm the timer", () => {
+    const unsub = manager.subscribe("ao-177", undefined, vi.fn());
+
+    // First unsub schedules the grace timer; expiry kills + evicts the entry.
+    unsub();
+    vi.advanceTimersByTime(30_000);
+    expect(ptyKill).toHaveBeenCalledTimes(1);
+    expect(manager.getBuffer("ao-177")).toBe(""); // entry evicted
+
+    // A defensive second unsub (e.g. React strict-mode double-invoke) must
+    // be a no-op — no new timer scheduled on the dead terminal closure.
+    unsub();
+    vi.advanceTimersByTime(30_000 * 2);
+    expect(ptyKill).toHaveBeenCalledTimes(1); // still exactly one kill
+  });
 });

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -192,11 +192,31 @@ interface ManagedTerminal {
   buffer: string[];
   bufferBytes: number;
   reattachAttempts: number;
+  /**
+   * Pending grace-period timer that resets reattachAttempts when the
+   * currently-attached PTY survives REATTACH_RESET_GRACE_MS. Tracked so
+   * cleanup paths (last-subscriber unsubscribe, subsequent re-attach) can
+   * clear it and avoid keeping the dead PTY/terminal closure references
+   * reachable for up to 5 s after teardown.
+   */
+  resetTimer?: ReturnType<typeof setTimeout>;
 }
 
 const RING_BUFFER_MAX = 50 * 1024; // 50KB max per terminal
 const WS_BUFFER_HIGH_WATERMARK = 64 * 1024; // 64KB
 const MAX_REATTACH_ATTEMPTS = 3;
+/**
+ * Grace period a freshly-attached PTY must survive before its successful
+ * attach is allowed to reset the re-attach counter. Prevents tight crash
+ * loops (e.g. attaching to a tmux session that no longer exists) from
+ * gaming the MAX_REATTACH_ATTEMPTS cap by resetting the counter to 0
+ * between every failed attempt.
+ *
+ * 5 s is comfortably longer than the ~40 ms a doomed `tmux attach-session`
+ * takes to exit, while still being short enough that a healthy PTY which
+ * crashes hours later gets a fresh retry budget.
+ */
+const REATTACH_RESET_GRACE_MS = 5_000;
 
 /**
  * TerminalManager manages PTY processes independently of WebSocket connections.
@@ -296,6 +316,25 @@ class TerminalManager {
 
     terminal.pty = pty;
 
+    // Schedule a grace-period reset of the re-attach counter. We only
+    // consider an attach "really successful" if the PTY survives long
+    // enough to suggest the underlying tmux session is actually usable.
+    // The closure-captured `pty` reference is compared with terminal.pty
+    // so a stale timer cannot reset the counter for a PTY that has
+    // already exited or been replaced by re-attach. Any previously-
+    // scheduled timer (from a now-replaced PTY) is cleared so we don't
+    // keep its closure references reachable until the timer fires.
+    if (terminal.resetTimer) {
+      clearTimeout(terminal.resetTimer);
+    }
+    terminal.resetTimer = setTimeout(() => {
+      terminal.resetTimer = undefined;
+      if (terminal.pty === pty) {
+        terminal.reattachAttempts = 0;
+      }
+    }, REATTACH_RESET_GRACE_MS);
+    terminal.resetTimer.unref();
+
     // Wire up data events
     pty.onData((data: string) => {
       // Push to all subscribers — isolate each callback so a throw in one
@@ -327,6 +366,12 @@ class TerminalManager {
       // Re-attach if subscribers are still present, up to MAX_REATTACH_ATTEMPTS.
       // The cap prevents an unbounded respawn loop when the PTY crashes immediately
       // after every attach (e.g. resource exhaustion or a broken tmux session).
+      // The counter is reset by a delayed timer in open() once the new PTY has
+      // survived REATTACH_RESET_GRACE_MS — see the comment on that constant.
+      // Resetting here would defeat the cap: when ao stop kills the tmux session
+      // out from under a still-subscribed dashboard, attach-session exits ~40 ms
+      // after spawn and the loop runs at ~80 spawns/sec, exhausting the system
+      // PTY pool in seconds (issue #1639).
       if (terminal.subscribers.size > 0 && terminal.reattachAttempts < MAX_REATTACH_ATTEMPTS) {
         terminal.reattachAttempts += 1;
         console.log(
@@ -334,7 +379,6 @@ class TerminalManager {
         );
         try {
           this.open(id, projectId, tmuxSessionId);
-          terminal.reattachAttempts = 0; // reset on successful attach
           return; // re-attached — don't notify exit
         } catch (err) {
           console.error(`[MuxServer] Failed to re-attach ${id}:`, err);
@@ -402,6 +446,10 @@ class TerminalManager {
       if (onExit) terminal.exitCallbacks.delete(onExit);
       // Kill PTY and clean up when the last subscriber leaves
       if (terminal.subscribers.size === 0) {
+        if (terminal.resetTimer) {
+          clearTimeout(terminal.resetTimer);
+          terminal.resetTimer = undefined;
+        }
         if (terminal.pty) {
           terminal.pty.kill();
           terminal.pty = null;

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -222,7 +222,7 @@ const REATTACH_RESET_GRACE_MS = 5_000;
  * TerminalManager manages PTY processes independently of WebSocket connections.
  * A single manager instance is shared across all mux connections.
  */
-class TerminalManager {
+export class TerminalManager {
   private terminals = new Map<string, ManagedTerminal>();
   private TMUX: string;
 
@@ -274,16 +274,18 @@ class TerminalManager {
       return tmuxSessionId;
     }
 
-    // Enable mouse mode
-    const exactTmuxTarget = `=${tmuxSessionId}`;
+    // tmux 3.4 only honours the `=` exact-match prefix on has-session and
+    // attach-session; set-option silently ignores it, so we use the bare id
+    // here. The `=`-prefixed form is built below for attach-session.
 
-    const mouseProc = spawn(this.TMUX, ["set-option", "-t", exactTmuxTarget, "mouse", "on"]);
+    // Enable mouse mode
+    const mouseProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "mouse", "on"]);
     mouseProc.on("error", (err) => {
       console.error(`[MuxServer] Failed to set mouse mode for ${tmuxSessionId}:`, err.message);
     });
 
     // Hide the status bar
-    const statusProc = spawn(this.TMUX, ["set-option", "-t", exactTmuxTarget, "status", "off"]);
+    const statusProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "status", "off"]);
     statusProc.on("error", (err) => {
       console.error(`[MuxServer] Failed to hide status bar for ${tmuxSessionId}:`, err.message);
     });
@@ -305,7 +307,9 @@ class TerminalManager {
       throw new Error("node-pty not available");
     }
 
-    // Spawn PTY
+    // Spawn PTY — use `=`-prefixed exact-match target so we never attach to
+    // a session whose name happens to be a prefix of the requested id.
+    const exactTmuxTarget = `=${tmuxSessionId}`;
     const pty = ptySpawn(this.TMUX, ["attach-session", "-t", exactTmuxTarget], {
       name: "xterm-256color",
       cols: 80,

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -200,6 +200,15 @@ interface ManagedTerminal {
    * reachable for up to 5 s after teardown.
    */
   resetTimer?: ReturnType<typeof setTimeout>;
+  /**
+   * Pending kill scheduled when the last subscriber leaves. macOS never
+   * recycles ptmx slot numbers within a boot, so churning PTYs across
+   * tab reloads / sleep-wake / network blips burns slots and eventually
+   * exhausts kern.tty.ptmx_max=511 (issue #1718). A grace window lets a
+   * quick reconnect reuse the existing PTY instead of allocating a fresh
+   * one.
+   */
+  idleGraceTimer: ReturnType<typeof setTimeout> | null;
 }
 
 const RING_BUFFER_MAX = 50 * 1024; // 50KB max per terminal
@@ -217,6 +226,7 @@ const MAX_REATTACH_ATTEMPTS = 3;
  * crashes hours later gets a fresh retry budget.
  */
 const REATTACH_RESET_GRACE_MS = 5_000;
+const PTY_IDLE_GRACE_MS = 30_000; // delay before killing an unsubscribed PTY (issue #1718)
 
 /**
  * TerminalManager manages PTY processes independently of WebSocket connections.
@@ -265,6 +275,7 @@ export class TerminalManager {
         buffer: [],
         bufferBytes: 0,
         reattachAttempts: 0,
+        idleGraceTimer: null,
       };
       this.terminals.set(key, terminal);
     }
@@ -444,21 +455,40 @@ export class TerminalManager {
     terminal.subscribers.add(callback);
     if (onExit) terminal.exitCallbacks.add(onExit);
 
+    // A subscriber arrived in time — cancel any pending idle-grace kill
+    // (e.g. tab reload landed within the grace window after a previous
+    // unsubscribe). The PTY is preserved; no new ptmx slot is allocated.
+    if (terminal.idleGraceTimer) {
+      clearTimeout(terminal.idleGraceTimer);
+      terminal.idleGraceTimer = null;
+    }
+
     // Return unsubscribe function
     return () => {
       terminal.subscribers.delete(callback);
       if (onExit) terminal.exitCallbacks.delete(onExit);
-      // Kill PTY and clean up when the last subscriber leaves
-      if (terminal.subscribers.size === 0) {
-        if (terminal.resetTimer) {
-          clearTimeout(terminal.resetTimer);
-          terminal.resetTimer = undefined;
-        }
-        if (terminal.pty) {
-          terminal.pty.kill();
-          terminal.pty = null;
-        }
-        this.terminals.delete(key);
+      // Defer PTY kill when the last subscriber leaves. macOS burns a ptmx
+      // slot per allocation for the lifetime of a boot (issue #1718), so
+      // killing immediately on every disconnect drains kern.tty.ptmx_max.
+      // A grace window lets a quick reconnect reuse the existing PTY.
+      // The reattach-counter resetTimer (#1640) is cleared at kill time so
+      // its closure doesn't keep the evicted terminal reachable.
+      if (terminal.subscribers.size === 0 && terminal.idleGraceTimer === null) {
+        terminal.idleGraceTimer = setTimeout(() => {
+          terminal.idleGraceTimer = null;
+          // Re-check: a subscriber may have arrived during the window.
+          if (terminal.subscribers.size > 0) return;
+          if (terminal.resetTimer) {
+            clearTimeout(terminal.resetTimer);
+            terminal.resetTimer = undefined;
+          }
+          if (terminal.pty) {
+            terminal.pty.kill();
+            terminal.pty = null;
+          }
+          this.terminals.delete(key);
+        }, PTY_IDLE_GRACE_MS);
+        terminal.idleGraceTimer.unref();
       }
     };
   }

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -473,7 +473,15 @@ export class TerminalManager {
       // A grace window lets a quick reconnect reuse the existing PTY.
       // The reattach-counter resetTimer (#1640) is cleared at kill time so
       // its closure doesn't keep the evicted terminal reachable.
-      if (terminal.subscribers.size === 0 && terminal.idleGraceTimer === null) {
+      // The terminals.has(key) guard makes unsub idempotent: once the grace
+      // timer has fired and evicted the entry, a defensive double-unsub
+      // (React strict-mode double-invoke, redundant teardown) must not arm
+      // a fresh 30 s timer on the dead `terminal` closure.
+      if (
+        terminal.subscribers.size === 0 &&
+        terminal.idleGraceTimer === null &&
+        this.terminals.has(key)
+      ) {
         terminal.idleGraceTimer = setTimeout(() => {
           terminal.idleGraceTimer = null;
           // Re-check: a subscriber may have arrived during the window.


### PR DESCRIPTION
## Summary

Fixes #1718.

When the last WebSocket subscriber disconnects from a terminal, `TerminalManager` used to call `pty.kill()` and drop the entry inline. Every reconnect — tab reload, sleep/wake, network blip — then allocated a fresh PTY with a new ptmx slot number.

**macOS never recycles ptmx slot numbers within a boot**, so this churn slowly burned through `kern.tty.ptmx_max=511`. A dashboard with ~30 sessions hit the cap after ~28 days of uptime; afterwards every new PTY allocation on the host (terminal tabs, tmux attach, ao spawn) failed until reboot.

This PR addresses the dominant churn source called out in the issue: **reconnect-driven re-allocation**.

## What changed

- `ManagedTerminal` now tracks an `idleGraceTimer`.
- On last unsubscribe, the kill is deferred by `PTY_IDLE_GRACE_MS = 30_000` instead of running inline. The timer's callback re-checks `subscribers.size` so a reconnect that lands inside the window transparently reuses the existing PTY and its ring buffer.
- On new subscribe, any pending timer is cleared.
- The timer is `.unref()`d so it doesn't hold the event loop alive on shutdown.
- `TerminalManager` is now exported so it can be unit-tested.

Together with #1640 (re-attach loop bound), this should push slot exhaustion from ~28 days out to several months under the same load.

## Test plan

- [x] `pnpm --filter @aoagents/ao-web test -- mux-websocket` — 14/14 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (warnings are pre-existing in unrelated files)
- [x] `pnpm build` — clean
- [x] New unit tests cover: kill deferred on last unsub, kill fires after 30s, reconnect within grace preserves PTY, kill fires only when truly the last subscriber leaves, ring buffer survives an unsub/resub within grace.

## Notes for reviewer

- This is intentionally orthogonal to #1640. That PR caps the re-attach loop on PTY *crashes*; this PR addresses PTY churn on clean *disconnects*.
- The 30s window is a tunable. It needs to be long enough to absorb tab reload (<1s) and brief sleep/wake (<10s typically), but short enough that abandoned sessions don't sit on PTY slots indefinitely. 30s mirrors the issue's proposed value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)