### PR TITLE
feat(pipelines): instantiate + hydrate engine in ao start

### DIFF
--- a/packages/cli/__tests__/lib/lifecycle-service.test.ts
+++ b/packages/cli/__tests__/lib/lifecycle-service.test.ts
@@ -16,6 +16,15 @@ import {
   listLifecycleWorkers,
 } from "../../src/lib/lifecycle-service.js";
 
+/**
+ * Convenience: `getLifecycleManager` now returns `{ lifecycle, pipelineEngine }`
+ * — we wrap the fake `LifecycleManager` so existing tests don't need to know
+ * about the engine handle.
+ */
+function asHandle(lifecycle: LifecycleManager) {
+  return { lifecycle, pipelineEngine: null };
+}
+
 function makeConfig(projectIds: string[]): OrchestratorConfig {
   return {
     configPath: "/tmp/agent-orchestrator.yaml",
@@ -55,7 +64,7 @@ describe("lifecycle-service", () => {
 
   it("starts polling in-process for a known project", async () => {
     const lifecycle = makeFakeLifecycle();
-    mockGetLifecycleManager.mockResolvedValue(lifecycle);
+    mockGetLifecycleManager.mockResolvedValue(asHandle(lifecycle));
 
     const result = await ensureLifecycleWorker(makeConfig(["app"]), "app", 1000);
 
@@ -66,7 +75,7 @@ describe("lifecycle-service", () => {
 
   it("is idempotent — second ensure is a no-op", async () => {
     const lifecycle = makeFakeLifecycle();
-    mockGetLifecycleManager.mockResolvedValue(lifecycle);
+    mockGetLifecycleManager.mockResolvedValue(asHandle(lifecycle));
 
     const first = await ensureLifecycleWorker(makeConfig(["app"]), "app");
     const second = await ensureLifecycleWorker(makeConfig(["app"]), "app");
@@ -88,7 +97,7 @@ describe("lifecycle-service", () => {
       if (projectId === "broken") {
         throw new Error("boom — broken project plugin");
       }
-      return healthy;
+      return asHandle(healthy);
     });
 
     const config = makeConfig(["healthy", "broken"]);
@@ -111,7 +120,7 @@ describe("lifecycle-service", () => {
     const a = makeFakeLifecycle();
     const b = makeFakeLifecycle();
     mockGetLifecycleManager.mockImplementation(async (_cfg, projectId: string) =>
-      projectId === "a" ? a : b,
+      projectId === "a" ? asHandle(a) : asHandle(b),
     );
 
     const config = makeConfig(["a", "b"]);
@@ -130,7 +139,7 @@ describe("lifecycle-service", () => {
     (broken.stop as ReturnType<typeof vi.fn>).mockImplementation(() => {
       throw new Error("stop failed");
     });
-    mockGetLifecycleManager.mockResolvedValue(broken);
+    mockGetLifecycleManager.mockResolvedValue(asHandle(broken));
 
     await ensureLifecycleWorker(makeConfig(["broken"]), "broken");
 
@@ -147,7 +156,7 @@ describe("lifecycle-service", () => {
     const a = makeFakeLifecycle();
     const b = makeFakeLifecycle();
     mockGetLifecycleManager.mockImplementation(async (_cfg, projectId: string) =>
-      projectId === "a" ? a : b,
+      projectId === "a" ? asHandle(a) : asHandle(b),
     );
 
     const config = makeConfig(["a", "b"]);
@@ -170,7 +179,7 @@ describe("lifecycle-service", () => {
     });
     const healthy = makeFakeLifecycle();
     mockGetLifecycleManager.mockImplementation(async (_cfg, projectId: string) =>
-      projectId === "broken" ? broken : healthy,
+      projectId === "broken" ? asHandle(broken) : asHandle(healthy),
     );
 
     const config = makeConfig(["broken", "healthy"]);

--- a/packages/cli/src/lib/create-session-manager.ts
+++ b/packages/cli/src/lib/create-session-manager.ts
@@ -8,13 +8,19 @@
  */
 
 import {
+  createAgentExecutor,
+  createLifecycleManager,
+  createPipelineEngine,
+  createPipelineStore,
   createPluginRegistry,
   createSessionManager,
-  createLifecycleManager,
-  type OrchestratorConfig,
-  type OpenCodeSessionManager,
-  type PluginRegistry,
+  getProjectPipelinesDir,
+  hydrateEngineState,
   type LifecycleManager,
+  type OpenCodeSessionManager,
+  type OrchestratorConfig,
+  type PipelineEngine,
+  type PluginRegistry,
 } from "@aoagents/ao-core";
 import { importPluginModuleFromSource } from "./plugin-store.js";
 
@@ -64,12 +70,52 @@ export async function getSessionManager(
 /**
  * Create a LifecycleManager backed by core's implementation.
  * Shares the same plugin registry initialization path as SessionManager.
+ *
+ * When a `projectId` is supplied, we also construct the per-project pipeline
+ * engine (hydrated from the flat-file store, with any leftover in-flight
+ * stages reconciled) and pass it into the lifecycle manager so `engine.tick()`
+ * runs on the existing 5s poll cadence (per C-14, no new timers).
+ *
+ * The engine is intentionally NOT constructed in the multi-project mode
+ * (`projectId === undefined`, used by the web dashboard's webhook-driven
+ * lifecycle manager): the engine is per-project and the web path currently
+ * doesn't own pipeline execution.
  */
+export interface LifecycleManagerHandle {
+  lifecycle: LifecycleManager;
+  /** Per-project pipeline engine. Null when no projectId was supplied. */
+  pipelineEngine: PipelineEngine | null;
+}
+
 export async function getLifecycleManager(
   config: OrchestratorConfig,
   projectId?: string,
-): Promise<LifecycleManager> {
+): Promise<LifecycleManagerHandle> {
   const registry = await getPluginRegistry(config);
   const sessionManager = createSessionManager({ config, registry });
-  return createLifecycleManager({ config, registry, sessionManager, projectId });
+
+  let pipelineEngine: PipelineEngine | null = null;
+  if (projectId) {
+    const store = createPipelineStore(getProjectPipelinesDir(projectId));
+    const agentExecutor = createAgentExecutor({ sessionManager });
+    pipelineEngine = createPipelineEngine({
+      store,
+      registry,
+      agentExecutor,
+      initialState: hydrateEngineState(store),
+    });
+    // Reconcile stages left in `running` from a previous process: their
+    // in-flight executor handles are gone, so dispatch STAGE_FAILED to let
+    // the reducer either advance the run or terminate it as `stalled`.
+    await pipelineEngine.reconcileInflightStages();
+  }
+
+  const lifecycle = createLifecycleManager({
+    config,
+    registry,
+    sessionManager,
+    projectId,
+    ...(pipelineEngine ? { pipelineEngine } : {}),
+  });
+  return { lifecycle, pipelineEngine };
 }

--- a/packages/cli/src/lib/lifecycle-service.ts
+++ b/packages/cli/src/lib/lifecycle-service.ts
@@ -1,8 +1,10 @@
 import {
   createCorrelationId,
   createProjectObserver,
+  recordActivityEvent,
   type LifecycleManager,
   type OrchestratorConfig,
+  type PipelineEngine,
 } from "@aoagents/ao-core";
 import { getLifecycleManager } from "./create-session-manager.js";
 
@@ -10,10 +12,22 @@ const DEFAULT_INTERVAL_MS = 30_000;
 
 interface ActiveLoop {
   lifecycle: LifecycleManager;
+  pipelineEngine: PipelineEngine | null;
+  /** Synchronous teardown (stops the lifecycle poll timer). */
   stop: () => void;
+  /** Async drain — cancels in-flight pipeline runs and persists state. */
+  drainPipelineEngine: () => Promise<void>;
 }
 
 const active = new Map<string, ActiveLoop>();
+/**
+ * Promises for in-flight pipeline drains kicked off by `stopLifecycleWorker`.
+ * Held so `drainAllLifecycleWorkerPipelines()` can `await` drains that were
+ * started before the shutdown handler began awaiting — i.e. ones that were
+ * fire-and-forgot from a synchronous `stopAllLifecycleWorkers()` call earlier
+ * in the same tick.
+ */
+const pendingDrains = new Set<Promise<void>>();
 
 // Note: no SIGINT/SIGTERM listeners are installed here. Adding a listener for
 // those signals removes Node.js's default "exit on signal" behavior, which
@@ -41,7 +55,7 @@ export async function ensureLifecycleWorker(
   }
 
   const observer = createProjectObserver(config, "lifecycle-service");
-  const lifecycle = await getLifecycleManager(config, projectId);
+  const { lifecycle, pipelineEngine } = await getLifecycleManager(config, projectId);
 
   lifecycle.start(intervalMs);
 
@@ -50,11 +64,12 @@ export async function ensureLifecycleWorker(
     status: "ok",
     projectId,
     correlationId: createCorrelationId("lifecycle-service"),
-    details: { projectId, intervalMs, inProcess: true },
+    details: { projectId, intervalMs, inProcess: true, pipelineEngine: pipelineEngine !== null },
   });
 
   active.set(projectId, {
     lifecycle,
+    pipelineEngine,
     stop: () => {
       try {
         lifecycle.stop();
@@ -66,6 +81,26 @@ export async function ensureLifecycleWorker(
           correlationId: createCorrelationId("lifecycle-service"),
           reason: "Lifecycle polling stopped",
           details: { projectId },
+        });
+      }
+    },
+    drainPipelineEngine: async () => {
+      if (!pipelineEngine) return;
+      try {
+        await pipelineEngine.shutdown();
+      } catch (err) {
+        // Best-effort: any persistence failure is recorded as an activity event
+        // so RCA can answer "did clean shutdown reach the engine?" but never
+        // blocks `ao stop` from completing.
+        recordActivityEvent({
+          projectId,
+          source: "lifecycle",
+          kind: "pipeline.shutdown_failed",
+          level: "warn",
+          summary: `pipeline engine shutdown failed for ${projectId}`,
+          data: {
+            errorMessage: err instanceof Error ? err.message : String(err),
+          },
         });
       }
     },
@@ -83,6 +118,17 @@ export function stopLifecycleWorker(projectId: string): void {
   } catch {
     // Best-effort
   }
+  // Drain the pipeline engine asynchronously. The synchronous `stop()` above
+  // already halted the poll timer, so it's safe to delete the active entry
+  // immediately. The drain promise is tracked in `pendingDrains` so the
+  // graceful-shutdown handler can `await drainAllLifecycleWorkerPipelines()`
+  // and pick up drains that started in an earlier synchronous burst.
+  if (entry.pipelineEngine) {
+    const p = entry.drainPipelineEngine().finally(() => {
+      pendingDrains.delete(p);
+    });
+    pendingDrains.add(p);
+  }
   active.delete(projectId);
 }
 
@@ -90,6 +136,23 @@ export function stopAllLifecycleWorkers(): void {
   for (const projectId of Array.from(active.keys())) {
     stopLifecycleWorker(projectId);
   }
+}
+
+/**
+ * Async drain of every active project's pipeline engine. Called by the
+ * graceful-shutdown handler (`installShutdownHandlers`) so in-flight stages
+ * are cancelled and final state persisted before the process exits.
+ *
+ * Covers both code paths:
+ *  - Drains started before this call landed (synchronous `stopLifecycleWorker`
+ *    bursts kicked off by `stopAllLifecycleWorkers`): awaited via `pendingDrains`.
+ *  - Loops still in `active`: drained inline.
+ */
+export async function drainAllLifecycleWorkerPipelines(): Promise<void> {
+  const stillActive = Array.from(active.values()).map((entry) =>
+    entry.drainPipelineEngine(),
+  );
+  await Promise.all([...pendingDrains, ...stillActive]);
 }
 
 export function isLifecycleWorkerRunning(projectId: string): boolean {

--- a/packages/cli/src/lib/pipeline-service.ts
+++ b/packages/cli/src/lib/pipeline-service.ts
@@ -19,6 +19,7 @@ import {
   asRunId,
   asStageRunId,
   configuredPipelineToRuntime,
+  hydrateEngineState,
   isTerminalLoopState,
   loopKey,
   reduce,
@@ -37,10 +38,13 @@ import {
   type PluginRegistry,
   type RunId,
   type RunState,
-  type RunSummary,
   type StageRunId,
   type StageState,
 } from "@aoagents/ao-core";
+
+// Re-export so existing CLI tests (and the `pipeline-service.ts:hydrateEngineState`
+// callsite documented in #1346) keep working.
+export { hydrateEngineState };
 
 /**
  * Thrown by `triggerRun` when a non-terminal run already exists for the same
@@ -212,48 +216,6 @@ export function readStageArtifacts(
   const stage = store.loadStage(stageRunId);
   if (!stage) throw new Error(`Stage not found: ${stageRunId}`);
   return store.listArtifacts(stage.runId, stageRunId);
-}
-
-/**
- * Rebuild engine state from the flat-file store. Used so reducer dispatches
- * see existing runs / loop pointers / history rather than starting from
- * `emptyEngineState()` (which would defeat the reducer's collision guards).
- *
- * Terminal runs go into `historySummaries`; the latest non-terminal run on
- * each loop key wins `currentRunByLoop`.
- */
-export function hydrateEngineState(store: PipelineStore): EngineState {
-  const runs: Record<string, RunState> = {};
-  const currentRunByLoop: Record<string, RunId> = {};
-  const historySummaries: Record<string, RunSummary[]> = {};
-
-  // Sort oldest-first so historySummaries preserves chronological order.
-  const sorted = [...store.listRuns()].sort((a, b) =>
-    a.createdAt.localeCompare(b.createdAt),
-  );
-
-  for (const run of sorted) {
-    runs[run.runId] = run;
-    const key = loopKey(run.sessionId, run.pipelineName);
-
-    if (isTerminalLoopState(run.loopState)) {
-      const list = historySummaries[key] ?? [];
-      list.push({
-        runId: run.runId,
-        loopState: run.loopState,
-        ...(run.terminationReason ? { terminationReason: run.terminationReason } : {}),
-        headSha: run.headSha,
-        loopRounds: run.loopRounds,
-        fingerprints: [],
-        createdAt: run.createdAt,
-      });
-      historySummaries[key] = list;
-    } else {
-      currentRunByLoop[key] = run.runId;
-    }
-  }
-
-  return { runs, currentRunByLoop, historySummaries };
 }
 
 /** Sentinel recorded in RunState.headSha when a run is triggered via CLI with no git context. */

--- a/packages/cli/src/lib/shutdown.ts
+++ b/packages/cli/src/lib/shutdown.ts
@@ -20,7 +20,10 @@ import {
 } from "@aoagents/ao-core";
 import { stopBunTmpJanitor } from "./bun-tmp-janitor.js";
 import { getSessionManager } from "./create-session-manager.js";
-import { stopAllLifecycleWorkers } from "./lifecycle-service.js";
+import {
+  drainAllLifecycleWorkerPipelines,
+  stopAllLifecycleWorkers,
+} from "./lifecycle-service.js";
 import { stopProjectSupervisor } from "./project-supervisor.js";
 import { unregister, writeLastStop } from "./running-state.js";
 
@@ -73,6 +76,15 @@ export function installShutdownHandlers(ctx: ShutdownContext): void {
     forceExit.unref();
 
     void (async () => {
+      try {
+        // Drain pipeline engines first so RUN_CANCELLED dispatches reach the
+        // store before we tear down session managers and sessions. The hard
+        // 10s force-exit timer above caps total shutdown time; drain is
+        // best-effort within that budget.
+        await drainAllLifecycleWorkerPipelines();
+      } catch {
+        // Best-effort — drain errors are recorded by lifecycle-service.
+      }
       try {
         const shutdownConfig = loadConfig(ctx.configPath);
         const sm = await getSessionManager(shutdownConfig);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -438,6 +438,7 @@ export {
   AgentExecutorSpawnError,
   STAGE_FINDINGS_RELATIVE_PATH,
   createPipelineEngine,
+  hydrateEngineState,
   // v1.1: DAG scheduler + runtime validation defense-in-depth
   findFirstStageCycle,
   scheduleAfterChange,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -479,6 +479,17 @@ export interface LifecycleManagerDeps {
   sessionManager: OpenCodeSessionManager;
   /** When set, only poll sessions belonging to this project. */
   projectId?: string;
+  /**
+   * Optional pipeline engine. When provided, the lifecycle manager invokes
+   * `engine.tick()` at the end of every poll cycle so the engine drives
+   * in-flight pipeline stages forward on the same 5s cadence as the rest of
+   * the polling loop (per C-14). The engine was designed to piggyback on this
+   * loop rather than introduce its own timer (see pipeline/engine.ts:19-21).
+   *
+   * Errors from `tick()` are captured and recorded but never bubble out —
+   * pipeline failures must not crash session polling for unrelated sessions.
+   */
+  pipelineEngine?: import("./pipeline/engine.js").PipelineEngine;
 }
 
 /** Track attempt counts for reactions per session. */
@@ -492,7 +503,7 @@ interface ReactionTracker {
 
 /** Create a LifecycleManager instance. */
 export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleManager {
-  const { config, registry, sessionManager, projectId: scopedProjectId } = deps;
+  const { config, registry, sessionManager, projectId: scopedProjectId, pipelineEngine } = deps;
   const observer = createProjectObserver(config, "lifecycle-manager");
 
   const states = new Map<SessionId, SessionStatus>();
@@ -2911,6 +2922,35 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             activeSessionCount: activeSessions.length,
           },
         });
+      }
+
+      // Drive the pipeline engine forward on the same 5s cadence as session
+      // polling (per C-14, no new timers). Errors are swallowed so a pipeline
+      // poll failure cannot crash the session loop for unrelated sessions.
+      if (pipelineEngine) {
+        try {
+          await pipelineEngine.tick();
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          observer.recordOperation({
+            metric: "lifecycle_poll",
+            operation: "pipeline.tick",
+            outcome: "failure",
+            correlationId,
+            projectId: scopedProjectId,
+            durationMs: Date.now() - startedAt,
+            reason: errorMsg,
+            level: "warn",
+          });
+          recordActivityEvent({
+            projectId: scopedProjectId,
+            source: "lifecycle",
+            kind: "pipeline.tick_failed",
+            level: "warn",
+            summary: "pipeline engine tick failed",
+            data: { errorMessage: errorMsg },
+          });
+        }
       }
     } catch (err) {
       const errorReason = err instanceof Error ? err.message : String(err);

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -51,6 +51,7 @@ import {
   cloneLifecycle,
   deriveLegacyStatus,
 } from "./lifecycle-state.js";
+import type { PipelineEngine } from "./pipeline/engine.js";
 import { updateMetadata } from "./metadata.js";
 import { getProjectSessionsDir } from "./paths.js";
 import { applyDecisionToLifecycle as commitLifecycleDecisionInPlace } from "./lifecycle-transition.js";
@@ -489,7 +490,7 @@ export interface LifecycleManagerDeps {
    * Errors from `tick()` are captured and recorded but never bubble out —
    * pipeline failures must not crash session polling for unrelated sessions.
    */
-  pipelineEngine?: import("./pipeline/engine.js").PipelineEngine;
+  pipelineEngine?: PipelineEngine;
 }
 
 /** Track attempt counts for reactions per session. */

--- a/packages/core/src/pipeline/engine.ts
+++ b/packages/core/src/pipeline/engine.ts
@@ -39,9 +39,12 @@ import {
   asStageRunId,
   emptyEngineState,
   isTerminalLoopState,
+  loopKey,
   type EngineState,
   type Pipeline,
   type RunId,
+  type RunState,
+  type RunSummary,
   type StageRunId,
   type StageTriggerEvent,
 } from "./types.js";
@@ -100,6 +103,63 @@ export interface PipelineEngine {
 
   /** Cancel an in-flight run via RUN_CANCELLED. Idempotent. */
   cancelRun(runId: RunId, reason?: "manual_cancel" | "config_change"): Promise<void>;
+
+  /**
+   * Reconcile after a process restart: every persisted stage left in `running`
+   * status has no inflight handle in this process, so dispatch STAGE_FAILED for
+   * each so the run can either advance or terminate as `stalled`. Safe to call
+   * multiple times — re-dispatches are no-ops once the stage is terminal.
+   */
+  reconcileInflightStages(): Promise<void>;
+
+  /**
+   * Clean shutdown: cancel every non-terminal run via RUN_CANCELLED (which
+   * routes CANCEL_STAGE effects through the agent executor) so in-flight
+   * stages are torn down and final state is persisted. After shutdown, the
+   * engine should not be ticked or dispatched into.
+   */
+  shutdown(): Promise<void>;
+}
+
+/**
+ * Rebuild engine state from the flat-file store. Used so a freshly constructed
+ * engine sees existing runs / loop pointers / history rather than starting from
+ * `emptyEngineState()` (which would defeat the reducer's collision guards).
+ *
+ * Terminal runs go into `historySummaries`; the latest non-terminal run on each
+ * loop key wins `currentRunByLoop`. The returned state is structurally equal to
+ * what the reducer would have produced via replay, modulo finding fingerprints
+ * — those are recomputed on demand by stalled-detection in v0.x.
+ */
+export function hydrateEngineState(store: PipelineStore): EngineState {
+  const runs: Record<string, RunState> = {};
+  const currentRunByLoop: Record<string, RunId> = {};
+  const historySummaries: Record<string, RunSummary[]> = {};
+
+  const sorted = [...store.listRuns()].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+
+  for (const run of sorted) {
+    runs[run.runId] = run;
+    const key = loopKey(run.sessionId, run.pipelineName);
+
+    if (isTerminalLoopState(run.loopState)) {
+      const list = historySummaries[key] ?? [];
+      list.push({
+        runId: run.runId,
+        loopState: run.loopState,
+        ...(run.terminationReason ? { terminationReason: run.terminationReason } : {}),
+        headSha: run.headSha,
+        loopRounds: run.loopRounds,
+        fingerprints: [],
+        createdAt: run.createdAt,
+      });
+      historySummaries[key] = list;
+    } else {
+      currentRunByLoop[key] = run.runId;
+    }
+  }
+
+  return { runs, currentRunByLoop, historySummaries };
 }
 
 export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
@@ -339,11 +399,50 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
     await dispatch({ type: "RUN_CANCELLED", now: now(), runId, reason });
   }
 
+  async function reconcileInflightStages(): Promise<void> {
+    // Snapshot the candidates outside the lock — dispatch reacquires it.
+    const candidates: Array<{ runId: RunId; stageName: string }> = [];
+    for (const run of Object.values(state.runs)) {
+      if (isTerminalLoopState(run.loopState)) continue;
+      for (const [stageName, stage] of Object.entries(run.stages)) {
+        if (stage.status === "running") {
+          candidates.push({ runId: run.runId, stageName });
+        }
+      }
+    }
+    for (const { runId, stageName } of candidates) {
+      await dispatch({
+        type: "STAGE_FAILED",
+        now: now(),
+        runId,
+        stageName,
+        errorMessage:
+          "Pipeline engine restarted while stage was running; in-flight executor handle is lost.",
+      });
+    }
+  }
+
+  async function shutdown(): Promise<void> {
+    const nonTerminalRunIds: RunId[] = [];
+    for (const run of Object.values(state.runs)) {
+      if (!isTerminalLoopState(run.loopState)) {
+        nonTerminalRunIds.push(run.runId);
+      }
+    }
+    for (const runId of nonTerminalRunIds) {
+      // cancelRun is a no-op on already-terminal runs and idempotent per the
+      // reducer's RUN_CANCELLED guard, so we never double-cancel.
+      await cancelRun(runId, "manual_cancel");
+    }
+  }
+
   return {
     state: () => state,
     startRun,
     tick,
     dispatch,
     cancelRun,
+    reconcileInflightStages,
+    shutdown,
   };
 }

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -43,6 +43,7 @@ export {
 
 export {
   createPipelineEngine,
+  hydrateEngineState,
   type PipelineEngine,
   type PipelineEngineDeps,
   type StartRunInput,

--- a/packages/integration-tests/src/pipeline-engine-lifecycle.integration.test.ts
+++ b/packages/integration-tests/src/pipeline-engine-lifecycle.integration.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Integration test for the v0.2 acceptance criterion of issue #191:
+ *
+ *   "start orchestrator, hand-fire TRIGGER_FIRED, observe a single-stage agent
+ *    pipeline run reach `done`."
+ *
+ * This test wires up the same primitives `ao start` does (createPipelineStore,
+ * createPipelineEngine, createLifecycleManager with `pipelineEngine` attached),
+ * runs the lifecycle poll loop on a tight interval, hand-fires a TRIGGER_FIRED
+ * event into the engine, and asserts the run reaches a terminal `done` loop
+ * state through the live polling path — not through any direct reducer
+ * invocation. The agent executor is a stub (no real session is spawned) so the
+ * test stays in-process and fast.
+ *
+ * What this exercises end-to-end:
+ *  - LifecycleManager.pollAll() invokes engine.tick() each cycle.
+ *  - engine.tick() polls the inflight stage and dispatches STAGE_COMPLETED.
+ *  - The reducer transitions a 1-stage pipeline to loopState=done.
+ *  - engine.shutdown() persists state cleanly on stop.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  asPipelineId,
+  asRunId,
+  asStageRunId,
+  createLifecycleManager,
+  createPipelineEngine,
+  createPipelineStore,
+  hydrateEngineState,
+  type AgentStageExecutor,
+  type ArtifactInput,
+  type LifecycleManager,
+  type OpenCodeSessionManager,
+  type OrchestratorConfig,
+  type Pipeline,
+  type PipelineEngine,
+  type PluginManifest,
+  type PluginRegistry,
+  type RunningAgentStage,
+  type RunState,
+  type StageOutcome,
+  type StartStageInput,
+} from "@aoagents/ao-core";
+
+const PIPELINE_NAME = "ci";
+const SESSION_ID = "test-session";
+
+/** Minimal config — only the keys lifecycle-manager actually reads on a no-session poll. */
+function buildConfig(configPath: string): OrchestratorConfig {
+  return {
+    configPath,
+    readyThresholdMs: 300_000,
+    defaults: {
+      runtime: "process",
+      agent: "stub-agent",
+      workspace: "worktree",
+      notifiers: [],
+    },
+    projects: {},
+    notifiers: {},
+    notificationRouting: {
+      urgent: [],
+      action: [],
+      warning: [],
+      info: [],
+    },
+    reactions: {},
+  };
+}
+
+function buildRegistry(agentManifest: PluginManifest): PluginRegistry {
+  return {
+    register: () => {},
+    get: () => null,
+    list: (slot) => (slot === "agent" ? [agentManifest] : []),
+    loadBuiltins: async () => {},
+    loadFromConfig: async () => {},
+  } as PluginRegistry;
+}
+
+/**
+ * `lifecycle-manager` calls `sessionManager.list(projectId)` on every poll.
+ * Returning [] short-circuits all session enrichment so the loop simply runs
+ * its tail — including `engine.tick()`.
+ */
+function buildSessionManager(): OpenCodeSessionManager {
+  return {
+    list: async () => [],
+    get: async () => null,
+    spawn: async () => {
+      throw new Error("stub spawn — should not be called in this test");
+    },
+    spawnOrchestrator: async () => {
+      throw new Error("stub spawnOrchestrator — should not be called");
+    },
+    ensureOrchestrator: async () => {
+      throw new Error("stub ensureOrchestrator — should not be called");
+    },
+    restore: async () => {
+      throw new Error("stub restore — should not be called");
+    },
+    kill: async () => ({ cleaned: false, alreadyTerminated: true }),
+    cleanup: async () => ({ killed: [], skipped: [], errors: [] }),
+    send: async () => {},
+    claimPR: async () => {
+      throw new Error("stub claimPR — should not be called");
+    },
+    remap: async () => "",
+    listCached: async () => [],
+    invalidateCache: () => {},
+  } as OpenCodeSessionManager;
+}
+
+interface StubExecutor extends AgentStageExecutor {
+  setNextOutcome(outcome: StageOutcome): void;
+  inflightCount(): number;
+}
+
+/**
+ * Stub agent executor — captures `startStage` inputs, returns the configured
+ * `nextOutcome` from `pollStage`, and counts inflight handles. No real session
+ * is spawned.
+ */
+function buildStubExecutor(): StubExecutor {
+  let nextOutcome: StageOutcome = { status: "running" };
+  const inflight = new Set<string>();
+
+  return {
+    setNextOutcome: (o) => {
+      nextOutcome = o;
+    },
+    inflightCount: () => inflight.size,
+    async startStage(input: StartStageInput): Promise<RunningAgentStage> {
+      inflight.add(input.stageRunId);
+      return {
+        runId: input.runId,
+        stageRunId: input.stageRunId,
+        stageName: input.stage.name,
+        sessionId: `mock-${input.stageRunId}`,
+        workspacePath: "/tmp/mock-workspace",
+        startedAt: Date.now(),
+        input,
+      };
+    },
+    async pollStage(handle: RunningAgentStage): Promise<StageOutcome> {
+      if (nextOutcome.status !== "running") {
+        inflight.delete(handle.stageRunId);
+      }
+      return nextOutcome;
+    },
+    async cancelStage(handle: RunningAgentStage): Promise<void> {
+      inflight.delete(handle.stageRunId);
+    },
+  };
+}
+
+function buildAgentManifest(): PluginManifest {
+  return {
+    name: "stub-agent",
+    slot: "agent",
+    description: "integration-test stub agent",
+    version: "0.0.0",
+    supportedTaskModes: ["review"],
+  };
+}
+
+/** Pipeline with a single agent stage in `review` mode. */
+function buildPipeline(): Pipeline {
+  return {
+    id: asPipelineId("pl-ci"),
+    name: PIPELINE_NAME,
+    maxConcurrentStages: 1,
+    stages: [
+      {
+        name: "lint",
+        trigger: { on: ["pr.opened"] },
+        executor: { kind: "agent", plugin: "stub-agent", mode: "review" },
+        task: { prompt: "lint" },
+      },
+    ],
+  };
+}
+
+async function waitForRunDone(
+  engine: PipelineEngine,
+  pipelineName: string,
+  sessionId: string,
+  timeoutMs: number,
+): Promise<RunState> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const state = engine.state();
+    for (const run of Object.values(state.runs)) {
+      if (
+        run.pipelineName === pipelineName &&
+        run.sessionId === sessionId &&
+        run.loopState === "done"
+      ) {
+        return run;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for run.loopState=done; ` +
+      `current=${JSON.stringify(
+        Object.values(engine.state().runs).map((r) => ({
+          id: r.runId,
+          loop: r.loopState,
+          stages: Object.fromEntries(
+            Object.entries(r.stages).map(([n, s]) => [n, s.status]),
+          ),
+        })),
+      )}`,
+  );
+}
+
+describe("pipeline engine wired into lifecycle manager (live poll path)", () => {
+  let tmpRoot: string;
+  let lifecycle: LifecycleManager | null = null;
+  let engine: PipelineEngine | null = null;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), "ao-pipe-lifecycle-"));
+  });
+
+  afterEach(async () => {
+    if (lifecycle) {
+      lifecycle.stop();
+      lifecycle = null;
+    }
+    if (engine) {
+      await engine.shutdown().catch(() => {});
+      engine = null;
+    }
+    await rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("TRIGGER_FIRED → live engine.tick() through lifecycle poll → run reaches done", async () => {
+    const config = buildConfig(join(tmpRoot, "agent-orchestrator.yaml"));
+    const registry = buildRegistry(buildAgentManifest());
+    const sessionManager = buildSessionManager();
+    const executor = buildStubExecutor();
+    const store = createPipelineStore(join(tmpRoot, "pipelines"));
+
+    engine = createPipelineEngine({
+      store,
+      registry,
+      agentExecutor: executor,
+      initialState: hydrateEngineState(store),
+    });
+    await engine.reconcileInflightStages();
+
+    lifecycle = createLifecycleManager({
+      config,
+      registry,
+      sessionManager,
+      projectId: "test-project",
+      pipelineEngine: engine,
+    });
+
+    // Tick every 50ms so the test completes quickly. The lifecycle manager
+    // drives engine.tick() from inside pollAll(); the engine itself doesn't
+    // install a timer (per C-14).
+    lifecycle.start(50);
+
+    // Hand-fire TRIGGER_FIRED — the user-facing "test seam" called out in #191.
+    // We don't go through `engine.startRun` because that helper also threads
+    // projectId/issueId; this lower-level path proves the reducer + tick loop
+    // alone is enough to drive a run to completion.
+    const pipeline = buildPipeline();
+    const runId = asRunId("run-integration-1");
+    const stageRunIds = { lint: asStageRunId("sr-integration-1") };
+    await engine.dispatch({
+      type: "TRIGGER_FIRED",
+      now: Date.now(),
+      trigger: "pr.opened",
+      sessionId: SESSION_ID,
+      pipeline,
+      headSha: "abc123",
+      runId,
+      stageRunIds,
+    });
+
+    // After dispatch, the engine has marked the stage running and started it
+    // through the stub executor. Confirm one handle is in flight before we
+    // ask the executor to report completion.
+    expect(executor.inflightCount()).toBe(1);
+
+    // Flip the stub to "completed". The next `engine.tick()` (driven by the
+    // 50ms lifecycle poll) will see this outcome and dispatch STAGE_COMPLETED,
+    // which the reducer will fold into a `done` loop state for the run.
+    const artifacts: ArtifactInput[] = [{ kind: "json", data: { ok: true } }];
+    executor.setNextOutcome({ status: "completed", artifacts });
+
+    const finalRun = await waitForRunDone(engine, PIPELINE_NAME, SESSION_ID, 5_000);
+    expect(finalRun.loopState).toBe("done");
+    expect(finalRun.stages["lint"]?.status).toBe("succeeded");
+    expect(executor.inflightCount()).toBe(0);
+
+    // Persistence round-trip: a fresh store reads back the same terminal run.
+    const reloaded = store.loadRun(finalRun.runId);
+    expect(reloaded?.loopState).toBe("done");
+    expect(reloaded?.stages["lint"]?.status).toBe("succeeded");
+  });
+
+  it("engine.shutdown() cancels in-flight runs and persists terminal state", async () => {
+    const config = buildConfig(join(tmpRoot, "agent-orchestrator.yaml"));
+    const registry = buildRegistry(buildAgentManifest());
+    const sessionManager = buildSessionManager();
+    const executor = buildStubExecutor();
+    const store = createPipelineStore(join(tmpRoot, "pipelines"));
+
+    engine = createPipelineEngine({
+      store,
+      registry,
+      agentExecutor: executor,
+      initialState: hydrateEngineState(store),
+    });
+
+    lifecycle = createLifecycleManager({
+      config,
+      registry,
+      sessionManager,
+      projectId: "test-project",
+      pipelineEngine: engine,
+    });
+    lifecycle.start(50);
+
+    const pipeline = buildPipeline();
+    const runId = asRunId("run-shutdown-1");
+    await engine.dispatch({
+      type: "TRIGGER_FIRED",
+      now: Date.now(),
+      trigger: "pr.opened",
+      sessionId: SESSION_ID,
+      pipeline,
+      headSha: "abc456",
+      runId,
+      stageRunIds: { lint: asStageRunId("sr-shutdown-1") },
+    });
+    expect(executor.inflightCount()).toBe(1);
+
+    // Stop the poll loop and tear the engine down WITHOUT advancing the stub
+    // to "completed". The engine should cancel via RUN_CANCELLED, which the
+    // reducer routes through CANCEL_STAGE → stub.cancelStage.
+    lifecycle.stop();
+    lifecycle = null;
+    await engine.shutdown();
+
+    const reloaded = store.loadRun(runId);
+    expect(reloaded).not.toBeNull();
+    expect(reloaded?.loopState).toBe("terminated");
+    expect(reloaded?.terminationReason).toBe("manual_cancel");
+    expect(executor.inflightCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #191. Wires the dead-code `createPipelineEngine` + `createAgentExecutor` into the running orchestrator so a TRIGGER_FIRED event actually drives a run to completion.

- `getLifecycleManager(config, projectId)` now constructs a per-project `PipelineEngine` alongside the lifecycle manager. The engine is hydrated from `createPipelineStore(getProjectPipelinesDir(projectId))` and then reconciled — in-flight `running` stages from a previous process flip to `failed` so the run advances or stalls (per acceptance, "marked failed" is permitted).
- `LifecycleManager` accepts an optional `pipelineEngine` dep and calls `engine.tick()` at the end of every `pollAll()` cycle. Same 5s cadence as session polling, no new timer (per C-14 and per the engine's design comment at `engine.ts:19-21`).
- `engine.shutdown()` dispatches RUN_CANCELLED on every non-terminal run — the reducer already emits CANCEL_STAGE for `running` stages and persists final state. The graceful-shutdown handler awaits the drain before tearing down session managers, capped by the existing 10s force-exit timer.
- `hydrateEngineState` moves from `cli/src/lib/pipeline-service.ts` into `packages/core/src/pipeline/engine.ts` so the engine module owns its own hydration (as #191 spells out in its "Files" list). The CLI re-exports the canonical version so existing CLI callers (triggerRun / cancelRun / resumeRun) stay source-compatible.

## Acceptance criteria coverage

- [x] `ao start` constructs `createPipelineEngine({ store, registry, agentExecutor })` once per project (via `getLifecycleManager`).
- [x] Engine state hydrated from `store` on startup; in-flight `running` stages reconciled via STAGE_FAILED.
- [x] `engine.tick()` invoked every poll cycle (same 5s cadence, no new timer).
- [x] Clean shutdown on `ao stop` / Ctrl+C: `engine.shutdown()` cancels in-flight stages via RUN_CANCELLED → CANCEL_STAGE; state persisted; awaited by the shutdown handler within the 10s budget.
- [x] Integration test (`packages/integration-tests/src/pipeline-engine-lifecycle.integration.test.ts`): orchestrator started, TRIGGER_FIRED hand-fired via test seam, single-stage agent pipeline reaches `done` via the live polling path (~63ms).

## Test plan

- [x] `pnpm -w build` — full workspace including web/webpack (catches missing dist emits)
- [x] `pnpm -w typecheck` — all 28 packages
- [x] `pnpm -w lint` — 0 errors
- [x] core: 1314 tests pass (includes 108 pipeline + 210 lifecycle)
- [x] cli: 761 tests pass (the lone failure `path-equality.test.ts > expands ~ to HOME` is a pre-existing macOS /private/var symlink env issue on `pipelines` itself — verified by re-running on a stashed working tree)
- [x] integration-tests: 2 new pipeline-engine-lifecycle tests pass

Depends on #190 (PR #200, already merged into `pipelines`).