### PR TITLE
feat(pipelines): codeReview shim + migration + conflict check

### DIFF
--- a/packages/cli/__tests__/commands/pipeline.test.ts
+++ b/packages/cli/__tests__/commands/pipeline.test.ts
@@ -10,6 +10,7 @@ const { mockConfigRef, mockStore, mockRegistry } = vi.hoisted(() => ({
     loadStage: vi.fn(),
     appendArtifacts: vi.fn(),
     listArtifacts: vi.fn(),
+    replaceArtifacts: vi.fn(),
     saveLoopState: vi.fn(),
     loadLoopState: vi.fn(),
   },
@@ -494,9 +495,9 @@ describe("ao pipeline resume", () => {
 });
 
 describe("ao pipeline migrate", () => {
-  it("prints a no-op message", async () => {
+  it("prints an idempotent no-op message when the store has no findings to backfill", async () => {
     await program.parseAsync(["node", "test", "pipeline", "migrate"]);
     const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
-    expect(out).toMatch(/v0\.3/);
+    expect(out).toMatch(/already migrated/);
   });
 });

--- a/packages/cli/__tests__/lib/pipeline-service.test.ts
+++ b/packages/cli/__tests__/lib/pipeline-service.test.ts
@@ -63,6 +63,9 @@ function createMockStore(): {
     listArtifacts: vi.fn((runId, stageRunId) => {
       return state.artifacts.get(`${runId}:${stageRunId}`) ?? [];
     }),
+    replaceArtifacts: vi.fn((runId, stageRunId, artifacts) => {
+      state.artifacts.set(`${runId}:${stageRunId}`, [...artifacts]);
+    }),
     saveLoopState: vi.fn((runId, loop) => {
       state.loops.set(runId, loop);
     }),
@@ -663,10 +666,11 @@ describe("resumeRun", () => {
 });
 
 describe("migrateStore", () => {
-  it("returns a no-op result for the v0.3 schema", () => {
+  it("is a no-op on an empty store (idempotency baseline)", () => {
     const { store } = createMockStore();
     const result = migrateStore(store);
     expect(result.migrated).toBe(0);
-    expect(result.message).toMatch(/v0\.3/);
+    expect(result.filesRewritten).toBe(0);
+    expect(result.message).toMatch(/already migrated/);
   });
 });

--- a/packages/cli/src/commands/pipeline.ts
+++ b/packages/cli/src/commands/pipeline.ts
@@ -388,7 +388,9 @@ export function registerPipeline(program: Command): void {
 
   pipeline
     .command("migrate")
-    .description("Run the pipeline store schema migration helper")
+    .description(
+      "Backfill missing finding fingerprints in the pipeline store (idempotent)",
+    )
     .option("-p, --project <id>", "Project to scope to")
     .option("--json", "Output as JSON")
     .action((opts: { project?: string; json?: boolean }) => {
@@ -401,7 +403,8 @@ export function registerPipeline(program: Command): void {
           return;
         }
 
-        console.log(chalk.green(`✓ ${result.message}`));
+        const icon = result.migrated === 0 ? chalk.dim("·") : chalk.green("✓");
+        console.log(`${icon} ${result.message}`);
       } catch (err) {
         fail(err);
       }

--- a/packages/cli/src/lib/pipeline-service.ts
+++ b/packages/cli/src/lib/pipeline-service.ts
@@ -21,11 +21,13 @@ import {
   hydrateEngineState,
   isTerminalLoopState,
   loopKey,
+  migrateStore as coreMigrateStore,
   reduce,
   type Artifact,
   type ConfiguredPipeline,
   type EngineState,
   type LoopState,
+  type MigrateResult as CoreMigrateResult,
   type OrchestratorConfig,
   type PersistedStageRun,
   type Pipeline,
@@ -374,20 +376,15 @@ export function resumeRun(
 }
 
 /**
- * Pipeline store-schema migration helper. v0.3 ships no schema changes yet —
- * the helper exists so the verb is wired and stable; future schema bumps
- * (the v0.4+ run-versioning epic) plug in here without churning the CLI.
+ * Pipeline store migration. Backfills missing finding fingerprints (scoped
+ * by stage name) so dismissals recorded against the legacy `codeReview:`
+ * flow keep matching post-migration artifacts (issue #193). Idempotent —
+ * see `pipeline/migrate.ts` for the scheme.
  */
-export interface MigrateResult {
-  migrated: number;
-  message: string;
-}
+export type MigrateResult = CoreMigrateResult;
 
-export function migrateStore(_store: PipelineStore): MigrateResult {
-  return {
-    migrated: 0,
-    message: "Pipeline store is already on the v0.3 schema — nothing to migrate.",
-  };
+export function migrateStore(store: PipelineStore): MigrateResult {
+  return coreMigrateStore(store);
 }
 
 /**

--- a/packages/core/src/__tests__/legacy-code-review.test.ts
+++ b/packages/core/src/__tests__/legacy-code-review.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Tests for the legacy `codeReview:` → single-stage pipeline migration shim
+ * (issue #193).
+ *
+ * Covers:
+ *   - Synthesis of the `legacy-code-review` pipeline from a `codeReview:` block.
+ *   - Hard error when both `codeReview:` and `pipelines:` are present.
+ *   - Fingerprint scoping (stage = `review`) — the property that lets prior
+ *     dismissals carry forward to post-migration artifacts.
+ *   - `migrateStore` idempotency.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { validateConfig } from "../config.js";
+import {
+  LEGACY_CODE_REVIEW_PIPELINE_NAME,
+  LEGACY_CODE_REVIEW_STAGE_NAME,
+  synthesizeLegacyCodeReviewPipeline,
+} from "../config-schema.js";
+import {
+  asPipelineId,
+  asRunId,
+  asStageRunId,
+  computeFindingFingerprint,
+  createPipelineStore,
+  migrateStore,
+  type Artifact,
+  type Pipeline,
+  type RunState,
+} from "../pipeline/index.js";
+
+// ============================================================================
+// Synthesis
+// ============================================================================
+
+describe("legacy codeReview shim — synthesis", () => {
+  it("synthesizes a single-stage `legacy-code-review` pipeline with the locked shape", () => {
+    const pipeline = synthesizeLegacyCodeReviewPipeline({});
+
+    expect(pipeline.name).toBe(LEGACY_CODE_REVIEW_PIPELINE_NAME);
+    expect(pipeline.stages).toHaveLength(1);
+
+    const stage = pipeline.stages[0];
+    expect(stage.name).toBe(LEGACY_CODE_REVIEW_STAGE_NAME);
+    expect(stage.trigger.on).toEqual(["pr.opened", "pr.updated"]);
+    expect(stage.executor.kind).toBe("agent");
+    if (stage.executor.kind !== "agent") throw new Error("non-agent executor");
+    expect(stage.executor.mode).toBe("review");
+    expect(stage.executor.plugin).toBe("claude-code");
+  });
+
+  it("respects agent / model / prompt overrides from the legacy block", () => {
+    const pipeline = synthesizeLegacyCodeReviewPipeline({
+      agent: "codex",
+      model: "o4",
+      prompt: "Review for security issues only.",
+    });
+
+    const stage = pipeline.stages[0];
+    if (stage.executor.kind !== "agent") throw new Error("non-agent executor");
+    expect(stage.executor.plugin).toBe("codex");
+    expect(stage.executor.config).toEqual({ model: "o4" });
+    expect(stage.task.prompt).toBe("Review for security issues only.");
+  });
+
+  it("installs the synthesized pipeline under project.pipelines at config load", () => {
+    const config = validateConfig({
+      projects: {
+        web: {
+          path: "/repos/web",
+          repo: "acme/web",
+          codeReview: { agent: "claude-code" },
+          storageKey: "storage-web",
+        },
+      },
+    });
+
+    const project = config.projects["web"];
+    expect(project.pipelines).toBeDefined();
+    expect(Object.keys(project.pipelines ?? {})).toEqual([
+      LEGACY_CODE_REVIEW_PIPELINE_NAME,
+    ]);
+
+    // `codeReview:` is stripped after synthesis — downstream only sees `pipelines:`.
+    expect((project as { codeReview?: unknown }).codeReview).toBeUndefined();
+
+    const synthesized = project.pipelines?.[LEGACY_CODE_REVIEW_PIPELINE_NAME];
+    expect(synthesized?.stages[0]?.name).toBe(LEGACY_CODE_REVIEW_STAGE_NAME);
+  });
+});
+
+// ============================================================================
+// Conflict check
+// ============================================================================
+
+describe("legacy codeReview shim — conflict with pipelines:", () => {
+  it("hard-errors when a project defines both `codeReview:` and `pipelines:`", () => {
+    const raw = {
+      projects: {
+        web: {
+          path: "/repos/web",
+          repo: "acme/web",
+          storageKey: "storage-web",
+          codeReview: { agent: "claude-code" },
+          pipelines: {
+            review: {
+              stages: [
+                {
+                  name: "review",
+                  trigger: { on: ["pr.opened"] },
+                  executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+                  task: { prompt: "review" },
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    expect(() => validateConfig(raw)).toThrow(
+      /defines both `codeReview:` and `pipelines:`/,
+    );
+  });
+
+  it("does NOT error when `pipelines:` is present but `codeReview:` is absent", () => {
+    expect(() =>
+      validateConfig({
+        projects: {
+          web: {
+            path: "/repos/web",
+            repo: "acme/web",
+            storageKey: "storage-web",
+            pipelines: {
+              review: {
+                stages: [
+                  {
+                    name: "review",
+                    trigger: { on: ["pr.opened"] },
+                    executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+                    task: { prompt: "review" },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ============================================================================
+// Fingerprint scoping & migrateStore
+// ============================================================================
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "migrate-store-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function makePipeline(): Pipeline {
+  return {
+    id: asPipelineId(LEGACY_CODE_REVIEW_PIPELINE_NAME),
+    name: LEGACY_CODE_REVIEW_PIPELINE_NAME,
+    stages: [
+      {
+        name: LEGACY_CODE_REVIEW_STAGE_NAME,
+        trigger: { on: ["pr.opened", "pr.updated"] },
+        executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+        task: {},
+      },
+    ],
+    maxConcurrentStages: 1,
+  };
+}
+
+function makeRun(): RunState {
+  return {
+    runId: asRunId("run-1"),
+    pipelineId: asPipelineId(LEGACY_CODE_REVIEW_PIPELINE_NAME),
+    pipelineName: LEGACY_CODE_REVIEW_PIPELINE_NAME,
+    sessionId: "ses-1",
+    pipelineConfigSnapshot: makePipeline(),
+    headSha: "sha-aaa",
+    loopState: "running",
+    loopRounds: 1,
+    stages: {
+      [LEGACY_CODE_REVIEW_STAGE_NAME]: {
+        stageRunId: asStageRunId("sr-1"),
+        status: "succeeded",
+        attempt: 1,
+        artifacts: [],
+      },
+    },
+    createdAt: "2026-05-04T00:00:00.000Z",
+    updatedAt: "2026-05-04T00:00:00.000Z",
+  };
+}
+
+function makeFinding(
+  artifactId: string,
+  overrides: Partial<Artifact> = {},
+): Artifact {
+  return {
+    kind: "finding",
+    filePath: "src/auth.ts",
+    startLine: 10,
+    endLine: 20,
+    title: "Missing input validation",
+    description: "Validate the token format before parsing.",
+    category: "security",
+    severity: "warning",
+    confidence: 0.8,
+    anchorSignature: "verifyToken",
+    artifactId: artifactId as Artifact["artifactId"],
+    pipelineRunId: asRunId("run-1"),
+    stageRunId: asStageRunId("sr-1"),
+    stageName: LEGACY_CODE_REVIEW_STAGE_NAME,
+    status: "open",
+    createdAt: "2026-05-04T00:00:00.000Z",
+    ...overrides,
+  } as Artifact;
+}
+
+describe("computeFindingFingerprint", () => {
+  it("scopes the fingerprint by stage name so the same finding under a different stage hashes differently", () => {
+    const finding = makeFinding("a-1");
+    const a = computeFindingFingerprint(
+      finding as Artifact & { kind: "finding" },
+      "review",
+    );
+    const b = computeFindingFingerprint(
+      finding as Artifact & { kind: "finding" },
+      "audit",
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it("is stable across calls with the same inputs", () => {
+    const finding = makeFinding("a-1");
+    const a = computeFindingFingerprint(
+      finding as Artifact & { kind: "finding" },
+      "review",
+    );
+    const b = computeFindingFingerprint(
+      finding as Artifact & { kind: "finding" },
+      "review",
+    );
+    expect(a).toBe(b);
+  });
+});
+
+describe("migrateStore", () => {
+  it("backfills missing fingerprints on findings, scoped by their stage name", () => {
+    const store = createPipelineStore(root);
+    const run = makeRun();
+    store.saveRun(run);
+    const a = makeFinding("a-1");
+    const b = makeFinding("a-2", { startLine: 50, endLine: 55, title: "Another issue" });
+    store.appendArtifacts(run.runId, asStageRunId("sr-1"), [a, b]);
+
+    const result = migrateStore(store);
+
+    expect(result.migrated).toBe(2);
+    expect(result.filesRewritten).toBe(1);
+
+    const migrated = store.listArtifacts(run.runId, asStageRunId("sr-1"));
+    expect(migrated).toHaveLength(2);
+    for (const artifact of migrated) {
+      if (artifact.kind !== "finding") throw new Error("expected finding");
+      expect(artifact.fingerprint).toBeDefined();
+      expect(artifact.fingerprint).toBe(
+        computeFindingFingerprint(artifact, LEGACY_CODE_REVIEW_STAGE_NAME),
+      );
+    }
+  });
+
+  it("is idempotent — a second run is a no-op", () => {
+    const store = createPipelineStore(root);
+    const run = makeRun();
+    store.saveRun(run);
+    store.appendArtifacts(run.runId, asStageRunId("sr-1"), [makeFinding("a-1")]);
+
+    const first = migrateStore(store);
+    expect(first.migrated).toBe(1);
+
+    const before = store.listArtifacts(run.runId, asStageRunId("sr-1"));
+    const second = migrateStore(store);
+    const after = store.listArtifacts(run.runId, asStageRunId("sr-1"));
+
+    expect(second.migrated).toBe(0);
+    expect(second.filesRewritten).toBe(0);
+    expect(after).toEqual(before);
+  });
+
+  it("preserves fingerprints already set — carries forward dismissals across migration", () => {
+    const store = createPipelineStore(root);
+    const run = makeRun();
+    store.saveRun(run);
+    const pre = computeFindingFingerprint(
+      makeFinding("a-1") as Artifact & { kind: "finding" },
+      LEGACY_CODE_REVIEW_STAGE_NAME,
+    );
+    store.appendArtifacts(run.runId, asStageRunId("sr-1"), [
+      makeFinding("a-1", { fingerprint: pre, status: "dismissed" }),
+    ]);
+
+    const result = migrateStore(store);
+    expect(result.migrated).toBe(0);
+
+    const after = store.listArtifacts(run.runId, asStageRunId("sr-1"));
+    expect(after).toHaveLength(1);
+    if (after[0].kind !== "finding") throw new Error("expected finding");
+    expect(after[0].fingerprint).toBe(pre);
+    expect(after[0].status).toBe("dismissed");
+  });
+
+  it("leaves JSON artifacts untouched (no fingerprint scheme for non-finding kinds)", () => {
+    const store = createPipelineStore(root);
+    const run = makeRun();
+    store.saveRun(run);
+    const jsonArtifact: Artifact = {
+      kind: "json",
+      data: { score: 0.5 },
+      artifactId: "j-1" as Artifact["artifactId"],
+      pipelineRunId: asRunId("run-1"),
+      stageRunId: asStageRunId("sr-1"),
+      stageName: LEGACY_CODE_REVIEW_STAGE_NAME,
+      status: "open",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    } as Artifact;
+    store.appendArtifacts(run.runId, asStageRunId("sr-1"), [jsonArtifact]);
+
+    const result = migrateStore(store);
+    expect(result.migrated).toBe(0);
+    expect(store.listArtifacts(run.runId, asStageRunId("sr-1"))).toEqual([jsonArtifact]);
+  });
+
+  it("reports zero migrated when the store is empty", () => {
+    const store = createPipelineStore(root);
+    const result = migrateStore(store);
+    expect(result.migrated).toBe(0);
+    expect(result.filesRewritten).toBe(0);
+    expect(result.message).toMatch(/already migrated/);
+  });
+});

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -1,0 +1,83 @@
+/**
+ * Legacy `codeReview:` config shim.
+ *
+ * Upstream's pre-pipelines world had a top-level `codeReview:` block per
+ * project. v0 of the pipelines epic (this branch) collapses that surface
+ * onto the single-stage pipeline path so the engine has one code path,
+ * not two.
+ *
+ * This module defines:
+ *   - LegacyCodeReviewSchema — Zod for the optional `codeReview:` YAML block
+ *   - synthesizeLegacyCodeReviewPipeline — turns it into a ConfiguredPipeline
+ *
+ * The synthesized pipeline is named `legacy-code-review` and contains a
+ * single stage named `review`. The stage name is part of every
+ * artifact fingerprint, so naming it `review` is what lets dismissals
+ * recorded against the legacy code-review keep matching new pipeline
+ * artifacts after migration.
+ */
+
+import { z } from "zod";
+
+import type { ConfiguredPipeline } from "./pipeline/config-schema.js";
+
+/** Map-key the synthesized pipeline is registered under in `project.pipelines`. */
+export const LEGACY_CODE_REVIEW_PIPELINE_NAME = "legacy-code-review";
+
+/** Name of the single stage inside the synthesized pipeline. Used for fingerprint scoping. */
+export const LEGACY_CODE_REVIEW_STAGE_NAME = "review";
+
+/** Default agent plugin if the legacy block omits one. */
+const DEFAULT_LEGACY_AGENT = "claude-code";
+
+/**
+ * Schema for the legacy `codeReview:` block. Intentionally permissive
+ * (passthrough) — upstream configs may carry fields we don't surface yet,
+ * and silently dropping them on synthesis is preferable to refusing to load.
+ */
+export const LegacyCodeReviewSchema = z
+  .object({
+    /** Agent plugin name (e.g. "claude-code"). Defaults to "claude-code". */
+    agent: z.string().min(1).optional(),
+    /** Optional model override (passed through to the agent executor config). */
+    model: z.string().min(1).optional(),
+    /** Optional prompt body injected into the review stage's task. */
+    prompt: z.string().optional(),
+  })
+  .passthrough();
+
+export type LegacyCodeReview = z.infer<typeof LegacyCodeReviewSchema>;
+
+/**
+ * Turn a legacy `codeReview:` block into a one-stage ConfiguredPipeline.
+ *
+ * Locked decisions (from issue #193 acceptance):
+ *   - pipeline name: "legacy-code-review"
+ *   - stage name:    "review"            (fingerprint scope key)
+ *   - trigger.on:    ["pr.opened", "pr.updated"]
+ *   - executor.mode: "review"
+ */
+export function synthesizeLegacyCodeReviewPipeline(
+  legacy: LegacyCodeReview,
+): ConfiguredPipeline {
+  const plugin = legacy.agent ?? DEFAULT_LEGACY_AGENT;
+  const executorConfig: Record<string, unknown> = {};
+  if (legacy.model !== undefined) executorConfig["model"] = legacy.model;
+
+  return {
+    name: LEGACY_CODE_REVIEW_PIPELINE_NAME,
+    stages: [
+      {
+        name: LEGACY_CODE_REVIEW_STAGE_NAME,
+        trigger: { on: ["pr.opened", "pr.updated"] },
+        executor: {
+          kind: "agent",
+          plugin,
+          mode: "review",
+          ...(Object.keys(executorConfig).length > 0 ? { config: executorConfig } : {}),
+        },
+        task: legacy.prompt !== undefined ? { prompt: legacy.prompt } : {},
+      },
+    ],
+  };
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -33,6 +33,11 @@ import {
 } from "./global-config.js";
 import { loadEffectiveProjectConfig } from "./project-resolver.js";
 import { PipelinesConfigSchema } from "./pipeline/config-schema.js";
+import {
+  LEGACY_CODE_REVIEW_PIPELINE_NAME,
+  LegacyCodeReviewSchema,
+  synthesizeLegacyCodeReviewPipeline,
+} from "./config-schema.js";
 
 function inferScmPlugin(project: {
   repo?: string;
@@ -268,6 +273,14 @@ const ProjectConfigSchema = z.object({
     .optional(),
   opencodeIssueSessionStrategy: z.enum(["reuse", "delete", "ignore"]).optional(),
   pipelines: PipelinesConfigSchema.optional(),
+  /**
+   * Legacy single-stage code-review block. When present, `validateConfig`
+   * synthesizes a `legacy-code-review` pipeline and registers it under
+   * `project.pipelines`. Cannot coexist with an explicit `pipelines:` block —
+   * the conflict is reported at load time so operators don't silently lose
+   * one or the other (issue #193).
+   */
+  codeReview: LegacyCodeReviewSchema.optional(),
 });
 
 const DefaultPluginsSchema = z.object({
@@ -973,6 +986,39 @@ export function loadConfigWithPath(configPath?: string): {
   return { config: config as LoadedConfig, path };
 }
 
+/**
+ * Walk projects: if `codeReview:` is present, synthesize the
+ * `legacy-code-review` pipeline and install it in `project.pipelines`. Hard
+ * error if both `codeReview:` and `pipelines:` are set on the same project so
+ * operators see the conflict immediately instead of one silently winning.
+ *
+ * The legacy field is stripped after synthesis so downstream consumers only
+ * ever see the unified `pipelines` shape — there is no "is this a synthesized
+ * pipeline" branch elsewhere in the codebase.
+ */
+function applyLegacyCodeReviewShim(config: OrchestratorConfig): OrchestratorConfig {
+  for (const [projectId, project] of Object.entries(config.projects)) {
+    const legacy = (project as { codeReview?: z.infer<typeof LegacyCodeReviewSchema> })
+      .codeReview;
+    if (legacy === undefined) continue;
+
+    if (project.pipelines && Object.keys(project.pipelines).length > 0) {
+      throw new Error(
+        `Project "${projectId}" defines both \`codeReview:\` and \`pipelines:\`. ` +
+          `These are mutually exclusive — \`codeReview:\` is the legacy shim that ` +
+          `synthesizes a \`${LEGACY_CODE_REVIEW_PIPELINE_NAME}\` pipeline, and you ` +
+          `already have a \`pipelines:\` block. Remove one. To finish the migration, ` +
+          `run \`ao pipeline migrate\` and drop the legacy \`codeReview:\` block.`,
+      );
+    }
+
+    const synthesized = synthesizeLegacyCodeReviewPipeline(legacy);
+    project.pipelines = { [LEGACY_CODE_REVIEW_PIPELINE_NAME]: synthesized };
+    delete (project as { codeReview?: unknown }).codeReview;
+  }
+  return config;
+}
+
 /** Validate a raw config object */
 export function validateConfig(raw: unknown): OrchestratorConfig {
   const validated = OrchestratorConfigSchema.parse(raw);
@@ -981,6 +1027,7 @@ export function validateConfig(raw: unknown): OrchestratorConfig {
   config = expandPaths(config);
   config = applyProjectDefaults(config);
   config = applyDefaultReactions(config);
+  config = applyLegacyCodeReviewShim(config);
 
   // Collect external plugin configs from inline tracker/scm/notifier configs
   // and merge them into config.plugins for loading

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -447,7 +447,19 @@ export {
   ConfiguredPipelineSchema,
   PipelinesConfigSchema,
   configuredPipelineToRuntime,
+  // Store migration — fingerprint-preserving backfill (issue #193)
+  computeFindingFingerprint,
+  migrateStore,
 } from "./pipeline/index.js";
+
+// Legacy `codeReview:` shim — synthesizes a single-stage pipeline (issue #193)
+export {
+  LEGACY_CODE_REVIEW_PIPELINE_NAME,
+  LEGACY_CODE_REVIEW_STAGE_NAME,
+  LegacyCodeReviewSchema,
+  synthesizeLegacyCodeReviewPipeline,
+} from "./config-schema.js";
+export type { LegacyCodeReview } from "./config-schema.js";
 
 export type {
   // IDs
@@ -507,6 +519,7 @@ export type {
   StartRunInput,
   ConfiguredPipeline,
   PipelinesConfig,
+  MigrateResult,
 } from "./pipeline/index.js";
 
 export {

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -56,3 +56,9 @@ export {
   type ConfiguredPipeline,
   type PipelinesConfig,
 } from "./config-schema.js";
+
+export {
+  computeFindingFingerprint,
+  migrateStore,
+  type MigrateResult,
+} from "./migrate.js";

--- a/packages/core/src/pipeline/migrate.ts
+++ b/packages/core/src/pipeline/migrate.ts
@@ -1,0 +1,100 @@
+/**
+ * Pipeline store migration.
+ *
+ * v0.3 introduces stable, stage-scoped fingerprints on finding artifacts so
+ * dismissals recorded against the legacy `codeReview:` flow survive the
+ * migration to single-stage pipelines (issue #193). This module walks the
+ * flat-file store, backfills any finding artifact missing a fingerprint, and
+ * rewrites only the JSONL files that changed.
+ *
+ * Idempotent by construction: a second invocation sees every finding already
+ * has a fingerprint and reports 0 migrated.
+ *
+ * Fingerprint scheme: SHA-256 over a NUL-delimited tuple of
+ *   stageName · filePath · anchorSignature|"L<start>:<end>" · category · title
+ * truncated to 16 hex chars. The stage name is part of the input on purpose
+ * — synthesizing the legacy code-review pipeline with stage `"review"` is
+ * what makes pre-migration dismissals continue to match post-migration
+ * artifacts.
+ */
+
+import { createHash } from "node:crypto";
+
+import type { PipelineStore } from "./store.js";
+import type { Artifact, FindingArtifactInput } from "./types.js";
+
+export interface MigrateResult {
+  /** Number of finding artifacts whose fingerprints were backfilled. */
+  migrated: number;
+  /** Number of stage-artifact JSONL files rewritten. */
+  filesRewritten: number;
+  /** Human-readable summary, suitable for direct CLI output. */
+  message: string;
+}
+
+/**
+ * Compute the canonical fingerprint for a finding artifact under a given stage.
+ *
+ * Treats `anchorSignature` (function/class name from the executor) as the
+ * stable anchor when present; falls back to a line range otherwise. The line
+ * range fallback is intentionally fragile — without an anchor a diff that
+ * shifts the finding by even one line invalidates the fingerprint, which is
+ * the correct behaviour for "we don't actually know what this attaches to".
+ */
+export function computeFindingFingerprint(
+  finding: Pick<
+    FindingArtifactInput,
+    "filePath" | "startLine" | "endLine" | "title" | "category" | "anchorSignature"
+  >,
+  stageName: string,
+): string {
+  const anchor =
+    finding.anchorSignature && finding.anchorSignature.length > 0
+      ? finding.anchorSignature
+      : `L${finding.startLine}:${finding.endLine}`;
+  const parts = [stageName, finding.filePath, anchor, finding.category, finding.title];
+  return createHash("sha256").update(parts.join("\0")).digest("hex").slice(0, 16);
+}
+
+function isFinding(a: Artifact): a is Artifact & { kind: "finding" } {
+  return a.kind === "finding";
+}
+
+/**
+ * Walk the store, backfill missing fingerprints on finding artifacts, and
+ * rewrite affected JSONL files. Safe to re-run.
+ *
+ * Only `kind: "finding"` artifacts are touched. JSON artifacts (`kind:
+ * "json"`) carry no fingerprint and are passed through unchanged.
+ */
+export function migrateStore(store: PipelineStore): MigrateResult {
+  let migrated = 0;
+  let filesRewritten = 0;
+
+  for (const run of store.listRuns()) {
+    for (const [stageName, stageState] of Object.entries(run.stages)) {
+      const artifacts = store.listArtifacts(run.runId, stageState.stageRunId);
+      if (artifacts.length === 0) continue;
+
+      let stageChanged = 0;
+      const next: Artifact[] = artifacts.map((a) => {
+        if (!isFinding(a) || a.fingerprint) return a;
+        stageChanged++;
+        return { ...a, fingerprint: computeFindingFingerprint(a, stageName) };
+      });
+
+      if (stageChanged > 0) {
+        store.replaceArtifacts(run.runId, stageState.stageRunId, next);
+        migrated += stageChanged;
+        filesRewritten++;
+      }
+    }
+  }
+
+  const message =
+    migrated === 0
+      ? "Pipeline store is already migrated — every finding already carries a fingerprint."
+      : `Backfilled fingerprints on ${migrated} finding(s) across ${filesRewritten} stage file(s).`;
+
+  return { migrated, filesRewritten, message };
+}

--- a/packages/core/src/pipeline/store.ts
+++ b/packages/core/src/pipeline/store.ts
@@ -27,6 +27,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  unlinkSync,
 } from "node:fs";
 import { join } from "node:path";
 
@@ -63,6 +64,12 @@ export interface PipelineStore {
 
   appendArtifacts(runId: RunId, stageRunId: StageRunId, artifacts: Artifact[]): void;
   listArtifacts(runId: RunId, stageRunId: StageRunId): Artifact[];
+  /**
+   * Atomically replace the artifact file for a stage run. Used by
+   * `migrateStore` to rewrite a JSONL with backfilled fingerprints — the
+   * normal append path can't update existing lines in place.
+   */
+  replaceArtifacts(runId: RunId, stageRunId: StageRunId, artifacts: Artifact[]): void;
 
   saveLoopState(runId: RunId, loopState: LoopState): void;
   loadLoopState(runId: RunId): LoopState | null;
@@ -133,6 +140,17 @@ export function createPipelineStore(root: string): PipelineStore {
         out.push(JSON.parse(trimmed) as Artifact);
       }
       return out;
+    },
+
+    replaceArtifacts(runId, stageRunId, artifacts) {
+      const path = artifactsFilePath(root, runId, stageRunId);
+      if (artifacts.length === 0) {
+        if (existsSync(path)) unlinkSync(path);
+        return;
+      }
+      ensureDir(artifactsDirForRun(root, runId));
+      const body = artifacts.map((a) => JSON.stringify(a)).join("\n") + "\n";
+      atomicWriteFileSync(path, body);
     },
 
     saveLoopState(runId, loopState) {


### PR DESCRIPTION
## Summary

Implements the legacy `codeReview:` → single-stage pipeline migration shim and replaces the no-op `migrateStore` stub with a real, fingerprint-preserving store migration. Closes #193.

### What this adds

- **Legacy `codeReview:` block** (`packages/core/src/config-schema.ts`)
  - Optional Zod schema (`LegacyCodeReviewSchema`), passthrough for forward-compat with upstream fields.
  - `synthesizeLegacyCodeReviewPipeline(...)` produces a one-stage `ConfiguredPipeline` with the locked shape:
    - pipeline name: `legacy-code-review`
    - stage name: `review` *(fingerprint scope key — see below)*
    - `trigger.on: ["pr.opened", "pr.updated"]`
    - `executor.kind: "agent"`, `executor.mode: "review"`
- **Config-load wiring** (`packages/core/src/config.ts`)
  - `applyLegacyCodeReviewShim` runs after `applyDefaultReactions`. If `codeReview:` is set, it synthesizes the pipeline and installs it under `project.pipelines`, then strips the legacy field so downstream code never sees two shapes.
  - **Hard error** when both `codeReview:` and `pipelines:` are defined on the same project — the user is told which one to remove, not left guessing why one was silently dropped.
- **Real `migrateStore`** (`packages/core/src/pipeline/migrate.ts`)
  - Walks every run/stage and backfills missing fingerprints on `kind: "finding"` artifacts, scoped by the stage name. Naming the synthesized stage `review` is exactly what makes pre-migration dismissals keep matching post-migration artifacts.
  - **Idempotent**: a second invocation sees every finding already has a fingerprint and reports `migrated: 0`.
  - Fingerprint scheme: `SHA-256(stageName · filePath · anchorSignature|L<start>:<end> · category · title)` truncated to 16 hex chars.
- **Store API** (`packages/core/src/pipeline/store.ts`)
  - `replaceArtifacts(runId, stageRunId, artifacts)` so the migration can rewrite a stage's JSONL in place (the append-only `appendArtifacts` can't update existing lines).
- **CLI** (`packages/cli/src/commands/pipeline.ts`, `packages/cli/src/lib/pipeline-service.ts`)
  - `ao pipeline migrate` now actually does work and shows a clear backfill / already-migrated message.

### Tests

`packages/core/src/__tests__/legacy-code-review.test.ts` covers:
- Synthesis (default agent, agent / model / prompt overrides, install under `project.pipelines`).
- Conflict-error when `codeReview:` + `pipelines:` coexist; happy path when only `pipelines:` is present.
- Fingerprint scoping — same finding under a different stage hashes differently; same inputs hash deterministically.
- `migrateStore`: backfill correctness, idempotency on second run, fingerprint preservation (dismissed status carries forward), JSON-artifact pass-through, empty-store no-op.

Existing CLI tests are refit for the new migrate message and the mock store gains `replaceArtifacts`.

## Test plan

- [x] `pnpm --filter @aoagents/ao-core test` — 1332 tests passing (includes 12 new tests).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — 0 errors.
- [x] `pnpm build` — full repo build green.
- [x] Pre-existing failures verified on origin/pipelines baseline (path-equality `~` on macOS, `pipeline run > triggers a manual run`, the kimicode / runtime-process `Failed Suite` issues) — not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)