### PR TITLE
feat(pipelines): wire PR events to TRIGGER_FIRED + reroute ao pipeline run

### DIFF
--- a/packages/cli/__tests__/lib/pipeline-service.test.ts
+++ b/packages/cli/__tests__/lib/pipeline-service.test.ts
@@ -3,13 +3,17 @@ import {
   asPipelineId,
   asRunId,
   asStageRunId,
+  emptyEngineState,
+  loopKey,
   type Artifact,
   type ConfiguredPipeline,
+  type EngineState,
   type LoopState,
   type PersistedStageRun,
   type Pipeline,
+  type PipelineEngine,
   type PipelineStore,
-  type PluginRegistry,
+  type RunId,
   type RunState,
 } from "@aoagents/ao-core";
 
@@ -84,22 +88,6 @@ function makeConfiguredPipeline(
     ],
     ...overrides,
   };
-}
-
-function makeMockRegistry(modes: string[] = ["review", "code", "answer"]): PluginRegistry {
-  return {
-    list: vi.fn((_slot: string) => [
-      {
-        name: "claude-code",
-        slot: "agent",
-        description: "mock",
-        version: "0.0.0",
-        supportedTaskModes: modes,
-      },
-    ]),
-    get: vi.fn(),
-    create: vi.fn(),
-  } as unknown as PluginRegistry;
 }
 
 const mockConfig = {
@@ -186,50 +174,124 @@ describe("resolveConfiguredPipeline", () => {
   });
 });
 
