### PR TITLE
feat(pipelines): add supportedTaskModes to claude-code, codex, opencode manifests

### DIFF
--- a/packages/core/src/__tests__/pipeline-validation.test.ts
+++ b/packages/core/src/__tests__/pipeline-validation.test.ts
@@ -124,6 +124,16 @@ describe("validatePipelineAgentModes", () => {
     expect(() => validatePipelineAgentModes(pipeline, r)).not.toThrow();
   });
 
+  it("accepts a mode='review' stage routed to plugin 'claude-code' (regression: #190)", () => {
+    // The claude-code plugin manifest must advertise supportedTaskModes
+    // for review/code/answer stages to clear pipeline validation.
+    const r = withRegistry([makeAgentPlugin("claude-code", ["review", "code", "answer"])]);
+    const pipeline = makePipeline([
+      makeStage({ executor: { kind: "agent", plugin: "claude-code", mode: "review" } }),
+    ]);
+    expect(() => validatePipelineAgentModes(pipeline, r)).not.toThrow();
+  });
+
   it("validates every stage in a multi-stage pipeline and fails on the first mismatch", () => {
     const r = withRegistry([
       makeAgentPlugin("codex", ["review"]),

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -211,6 +211,7 @@ describe("plugin manifest & exports", () => {
       description: "Agent plugin: Claude Code CLI",
       version: "0.1.0",
       displayName: "Claude Code",
+      supportedTaskModes: ["review", "code", "answer"],
     });
   });
 

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -17,6 +17,7 @@ import {
   type ProcessProbeResult,
   type RuntimeHandle,
   type Session,
+  type TaskMode,
   type WorkspaceHooksConfig,
 } from "@aoagents/ao-core";
 import { execFile, execFileSync } from "node:child_process";
@@ -391,6 +392,7 @@ export const manifest = {
   description: "Agent plugin: Claude Code CLI",
   version: "0.1.0",
   displayName: "Claude Code",
+  supportedTaskModes: ["review", "code", "answer"] as TaskMode[],
 };
 
 // =============================================================================

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -230,6 +230,7 @@ describe("plugin manifest & exports", () => {
       description: "Agent plugin: OpenAI Codex CLI",
       version: "0.1.1",
       displayName: "OpenAI Codex",
+      supportedTaskModes: ["review", "code", "answer"],
     });
   });
 

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -21,6 +21,7 @@ import {
   type ProjectConfig,
   type RuntimeHandle,
   type Session,
+  type TaskMode,
   type WorkspaceHooksConfig,
 } from "@aoagents/ao-core";
 import { execFile, execFileSync } from "node:child_process";
@@ -44,6 +45,7 @@ export const manifest = {
   description: "Agent plugin: OpenAI Codex CLI",
   version: "0.1.1",
   displayName: "OpenAI Codex",
+  supportedTaskModes: ["review", "code", "answer"] as TaskMode[],
 };
 
 // =============================================================================

--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -131,6 +131,7 @@ describe("plugin manifest & exports", () => {
       description: "Agent plugin: OpenCode",
       version: "0.1.0",
       displayName: "OpenCode",
+      supportedTaskModes: ["review", "code", "answer"],
     });
   });
 

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -23,6 +23,7 @@ import {
   type ProjectConfig,
   type RuntimeHandle,
   type Session,
+  type TaskMode,
   type WorkspaceHooksConfig,
   type OpenCodeAgentConfig,
   type OpenCodeSessionListEntry,
@@ -181,6 +182,7 @@ export const manifest = {
   description: "Agent plugin: OpenCode",
   version: "0.1.0",
   displayName: "OpenCode",
+  supportedTaskModes: ["review", "code", "answer"] as TaskMode[],
 };
 
 // =============================================================================


### PR DESCRIPTION
Closes #190

## Summary

Pipeline validation (`packages/core/src/pipeline/validation.ts`) rejects any agent-executor stage whose `mode` isn't advertised in the plugin manifest's `supportedTaskModes`. Today no plugin sets it, so every pipeline run with a `mode: review|code|answer` stage routed to `claude-code`, `codex`, or `opencode` fails at config load.

This PR adds `supportedTaskModes: ["review", "code", "answer"]` to all three plugin manifests. Manifest-only — no runtime behavior change. `agent-aider` is left out (still gated as optional in the issue).

## What changed

- `packages/plugins/agent-claude-code/src/index.ts` — manifest gets `supportedTaskModes: ["review", "code", "answer"]` (cast via the public `TaskMode` type so the field is assignable to `PluginManifest.supportedTaskModes`).
- `packages/plugins/agent-codex/src/index.ts` — same field, same value.
- `packages/plugins/agent-opencode/src/index.ts` — same field, same value.
- `packages/core/src/__tests__/pipeline-validation.test.ts` — regression test asserting a stage with `mode: "review"` routed to plugin `"claude-code"` clears `validatePipelineAgentModes`.
- `agent-claude-code`, `agent-codex`, `agent-opencode` `has correct manifest` unit tests updated to assert the new field via `toEqual` — content-level regression guard against the field being removed.

## Test plan

- [x] `pnpm --filter @aoagents/ao-core typecheck`
- [x] `pnpm --filter @aoagents/ao-plugin-agent-claude-code typecheck`
- [x] `pnpm --filter @aoagents/ao-plugin-agent-codex typecheck`
- [x] `pnpm --filter @aoagents/ao-plugin-agent-opencode typecheck`
- [x] `pnpm --filter @aoagents/ao-core test` — 1314/1314 pass (incl. new `accepts a mode='review' stage routed to plugin 'claude-code' (regression: #190)` case)
- [x] `pnpm --filter @aoagents/ao-plugin-agent-claude-code test` — 171/171 pass
- [x] `pnpm --filter @aoagents/ao-plugin-agent-codex test` — 198/198 pass
- [x] `pnpm --filter @aoagents/ao-plugin-agent-opencode test` — 94/94 pass

## Base branch

Targets `pipelines` (integration branch for the pipelines takeover), **not `main`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)