### PR TITLE
feat(pipelines): builtin executors (router + compose) + BuiltinTaskContext

### DIFF
--- a/packages/core/src/__tests__/pipeline-builtin-executors.test.ts
+++ b/packages/core/src/__tests__/pipeline-builtin-executors.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Tests for the builtin executors (router + compose) and the engine wiring
+ * that dispatches them.
+ *
+ * Coverage:
+ *  - router success: alive worker → ctx.sendToSession called once per input
+ *    stage; STAGE_COMPLETED records a `delivered` JSON artifact per stage
+ *  - router worker-dead: terminal/missing worker → no send, observation
+ *    `pipeline.send.skipped_worker_dead` emitted, `delivery_failed` artifact
+ *    recorded, run still succeeds (router verdict is neutral)
+ *  - compose: merges multiple upstream artifact lists into one JSON artifact
+ *
+ * The engine is exercised end-to-end with a 2-stage pipeline: an upstream
+ * agent stage produces findings, then the downstream builtin consumes them
+ * via `dependsOn`.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  asPipelineId,
+  createPipelineEngine,
+  createPipelineStore,
+  type AgentStageExecutor,
+  type ArtifactInput,
+  type Pipeline,
+  type RunningAgentStage,
+  type Stage,
+  type StageOutcome,
+  type StartStageInput,
+  type TaskMode,
+} from "../pipeline/index.js";
+import { createPluginRegistry } from "../plugin-registry.js";
+import type { Agent, PluginManifest, PluginModule, PluginRegistry } from "../types.js";
+
+let storeRoot: string;
+
+beforeEach(() => {
+  storeRoot = mkdtempSync(join(tmpdir(), "pipeline-builtin-"));
+});
+
+afterEach(() => {
+  rmSync(storeRoot, { recursive: true, force: true });
+});
+
+function makeAgentPlugin(name: string, modes: TaskMode[]): PluginModule<Agent> {
+  const manifest: PluginManifest = {
+    name,
+    slot: "agent",
+    description: "test",
+    version: "0.0.0",
+    supportedTaskModes: modes,
+  };
+  return {
+    manifest,
+    create: () =>
+      ({
+        name,
+        processName: name,
+        getLaunchCommand: () => "true",
+        getEnvironment: () => ({}),
+        detectActivity: () => "idle",
+        getActivityState: async () => null,
+        isProcessRunning: async () => true,
+        getSessionInfo: async () => null,
+      }) as Agent,
+  };
+}
+
+function withRegistry(plugins: PluginModule[]): PluginRegistry {
+  const r = createPluginRegistry();
+  for (const p of plugins) r.register(p);
+  return r;
+}
+
+interface MockExecutor extends AgentStageExecutor {
+  startCalls: StartStageInput[];
+  setNextOutcome: (outcome: StageOutcome) => void;
+}
+
+function makeMockAgentExecutor(): MockExecutor {
+  let nextOutcome: StageOutcome = { status: "running" };
+  const startCalls: StartStageInput[] = [];
+  const exec: MockExecutor = {
+    startCalls,
+    setNextOutcome: (o) => {
+      nextOutcome = o;
+    },
+    async startStage(input) {
+      startCalls.push(input);
+      return {
+        runId: input.runId,
+        stageRunId: input.stageRunId,
+        stageName: input.stage.name,
+        sessionId: `mock-ses-${startCalls.length}`,
+        workspacePath: "/tmp/mock",
+        startedAt: Date.now(),
+        input,
+      };
+    },
+    async pollStage(_h: RunningAgentStage) {
+      return nextOutcome;
+    },
+    async cancelStage() {
+      /* no-op */
+    },
+  };
+  return exec;
+}
+
+function makeAgentStage(name: string, overrides: Partial<Stage> = {}): Stage {
+  return {
+    name,
+    trigger: { on: ["pr.opened"] },
+    executor: { kind: "agent", plugin: "codex", mode: "review" },
+    task: { prompt: name },
+    ...overrides,
+  };
+}
+
+function makeBuiltinStage(
+  name: string,
+  builtinName: "router" | "compose",
+  dependsOn: string[],
+): Stage {
+  return {
+    name,
+    trigger: { on: ["pr.opened"] },
+    executor: { kind: "builtin", name: builtinName },
+    task: {},
+    dependsOn,
+  };
+}
+
+function makePipeline(stages: Stage[]): Pipeline {
+  return { id: asPipelineId("pl-builtin"), name: "builtin", stages, maxConcurrentStages: 1 };
+}
+
+const sampleFinding = (idx: number): ArtifactInput => ({
+  kind: "finding",
+  filePath: `src/file${idx}.ts`,
+  startLine: idx,
+  endLine: idx,
+  title: `Finding ${idx}`,
+  description: `Issue at line ${idx}`,
+  category: "general",
+  severity: "warning",
+  confidence: 0.9,
+});
+
+describe("pipeline builtin executors", () => {
+  describe("router", () => {
+    it("delivers upstream findings to the linked worker via sendToSession", async () => {
+      const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+      const store = createPipelineStore(storeRoot);
+      const agentExecutor = makeMockAgentExecutor();
+      const isSessionAlive = vi.fn(async () => true);
+      const sendToSession = vi.fn(async (_id: string, _msg: string) => {
+        /* delivered */
+      });
+
+      const engine = createPipelineEngine({
+        store,
+        registry,
+        agentExecutor,
+        builtin: { isSessionAlive, sendToSession },
+      });
+
+      const pipeline = makePipeline([
+        makeAgentStage("review"),
+        makeBuiltinStage("deliver", "router", ["review"]),
+      ]);
+
+      const runId = await engine.startRun({
+        pipeline,
+        projectId: "proj-a",
+        sessionId: "worker-session-1",
+        headSha: "sha",
+      });
+
+      // Upstream stage produces two findings, then completes.
+      agentExecutor.setNextOutcome({
+        status: "completed",
+        artifacts: [sampleFinding(1), sampleFinding(2)],
+      });
+      await engine.tick();
+
+      // Router runs synchronously as part of the upstream's STAGE_COMPLETED
+      // cascade, so by the time the tick resolves the whole pipeline is done.
+      const finalRun = store.loadRun(runId)!;
+      expect(finalRun.stages["deliver"]?.status).toBe("succeeded");
+      expect(finalRun.stages["deliver"]?.verdict).toBe("neutral");
+      expect(finalRun.loopState).toBe("done");
+
+      // Liveness probed exactly once; send called exactly once (one input stage)
+      expect(isSessionAlive).toHaveBeenCalledTimes(1);
+      expect(isSessionAlive).toHaveBeenCalledWith("worker-session-1");
+      expect(sendToSession).toHaveBeenCalledTimes(1);
+      expect(sendToSession.mock.calls[0]?.[0]).toBe("worker-session-1");
+      expect(sendToSession.mock.calls[0]?.[1]).toContain("review");
+      expect(sendToSession.mock.calls[0]?.[1]).toContain("Finding 1");
+      expect(sendToSession.mock.calls[0]?.[1]).toContain("Finding 2");
+
+      // One `delivered` artifact recorded on disk.
+      const deliverRunId = finalRun.stages["deliver"]!.stageRunId;
+      const deliverArtifacts = store.listArtifacts(runId, deliverRunId);
+      expect(deliverArtifacts).toHaveLength(1);
+      expect(deliverArtifacts[0]).toMatchObject({
+        kind: "json",
+        data: {
+          result: "delivered",
+          fromStage: "review",
+          targetSessionId: "worker-session-1",
+          artifactCount: 2,
+        },
+      });
+    });
+
+    it("skips delivery when the linked worker is dead (no retry-spam)", async () => {
+      const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+      const store = createPipelineStore(storeRoot);
+      const agentExecutor = makeMockAgentExecutor();
+      const isSessionAlive = vi.fn(async () => false);
+      const sendToSession = vi.fn(async () => {
+        throw new Error("should not be called");
+      });
+
+      const engine = createPipelineEngine({
+        store,
+        registry,
+        agentExecutor,
+        builtin: { isSessionAlive, sendToSession },
+      });
+
+      const pipeline = makePipeline([
+        makeAgentStage("review"),
+        makeBuiltinStage("deliver", "router", ["review"]),
+      ]);
+
+      const runId = await engine.startRun({
+        pipeline,
+        projectId: "proj-a",
+        sessionId: "dead-worker",
+        headSha: "sha",
+      });
+
+      agentExecutor.setNextOutcome({
+        status: "completed",
+        artifacts: [sampleFinding(1)],
+      });
+      await engine.tick();
+
+      const finalRun = store.loadRun(runId)!;
+      // Router still succeeds (verdict neutral) — worker_dead is a runtime
+      // delivery condition, not a stage failure.
+      expect(finalRun.stages["deliver"]?.status).toBe("succeeded");
+      expect(finalRun.stages["deliver"]?.verdict).toBe("neutral");
+
+      // sendToSession never called; pre-send probe returned false.
+      expect(sendToSession).not.toHaveBeenCalled();
+      expect(isSessionAlive).toHaveBeenCalledTimes(1);
+
+      // Artifact records `delivery_failed` with reason=worker_dead.
+      const deliverRunId = finalRun.stages["deliver"]!.stageRunId;
+      const deliverArtifacts = store.listArtifacts(runId, deliverRunId);
+      expect(deliverArtifacts).toHaveLength(1);
+      expect(deliverArtifacts[0]).toMatchObject({
+        kind: "json",
+        data: {
+          result: "delivery_failed",
+          reason: "worker_dead",
+          fromStage: "review",
+          targetSessionId: "dead-worker",
+        },
+      });
+
+      // Upstream finding stays `open` (router does not flip status).
+      const reviewRunId = finalRun.stages["review"]!.stageRunId;
+      const reviewArtifacts = store.listArtifacts(runId, reviewRunId);
+      expect(reviewArtifacts).toHaveLength(1);
+      expect(reviewArtifacts[0]?.status).toBe("open");
+    });
+  });
+
+  describe("compose", () => {
+    it("merges multiple upstream artifact lists into a single JSON artifact", async () => {
+      const registry = withRegistry([makeAgentPlugin("codex", ["review", "code"])]);
+      const store = createPipelineStore(storeRoot);
+      const agentExecutor = makeMockAgentExecutor();
+      const isSessionAlive = vi.fn(async () => true);
+      const sendToSession = vi.fn(async () => {
+        /* unused */
+      });
+
+      const engine = createPipelineEngine({
+        store,
+        registry,
+        agentExecutor,
+        builtin: { isSessionAlive, sendToSession },
+      });
+
+      // Two parallel upstream stages → compose merges both.
+      const pipeline = makePipeline([
+        makeAgentStage("review-a"),
+        makeAgentStage("review-b", {
+          executor: { kind: "agent", plugin: "codex", mode: "code" },
+        }),
+        makeBuiltinStage("merge", "compose", ["review-a", "review-b"]),
+      ]);
+
+      const runId = await engine.startRun({
+        pipeline,
+        projectId: "proj-a",
+        sessionId: "worker",
+        headSha: "sha",
+      });
+
+      // Complete first upstream (review-a) → engine schedules review-b next
+      // (serial scheduling with maxConcurrentStages=1).
+      agentExecutor.setNextOutcome({
+        status: "completed",
+        artifacts: [sampleFinding(1), sampleFinding(2)],
+      });
+      await engine.tick();
+
+      // Complete review-b → compose runs synchronously after.
+      agentExecutor.setNextOutcome({
+        status: "completed",
+        artifacts: [sampleFinding(3)],
+      });
+      await engine.tick();
+
+      const finalRun = store.loadRun(runId)!;
+      expect(finalRun.stages["merge"]?.status).toBe("succeeded");
+      expect(finalRun.loopState).toBe("done");
+
+      // sendToSession never called — compose doesn't deliver.
+      expect(sendToSession).not.toHaveBeenCalled();
+
+      const mergeRunId = finalRun.stages["merge"]!.stageRunId;
+      const composedArtifacts = store.listArtifacts(runId, mergeRunId);
+      expect(composedArtifacts).toHaveLength(1);
+      const data = composedArtifacts[0]?.kind === "json" ? composedArtifacts[0].data : null;
+      expect(data).toMatchObject({
+        composedFrom: expect.arrayContaining(["review-a", "review-b"]),
+        totalArtifacts: 3,
+      });
+      const stages = (data as { stages: Record<string, unknown[]> }).stages;
+      expect(stages["review-a"]).toHaveLength(2);
+      expect(stages["review-b"]).toHaveLength(1);
+    });
+  });
+
+  describe("engine wiring", () => {
+    it("fails a builtin stage with a clear message when builtin deps are not configured", async () => {
+      const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+      const store = createPipelineStore(storeRoot);
+      const agentExecutor = makeMockAgentExecutor();
+      // No `builtin` dep passed — router stages must fail with a clear message.
+      const engine = createPipelineEngine({ store, registry, agentExecutor });
+
+      const pipeline = makePipeline([makeBuiltinStage("deliver", "router", [])]);
+
+      const runId = await engine.startRun({
+        pipeline,
+        projectId: "proj-a",
+        sessionId: "ses",
+        headSha: "sha",
+      });
+
+      const run = store.loadRun(runId)!;
+      expect(run.stages["deliver"]?.status).toBe("failed");
+      expect(run.stages["deliver"]?.errorMessage).toMatch(/builtin.*configured/i);
+    });
+  });
+});