+function createMockEngine(initial?: EngineState): {
+  engine: PipelineEngine;
+  startRun: ReturnType<typeof vi.fn>;
+} {
+  let current: EngineState = initial ?? emptyEngineState();
+  const startRun = vi.fn(async ({ pipeline, sessionId }) => {
+    const runId = asRunId(`run-${pipeline.name}-${Object.keys(current.runs).length}`);
+    const key = loopKey(sessionId ?? `pipeline.${pipeline.name}`, pipeline.name);
+    // Synthesize a minimal RunState — the mock doesn't need the real
+    // reducer's full output, these tests only assert on what triggerRun
+    // returned and which engine method was called.
+    const stub: RunState = {
+      runId,
+      pipelineId: pipeline.id,
+      pipelineName: pipeline.name,
+      sessionId: sessionId ?? `pipeline.${pipeline.name}`,
+      pipelineConfigSnapshot: pipeline,
+      headSha: "test-sha",
+      loopState: "running",
+      loopRounds: 1,
+      stages: {},
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    };
+    current = {
+      ...current,
+      runs: { ...current.runs, [runId]: stub },
+      currentRunByLoop: { ...current.currentRunByLoop, [key]: runId },
+    };
+    return runId;
+  });
+  const engine: PipelineEngine = {
+    state: () => current,
+    startRun,
+    tick: vi.fn(),
+    dispatch: vi.fn(),
+    cancelRun: vi.fn(),
+    reconcileInflightStages: vi.fn(),
+    shutdown: vi.fn(),
+  };
+  return { engine, startRun };
+}
+
 describe("triggerRun", () => {
-  it("validates the pipeline against the registry and persists initial run state", () => {
-    const { store, state } = createMockStore();
-    const registry = makeMockRegistry();
+  it("delegates to engine.startRun with manual trigger and returns the engine's run id", async () => {
+    const { engine, startRun } = createMockEngine();
     const pipeline = resolveConfiguredPipeline(mockConfig, "proj", "review");
 
-    const runId = triggerRun(store, registry, pipeline, {}, () => 1_700_000_000_000);
+    const runId = await triggerRun(engine, pipeline, { projectId: "proj" });
 
     expect(runId).toMatch(/^run-/);
-    expect(state.runs.size).toBe(1);
-    const run = state.runs.get(runId)!;
-    expect(run.pipelineName).toBe("review");
-    expect(run.loopState).toBe("running");
-    expect(Object.keys(run.stages)).toEqual(["review-stage"]);
-    expect(state.loops.size).toBe(1);
-    expect(state.stages.size).toBe(1);
+    expect(startRun).toHaveBeenCalledTimes(1);
+    expect(startRun).toHaveBeenCalledWith({
+      pipeline,
+      projectId: "proj",
+      sessionId: "pipeline.review",
+      trigger: "manual",
+      headSha: "manual",
+    });
   });
 
-  it("throws PipelineConfigError when an agent doesn't support the requested mode", () => {
-    const { store } = createMockStore();
-    const registry = makeMockRegistry(["code"]); // no "review"
+  it("forwards sessionId, headSha, and issueId overrides into engine.startRun", async () => {
+    const { engine, startRun } = createMockEngine();
     const pipeline = resolveConfiguredPipeline(mockConfig, "proj", "review");
-    expect(() => triggerRun(store, registry, pipeline)).toThrow(
-      /supportedTaskModes/i,
-    );
+
+    await triggerRun(engine, pipeline, {
+      projectId: "proj",
+      sessionId: "worker-7",
+      headSha: "deadbeef",
+      issueId: "AO-42",
+    });
+
+    expect(startRun).toHaveBeenCalledWith({
+      pipeline,
+      projectId: "proj",
+      sessionId: "worker-7",
+      trigger: "manual",
+      headSha: "deadbeef",
+      issueId: "AO-42",
+    });
   });
 
-  it("rejects with LoopAlreadyActiveError when an active run already owns the loop key", async () => {
+  it("rejects with LoopAlreadyActiveError when engine state already has an active run for the loop", async () => {
     const { LoopAlreadyActiveError } = await import("../../src/lib/pipeline-service.js");
-    const { store, state } = createMockStore();
-    const registry = makeMockRegistry();
     const pipeline = resolveConfiguredPipeline(mockConfig, "proj", "review");
-
-    triggerRun(store, registry, pipeline);
-    expect(state.runs.size).toBe(1);
+    const activeRunId = asRunId("run-existing");
+    const sessionId = "pipeline.review";
+    const initial: EngineState = {
+      runs: {
+        [activeRunId]: {
+          runId: activeRunId,
+          pipelineId: pipeline.id,
+          pipelineName: pipeline.name,
+          sessionId,
+          pipelineConfigSnapshot: pipeline,
+          headSha: "x",
+          loopState: "running",
+          loopRounds: 1,
+          stages: {},
+          createdAt: "x",
+          updatedAt: "x",
+        },
+      },
+      currentRunByLoop: { [loopKey(sessionId, pipeline.name)]: activeRunId },
+      historySummaries: {},
+    };
+    const { engine, startRun } = createMockEngine(initial);
 
     let captured: unknown;
     try {
-      triggerRun(store, registry, pipeline);
+      await triggerRun(engine, pipeline, { projectId: "proj" });
     } catch (err) {
       captured = err;
     }
     expect(captured).toBeInstanceOf(LoopAlreadyActiveError);
-    expect(state.runs.size).toBe(1); // still only one run
+    expect((captured as InstanceType<typeof LoopAlreadyActiveError>).activeRunId).toBe(activeRunId);
+    // Live engine was never asked to start a run when the loop is busy.
+    expect(startRun).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/__tests__/lib/pipeline-service.test.ts
+++ b/packages/cli/__tests__/lib/pipeline-service.test.ts
@@ -13,7 +13,6 @@ import {
   type Pipeline,
   type PipelineEngine,
   type PipelineStore,
-  type RunId,
   type RunState,
 } from "@aoagents/ao-core";
 

--- a/packages/cli/src/commands/pipeline.ts
+++ b/packages/cli/src/commands/pipeline.ts
@@ -21,7 +21,7 @@ import {
 } from "@aoagents/ao-core";
 
 import { fail } from "../lib/cli-utils.js";
-import { getPluginRegistry } from "../lib/create-session-manager.js";
+import { getOneShotPipelineEngine } from "../lib/create-session-manager.js";
 import { resolveScopedProjectId } from "../lib/project-resolution.js";
 import { getRunning } from "../lib/running-state.js";
 import {
@@ -50,28 +50,34 @@ function openScope(projectOpt?: string): ProjectScope {
 }
 
 /**
- * Inverse of `warnIfAONotRunning` in spawn.ts. The running orchestrator
- * holds engine state in memory and (until v0.4 lifecycle wiring lands) does
- * not re-read pipeline runs from disk. CLI mutations therefore won't be seen
- * by the in-process engine until the user restarts it. Make that explicit.
+ * Inverse of `warnIfAONotRunning` in spawn.ts. The running orchestrator owns
+ * its own engine instance in memory; the CLI builds a transient engine that
+ * shares the same flat-file store but cannot reach into the running process.
+ * A CLI dispatch therefore spawns the stage (now that #192 routes through the
+ * live engine) but the running orchestrator's in-memory engine will not see
+ * the new run until it is restarted. Make that gap explicit so the operator
+ * isn't surprised when the dashboard lags behind the CLI output.
  */
 async function warnIfAORunning(projectId: string): Promise<void> {
   const running = await getRunning();
   if (!running || !running.projects.includes(projectId)) return;
   console.log(
     chalk.yellow(
-      `⚠ AO is running (pid ${running.pid}) and holds in-memory pipeline state.`,
+      `⚠ AO is running (pid ${running.pid}) on this project with its own engine.`,
     ),
   );
   console.log(
     chalk.dim(
-      `  This change is persisted to disk but the running engine won't pick it up until v0.4 lifecycle wiring lands.`,
+      `  This CLI dispatch will spawn the stage and persist the run, but the running`,
     ),
   );
   console.log(
     chalk.dim(
-      `  Restart \`ao start\` to re-hydrate engine state from the store.`,
+      `  AO process won't observe the new run until it is restarted. Restart`,
     ),
+  );
+  console.log(
+    chalk.dim(`  \`ao start\` to re-hydrate engine state from the store.`),
   );
 }
 
@@ -248,12 +254,26 @@ export function registerPipeline(program: Command): void {
         opts: { project?: string; session?: string; headSha?: string; json?: boolean },
       ) => {
         try {
-          const { config, projectId, store } = openScope(opts.project);
+          const { config, projectId } = openScope(opts.project);
           const pipeline = resolveConfiguredPipeline(config, projectId, pipelineRef);
-          const registry = await getPluginRegistry(config);
+
+          // Live engine path (issue #192): construct a transient engine the
+          // same way `ao start` does so the START_STAGE effect actually spawns
+          // the stage's agent session — the prior store-only path persisted
+          // the run but the stage sat at `pending` forever (#1346 / #192).
+          // `getOneShotPipelineEngine` deliberately skips
+          // `reconcileInflightStages` so a CLI invocation can't STAGE_FAILED
+          // stages that a separately-running `ao start` is still driving.
+          //
+          // Warn BEFORE dispatching so the user can Ctrl+C if they didn't mean
+          // to take this path while AO is also running on the same project.
+          await warnIfAORunning(projectId);
+
+          const pipelineEngine = await getOneShotPipelineEngine(config, projectId);
           let runId;
           try {
-            runId = triggerRun(store, registry, pipeline, {
+            runId = await triggerRun(pipelineEngine, pipeline, {
+              projectId,
               ...(opts.session ? { sessionId: opts.session } : {}),
               ...(opts.headSha ? { headSha: opts.headSha } : {}),
             });
@@ -276,12 +296,6 @@ export function registerPipeline(program: Command): void {
               `✓ Triggered ${chalk.bold(pipeline.name)} for ${chalk.bold(projectId)} → ${runId}`,
             ),
           );
-          console.log(
-            chalk.dim(
-              `  Run state persisted. v0.4 lifecycle integration will pick it up.`,
-            ),
-          );
-          await warnIfAORunning(projectId);
         } catch (err) {
           fail(err);
         }

--- a/packages/cli/src/lib/create-session-manager.ts
+++ b/packages/cli/src/lib/create-session-manager.ts
@@ -119,3 +119,32 @@ export async function getLifecycleManager(
   });
   return { lifecycle, pipelineEngine };
 }
+
+/**
+ * Build a transient pipeline engine for one-shot CLI dispatches (e.g.
+ * `ao pipeline run`). Hydrates state from the persisted store and wires up
+ * a real agent executor so the engine can spawn stages — but does NOT call
+ * `reconcileInflightStages`, because reconcile assumes the caller owns the
+ * lifecycle for those stages. Calling it from a transient CLI process would
+ * STAGE_FAILED stages that a separately-running `ao start` is still driving,
+ * corrupting that other process's view of the world.
+ *
+ * After dispatch, the CLI should exit without ticking the engine. The agent
+ * session it spawned lives on in the runtime plugin; a future `ao start`
+ * will surface the resulting run in the dashboard.
+ */
+export async function getOneShotPipelineEngine(
+  config: OrchestratorConfig,
+  projectId: string,
+): Promise<PipelineEngine> {
+  const registry = await getPluginRegistry(config);
+  const sessionManager = createSessionManager({ config, registry });
+  const store = createPipelineStore(getProjectPipelinesDir(projectId));
+  const agentExecutor = createAgentExecutor({ sessionManager });
+  return createPipelineEngine({
+    store,
+    registry,
+    agentExecutor,
+    initialState: hydrateEngineState(store),
+  });
+}

--- a/packages/cli/src/lib/pipeline-service.ts
+++ b/packages/cli/src/lib/pipeline-service.ts
@@ -16,15 +16,12 @@
 import { randomUUID } from "node:crypto";
 import {
   asPipelineId,
-  asRunId,
   asStageRunId,
   configuredPipelineToRuntime,
   hydrateEngineState,
   isTerminalLoopState,
   loopKey,
   reduce,
-  validatePipelineAgentModes,
-  validatePipelineDag,
   type Artifact,
   type ConfiguredPipeline,
   type EngineState,
@@ -33,9 +30,9 @@ import {
   type PersistedStageRun,
   type Pipeline,
   type PipelineEffect,
+  type PipelineEngine,
   type PipelineEvent,
   type PipelineStore,
-  type PluginRegistry,
   type RunId,
   type RunState,
   type StageRunId,
@@ -224,33 +221,38 @@ const MANUAL_TRIGGER_SHA = "manual";
 export interface TriggerOptions {
   sessionId?: string;
   headSha?: string;
+  projectId?: string;
+  issueId?: string;
 }
 
 /**
- * Trigger a manual run for a pipeline. Hydrates engine state from the store
- * so the reducer's "active run already in flight for this loop" guard fires
- * when a non-terminal run already exists. Returns the allocated run id; the
- * running orchestrator drives stage execution.
+ * Trigger a manual pipeline run via the live engine. The engine validates the
+ * pipeline against the registry, persists the initial run state, AND fires the
+ * START_STAGE effect through the agent executor — so the stage actually spawns
+ * a session instead of sitting at `pending` like the previous store-only path
+ * did (issue #192).
+ *
+ * The pre-flight `LoopAlreadyActiveError` mirrors the reducer's TRIGGER_FIRED
+ * guard but surfaces it to the CLI as an explicit error with the active runId
+ * (the reducer alone would just no-op silently). The check reads engine state
+ * directly so it reflects the engine's in-memory view, not what the store
+ * happens to contain at the moment.
  *
  * `sessionId` defaults to `pipeline.<name>` so a CLI-triggered run can be
  * looked up by name without a worker session attached. Callers that already
- * have a session (e.g. lifecycle integration in v0.4) should override it.
+ * have a session (e.g. the lifecycle PR-event bridge in lifecycle-manager)
+ * should override it.
  */
-export function triggerRun(
-  store: PipelineStore,
-  registry: PluginRegistry,
+export async function triggerRun(
+  engine: PipelineEngine,
   pipeline: Pipeline,
   options: TriggerOptions = {},
-  now: () => number = Date.now,
-): RunId {
-  validatePipelineAgentModes(pipeline, registry);
-  validatePipelineDag(pipeline);
-
+): Promise<RunId> {
   const sessionId = options.sessionId ?? `pipeline.${pipeline.name}`;
-  const initialState = hydrateEngineState(store);
+  const state = engine.state();
   const key = loopKey(sessionId, pipeline.name);
-  const activeRunId = initialState.currentRunByLoop[key];
-  if (activeRunId && initialState.runs[activeRunId]) {
+  const activeRunId = state.currentRunByLoop[key];
+  if (activeRunId && state.runs[activeRunId]) {
     throw new LoopAlreadyActiveError(
       `Pipeline "${pipeline.name}" already has an active run (${activeRunId}). ` +
         `Cancel it with \`ao pipeline cancel ${activeRunId}\` before triggering a new one.`,
@@ -260,24 +262,14 @@ export function triggerRun(
     );
   }
 
-  const runId = asRunId(`run-${randomUUID()}`);
-  const stageRunIds: Record<string, StageRunId> = {};
-  for (const stage of pipeline.stages) {
-    stageRunIds[stage.name] = asStageRunId(`sr-${randomUUID()}`);
-  }
-
-  applyEvent(store, initialState, {
-    type: "TRIGGER_FIRED",
-    now: now(),
-    trigger: "manual",
-    sessionId,
+  return engine.startRun({
     pipeline,
+    projectId: options.projectId ?? "",
+    sessionId,
+    trigger: "manual",
     headSha: options.headSha ?? MANUAL_TRIGGER_SHA,
-    runId,
-    stageRunIds,
+    ...(options.issueId ? { issueId: options.issueId } : {}),
   });
-
-  return runId;
 }
 
 /**

--- a/packages/core/src/__tests__/lifecycle-pipeline-bridge.test.ts
+++ b/packages/core/src/__tests__/lifecycle-pipeline-bridge.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Unit tests for the lifecycle-manager → pipeline-engine bridge (issue #192).
+ *
+ * The bridge converts PR-state transitions on a session into the matching
+ * pipeline trigger events (`pr.opened`, `pr.updated`, `pr.merged`) and
+ * dispatches them into the engine via `startRun` / `dispatch(NEW_SHA_DETECTED)`.
+ *
+ * These tests stub the engine so we can assert exactly what was dispatched.
+ * Stage execution and reducer behaviour are covered separately in
+ * pipeline-engine.test.ts and pipeline-reducer.test.ts.
+ */
+
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+import { writeMetadata } from "../metadata.js";
+import { createLifecycleManager } from "../lifecycle-manager.js";
+import { recordActivityEvent } from "../activity-events.js";
+import type {
+  OrchestratorConfig,
+  PluginRegistry,
+  OpenCodeSessionManager,
+  PRInfo,
+  SCM,
+  Session,
+  SessionMetadata,
+} from "../types.js";
+import type { PipelineEngine } from "../pipeline/engine.js";
+import {
+  createMockPlugins,
+  createMockRegistry,
+  createMockSCM,
+  createMockSessionManager,
+  createTestEnvironment,
+  makePR,
+  makeSession,
+  type TestEnvironment,
+} from "./test-utils.js";
+
+vi.mock("../activity-events.js", () => ({
+  recordActivityEvent: vi.fn(),
+}));
+
+interface EngineCalls {
+  startRun: ReturnType<typeof vi.fn>;
+  dispatch: ReturnType<typeof vi.fn>;
+}
+
+function createStubEngine(): { engine: PipelineEngine; calls: EngineCalls } {
+  const startRun = vi.fn().mockResolvedValue("run-stub");
+  const dispatch = vi.fn().mockResolvedValue(undefined);
+  const engine: PipelineEngine = {
+    state: () => ({ runs: {}, currentRunByLoop: {}, historySummaries: {} }),
+    startRun: startRun as unknown as PipelineEngine["startRun"],
+    dispatch: dispatch as unknown as PipelineEngine["dispatch"],
+    tick: vi.fn().mockResolvedValue(undefined) as unknown as PipelineEngine["tick"],
+    cancelRun: vi.fn().mockResolvedValue(undefined) as unknown as PipelineEngine["cancelRun"],
+    reconcileInflightStages: vi
+      .fn()
+      .mockResolvedValue(undefined) as unknown as PipelineEngine["reconcileInflightStages"],
+    shutdown: vi.fn().mockResolvedValue(undefined) as unknown as PipelineEngine["shutdown"],
+  };
+  return { engine, calls: { startRun, dispatch } };
+}
+
+/**
+ * Build a project config with one pipeline whose only stage subscribes to
+ * the listed trigger events. Lets each test exercise a specific trigger.
+ */
+function configWithPipeline(
+  env: TestEnvironment,
+  triggers: ReadonlyArray<"pr.opened" | "pr.updated" | "pr.merged" | "pr.merge_ready" | "manual">,
+): OrchestratorConfig {
+  return {
+    ...env.config,
+    projects: {
+      ...env.config.projects,
+      "my-app": {
+        ...env.config.projects["my-app"]!,
+        pipelines: {
+          review: {
+            name: "review",
+            stages: [
+              {
+                name: "lint",
+                trigger: { on: [...triggers] },
+                executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+                task: { prompt: "lint" },
+              },
+            ],
+          },
+        },
+      },
+    },
+  };
+}
+
+function sessionWithOpenPR(pr: PRInfo): Session {
+  return makeSession({
+    pr,
+    lifecycle: {
+      ...makeSession().lifecycle,
+      pr: {
+        state: "open",
+        reason: "in_progress",
+        number: pr.number,
+        url: pr.url,
+        lastObservedAt: new Date().toISOString(),
+      },
+    },
+  });
+}
+
+describe("lifecycle pipeline-trigger bridge", () => {
+  let env: TestEnvironment;
+  let mockSCM: SCM;
+  let mockSessionManager: OpenCodeSessionManager;
+  let mockRegistry: PluginRegistry;
+  let scmHeadSha: string | null;
+
+  beforeEach(() => {
+    env = createTestEnvironment();
+    vi.mocked(recordActivityEvent).mockClear();
+    scmHeadSha = "sha-aaa";
+    const plugins = createMockPlugins();
+    mockSCM = createMockSCM({
+      detectPR: vi.fn().mockResolvedValue(makePR({ owner: "org", repo: "my-app" })),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      enrichSessionsPRBatch: vi.fn().mockImplementation(async (prs: PRInfo[]) => {
+        const result = new Map();
+        for (const pr of prs) {
+          result.set(`${pr.owner}/${pr.repo}#${pr.number}`, {
+            state: "open",
+            ciStatus: "passing",
+            reviewDecision: "none",
+            mergeable: false,
+            headSha: scmHeadSha,
+          });
+        }
+        return result;
+      }),
+    });
+    mockSessionManager = createMockSessionManager();
+    mockRegistry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      workspace: plugins.workspace,
+      scm: mockSCM,
+    });
+  });
+
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  it("dispatches TRIGGER_FIRED(pr.opened) when a PR transitions none→open", async () => {
+    const config = configWithPipeline(env, ["pr.opened"]);
+    const pr = makePR({ owner: "org", repo: "my-app" });
+    // session.pr is set but lifecycle.pr.state is still "none" (synthesized
+    // from empty metadata). populatePREnrichmentCache fills the cache via the
+    // batch SCM mock; then determineStatus flips lifecycle.pr.state to "open"
+    // and the bridge sees the real transition with headSha already available.
+    const session = makeSession({ pr });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    writeMetadata(env.sessionsDir, session.id, {
+      worktree: "/tmp",
+      branch: "feat/test",
+      status: "working",
+      project: "my-app",
+    } as unknown as SessionMetadata);
+    vi.mocked(mockSCM.detectPR).mockResolvedValue(pr);
+
+    const { engine, calls } = createStubEngine();
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+      projectId: "my-app",
+      pipelineEngine: engine,
+    });
+
+    await lm.check(session.id);
+
+    expect(calls.startRun).toHaveBeenCalledTimes(1);
+    const call = calls.startRun.mock.calls[0][0];
+    expect(call.trigger).toBe("pr.opened");
+    expect(call.sessionId).toBe(session.id);
+    expect(call.projectId).toBe("my-app");
+    expect(call.pipeline.name).toBe("review");
+    expect(call.headSha).toBe("sha-aaa");
+    expect(calls.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch when the configured pipeline doesn't subscribe to the event", async () => {
+    // Pipeline only subscribes to pr.merge_ready — pr.opened must NOT trigger.
+    const config = configWithPipeline(env, ["pr.merge_ready"]);
+    const pr = makePR({ owner: "org", repo: "my-app" });
+    const session = makeSession({ pr: null });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    writeMetadata(env.sessionsDir, session.id, {
+      worktree: "/tmp",
+      branch: "feat/test",
+      status: "working",
+      project: "my-app",
+    } as unknown as SessionMetadata);
+    vi.mocked(mockSCM.detectPR).mockResolvedValue(pr);
+
+    const { engine, calls } = createStubEngine();
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+      projectId: "my-app",
+      pipelineEngine: engine,
+    });
+
+    await lm.check(session.id);
+
+    expect(calls.startRun).not.toHaveBeenCalled();
+    expect(calls.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent across polls when PR state does not change", async () => {
+    const config = configWithPipeline(env, ["pr.opened"]);
+    const pr = makePR({ owner: "org", repo: "my-app" });
+    const session = sessionWithOpenPR(pr);
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    writeMetadata(env.sessionsDir, session.id, {
+      worktree: "/tmp",
+      branch: "feat/test",
+      status: "pr_open",
+      project: "my-app",
+      pr: pr.url,
+    } as unknown as SessionMetadata);
+    vi.mocked(mockSCM.detectPR).mockResolvedValue(pr);
+
+    const { engine, calls } = createStubEngine();
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+      projectId: "my-app",
+      pipelineEngine: engine,
+    });
+
+    // PR was already open BEFORE the first poll — no transition, no dispatch.
+    await lm.check(session.id);
+    await lm.check(session.id);
+    await lm.check(session.id);
+
+    expect(calls.startRun).not.toHaveBeenCalled();
+    expect(calls.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("dispatches NEW_SHA_DETECTED + TRIGGER_FIRED(pr.updated) when HEAD SHA changes on open PR", async () => {
+    const config = configWithPipeline(env, ["pr.updated"]);
+    const pr = makePR({ owner: "org", repo: "my-app" });
+    const session = sessionWithOpenPR(pr);
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    writeMetadata(env.sessionsDir, session.id, {
+      worktree: "/tmp",
+      branch: "feat/test",
+      status: "pr_open",
+      project: "my-app",
+      pr: pr.url,
+    } as unknown as SessionMetadata);
+    vi.mocked(mockSCM.detectPR).mockResolvedValue(pr);
+
+    const { engine, calls } = createStubEngine();
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+      projectId: "my-app",
+      pipelineEngine: engine,
+    });
+
+    // First poll seeds the SHA tracker; no transition so no dispatch.
+    scmHeadSha = "sha-aaa";
+    await lm.check(session.id);
+    expect(calls.startRun).not.toHaveBeenCalled();
+    expect(calls.dispatch).not.toHaveBeenCalled();
+
+    // Second poll observes a new SHA — bridge dispatches both events.
+    scmHeadSha = "sha-bbb";
+    await lm.check(session.id);
+
+    expect(calls.dispatch).toHaveBeenCalledTimes(1);
+    const dispatchCall = calls.dispatch.mock.calls[0][0];
+    expect(dispatchCall).toMatchObject({
+      type: "NEW_SHA_DETECTED",
+      sessionId: session.id,
+      pipelineName: "review",
+      sha: "sha-bbb",
+    });
+    expect(calls.startRun).toHaveBeenCalledTimes(1);
+    expect(calls.startRun.mock.calls[0][0].trigger).toBe("pr.updated");
+    expect(calls.startRun.mock.calls[0][0].headSha).toBe("sha-bbb");
+
+    // Third poll with the same SHA — no further dispatches.
+    await lm.check(session.id);
+    expect(calls.dispatch).toHaveBeenCalledTimes(1);
+    expect(calls.startRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops when the project has no pipelines configured at all", async () => {
+    // env.config has no pipelines — keep it as-is.
+    const pr = makePR({ owner: "org", repo: "my-app" });
+    const session = makeSession({ pr: null });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    writeMetadata(env.sessionsDir, session.id, {
+      worktree: "/tmp",
+      branch: "feat/test",
+      status: "working",
+      project: "my-app",
+    } as unknown as SessionMetadata);
+    vi.mocked(mockSCM.detectPR).mockResolvedValue(pr);
+
+    const { engine, calls } = createStubEngine();
+    const lm = createLifecycleManager({
+      config: env.config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+      projectId: "my-app",
+      pipelineEngine: engine,
+    });
+
+    await lm.check(session.id);
+
+    expect(calls.startRun).not.toHaveBeenCalled();
+    expect(calls.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when no pipelineEngine is wired into the lifecycle manager", async () => {
+    const config = configWithPipeline(env, ["pr.opened"]);
+    const pr = makePR({ owner: "org", repo: "my-app" });
+    const session = makeSession({ pr: null });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    writeMetadata(env.sessionsDir, session.id, {
+      worktree: "/tmp",
+      branch: "feat/test",
+      status: "working",
+      project: "my-app",
+    } as unknown as SessionMetadata);
+    vi.mocked(mockSCM.detectPR).mockResolvedValue(pr);
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+      projectId: "my-app",
+    });
+
+    // Should not throw — the bridge is a no-op when no engine is configured.
+    await expect(lm.check(session.id)).resolves.not.toThrow();
+  });
+});

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -52,6 +52,8 @@ import {
   deriveLegacyStatus,
 } from "./lifecycle-state.js";
 import type { PipelineEngine } from "./pipeline/engine.js";
+import { configuredPipelineToRuntime } from "./pipeline/config-schema.js";
+import type { StageTriggerEvent } from "./pipeline/types.js";
 import { updateMetadata } from "./metadata.js";
 import { getProjectSessionsDir } from "./paths.js";
 import { applyDecisionToLifecycle as commitLifecycleDecisionInPlace } from "./lifecycle-transition.js";
@@ -534,6 +536,15 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   /** Throttle interval for review backlog API calls (2 minutes). */
   const REVIEW_BACKLOG_THROTTLE_MS = 2 * 60 * 1000;
+
+  /**
+   * Last PR head SHA observed per session. Used by the pipeline-trigger bridge
+   * to detect `pr.updated` (new commit) transitions and dispatch
+   * NEW_SHA_DETECTED into the pipeline engine. In-memory only — on restart the
+   * engine's persisted run.headSha plus the reducer's idempotency guard
+   * (`run.headSha === sha` no-op) prevents duplicate dispatches.
+   */
+  const lastPipelineSha = new Map<SessionId, string>();
 
   /**
    * Populate the PR enrichment cache using batch GraphQL queries.
@@ -2145,6 +2156,135 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
   }
 
   /**
+   * Bridge PR-state transitions and HEAD-SHA changes into the pipeline engine.
+   *
+   * Three transitions fire dispatches:
+   *  - PR transitioned to `open` (from any other state): TRIGGER_FIRED(pr.opened)
+   *  - PR transitioned `open → merged`: TRIGGER_FIRED(pr.merged)
+   *  - PR stayed `open` but its HEAD SHA changed: NEW_SHA_DETECTED followed by
+   *    TRIGGER_FIRED(pr.updated). NEW_SHA_DETECTED terminates the prior run as
+   *    `outdated` and frees the loop key so the new TRIGGER_FIRED can start
+   *    a fresh run for the new SHA.
+   *
+   * For each transition, every configured pipeline whose stages subscribe
+   * (`stage.trigger.on` includes the event) is dispatched. Pipelines that
+   * don't subscribe are skipped.
+   *
+   * Idempotency: pr.opened / pr.merged fire on the previousPRState !==
+   * newPRState edge only — repeated polls without a state change emit no
+   * dispatch. pr.updated guards on `lastPipelineSha` and the reducer's
+   * `run.headSha === sha` no-op in NEW_SHA_DETECTED gives a second layer of
+   * idempotency across restarts.
+   */
+  async function bridgePipelineTriggers(
+    session: Session,
+    previousPRState: Session["lifecycle"]["pr"]["state"],
+  ): Promise<void> {
+    if (!pipelineEngine) return;
+
+    const project = config.projects[session.projectId];
+    const configuredPipelines = project?.pipelines;
+    if (!configuredPipelines || Object.keys(configuredPipelines).length === 0) return;
+
+    const newPRState = session.lifecycle.pr.state;
+    let currentHeadSha: string | null = null;
+    if (session.pr) {
+      const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
+      const cached = prEnrichmentCache.get(prKey);
+      currentHeadSha = cached?.headSha ?? null;
+    }
+
+    const trigger = decidePipelineTrigger(previousPRState, newPRState);
+
+    // SHA-change detection only applies to PRs still in `open` state — a PR
+    // that just transitioned to `open` rides the pr.opened branch instead.
+    const isContinuingOpen =
+      previousPRState === "open" && newPRState === "open" && currentHeadSha !== null;
+    const lastSha = lastPipelineSha.get(session.id);
+    const shaChanged = isContinuingOpen && lastSha !== undefined && lastSha !== currentHeadSha;
+
+    if (currentHeadSha) {
+      lastPipelineSha.set(session.id, currentHeadSha);
+    }
+
+    if (!trigger && !shaChanged) return;
+
+    // On SHA change, dispatch NEW_SHA_DETECTED FIRST so the reducer frees the
+    // loop key before the pr.updated TRIGGER_FIRED arrives — otherwise the
+    // new trigger no-ops against the still-active prior run.
+    if (shaChanged && currentHeadSha) {
+      for (const pipelineName of Object.keys(configuredPipelines)) {
+        try {
+          await pipelineEngine.dispatch({
+            type: "NEW_SHA_DETECTED",
+            now: Date.now(),
+            sessionId: session.id,
+            pipelineName: configuredPipelines[pipelineName].name ?? pipelineName,
+            sha: currentHeadSha,
+          });
+        } catch (err) {
+          recordActivityEvent({
+            projectId: session.projectId,
+            sessionId: session.id,
+            source: "lifecycle",
+            kind: "pipeline.new_sha_dispatch_failed",
+            level: "warn",
+            summary: `NEW_SHA_DETECTED dispatch failed for ${pipelineName}`,
+            data: { errorMessage: err instanceof Error ? err.message : String(err) },
+          });
+        }
+      }
+    }
+
+    const effectiveTrigger: StageTriggerEvent | null = trigger ?? (shaChanged ? "pr.updated" : null);
+    if (!effectiveTrigger) return;
+
+    const dispatchSha = currentHeadSha ?? "unknown";
+    for (const [key, configured] of Object.entries(configuredPipelines)) {
+      const subscribes = configured.stages.some((stage) =>
+        stage.trigger.on.includes(effectiveTrigger),
+      );
+      if (!subscribes) continue;
+      try {
+        const pipeline = configuredPipelineToRuntime(key, configured);
+        await pipelineEngine.startRun({
+          pipeline,
+          projectId: session.projectId,
+          sessionId: session.id,
+          trigger: effectiveTrigger,
+          headSha: dispatchSha,
+          ...(session.issueId ? { issueId: session.issueId } : {}),
+        });
+      } catch (err) {
+        recordActivityEvent({
+          projectId: session.projectId,
+          sessionId: session.id,
+          source: "lifecycle",
+          kind: "pipeline.trigger_fired_dispatch_failed",
+          level: "warn",
+          summary: `TRIGGER_FIRED(${effectiveTrigger}) dispatch failed for ${key}`,
+          data: { errorMessage: err instanceof Error ? err.message : String(err) },
+        });
+      }
+    }
+  }
+
+  /**
+   * Map a PR state transition to the corresponding pipeline trigger event.
+   * Returns null when the transition doesn't correspond to a pipeline trigger
+   * (e.g. `open → closed`, or no state change at all).
+   */
+  function decidePipelineTrigger(
+    previousPRState: Session["lifecycle"]["pr"]["state"],
+    newPRState: Session["lifecycle"]["pr"]["state"],
+  ): StageTriggerEvent | null {
+    if (previousPRState === newPRState) return null;
+    if (newPRState === "open") return "pr.opened";
+    if (newPRState === "merged" && previousPRState === "open") return "pr.merged";
+    return null;
+  }
+
+  /**
    * Dispatch merge conflict notifications to the agent session.
    * Conflicts are detected from the PR enrichment cache or getMergeability()
    * and dispatched independently of the session status (conflicts can coexist
@@ -2685,6 +2825,26 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         });
         await notifyHuman(prEvent, inferPriority(prEventType));
       }
+    }
+
+    // Bridge PR-state transitions into the pipeline engine: when a PR
+    // transitions none→open, open→merged, or a new HEAD SHA lands on an open
+    // PR, fire TRIGGER_FIRED (and NEW_SHA_DETECTED on SHA change) so any
+    // configured pipeline subscribed to the corresponding event auto-runs.
+    // Errors are swallowed: a misconfigured pipeline must not block session
+    // lifecycle progression for unrelated sessions.
+    try {
+      await bridgePipelineTriggers(session, previousPRState);
+    } catch (err) {
+      recordActivityEvent({
+        projectId: session.projectId,
+        sessionId: session.id,
+        source: "lifecycle",
+        kind: "pipeline.trigger_bridge_failed",
+        level: "warn",
+        summary: "pipeline trigger bridge failed",
+        data: { errorMessage: err instanceof Error ? err.message : String(err) },
+      });
     }
 
     // Pin first quality summary for title stability

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -908,6 +908,13 @@ export interface PREnrichmentData {
   isBehind?: boolean;
   /** List of blockers preventing merge */
   blockers?: string[];
+  /**
+   * Head commit SHA of the PR. Surfaced so the lifecycle manager can detect
+   * `pr.updated` (new commit) transitions and dispatch NEW_SHA_DETECTED /
+   * TRIGGER_FIRED into the pipeline engine. Null when the SCM plugin could
+   * not extract it; consumers must treat absence as "unknown", not "unchanged".
+   */
+  headSha?: string | null;
 }
 
 /**
@@ -1114,6 +1121,13 @@ export interface PREnrichmentData {
   blockers?: string[];
   /** Individual CI check results (populated from batch enrichment when available) */
   ciChecks?: CICheck[];
+  /**
+   * Head commit SHA of the PR. Surfaced so the lifecycle manager can detect
+   * `pr.updated` (new commit) transitions and dispatch NEW_SHA_DETECTED /
+   * TRIGGER_FIRED into the pipeline engine. Null when the SCM plugin could
+   * not extract it; consumers must treat absence as "unknown", not "unchanged".
+   */
+  headSha?: string | null;
 }
 
 /**

--- a/packages/integration-tests/src/pipeline-pr-trigger.integration.test.ts
+++ b/packages/integration-tests/src/pipeline-pr-trigger.integration.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Integration test for issue #192:
+ *
+ *   "open a PR on a session → assert a pr.opened-triggered pipeline reaches
+ *    `done` end-to-end"
+ *
+ * This wires the same primitives `ao start` does — store, engine,
+ * lifecycle-manager, plugin registry — and drives a real poll cycle. The SCM
+ * plugin is mocked to surface a PR on a particular poll, which simulates the
+ * remote git host advertising a newly-opened PR. The agent executor is a stub
+ * so no actual session is spawned; the test asserts the run progresses through
+ * TRIGGER_FIRED → START_STAGE → tick() → STAGE_COMPLETED → loopState=done.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createLifecycleManager,
+  createPipelineEngine,
+  createPipelineStore,
+  hydrateEngineState,
+  type AgentStageExecutor,
+  type Agent,
+  type ActivityState,
+  type ConfiguredPipeline,
+  type LifecycleManager,
+  type OpenCodeSessionManager,
+  type OrchestratorConfig,
+  type PipelineEngine,
+  type PluginManifest,
+  type PluginRegistry,
+  type PREnrichmentData,
+  type PRInfo,
+  type Runtime,
+  type RunningAgentStage,
+  type RunState,
+  type SCM,
+  type Session,
+  type StageOutcome,
+  type StartStageInput,
+} from "@aoagents/ao-core";
+
+const PROJECT_ID = "test-project";
+const SESSION_ID = "ao-pipe-1";
+const PIPELINE_NAME = "review";
+
+function buildPipeline(): ConfiguredPipeline {
+  return {
+    name: PIPELINE_NAME,
+    stages: [
+      {
+        name: "lint",
+        trigger: { on: ["pr.opened"] },
+        executor: { kind: "agent", plugin: "stub-agent", mode: "review" },
+        task: { prompt: "lint" },
+      },
+    ],
+  };
+}
+
+function buildConfig(configPath: string): OrchestratorConfig {
+  return {
+    configPath,
+    readyThresholdMs: 300_000,
+    defaults: {
+      runtime: "process",
+      agent: "stub-agent",
+      workspace: "worktree",
+      notifiers: [],
+    },
+    projects: {
+      [PROJECT_ID]: {
+        name: PROJECT_ID,
+        repo: "org/test-project",
+        path: "/tmp/proj",
+        defaultBranch: "main",
+        sessionPrefix: "ao",
+        scm: { plugin: "github" },
+        pipelines: {
+          [PIPELINE_NAME]: buildPipeline(),
+        },
+      },
+    },
+    notifiers: {},
+    notificationRouting: {
+      urgent: [],
+      action: [],
+      warning: [],
+      info: [],
+    },
+    reactions: {},
+  };
+}
+
+interface StubExecutor extends AgentStageExecutor {
+  setNextOutcome(outcome: StageOutcome): void;
+  inflightCount(): number;
+}
+
+function buildStubExecutor(): StubExecutor {
+  let nextOutcome: StageOutcome = { status: "running" };
+  const inflight = new Set<string>();
+  return {
+    setNextOutcome: (o) => {
+      nextOutcome = o;
+    },
+    inflightCount: () => inflight.size,
+    async startStage(input: StartStageInput): Promise<RunningAgentStage> {
+      inflight.add(input.stageRunId);
+      return {
+        runId: input.runId,
+        stageRunId: input.stageRunId,
+        stageName: input.stage.name,
+        sessionId: `mock-${input.stageRunId}`,
+        workspacePath: "/tmp/mock-workspace",
+        startedAt: Date.now(),
+        input,
+      };
+    },
+    async pollStage(handle: RunningAgentStage): Promise<StageOutcome> {
+      if (nextOutcome.status !== "running") {
+        inflight.delete(handle.stageRunId);
+      }
+      return nextOutcome;
+    },
+    async cancelStage(handle: RunningAgentStage): Promise<void> {
+      inflight.delete(handle.stageRunId);
+    },
+  };
+}
+
+function makePR(): PRInfo {
+  return {
+    number: 99,
+    url: "https://github.com/org/test-project/pull/99",
+    title: "Add feature",
+    owner: "org",
+    repo: "test-project",
+    branch: "feat/x",
+    baseBranch: "main",
+    isDraft: false,
+  };
+}
+
+function makeSession(pr: PRInfo): Session {
+  // session.pr is set from the start so populatePREnrichmentCache fills the
+  // batch cache (including headSha) BEFORE checkSession runs. lifecycle.pr
+  // is still "none" — flips to "open" inside determineStatus on the first
+  // poll, which is the transition the bridge fires on. This models the
+  // "PR is opened and observed in the same poll" case end-to-end.
+  const lifecycle = {
+    version: 2 as const,
+    session: {
+      kind: "worker" as const,
+      state: "working" as const,
+      reason: "task_in_progress" as const,
+      startedAt: new Date().toISOString(),
+      completedAt: null,
+      terminatedAt: null,
+      lastTransitionAt: new Date().toISOString(),
+    },
+    pr: {
+      state: "none" as const,
+      reason: "not_created" as const,
+      number: null,
+      url: null,
+      lastObservedAt: null,
+    },
+    runtime: {
+      state: "alive" as const,
+      reason: "process_running" as const,
+      lastObservedAt: new Date().toISOString(),
+      handle: { id: "rt-1", runtimeName: "stub", data: {} },
+      tmuxName: null,
+    },
+  };
+  return {
+    id: SESSION_ID,
+    projectId: PROJECT_ID,
+    status: "working",
+    activity: "active",
+    activitySignal: {
+      state: "valid",
+      activity: "active",
+      timestamp: new Date(),
+      source: "native",
+    },
+    lifecycle,
+    branch: "feat/x",
+    issueId: null,
+    pr,
+    workspacePath: "/tmp/ws",
+    runtimeHandle: { id: "rt-1", runtimeName: "stub", data: {} },
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: { project: PROJECT_ID, status: "working", worktree: "/tmp/ws" },
+  };
+}
+
+function buildAgentManifest(): PluginManifest {
+  return {
+    name: "stub-agent",
+    slot: "agent",
+    description: "integration-test stub agent",
+    version: "0.0.0",
+    supportedTaskModes: ["review"],
+  };
+}
+
+function buildStubAgent(): Agent {
+  return {
+    name: "stub-agent",
+    processName: "stub-agent",
+    getLaunchCommand: () => "stub-agent --start",
+    getEnvironment: () => ({}),
+    detectActivity: () => "active" as ActivityState,
+    getActivityState: async () => ({ state: "active" as ActivityState }),
+    isProcessRunning: async () => true,
+    getSessionInfo: async () => null,
+  };
+}
+
+function buildStubRuntime(): Runtime {
+  return {
+    name: "stub",
+    create: async () => ({ id: "rt-1", runtimeName: "stub", data: {} }),
+    destroy: async () => undefined,
+    sendMessage: async () => undefined,
+    getOutput: async () => "",
+    isAlive: async () => true,
+  };
+}
+
+function buildStubSCM(pr: PRInfo, headSha: string): SCM {
+  return {
+    name: "github",
+    detectPR: vi.fn().mockResolvedValue(pr),
+    getPRState: async () => "open",
+    mergePR: async () => undefined,
+    closePR: async () => undefined,
+    getCIChecks: async () => [],
+    getCISummary: async () => "passing",
+    getReviews: async () => [],
+    getReviewDecision: async () => "none",
+    getPendingComments: async () => [],
+    getMergeability: async () => ({
+      mergeable: false,
+      ciPassing: true,
+      approved: false,
+      noConflicts: true,
+      blockers: [],
+    }),
+    enrichSessionsPRBatch: vi.fn().mockImplementation(async (prs: PRInfo[]) => {
+      const result = new Map<string, PREnrichmentData>();
+      for (const p of prs) {
+        result.set(`${p.owner}/${p.repo}#${p.number}`, {
+          state: "open",
+          ciStatus: "passing",
+          reviewDecision: "none",
+          mergeable: false,
+          headSha,
+        });
+      }
+      return result;
+    }),
+  };
+}
+
+function buildRegistry(scm: SCM, agentManifest: PluginManifest): PluginRegistry {
+  const agent = buildStubAgent();
+  const runtime = buildStubRuntime();
+  return {
+    register: () => {},
+    get: (slot: string, name?: string) => {
+      if (slot === "scm") return scm;
+      if (slot === "agent") {
+        if (!name || name === agent.name) return agent;
+      }
+      if (slot === "runtime") return runtime;
+      return null;
+    },
+    list: (slot: string) => {
+      if (slot === "agent") return [agentManifest];
+      return [];
+    },
+    loadBuiltins: async () => {},
+    loadFromConfig: async () => {},
+  } as PluginRegistry;
+}
+
+function buildSessionManager(session: Session): OpenCodeSessionManager {
+  return {
+    list: vi.fn().mockResolvedValue([session]),
+    get: vi.fn().mockResolvedValue(session),
+    spawn: async () => {
+      throw new Error("stub spawn — should not be called");
+    },
+    spawnOrchestrator: async () => {
+      throw new Error("stub spawnOrchestrator — should not be called");
+    },
+    ensureOrchestrator: async () => {
+      throw new Error("stub ensureOrchestrator — should not be called");
+    },
+    restore: async () => {
+      throw new Error("stub restore — should not be called");
+    },
+    kill: async () => ({ cleaned: false, alreadyTerminated: true }),
+    cleanup: async () => ({ killed: [], skipped: [], errors: [] }),
+    send: async () => undefined,
+    claimPR: async () => {
+      throw new Error("stub claimPR — should not be called");
+    },
+    remap: async () => "",
+    listCached: async () => [session],
+    invalidateCache: () => {},
+  } as OpenCodeSessionManager;
+}
+
+async function waitForRunDone(
+  engine: PipelineEngine,
+  timeoutMs: number,
+): Promise<RunState> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const state = engine.state();
+    for (const run of Object.values(state.runs)) {
+      if (
+        run.pipelineName === PIPELINE_NAME &&
+        run.sessionId === SESSION_ID &&
+        run.loopState === "done"
+      ) {
+        return run;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(
+    `Timed out waiting for run.loopState=done; current=${JSON.stringify(
+      Object.values(engine.state().runs).map((r) => ({
+        id: r.runId,
+        loop: r.loopState,
+        stages: Object.fromEntries(
+          Object.entries(r.stages).map(([n, s]) => [n, s.status]),
+        ),
+      })),
+    )}`,
+  );
+}
+
+describe("pipeline trigger bridge (PR opened → engine starts run → done)", () => {
+  let tmpRoot: string;
+  let lifecycle: LifecycleManager | null = null;
+  let engine: PipelineEngine | null = null;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), "ao-pipe-pr-trigger-"));
+  });
+
+  afterEach(async () => {
+    if (lifecycle) {
+      lifecycle.stop();
+      lifecycle = null;
+    }
+    if (engine) {
+      await engine.shutdown().catch(() => undefined);
+      engine = null;
+    }
+    await rm(tmpRoot, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it("opens a PR on a session → bridge fires pr.opened → run reaches done end-to-end", async () => {
+    const pr = makePR();
+    const config = buildConfig(join(tmpRoot, "agent-orchestrator.yaml"));
+    const session = makeSession(pr);
+    const scm = buildStubSCM(pr, "sha-init");
+    const registry = buildRegistry(scm, buildAgentManifest());
+    const sessionManager = buildSessionManager(session);
+    const executor = buildStubExecutor();
+    const store = createPipelineStore(join(tmpRoot, "pipelines"));
+
+    engine = createPipelineEngine({
+      store,
+      registry,
+      agentExecutor: executor,
+      initialState: hydrateEngineState(store),
+    });
+
+    lifecycle = createLifecycleManager({
+      config,
+      registry,
+      sessionManager,
+      projectId: PROJECT_ID,
+      pipelineEngine: engine,
+    });
+
+    // First check populates the PR enrichment cache and triggers the bridge.
+    // The bridge calls engine.startRun, which calls START_STAGE, which calls
+    // the stub executor. After this, exactly one inflight stage exists.
+    await lifecycle.check(SESSION_ID);
+    expect(executor.inflightCount()).toBe(1);
+
+    // Verify the run came from the right trigger.
+    const runsBefore = Object.values(engine.state().runs);
+    expect(runsBefore).toHaveLength(1);
+    expect(runsBefore[0].headSha).toBe("sha-init");
+    expect(runsBefore[0].sessionId).toBe(SESSION_ID);
+    expect(runsBefore[0].pipelineName).toBe(PIPELINE_NAME);
+
+    // Tell the stub executor the next poll completes the stage; start the
+    // lifecycle's 50ms poll loop so engine.tick() observes the outcome and
+    // drives the reducer to STAGE_COMPLETED → loopState=done.
+    executor.setNextOutcome({ status: "completed", artifacts: [] });
+    lifecycle.start(50);
+
+    const finalRun = await waitForRunDone(engine, 5_000);
+    expect(finalRun.loopState).toBe("done");
+    expect(finalRun.stages["lint"]?.status).toBe("succeeded");
+    expect(executor.inflightCount()).toBe(0);
+
+    // Persistence round-trip: a fresh store reads back the same terminal run.
+    const reloaded = store.loadRun(finalRun.runId);
+    expect(reloaded?.loopState).toBe("done");
+  });
+});

--- a/packages/plugins/scm-github/src/graphql-batch.ts
+++ b/packages/plugins/scm-github/src/graphql-batch.ts
@@ -1023,6 +1023,7 @@ function extractPREnrichment(
     hasConflicts,
     isBehind,
     blockers,
+    headSha,
     ...(ciChecks !== undefined ? { ciChecks } : {}),
   };
 


### PR DESCRIPTION
Closes #192.

## Summary

Third and final piece of the critical path: after this lands, single-stage agent pipelines auto-fire on PR events end-to-end on the fork.

- **PR-event → engine bridge** in `lifecycle-manager.ts`. On each poll, when a session's PR transitions `none→open`, `open→merged`, or the HEAD SHA changes on an open PR, the bridge dispatches the matching trigger (`pr.opened` / `pr.merged` / `NEW_SHA_DETECTED` + `pr.updated`) into the engine via `startRun` / `dispatch`. Only pipelines whose stages subscribe to the trigger are fired.
- **HEAD SHA surfaced** on `PREnrichmentData` so the bridge has the data without re-fetching per poll. `scm-github` already extracted the SHA for ETag caching — this just stops discarding it on the return path.
- **`ao pipeline run` rerouted** through a transient live engine (`getOneShotPipelineEngine`) so the CLI's manual dispatch actually spawns the stage instead of persistence-only no-op. The helper deliberately skips `reconcileInflightStages` so a CLI invocation cannot STAGE_FAILED a separately-running `ao start`'s in-flight stages.
- **Idempotency** is preserved at two levels: the bridge fires only on the actual state-transition edge (gated by `previousPRState` and an in-memory `lastPipelineSha` map), and the reducer's existing `run.headSha === sha` guard in `NEW_SHA_DETECTED` provides a second layer across restarts.

## Acceptance checklist

- [x] On PR state transition, dispatch `TRIGGER_FIRED` with the matching trigger for every pipeline whose stages subscribe
- [x] On HEAD SHA change for the linked worker session, dispatch `NEW_SHA_DETECTED`
- [x] `ao pipeline run` actually spawns the stage (no more silent persistence-only path)
- [x] Integration test: PR opened on a session → `pr.opened`-triggered pipeline reaches `done` end-to-end (`pipeline-pr-trigger.integration.test.ts`)
- [x] Bridge is idempotent across poll cycles (unit test asserts no duplicate runs when state is unchanged)

## Test plan

- [x] `pnpm build` at the repo root succeeds
- [x] `pnpm typecheck` clean across all packages
- [x] `pnpm exec eslint` clean on changed files
- [x] New unit tests in `core/src/__tests__/lifecycle-pipeline-bridge.test.ts` cover the six bridge behaviours (6/6 pass)
- [x] CLI service tests adapted to engine-routed path (21/21 pass)
- [x] Integration test in `integration-tests/src/pipeline-pr-trigger.integration.test.ts` drives PR-opened → `done` (1/1 pass)
- [x] Existing `pipeline-engine-lifecycle.integration.test.ts` still passes (2/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)