--- a/packages/core/src/__tests__/pipeline-engine.test.ts
+++ b/packages/core/src/__tests__/pipeline-engine.test.ts
@@ -293,7 +293,7 @@ describe("pipeline engine — end-to-end", () => {
     expect(executor.startCalls).toHaveLength(0);
   });
 
-  it("synthesizes STAGE_FAILED for non-agent executor kinds (v0.2 only supports agent)", async () => {
+  it("synthesizes STAGE_FAILED for the command executor (not yet supported by engine)", async () => {
     const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
     const store = createPipelineStore(storeRoot);
     const executor = makeMockExecutor();
@@ -317,7 +317,7 @@ describe("pipeline engine — end-to-end", () => {
 
     const run = store.loadRun(runId)!;
     expect(run.stages["lint"]?.status).toBe("failed");
-    expect(run.stages["lint"]?.errorMessage).toContain("not supported in v0.2");
+    expect(run.stages["lint"]?.errorMessage).toContain("not yet supported");
     expect(executor.startCalls).toHaveLength(0);
   });
 

--- a/packages/core/src/pipeline/config-schema.ts
+++ b/packages/core/src/pipeline/config-schema.ts
@@ -44,9 +44,16 @@ const CommandExecutorSchema = z.object({
   cwd: z.string().optional(),
 });
 
+const BuiltinExecutorSchema = z.object({
+  kind: z.literal("builtin"),
+  name: z.enum(["router", "compose"]),
+  config: z.record(z.unknown()).optional(),
+});
+
 const StageExecutorSchema = z.discriminatedUnion("kind", [
   AgentExecutorSchema,
   CommandExecutorSchema,
+  BuiltinExecutorSchema,
 ]);
 
 const TaskSpecSchema = z.object({
@@ -191,21 +198,29 @@ export type PipelinesConfig = z.infer<typeof PipelinesConfigSchema>;
 /** Convert a parsed YAML pipeline entry into a runtime Pipeline (branded id). */
 export function configuredPipelineToRuntime(key: string, configured: ConfiguredPipeline): Pipeline {
   const stages = configured.stages.map((stage): Stage => {
-    const executor: StageExecutor =
-      stage.executor.kind === "agent"
-        ? {
-            kind: "agent",
-            plugin: stage.executor.plugin,
-            mode: stage.executor.mode as TaskMode,
-            ...(stage.executor.config !== undefined ? { config: stage.executor.config } : {}),
-          }
-        : {
-            kind: "command",
-            command: stage.executor.command,
-            ...(stage.executor.args !== undefined ? { args: stage.executor.args } : {}),
-            ...(stage.executor.env !== undefined ? { env: stage.executor.env } : {}),
-            ...(stage.executor.cwd !== undefined ? { cwd: stage.executor.cwd } : {}),
-          };
+    let executor: StageExecutor;
+    if (stage.executor.kind === "agent") {
+      executor = {
+        kind: "agent",
+        plugin: stage.executor.plugin,
+        mode: stage.executor.mode as TaskMode,
+        ...(stage.executor.config !== undefined ? { config: stage.executor.config } : {}),
+      };
+    } else if (stage.executor.kind === "command") {
+      executor = {
+        kind: "command",
+        command: stage.executor.command,
+        ...(stage.executor.args !== undefined ? { args: stage.executor.args } : {}),
+        ...(stage.executor.env !== undefined ? { env: stage.executor.env } : {}),
+        ...(stage.executor.cwd !== undefined ? { cwd: stage.executor.cwd } : {}),
+      };
+    } else {
+      executor = {
+        kind: "builtin",
+        name: stage.executor.name,
+        ...(stage.executor.config !== undefined ? { config: stage.executor.config } : {}),
+      };
+    }
 
     const routes: StageRoutes | undefined = stage.routes
       ? {

--- a/packages/core/src/pipeline/engine.ts
+++ b/packages/core/src/pipeline/engine.ts
@@ -40,13 +40,16 @@ import {
   emptyEngineState,
   isTerminalLoopState,
   loopKey,
+  type Artifact,
   type EngineState,
   type Pipeline,
   type RunId,
   type RunState,
   type RunSummary,
+  type Stage,
   type StageRunId,
   type StageTriggerEvent,
+  type TaskContext,
 } from "./types.js";
 import { validatePipelineAgentModes, validatePipelineDag } from "./validation.js";
 import {
@@ -54,11 +57,22 @@ import {
   type RunningAgentStage,
   type StartStageInput,
 } from "./executors/agent.js";
+import {
+  dispatchBuiltin,
+  type BuiltinDispatcherDeps,
+} from "./executors/builtin/dispatcher.js";
 
 export interface PipelineEngineDeps {
   store: PipelineStore;
   registry: PluginRegistry;
   agentExecutor: AgentStageExecutor;
+  /**
+   * Optional dependencies for builtin executors (router/compose). When omitted,
+   * any builtin-executor stage fails with STAGE_FAILED — matches the existing
+   * "unsupported executor kind" behavior so callers that don't use builtins
+   * (most v0.x tests) need not wire this up.
+   */
+  builtin?: BuiltinDispatcherDeps;
   /** Optional initial state (e.g. restored from disk on startup). Defaults to empty. */
   initialState?: EngineState;
   /** Override clock for tests. */
@@ -163,7 +177,7 @@ export function hydrateEngineState(store: PipelineStore): EngineState {
 }
 
 export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
-  const { store, registry, agentExecutor, now = Date.now } = deps;
+  const { store, registry, agentExecutor, builtin, now = Date.now } = deps;
 
   let state: EngineState = deps.initialState ?? emptyEngineState();
   /** stageRunId → executor handle for stages we own. */
@@ -250,15 +264,23 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
       case "START_STAGE": {
         const run = state.runs[effect.runId];
         if (!run) break;
-        if (effect.stage.executor.kind !== "agent") {
-          // command/builtin executors are out of scope for v0.2 — synthesize
-          // a STAGE_FAILED so the run terminates cleanly instead of hanging.
+        const kind = effect.stage.executor.kind;
+
+        if (kind === "builtin") {
+          await runBuiltinStage(run, effect.stage, effect.stageRunId);
+          break;
+        }
+
+        if (kind !== "agent") {
+          // command executor is out of scope for this slice — synthesize a
+          // STAGE_FAILED so the run terminates cleanly instead of hanging.
+          // Issue #194 lands the command branch.
           await dispatchInline({
             type: "STAGE_FAILED",
             now: now(),
             runId: effect.runId,
             stageName: effect.stage.name,
-            errorMessage: `Executor kind "${effect.stage.executor.kind}" is not supported in v0.2 (agent executor only).`,
+            errorMessage: `Executor kind "${kind}" is not yet supported by the engine.`,
           });
           break;
         }
@@ -316,6 +338,98 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
         // Engine doesn't own observation routing. v0.2 leaves this as a no-op;
         // a later sub-task (#1629/#1630) wires it into the activity-event log.
         break;
+    }
+  }
+
+  /**
+   * Execute a builtin (router / compose) stage end-to-end inside the engine:
+   * mark STARTED, build the TaskContext from upstream artifacts, dispatch
+   * through the builtin dispatcher, and synthesize STAGE_COMPLETED /
+   * STAGE_FAILED based on the outcome.
+   *
+   * Builtins do not produce inflight handles — they complete synchronously
+   * from `tick()`'s perspective. The dispatcher upcasts the TaskContext to a
+   * BuiltinTaskContext; this engine code never constructs one directly so
+   * `sendToSession` stays gated behind the dispatcher.
+   */
+  async function runBuiltinStage(
+    run: RunState,
+    stage: Stage,
+    stageRunId: StageRunId,
+  ): Promise<void> {
+    if (stage.executor.kind !== "builtin") return; // type narrowing for downstream code
+    const executor = stage.executor;
+
+    if (!builtin) {
+      await dispatchInline({
+        type: "STAGE_FAILED",
+        now: now(),
+        runId: run.runId,
+        stageName: stage.name,
+        errorMessage: `Builtin executor "${executor.name}" requires PipelineEngineDeps.builtin to be configured.`,
+      });
+      return;
+    }
+
+    await dispatchInline({
+      type: "STAGE_STARTED",
+      now: now(),
+      runId: run.runId,
+      stageName: stage.name,
+    });
+
+    // Gather upstream artifacts from the store, keyed by upstream stage
+    // name. `dependsOn` is the contract for what's visible to builtins —
+    // routes-only refs are deliberately excluded (those are scheduling
+    // predicates, not data bindings).
+    const inputs: Record<string, Artifact[]> = {};
+    for (const upstreamName of stage.dependsOn ?? []) {
+      const upstream = run.stages[upstreamName];
+      if (!upstream) continue;
+      inputs[upstreamName] = store.listArtifacts(run.runId, upstream.stageRunId);
+    }
+
+    const ctx: TaskContext = {
+      pipelineName: run.pipelineName,
+      runId: run.runId,
+      stageRunId,
+      stage,
+      linkedSessionId: run.sessionId,
+      inputs,
+    };
+
+    let outcome;
+    try {
+      outcome = await dispatchBuiltin(ctx, executor, builtin);
+    } catch (err) {
+      await dispatchInline({
+        type: "STAGE_FAILED",
+        now: now(),
+        runId: run.runId,
+        stageName: stage.name,
+        errorMessage:
+          err instanceof Error
+            ? err.message
+            : `Builtin executor "${executor.name}" failed: ${String(err)}`,
+      });
+      return;
+    }
+
+    await dispatchInline({
+      type: "STAGE_COMPLETED",
+      now: now(),
+      runId: run.runId,
+      stageName: stage.name,
+      verdict: outcome.verdict,
+      artifacts: outcome.artifacts,
+    });
+
+    // Forward dispatcher observations through the same effect channel the
+    // reducer uses for its own stage-lifecycle observations. The reducer
+    // doesn't surface these itself — they're builtin-specific operational
+    // signals (e.g. router skipped delivery because the worker is dead).
+    for (const obs of outcome.observations) {
+      await executeEffect({ type: "EMIT_OBSERVATION", event: obs });
     }
   }
 

--- a/packages/core/src/pipeline/executors/builtin/compose.ts
+++ b/packages/core/src/pipeline/executors/builtin/compose.ts
@@ -1,0 +1,38 @@
+/**
+ * Builtin executor: `compose`.
+ *
+ * Merges `ctx.inputs` (upstream stage artifacts keyed by stage name) into a
+ * single JSON artifact. Used downstream of fan-out stages so a later stage
+ * can consume one structured input instead of N per-stage artifact files.
+ *
+ * Like router, compose runs in the engine process and never writes to the
+ * store directly — the engine threads the returned artifact through the
+ * normal STAGE_COMPLETED path.
+ */
+
+import type { ArtifactInput, BuiltinTaskContext, Verdict } from "../../types.js";
+
+export interface ComposeOutcome {
+  artifacts: ArtifactInput[];
+  verdict: Verdict;
+}
+
+export async function runCompose(ctx: BuiltinTaskContext): Promise<ComposeOutcome> {
+  const stages: Record<string, unknown[]> = {};
+  let totalArtifacts = 0;
+  for (const [stageName, stageArtifacts] of Object.entries(ctx.inputs)) {
+    stages[stageName] = stageArtifacts;
+    totalArtifacts += stageArtifacts.length;
+  }
+
+  const artifact: ArtifactInput = {
+    kind: "json",
+    data: {
+      composedFrom: Object.keys(stages),
+      totalArtifacts,
+      stages,
+    },
+  };
+
+  return { artifacts: [artifact], verdict: "neutral" };
+}

--- a/packages/core/src/pipeline/executors/builtin/dispatcher.ts
+++ b/packages/core/src/pipeline/executors/builtin/dispatcher.ts
@@ -1,0 +1,75 @@
+/**
+ * Builtin executor dispatcher.
+ *
+ * The single point that upcasts a base `TaskContext` to a privileged
+ * `BuiltinTaskContext` (which exposes `sendToSession`). Agent and command
+ * executors must never see this capability — keep the dispatcher the only
+ * caller that constructs a `BuiltinTaskContext`.
+ *
+ * The engine wires this in alongside the agent executor; on START_STAGE for
+ * a builtin executor, it gathers upstream artifacts into a TaskContext and
+ * hands them here.
+ */
+
+import type {
+  ArtifactInput,
+  BuiltinExecutor,
+  BuiltinTaskContext,
+  TaskContext,
+  Verdict,
+} from "../../types.js";
+import { runCompose } from "./compose.js";
+import { runRouter } from "./router.js";
+
+export interface BuiltinDispatcherDeps {
+  /** Probe a session before router attempts to deliver. */
+  isSessionAlive: (sessionId: string) => Promise<boolean>;
+  /** Deliver a message to a session. Wraps SessionManager.send. */
+  sendToSession: (sessionId: string, message: string) => Promise<void>;
+}
+
+export interface BuiltinDispatchObservation {
+  name: string;
+  data: Record<string, unknown>;
+}
+
+export interface BuiltinDispatchOutcome {
+  artifacts: ArtifactInput[];
+  verdict: Verdict;
+  observations: BuiltinDispatchObservation[];
+}
+
+export class UnknownBuiltinExecutorError extends Error {
+  constructor(name: string) {
+    super(`Unknown builtin executor name: "${name}"`);
+    this.name = "UnknownBuiltinExecutorError";
+  }
+}
+
+export async function dispatchBuiltin(
+  ctx: TaskContext,
+  executor: BuiltinExecutor,
+  deps: BuiltinDispatcherDeps,
+): Promise<BuiltinDispatchOutcome> {
+  const builtinCtx: BuiltinTaskContext = {
+    ...ctx,
+    sendToSession: deps.sendToSession,
+  };
+
+  switch (executor.name) {
+    case "router": {
+      const outcome = await runRouter(builtinCtx, { isSessionAlive: deps.isSessionAlive });
+      return outcome;
+    }
+    case "compose": {
+      const outcome = await runCompose(builtinCtx);
+      return { ...outcome, observations: [] };
+    }
+    default: {
+      // Exhaustiveness guard — a new BuiltinExecutor.name would land here
+      // until the dispatcher is updated.
+      const _exhaustive: never = executor.name;
+      throw new UnknownBuiltinExecutorError(_exhaustive);
+    }
+  }
+}

--- a/packages/core/src/pipeline/executors/builtin/router.ts
+++ b/packages/core/src/pipeline/executors/builtin/router.ts
@@ -1,0 +1,138 @@
+/**
+ * Builtin executor: `router`.
+ *
+ * Reads upstream stage artifacts via `ctx.inputs` (keyed by upstream stage
+ * name), composes one message per upstream stage, and delivers each to the
+ * linked worker session via `ctx.sendToSession`.
+ *
+ * Replaces the removed v0 `SEND_TO_AGENT` reducer command path. Router runs
+ * in the engine process; the engine writes any resulting artifacts through
+ * the normal STAGE_COMPLETED path. Router never mutates the pipeline store.
+ *
+ * Pre-send liveness: a single `isSessionAlive` probe per invocation. If the
+ * worker is terminal/killed/missing we emit `pipeline.send.skipped_worker_dead`
+ * once per input stage, leave the underlying findings `open`, and skip
+ * delivery (no retry-spam — the next pipeline tick will reprobe).
+ */
+
+import type {
+  Artifact,
+  ArtifactInput,
+  BuiltinTaskContext,
+  Verdict,
+} from "../../types.js";
+
+export interface RouterDeps {
+  /** Probe the linked worker session before attempting delivery. */
+  isSessionAlive: (sessionId: string) => Promise<boolean>;
+}
+
+export interface RouterObservation {
+  name: string;
+  data: Record<string, unknown>;
+}
+
+export interface RouterOutcome {
+  artifacts: ArtifactInput[];
+  verdict: Verdict;
+  observations: RouterObservation[];
+}
+
+export async function runRouter(
+  ctx: BuiltinTaskContext,
+  deps: RouterDeps,
+): Promise<RouterOutcome> {
+  const artifacts: ArtifactInput[] = [];
+  const observations: RouterObservation[] = [];
+  const targetSessionId = ctx.linkedSessionId;
+
+  // Single liveness probe — input stages share the same target worker, so
+  // probing once avoids hammering the runtime when there are many findings.
+  const alive = await deps.isSessionAlive(targetSessionId);
+
+  for (const [fromStage, stageArtifacts] of Object.entries(ctx.inputs)) {
+    if (stageArtifacts.length === 0) continue;
+
+    if (!alive) {
+      observations.push({
+        name: "pipeline.send.skipped_worker_dead",
+        data: {
+          runId: ctx.runId,
+          stageRunId: ctx.stageRunId,
+          stageName: ctx.stage.name,
+          fromStage,
+          targetSessionId,
+          artifactCount: stageArtifacts.length,
+        },
+      });
+      artifacts.push({
+        kind: "json",
+        data: {
+          result: "delivery_failed",
+          reason: "worker_dead",
+          fromStage,
+          targetSessionId,
+          artifactCount: stageArtifacts.length,
+        },
+      });
+      continue;
+    }
+
+    const message = composeMessage(fromStage, stageArtifacts);
+
+    try {
+      await ctx.sendToSession(targetSessionId, message);
+      artifacts.push({
+        kind: "json",
+        data: {
+          result: "delivered",
+          fromStage,
+          targetSessionId,
+          artifactCount: stageArtifacts.length,
+        },
+      });
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      observations.push({
+        name: "pipeline.send.failed",
+        data: {
+          runId: ctx.runId,
+          stageRunId: ctx.stageRunId,
+          stageName: ctx.stage.name,
+          fromStage,
+          targetSessionId,
+          error: errorMessage,
+        },
+      });
+      artifacts.push({
+        kind: "json",
+        data: {
+          result: "delivery_failed",
+          reason: "send_error",
+          fromStage,
+          targetSessionId,
+          error: errorMessage,
+        },
+      });
+    }
+  }
+
+  return { artifacts, verdict: "neutral", observations };
+}
+
+function composeMessage(stageName: string, artifacts: Artifact[]): string {
+  const lines: string[] = [];
+  lines.push(`Findings from upstream pipeline stage "${stageName}":`);
+  lines.push("");
+  for (const artifact of artifacts) {
+    if (artifact.kind === "finding") {
+      lines.push(
+        `- [${artifact.severity}] ${artifact.filePath}:${artifact.startLine}-${artifact.endLine} — ${artifact.title}`,
+      );
+      lines.push(`  ${artifact.description}`);
+    } else {
+      lines.push(`- ${JSON.stringify(artifact.data)}`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/packages/core/src/pipeline/executors/index.ts
+++ b/packages/core/src/pipeline/executors/index.ts
@@ -8,3 +8,18 @@ export {
   type StageOutcome,
   type StartStageInput,
 } from "./agent.js";
+
+export {
+  dispatchBuiltin,
+  UnknownBuiltinExecutorError,
+  type BuiltinDispatcherDeps,
+  type BuiltinDispatchObservation,
+  type BuiltinDispatchOutcome,
+} from "./builtin/dispatcher.js";
+export {
+  runRouter,
+  type RouterDeps,
+  type RouterObservation,
+  type RouterOutcome,
+} from "./builtin/router.js";
+export { runCompose, type ComposeOutcome } from "./builtin/compose.js";

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -39,6 +39,17 @@ export {
   type RunningAgentStage,
   type StageOutcome,
   type StartStageInput,
+  dispatchBuiltin,
+  UnknownBuiltinExecutorError,
+  runRouter,
+  runCompose,
+  type BuiltinDispatcherDeps,
+  type BuiltinDispatchObservation,
+  type BuiltinDispatchOutcome,
+  type RouterDeps,
+  type RouterObservation,
+  type RouterOutcome,
+  type ComposeOutcome,
 } from "./executors/index.js";
 
 export {

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -64,7 +64,23 @@ export interface CommandExecutor {
   cwd?: string;
 }
 
-export type StageExecutor = AgentExecutor | CommandExecutor;
+/**
+ * Engine-internal executor. Builtins run inside the engine process — they
+ * do not spawn a session or shell out. Today: `router` (delivers upstream
+ * findings to the linked worker session) and `compose` (merges upstream
+ * artifacts into a single JSON artifact).
+ *
+ * Builtins must never mutate the pipeline store directly. They return
+ * artifacts/observations through the dispatcher's outcome shape, and the
+ * engine's normal STAGE_COMPLETED path is the only writer.
+ */
+export interface BuiltinExecutor {
+  kind: "builtin";
+  name: "router" | "compose";
+  config?: Record<string, unknown>;
+}
+
+export type StageExecutor = AgentExecutor | CommandExecutor | BuiltinExecutor;
 
 export interface TaskSpec {
   /** Prompt text injected into the spawned agent session, or main script body for command. */
@@ -321,4 +337,39 @@ export function emptyEngineState(): EngineState {
     currentRunByLoop: {},
     historySummaries: {},
   };
+}
+
+// ============================================================================
+// Task contexts (passed to executors)
+// ============================================================================
+
+/**
+ * Base context handed to any in-process executor. The agent / command
+ * executors don't consume it today (they use their own input shapes), but
+ * builtin executors do — and `BuiltinTaskContext` extends this so the
+ * dispatcher can hand non-privileged data through to both router & compose.
+ *
+ * `inputs` is keyed by upstream stage name (from `stage.dependsOn`); the
+ * engine pre-fetches those stages' artifacts from the store before invoking
+ * the dispatcher so builtins never read storage directly.
+ */
+export interface TaskContext {
+  pipelineName: string;
+  runId: RunId;
+  stageRunId: StageRunId;
+  stage: Stage;
+  /** The "linked worker" session this pipeline was triggered for. */
+  linkedSessionId: string;
+  /** Upstream stage artifacts, keyed by stage name. Empty record if no deps. */
+  inputs: Record<string, Artifact[]>;
+}
+
+/**
+ * Privileged context handed only to builtin executors via the builtin
+ * dispatcher. The `sendToSession` capability is intentionally NOT exposed
+ * to agent/command executors — sending messages to the linked worker is a
+ * router-only operation that must route through the dispatcher.
+ */
+export interface BuiltinTaskContext extends TaskContext {
+  sendToSession: (sessionId: string, message: string) => Promise<void>;
 }


### PR DESCRIPTION
Closes #195.

## Summary

- Adds `builtin` stage executor kind with two builtins: `router` (delivers upstream findings to the linked worker via `ctx.sendToSession`) and `compose` (merges upstream artifacts into a single JSON artifact).
- Introduces `TaskContext` + `BuiltinTaskContext`. The builtin dispatcher is the only thing that upcasts the base context, so agent/command executors never see `sendToSession`.
- Engine wires the builtin dispatcher alongside the agent executor via a new optional `builtin` dep. Router/compose run synchronously inside the engine — no inflight handles; the engine surfaces their artifacts through the normal `STAGE_COMPLETED` path. Builtins never mutate the pipeline store directly.
- Router pre-probes the linked worker once per invocation; if terminal/missing → emits `pipeline.send.skipped_worker_dead` observation, records a `delivery_failed` JSON artifact, leaves upstream findings `open`. No retry-spam.
- Zod schema adds the `builtin` discriminator with `name: "router" | "compose"`.

Replaces the removed v0 `SEND_TO_AGENT` reducer path.

## New files

- `packages/core/src/pipeline/executors/builtin/router.ts`
- `packages/core/src/pipeline/executors/builtin/compose.ts`
- `packages/core/src/pipeline/executors/builtin/dispatcher.ts`
- `packages/core/src/__tests__/pipeline-builtin-executors.test.ts`

## Touched files

- `packages/core/src/pipeline/types.ts` — added `BuiltinExecutor`, `TaskContext`, `BuiltinTaskContext`; extended `StageExecutor` union.
- `packages/core/src/pipeline/engine.ts` — added `runBuiltinStage`, builtin-aware `START_STAGE` branch, optional `builtin` dep in `PipelineEngineDeps`.
- `packages/core/src/pipeline/config-schema.ts` — added `BuiltinExecutorSchema`, updated `configuredPipelineToRuntime`.
- `packages/core/src/pipeline/{index,executors/index}.ts` — re-exports.
- `packages/core/src/__tests__/pipeline-engine.test.ts` — updated wording on one existing test (the command executor's "not yet supported" message).

## Heads up to sibling worker (#194 / command executor)

We both touched `types.ts` (StageExecutor union), `engine.ts` (START_STAGE switch), and `config-schema.ts` (executor Zod). Edits here are additive, but you'll need to merge our changes when rebasing.

## Test plan

- [x] `pnpm vitest run pipeline` — 118 passed, 0 failed
- [x] `pnpm vitest run config` — 146 passed, 0 failed
- [x] `pnpm build` at repo root — clean
- [x] `pnpm lint` — no issues in new files
- [x] Acceptance criteria from #195:
  - [x] router reads `ctx.inputs`, composes one message per stage, delivers via `sendToSession`, returns `delivered`/`delivery_failed` artifact, verdict `neutral`, never mutates store
  - [x] compose merges `ctx.inputs` into a single JSON artifact
  - [x] Agent/command executors can't see `sendToSession` (only dispatcher upcasts)
  - [x] Worker-alive pre-send check: emits `pipeline.send.skipped_worker_dead`, finding stays `open`, no retry-spam
  - [x] Tests: router success, router worker-dead, compose merging multiple inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)