### PR TITLE
feat(pipelines): typed Predicate DSL + exitPredicates + failure-tolerant scheduling

### DIFF
--- a/packages/core/src/__tests__/pipeline-dag.test.ts
+++ b/packages/core/src/__tests__/pipeline-dag.test.ts
@@ -478,10 +478,12 @@ describe("pipeline DAG — multi-pipeline support", () => {
 });
 
 describe("pipeline DAG — failure path (parallel)", () => {
-  it("STAGE_FAILED on a parallel branch terminates the run and marks sibling stages outdated/skipped", () => {
-    // Two independent branches running concurrently; the running sibling
-    // should transition `running → outdated` and emit a CANCEL_STAGE effect,
-    // while a not-yet-started downstream stage transitions `pending → skipped`.
+  it("failure-tolerant: parallel sibling keeps running, downstream cascade-skips", () => {
+    // Failure-tolerance (issue #196): a stage failure no longer terminates
+    // the run or cancels independent parallel siblings. The running sibling
+    // gets to finish naturally, the downstream stage with `dependsOn: [a]`
+    // (and no recovery routes) still cascade-skips, and the run only
+    // resolves to `stalled` once every stage is terminal.
     const pipeline = makePipeline(
       [
         makeStage("a"),
@@ -502,16 +504,22 @@ describe("pipeline DAG — failure path (parallel)", () => {
     });
 
     const run = failed.state.runs[asRunId("run-1")];
-    expect(run.loopState).toBe("stalled");
-    expect(run.terminationReason).toBe("stage_failure");
+    expect(run.loopState).toBe("running");
     expect(run.stages.a.status).toBe("failed");
-    expect(run.stages.b.status).toBe("outdated");
+    expect(run.stages.b.status).toBe("running");
     expect(run.stages.c.status).toBe("skipped");
+    expect(failed.effects.find((e) => e.type === "CANCEL_STAGE")).toBeUndefined();
 
-    const cancelB = failed.effects.find(
-      (e) => e.type === "CANCEL_STAGE" && e.stageName === "b",
-    );
-    expect(cancelB).toBeDefined();
+    // b completes — run is now all-terminal, v0 default → stalled.
+    const finished = reduce(failed.state, {
+      type: "STAGE_COMPLETED",
+      now: NOW + 4,
+      runId: asRunId("run-1"),
+      stageName: "b",
+      artifacts: [],
+    });
+    expect(finished.state.runs[asRunId("run-1")].loopState).toBe("stalled");
+    expect(finished.state.runs[asRunId("run-1")].terminationReason).toBe("stage_failure");
   });
 });
 
@@ -561,8 +569,9 @@ describe("pipeline DAG — RUN_RESUMED with cascade-skipped stages", () => {
   });
 
   it("revives `outdated` stages (running-at-terminate) so parallel branches recover", () => {
-    // a and b run concurrently; a fails and `terminateRunFromState` marks b
-    // `outdated` (because b was running). Without reviving outdated, b would
+    // a and b run concurrently; `STAGE_FAILED(a)` no longer cancels b under
+    // failure-tolerant scheduling, so we follow up with `RUN_CANCELLED` to
+    // outdate b (running → outdated). Without reviving outdated, b would
     // never recover and any downstream stage on b (here d) would cascade-skip
     // after resume.
     const pipeline = makePipeline(
@@ -576,13 +585,20 @@ describe("pipeline DAG — RUN_RESUMED with cascade-skipped stages", () => {
     const triggered = fireTrigger(pipeline);
     let s = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1).state;
     s = startStage(s, asRunId("run-1"), "b", NOW + 2).state;
-    const failed = reduce(s, {
+    s = reduce(s, {
       type: "STAGE_FAILED",
       now: NOW + 3,
       runId: asRunId("run-1"),
       stageName: "a",
       errorMessage: "boom",
+    }).state;
+    const failed = reduce(s, {
+      type: "RUN_CANCELLED",
+      now: NOW + 4,
+      runId: asRunId("run-1"),
+      reason: "manual_cancel",
     });
+    expect(failed.state.runs[asRunId("run-1")].stages.a.status).toBe("failed");
     expect(failed.state.runs[asRunId("run-1")].stages.b.status).toBe("outdated");
 
     // Resume: caller must allocate fresh stageRunIds for BOTH a (failed) and
@@ -625,14 +641,24 @@ describe("pipeline DAG — RUN_RESUMED with cascade-skipped stages", () => {
     const triggered = fireTrigger(pipeline);
     let s = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1).state;
     s = startStage(s, asRunId("run-1"), "b", NOW + 2).state;
-    // a fails -> run terminates, b is marked outdated (it was running).
-    const failed = reduce(s, {
+    // a fails (failure-tolerant: b keeps running); cancel terminates the
+    // run, outdating b. The combined sequence reproduces the v0 "failure
+    // outdates parallel sibling" state that this test was originally written
+    // against.
+    s = reduce(s, {
       type: "STAGE_FAILED",
       now: NOW + 3,
       runId: asRunId("run-1"),
       stageName: "a",
       errorMessage: "boom",
+    }).state;
+    const failed = reduce(s, {
+      type: "RUN_CANCELLED",
+      now: NOW + 4,
+      runId: asRunId("run-1"),
+      reason: "manual_cancel",
     });
+    expect(failed.state.runs[asRunId("run-1")].stages.a.status).toBe("failed");
     expect(failed.state.runs[asRunId("run-1")].stages.b.status).toBe("outdated");
     expect(failed.state.runs[asRunId("run-1")].stages.b.attempt).toBe(1);
 
@@ -700,16 +726,22 @@ describe("pipeline DAG — RUN_RESUMED with cascade-skipped stages", () => {
     const triggered = fireTrigger(pipeline);
     let s = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1).state;
     s = startStage(s, asRunId("run-1"), "b", NOW + 2).state;
-    const failed = reduce(s, {
+    s = reduce(s, {
       type: "STAGE_FAILED",
       now: NOW + 3,
       runId: asRunId("run-1"),
       stageName: "a",
       errorMessage: "boom",
+    }).state;
+    const failed = reduce(s, {
+      type: "RUN_CANCELLED",
+      now: NOW + 4,
+      runId: asRunId("run-1"),
+      reason: "manual_cancel",
     });
     const resumed = reduce(failed.state, {
       type: "RUN_RESUMED",
-      now: NOW + 4,
+      now: NOW + 5,
       runId: asRunId("run-1"),
       stageRunIds: { a: asStageRunId("sr-a-2") }, // missing b
     });
@@ -771,9 +803,12 @@ describe("pipeline DAG — RUN_RESUMED with cascade-skipped stages", () => {
   });
 
   it("revived stages still get re-skipped when their routes predicate is unsatisfied", () => {
-    // c had `routes: { anyFailed: [a] }` — it was skipped via routes (not
-    // cascade) before the failure, then double-skipped by terminate. After
-    // resume + a-succeeds, c must re-skip because a no longer matches anyFailed.
+    // c routes against `b` succeeding, not `a` failing — so when a fails and
+    // the run falls to stalled (b cascade-skips because its dep failed),
+    // c is also cascade-skipped (routes reference b which is now skipped,
+    // not succeeded). After resume + a-succeeds + b-succeeds, c's routes
+    // would re-evaluate true; we make the route reference a sibling that
+    // STAYS skipped after revival to verify re-evaluation still skips c.
     const pipeline = makePipeline(
       [
         makeStage("a"),
@@ -781,14 +816,16 @@ describe("pipeline DAG — RUN_RESUMED with cascade-skipped stages", () => {
         {
           ...makeStage("c"),
           dependsOn: ["a"],
-          routes: { when: { kind: "anyFailed", stages: ["a"] } },
+          routes: { when: { kind: "anyFailed", stages: ["b"] } },
         },
       ],
       1,
     );
     const triggered = fireTrigger(pipeline);
     const startedA = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1);
-    // a fails → terminate marks b, c skipped.
+    // a fails → b cascade-skips (dep failed, no routes), c cascade-skips
+    // (routes reference b which is skipped — `anyFailed: [b]` is false). All
+    // terminal → v0 default → stalled.
     const failedA = reduce(startedA.state, {
       type: "STAGE_FAILED",
       now: NOW + 2,
@@ -796,6 +833,7 @@ describe("pipeline DAG — RUN_RESUMED with cascade-skipped stages", () => {
       stageName: "a",
       errorMessage: "boom",
     });
+    expect(failedA.state.runs[asRunId("run-1")].loopState).toBe("stalled");
 
     const resumed = reduce(failedA.state, {
       type: "RUN_RESUMED",
@@ -804,11 +842,14 @@ describe("pipeline DAG — RUN_RESUMED with cascade-skipped stages", () => {
       stageRunIds: { a: asStageRunId("sr-a-2") },
     });
     const startedRetry = startStage(resumed.state, asRunId("run-1"), "a", NOW + 4);
-    const completed = completeStage(startedRetry.state, asRunId("run-1"), "a", NOW + 5);
+    const completedA = completeStage(startedRetry.state, asRunId("run-1"), "a", NOW + 5);
+    const startedB = startStage(completedA.state, asRunId("run-1"), "b", NOW + 6);
+    const completed = completeStage(startedB.state, asRunId("run-1"), "b", NOW + 7);
 
     const run = completed.state.runs[asRunId("run-1")];
     expect(run.stages.a.status).toBe("succeeded");
-    // b ran (deps satisfied, no routes), c re-skipped (anyFailed false).
+    expect(run.stages.b.status).toBe("succeeded");
+    // b succeeded (not failed), c's `anyFailed: [b]` route is still false → re-skipped.
     expect(run.stages.c.status).toBe("skipped");
   });
 });

--- a/packages/core/src/__tests__/pipeline-exit-and-recovery.test.ts
+++ b/packages/core/src/__tests__/pipeline-exit-and-recovery.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Issue #196 — exitPredicates + failure-tolerant scheduling.
+ *
+ * Tests cover:
+ *  - Recovery branch end-to-end: a stage with `routes.when` matching an
+ *    upstream failure starts instead of being cascade-skipped + terminating
+ *    the run (the v1.1 limitation #196 fixes).
+ *  - `exitPredicates.done` overrides the v0 "any failure → stalled" rule.
+ *  - `exitPredicates.stalled` overrides v0 by demanding a custom condition
+ *    before marking the run as stalled.
+ *  - `{kind: "v0_default"}` opts a branch back into v0 behavior explicitly.
+ *  - Schema back-compat: legacy 3 route forms parse + behave identically.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ConfiguredPipelineSchema,
+  asPipelineId,
+  asRunId,
+  asStageRunId,
+  configuredPipelineToRuntime,
+  emptyEngineState,
+  reduce,
+  type EngineState,
+  type Pipeline,
+  type PipelineEvent,
+  type RunId,
+  type Stage,
+  type StageRunId,
+} from "../pipeline/index.js";
+
+const NOW = 1_700_000_000_000;
+
+function makeStage(name: string, overrides: Partial<Stage> = {}): Stage {
+  return {
+    name,
+    trigger: { on: ["pr.opened"] },
+    executor: { kind: "agent", plugin: "codex", mode: "review" },
+    task: { prompt: `run ${name}` },
+    ...overrides,
+  };
+}
+
+function makePipeline(stages: Stage[], overrides: Partial<Pipeline> = {}): Pipeline {
+  return {
+    id: asPipelineId("pl-1"),
+    name: "default",
+    stages,
+    maxConcurrentStages: 2,
+    ...overrides,
+  };
+}
+
+function fireTrigger(pipeline: Pipeline, runId = asRunId("run-1")) {
+  const stageRunIds: Record<string, StageRunId> = Object.fromEntries(
+    pipeline.stages.map((s, i) => [s.name, asStageRunId(`sr-${s.name}-${i}`)]),
+  );
+  const event: PipelineEvent = {
+    type: "TRIGGER_FIRED",
+    now: NOW,
+    trigger: "manual",
+    sessionId: "ses-1",
+    pipeline,
+    headSha: "sha-aaa",
+    runId,
+    stageRunIds,
+  };
+  return reduce(emptyEngineState(), event);
+}
+
+function startStage(state: EngineState, runId: RunId, stageName: string, t = NOW + 1) {
+  return reduce(state, { type: "STAGE_STARTED", now: t, runId, stageName });
+}
+
+function completeStage(state: EngineState, runId: RunId, stageName: string, t = NOW + 2) {
+  return reduce(state, {
+    type: "STAGE_COMPLETED",
+    now: t,
+    runId,
+    stageName,
+    artifacts: [],
+  });
+}
+
+describe("recovery branches (issue #196)", () => {
+  it("starts a stage whose routes match an upstream failure instead of cascade-skipping", () => {
+    const pipeline = makePipeline(
+      [
+        makeStage("a"),
+        {
+          ...makeStage("recovery"),
+          dependsOn: ["a"],
+          routes: { when: { kind: "anyFailed", stages: ["a"] } },
+        },
+      ],
+      { maxConcurrentStages: 1 },
+    );
+    const triggered = fireTrigger(pipeline);
+    const started = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1);
+    const failed = reduce(started.state, {
+      type: "STAGE_FAILED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      errorMessage: "boom",
+    });
+
+    // The run does NOT terminate — recovery starts.
+    expect(failed.state.runs[asRunId("run-1")].loopState).toBe("running");
+    const startRecovery = failed.effects.find(
+      (e) => e.type === "START_STAGE" && e.stage.name === "recovery",
+    );
+    expect(startRecovery).toBeDefined();
+  });
+
+  it("recovery branch completes → run resolves under v0 default (stalled, because `a` failed)", () => {
+    const pipeline = makePipeline(
+      [
+        makeStage("a"),
+        {
+          ...makeStage("recovery"),
+          dependsOn: ["a"],
+          routes: { when: { kind: "anyFailed", stages: ["a"] } },
+        },
+      ],
+      { maxConcurrentStages: 1 },
+    );
+    const triggered = fireTrigger(pipeline);
+    let s = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1).state;
+    s = reduce(s, {
+      type: "STAGE_FAILED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      errorMessage: "boom",
+    }).state;
+    s = startStage(s, asRunId("run-1"), "recovery", NOW + 3).state;
+    const done = completeStage(s, asRunId("run-1"), "recovery", NOW + 4);
+
+    expect(done.state.runs[asRunId("run-1")].loopState).toBe("stalled");
+    expect(done.state.runs[asRunId("run-1")].stages.recovery.status).toBe("succeeded");
+  });
+
+  it("with exitPredicates.done = any_pass(recovery), recovery success → run done", () => {
+    const pipeline = makePipeline(
+      [
+        makeStage("a"),
+        {
+          ...makeStage("recovery"),
+          dependsOn: ["a"],
+          routes: { when: { kind: "anyFailed", stages: ["a"] } },
+        },
+      ],
+      {
+        maxConcurrentStages: 1,
+        exitPredicates: {
+          done: { kind: "any_pass", stages: ["recovery"] },
+        },
+      },
+    );
+    const triggered = fireTrigger(pipeline);
+    let s = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1).state;
+    s = reduce(s, {
+      type: "STAGE_FAILED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      errorMessage: "boom",
+    }).state;
+    s = startStage(s, asRunId("run-1"), "recovery", NOW + 3).state;
+    const done = completeStage(s, asRunId("run-1"), "recovery", NOW + 4);
+
+    expect(done.state.runs[asRunId("run-1")].loopState).toBe("done");
+    expect(done.state.runs[asRunId("run-1")].terminationReason).toBe("completed");
+  });
+});
+
+describe("exitPredicates override v0 rules", () => {
+  it("exitPredicates.done: must evaluate true for the run to finish as done", () => {
+    // Pipeline succeeds, but `done` requires a finding count > some threshold —
+    // since there are no findings here, exit decision falls through to v0.
+    const pipeline = makePipeline(
+      [makeStage("a")],
+      {
+        maxConcurrentStages: 1,
+        exitPredicates: {
+          done: { kind: "loop_rounds_at_least", n: 99 },
+        },
+      },
+    );
+    const triggered = fireTrigger(pipeline);
+    const started = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1);
+    const done = completeStage(started.state, asRunId("run-1"), "a", NOW + 2);
+
+    // `done` predicate evaluated false → falls through to v0 default → no
+    // failures, so `done` anyway.
+    expect(done.state.runs[asRunId("run-1")].loopState).toBe("done");
+  });
+
+  it("exitPredicates.stalled: triggers stalled even when no stage failed", () => {
+    // Configure stalled to fire when any stage hit its retry budget.
+    const pipeline = makePipeline(
+      [makeStage("a", { retries: 1 })],
+      {
+        maxConcurrentStages: 1,
+        exitPredicates: {
+          done: { kind: "stage_retried_at_least", stage: "a", n: 99 }, // never true
+          stalled: { kind: "all_pass", stages: ["a"] }, // succeeded → stalled (contrived but exercises override)
+        },
+      },
+    );
+    const triggered = fireTrigger(pipeline);
+    const started = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1);
+    const finished = completeStage(started.state, asRunId("run-1"), "a", NOW + 2);
+
+    expect(finished.state.runs[asRunId("run-1")].loopState).toBe("stalled");
+  });
+
+  it("{kind: v0_default} branch opts into the hardcoded v0 rule", () => {
+    // `done` is explicit v0_default → fall through. `stalled` is unset.
+    // With one failure, v0 says stalled.
+    const pipeline = makePipeline(
+      [makeStage("a"), makeStage("b", { dependsOn: ["a"] })],
+      {
+        maxConcurrentStages: 1,
+        exitPredicates: {
+          done: { kind: "v0_default" },
+        },
+      },
+    );
+    const triggered = fireTrigger(pipeline);
+    const started = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1);
+    const failed = reduce(started.state, {
+      type: "STAGE_FAILED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      errorMessage: "boom",
+    });
+    expect(failed.state.runs[asRunId("run-1")].loopState).toBe("stalled");
+  });
+});
+
+describe("config schema — typed Predicate + back-compat", () => {
+  it("parses the typed Predicate DSL inside routes.when", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [
+        makeStage("a"),
+        {
+          ...makeStage("b"),
+          dependsOn: ["a"],
+          routes: {
+            when: {
+              kind: "and",
+              predicates: [
+                { kind: "all_pass", stages: ["a"] },
+                { kind: "not", predicate: { kind: "stage_verdict", stage: "a", verdict: "fail" } },
+              ],
+            },
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("normalizes legacy 3 route forms into typed equivalents at runtime conversion", () => {
+    const parsed = ConfiguredPipelineSchema.parse({
+      stages: [
+        makeStage("a"),
+        {
+          ...makeStage("b"),
+          dependsOn: ["a"],
+          routes: { when: { kind: "allSucceeded", stages: ["a"] } },
+        },
+        {
+          ...makeStage("c"),
+          dependsOn: ["a"],
+          routes: { when: { kind: "anyFailed", stages: ["a"] } },
+        },
+      ],
+    });
+    const runtime = configuredPipelineToRuntime("test", parsed);
+    expect(runtime.stages[1].routes?.when).toEqual({ kind: "all_pass", stages: ["a"] });
+    expect(runtime.stages[2].routes?.when).toEqual({
+      kind: "or",
+      predicates: [{ kind: "stage_verdict", stage: "a", verdict: "fail" }],
+    });
+  });
+
+  it("parses and exposes exitPredicates on the runtime Pipeline", () => {
+    const parsed = ConfiguredPipelineSchema.parse({
+      stages: [makeStage("a")],
+      exitPredicates: {
+        done: { kind: "all_pass", stages: ["a"] },
+        blocksMerge: { kind: "no_open_findings" },
+      },
+    });
+    const runtime = configuredPipelineToRuntime("test", parsed);
+    expect(runtime.exitPredicates).toEqual({
+      done: { kind: "all_pass", stages: ["a"] },
+      blocksMerge: { kind: "no_open_findings" },
+    });
+  });
+
+  it("rejects exitPredicates that reference unknown stages", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [makeStage("a")],
+      exitPredicates: {
+        done: { kind: "all_pass", stages: ["nope"] },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const messages = result.error.issues.map((i) => i.message).join("\n");
+    expect(messages).toContain("exitPredicates.done references unknown stage");
+  });
+
+  it("rejects routes.when predicates that reference unknown stages", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [
+        makeStage("a"),
+        {
+          ...makeStage("b"),
+          dependsOn: ["a"],
+          routes: { when: { kind: "stage_verdict", stage: "ghost", verdict: "fail" } },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const messages = result.error.issues.map((i) => i.message).join("\n");
+    expect(messages).toContain('unknown stage "ghost"');
+  });
+});

--- a/packages/core/src/__tests__/pipeline-predicate-evaluator.test.ts
+++ b/packages/core/src/__tests__/pipeline-predicate-evaluator.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Typed Predicate DSL coverage (issue #196):
+ *  - Per-kind evaluation against a minimal `PredicateCtx`.
+ *  - and/or/not composition, with short-circuit / nested behavior.
+ *  - Back-compat: legacy `StageRoutePredicate` shapes evaluate as the
+ *    equivalent typed predicate.
+ *  - `v0_default` evaluates to `false` (so reducer falls back to v0 rules).
+ *  - `predicateReferencedStages` walks recursive predicates correctly.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluate,
+  isV0Default,
+  predicateReferencedStages,
+} from "../pipeline/predicate-evaluator.js";
+import {
+  asArtifactId,
+  asPipelineId,
+  asRunId,
+  asStageRunId,
+  type Artifact,
+  type Predicate,
+  type PredicateCtx,
+  type RunState,
+  type StageStatus,
+  type Verdict,
+} from "../pipeline/index.js";
+
+function makeRun(
+  stageSpecs: Array<{ name: string; status: StageStatus; verdict?: Verdict; attempt?: number }>,
+  overrides: Partial<RunState> = {},
+): RunState {
+  const stages: RunState["stages"] = {};
+  for (const spec of stageSpecs) {
+    stages[spec.name] = {
+      stageRunId: asStageRunId(`sr-${spec.name}`),
+      status: spec.status,
+      attempt: spec.attempt ?? 1,
+      ...(spec.verdict !== undefined ? { verdict: spec.verdict } : {}),
+      artifacts: [],
+    };
+  }
+  return {
+    runId: asRunId("run-1"),
+    pipelineId: asPipelineId("pl-1"),
+    pipelineName: "default",
+    sessionId: "ses-1",
+    pipelineConfigSnapshot: {
+      id: asPipelineId("pl-1"),
+      name: "default",
+      stages: [],
+    },
+    headSha: "sha-aaa",
+    loopState: "running",
+    loopRounds: 1,
+    stages,
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeFinding(
+  overrides: Partial<Artifact> & { stageName?: string } = {},
+): Artifact {
+  return {
+    artifactId: asArtifactId("art-1"),
+    pipelineRunId: asRunId("run-1"),
+    stageRunId: asStageRunId("sr-review"),
+    stageName: overrides.stageName ?? "review",
+    kind: "finding",
+    filePath: "src/x.ts",
+    startLine: 1,
+    endLine: 2,
+    title: "Finding",
+    description: "...",
+    category: "general",
+    severity: "warning",
+    confidence: 0.7,
+    status: "open",
+    createdAt: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  } as Artifact;
+}
+
+function ctx(run: RunState, findings: Artifact[] = []): PredicateCtx {
+  return { run, history: [], findings };
+}
+
+describe("predicate evaluator — stage-set kinds", () => {
+  it("all_pass: true only when every listed stage succeeded", () => {
+    const run = makeRun([
+      { name: "a", status: "succeeded" },
+      { name: "b", status: "succeeded" },
+      { name: "c", status: "skipped" },
+    ]);
+    expect(evaluate({ kind: "all_pass", stages: ["a", "b"] }, ctx(run))).toBe(true);
+    expect(evaluate({ kind: "all_pass", stages: ["a", "b", "c"] }, ctx(run))).toBe(false);
+  });
+
+  it("any_pass: true when any listed stage succeeded", () => {
+    const run = makeRun([
+      { name: "a", status: "failed" },
+      { name: "b", status: "succeeded" },
+    ]);
+    expect(evaluate({ kind: "any_pass", stages: ["a", "b"] }, ctx(run))).toBe(true);
+    expect(evaluate({ kind: "any_pass", stages: ["a"] }, ctx(run))).toBe(false);
+  });
+
+  it("majority_pass: strict majority (>50%) of listed stages succeeded", () => {
+    const run = makeRun([
+      { name: "a", status: "succeeded" },
+      { name: "b", status: "succeeded" },
+      { name: "c", status: "failed" },
+    ]);
+    expect(evaluate({ kind: "majority_pass", stages: ["a", "b", "c"] }, ctx(run))).toBe(true);
+    expect(
+      evaluate(
+        { kind: "majority_pass", stages: ["a", "b", "c", "d"] },
+        ctx(makeRun([
+          { name: "a", status: "succeeded" },
+          { name: "b", status: "succeeded" },
+          { name: "c", status: "failed" },
+          { name: "d", status: "skipped" },
+        ])),
+      ),
+    ).toBe(false); // 2/4 is not strict majority
+    expect(evaluate({ kind: "majority_pass", stages: [] }, ctx(run))).toBe(false);
+  });
+});
+
+describe("predicate evaluator — verdict and retries", () => {
+  it("stage_verdict: matches explicit verdict over inferred", () => {
+    const run = makeRun([
+      { name: "a", status: "succeeded", verdict: "fail" },
+      { name: "b", status: "failed" },
+      { name: "c", status: "succeeded" },
+    ]);
+    expect(evaluate({ kind: "stage_verdict", stage: "a", verdict: "fail" }, ctx(run))).toBe(true);
+    expect(evaluate({ kind: "stage_verdict", stage: "a", verdict: "pass" }, ctx(run))).toBe(false);
+    // Failed stage with no explicit verdict → effective verdict "fail".
+    expect(evaluate({ kind: "stage_verdict", stage: "b", verdict: "fail" }, ctx(run))).toBe(true);
+    // Succeeded stage with no explicit verdict → effective verdict "pass".
+    expect(evaluate({ kind: "stage_verdict", stage: "c", verdict: "pass" }, ctx(run))).toBe(true);
+  });
+
+  it("stage_retried_at_least: matches when attempt >= n", () => {
+    const run = makeRun([{ name: "a", status: "failed", attempt: 3 }]);
+    expect(evaluate({ kind: "stage_retried_at_least", stage: "a", n: 3 }, ctx(run))).toBe(true);
+    expect(evaluate({ kind: "stage_retried_at_least", stage: "a", n: 4 }, ctx(run))).toBe(false);
+  });
+
+  it("loop_rounds_at_least: matches when run.loopRounds >= n", () => {
+    const run = makeRun([{ name: "a", status: "succeeded" }], { loopRounds: 5 });
+    expect(evaluate({ kind: "loop_rounds_at_least", n: 5 }, ctx(run))).toBe(true);
+    expect(evaluate({ kind: "loop_rounds_at_least", n: 6 }, ctx(run))).toBe(false);
+  });
+});
+
+describe("predicate evaluator — finding kinds", () => {
+  const run = makeRun([{ name: "review", status: "succeeded" }]);
+  const findings = [
+    makeFinding({ artifactId: asArtifactId("a1"), severity: "error" }),
+    makeFinding({ artifactId: asArtifactId("a2"), severity: "warning" }),
+    makeFinding({ artifactId: asArtifactId("a3"), severity: "info" }),
+    makeFinding({
+      artifactId: asArtifactId("a4"),
+      severity: "error",
+      status: "dismissed",
+    }),
+  ];
+
+  it("no_open_findings: counts only open findings", () => {
+    expect(evaluate({ kind: "no_open_findings" }, ctx(run, []))).toBe(true);
+    expect(evaluate({ kind: "no_open_findings" }, ctx(run, findings))).toBe(false);
+  });
+
+  it("no_open_findings (per-stage): scopes to one stage", () => {
+    const stageFindings = [
+      makeFinding({ stageName: "review", artifactId: asArtifactId("r1") }),
+      makeFinding({ stageName: "lint", artifactId: asArtifactId("l1") }),
+    ];
+    expect(evaluate({ kind: "no_open_findings", stage: "lint" }, ctx(run, stageFindings))).toBe(
+      false,
+    );
+    expect(evaluate({ kind: "no_open_findings", stage: "other" }, ctx(run, stageFindings))).toBe(
+      true,
+    );
+  });
+
+  it("finding_count_below: counts respecting severity filter", () => {
+    expect(evaluate({ kind: "finding_count_below", max: 3 }, ctx(run, findings))).toBe(false);
+    expect(evaluate({ kind: "finding_count_below", max: 4 }, ctx(run, findings))).toBe(true);
+    expect(
+      evaluate(
+        { kind: "finding_count_below", max: 2, severity: "error" },
+        ctx(run, findings),
+      ),
+    ).toBe(true); // only 1 open error (a4 is dismissed); 1 < 2
+    expect(
+      evaluate(
+        { kind: "finding_count_below", max: 1, severity: "warning" },
+        ctx(run, findings),
+      ),
+    ).toBe(false); // 1 open warning, max=1 is not strictly below
+  });
+});
+
+describe("predicate evaluator — composition", () => {
+  const run = makeRun([
+    { name: "a", status: "succeeded" },
+    { name: "b", status: "failed" },
+  ]);
+
+  it("and: every child must be true", () => {
+    expect(
+      evaluate(
+        {
+          kind: "and",
+          predicates: [
+            { kind: "any_pass", stages: ["a"] },
+            { kind: "stage_verdict", stage: "b", verdict: "fail" },
+          ],
+        },
+        ctx(run),
+      ),
+    ).toBe(true);
+    expect(
+      evaluate(
+        {
+          kind: "and",
+          predicates: [
+            { kind: "any_pass", stages: ["a"] },
+            { kind: "stage_verdict", stage: "b", verdict: "pass" },
+          ],
+        },
+        ctx(run),
+      ),
+    ).toBe(false);
+  });
+
+  it("or: any child true is enough", () => {
+    expect(
+      evaluate(
+        {
+          kind: "or",
+          predicates: [
+            { kind: "stage_verdict", stage: "a", verdict: "fail" },
+            { kind: "stage_verdict", stage: "b", verdict: "fail" },
+          ],
+        },
+        ctx(run),
+      ),
+    ).toBe(true);
+  });
+
+  it("not: inverts the inner predicate", () => {
+    expect(
+      evaluate({ kind: "not", predicate: { kind: "any_pass", stages: ["b"] } }, ctx(run)),
+    ).toBe(true);
+    expect(
+      evaluate({ kind: "not", predicate: { kind: "any_pass", stages: ["a"] } }, ctx(run)),
+    ).toBe(false);
+  });
+
+  it("nested and/or/not: works to arbitrary depth", () => {
+    const pred: Predicate = {
+      kind: "or",
+      predicates: [
+        {
+          kind: "and",
+          predicates: [
+            { kind: "all_pass", stages: ["a"] },
+            { kind: "not", predicate: { kind: "any_pass", stages: ["b"] } },
+          ],
+        },
+        { kind: "stage_verdict", stage: "b", verdict: "fail" },
+      ],
+    };
+    expect(evaluate(pred, ctx(run))).toBe(true);
+  });
+});
+
+describe("predicate evaluator — back-compat with legacy 3 route forms", () => {
+  const run = makeRun([
+    { name: "a", status: "succeeded" },
+    { name: "b", status: "failed" },
+  ]);
+
+  it("allSucceeded == all_pass", () => {
+    expect(evaluate({ kind: "allSucceeded", stages: ["a"] }, ctx(run))).toBe(true);
+    expect(evaluate({ kind: "allSucceeded", stages: ["a", "b"] }, ctx(run))).toBe(false);
+  });
+
+  it("anySucceeded == any_pass", () => {
+    expect(evaluate({ kind: "anySucceeded", stages: ["a", "b"] }, ctx(run))).toBe(true);
+    expect(evaluate({ kind: "anySucceeded", stages: ["b"] }, ctx(run))).toBe(false);
+  });
+
+  it("anyFailed: matches failed-by-status (no explicit verdict)", () => {
+    // b has status=failed (no explicit verdict) — `effectiveVerdict` derives "fail".
+    expect(evaluate({ kind: "anyFailed", stages: ["a", "b"] }, ctx(run))).toBe(true);
+    expect(evaluate({ kind: "anyFailed", stages: ["a"] }, ctx(run))).toBe(false);
+  });
+});
+
+describe("predicate evaluator — v0_default and references", () => {
+  it("v0_default evaluates to false (reducer detects kind and falls through)", () => {
+    const run = makeRun([{ name: "a", status: "succeeded" }]);
+    expect(evaluate({ kind: "v0_default" }, ctx(run))).toBe(false);
+    expect(isV0Default({ kind: "v0_default" })).toBe(true);
+    expect(isV0Default({ kind: "all_pass", stages: ["a"] })).toBe(false);
+  });
+
+  it("predicateReferencedStages walks the tree and dedups", () => {
+    const pred: Predicate = {
+      kind: "and",
+      predicates: [
+        { kind: "all_pass", stages: ["a", "b"] },
+        { kind: "or", predicates: [{ kind: "stage_verdict", stage: "b", verdict: "fail" }] },
+        { kind: "not", predicate: { kind: "stage_retried_at_least", stage: "c", n: 2 } },
+        { kind: "no_open_findings", stage: "d" },
+        { kind: "loop_rounds_at_least", n: 1 },
+      ],
+    };
+    expect(predicateReferencedStages(pred).sort()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("predicateReferencedStages handles legacy shapes at the top level", () => {
+    expect(predicateReferencedStages({ kind: "anyFailed", stages: ["x", "y"] }).sort()).toEqual([
+      "x",
+      "y",
+    ]);
+  });
+});

--- a/packages/core/src/__tests__/pipeline-reducer.test.ts
+++ b/packages/core/src/__tests__/pipeline-reducer.test.ts
@@ -241,9 +241,13 @@ describe("pipeline reducer — STAGE_STARTED / STAGE_COMPLETED", () => {
 });
 
 describe("pipeline reducer — STAGE_FAILED", () => {
-  it("marks the run stalled and freezes remaining stages", () => {
+  it("cascade-skips downstream stages and terminates as stalled under v0 defaults", () => {
+    // Failure-tolerant scheduling keeps the run alive when an upstream fails;
+    // here `b` has `dependsOn: ["a"]` with no recovery routes, so the
+    // scheduler cascade-skips it. With every stage now terminal and no
+    // `exitPredicates`, the v0 fallback ("any failed → stalled") fires.
     const pipeline = makePipeline({
-      stages: [makeStage("a"), makeStage("b")],
+      stages: [makeStage("a"), makeStage("b", { dependsOn: ["a"] })],
       maxConcurrentStages: 1,
     });
     const triggered = fireTrigger(emptyEngineState(), { pipeline });
@@ -270,6 +274,54 @@ describe("pipeline reducer — STAGE_FAILED", () => {
       .filter((e) => e.type === "EMIT_OBSERVATION")
       .map((e) => (e.type === "EMIT_OBSERVATION" ? e.event.name : ""));
     expect(obs).toContain("pipeline.run.terminated");
+  });
+
+  it("lets independent siblings keep running after a parallel failure", () => {
+    // Failure-tolerance: a failing in one branch no longer cancels parallel
+    // siblings (the v0 "any STAGE_FAILED terminates the run as stalled"
+    // limitation that #196 fixes). The run stays `running` until every
+    // stage reaches a terminal status; only then does the exit decision fire.
+    const pipeline = makePipeline({
+      stages: [makeStage("a"), makeStage("b")],
+      maxConcurrentStages: 2,
+    });
+    const triggered = fireTrigger(emptyEngineState(), { pipeline });
+    const startedA = reduce(triggered.state, {
+      type: "STAGE_STARTED",
+      now: NOW + 1,
+      runId: asRunId("run-1"),
+      stageName: "a",
+    });
+    const startedB = reduce(startedA.state, {
+      type: "STAGE_STARTED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      stageName: "b",
+    });
+    const failedA = reduce(startedB.state, {
+      type: "STAGE_FAILED",
+      now: NOW + 3,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      errorMessage: "boom",
+    });
+
+    expect(failedA.state.runs[asRunId("run-1")].loopState).toBe("running");
+    expect(failedA.state.runs[asRunId("run-1")].stages.a.status).toBe("failed");
+    expect(failedA.state.runs[asRunId("run-1")].stages.b.status).toBe("running");
+    // No CANCEL_STAGE for the running sibling — it gets to finish.
+    expect(failedA.effects.find((e) => e.type === "CANCEL_STAGE")).toBeUndefined();
+
+    // Once b succeeds, exit-decision fires: v0 default → any failed → stalled.
+    const completedB = reduce(failedA.state, {
+      type: "STAGE_COMPLETED",
+      now: NOW + 4,
+      runId: asRunId("run-1"),
+      stageName: "b",
+      artifacts: [],
+    });
+    expect(completedB.state.runs[asRunId("run-1")].loopState).toBe("stalled");
+    expect(completedB.state.runs[asRunId("run-1")].terminationReason).toBe("stage_failure");
   });
 });
 

--- a/packages/core/src/pipeline/config-schema.ts
+++ b/packages/core/src/pipeline/config-schema.ts
@@ -13,12 +13,14 @@
 import { z } from "zod";
 
 import { findFirstStageCycle } from "./dag.js";
+import { predicateReferencedStages } from "./predicate-evaluator.js";
 import {
   asPipelineId,
+  type ExitPredicates,
   type Pipeline,
+  type Predicate,
   type Stage,
   type StageExecutor,
-  type StageRoutePredicate,
   type StageRoutes,
   type TaskMode,
 } from "./types.js";
@@ -72,14 +74,82 @@ const StageBudgetSchema = z.object({
   maxDurationMs: z.number().int().nonnegative().optional(),
 });
 
-const StageRoutePredicateSchema = z.discriminatedUnion("kind", [
+const VerdictSchema = z.enum(["pass", "fail", "neutral"]);
+const SeveritySchema = z.enum(["error", "warning", "info"]);
+
+/**
+ * Recursive Zod schema for the typed `Predicate` DSL plus the legacy three
+ * `StageRoutePredicate` shapes. The legacy shapes are accepted at parse
+ * time and TRANSFORMED into their typed equivalents — runtime code only
+ * ever sees the canonical `Predicate` form coming out of config load.
+ *
+ * Transformation:
+ *  - `allSucceeded` → `all_pass`
+ *  - `anySucceeded` → `any_pass`
+ *  - `anyFailed`    → `or` of per-stage `stage_verdict: "fail"`
+ *
+ * `z.lazy` powers the recursion for `and` / `or` / `not`. The discriminator
+ * stays on `kind`, but we use `z.union` (not `discriminatedUnion`) because
+ * `z.lazy` cannot participate in discriminatedUnion's eager analysis.
+ */
+const PredicateSchema: z.ZodType<Predicate> = z.lazy(() =>
+  z.union([
+    z.object({ kind: z.literal("all_pass"), stages: z.array(z.string().min(1)).min(1) }),
+    z.object({ kind: z.literal("any_pass"), stages: z.array(z.string().min(1)).min(1) }),
+    z.object({ kind: z.literal("majority_pass"), stages: z.array(z.string().min(1)).min(1) }),
+    z.object({
+      kind: z.literal("no_open_findings"),
+      stage: z.string().min(1).optional(),
+    }),
+    z.object({
+      kind: z.literal("finding_count_below"),
+      max: z.number().int().nonnegative(),
+      stage: z.string().min(1).optional(),
+      severity: SeveritySchema.optional(),
+    }),
+    z.object({
+      kind: z.literal("loop_rounds_at_least"),
+      n: z.number().int().positive(),
+    }),
+    z.object({
+      kind: z.literal("stage_retried_at_least"),
+      stage: z.string().min(1),
+      n: z.number().int().positive(),
+    }),
+    z.object({
+      kind: z.literal("stage_verdict"),
+      stage: z.string().min(1),
+      verdict: VerdictSchema,
+    }),
+    z.object({ kind: z.literal("and"), predicates: z.array(PredicateSchema).min(1) }),
+    z.object({ kind: z.literal("or"), predicates: z.array(PredicateSchema).min(1) }),
+    z.object({ kind: z.literal("not"), predicate: PredicateSchema }),
+    z.object({ kind: z.literal("v0_default") }),
+  ]),
+);
+
+/**
+ * Accept either the typed Predicate DSL or one of the legacy three shapes
+ * (`allSucceeded` / `anySucceeded` / `anyFailed`). Both are accepted at
+ * parse time; the route normalizer below normalizes legacy → typed before
+ * the runtime Pipeline is constructed.
+ */
+const LegacyRoutePredicateSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("allSucceeded"), stages: z.array(z.string().min(1)).min(1) }),
   z.object({ kind: z.literal("anySucceeded"), stages: z.array(z.string().min(1)).min(1) }),
   z.object({ kind: z.literal("anyFailed"), stages: z.array(z.string().min(1)).min(1) }),
 ]);
 
+const RoutePredicateSchema = z.union([PredicateSchema, LegacyRoutePredicateSchema]);
+
 const StageRoutesSchema = z.object({
-  when: StageRoutePredicateSchema,
+  when: RoutePredicateSchema,
+});
+
+const ExitPredicatesSchema = z.object({
+  done: PredicateSchema.optional(),
+  stalled: PredicateSchema.optional(),
+  blocksMerge: PredicateSchema.optional(),
 });
 
 const StageSchema = z.object({
@@ -115,6 +185,7 @@ export const ConfiguredPipelineSchema = z
     name: z.string().min(1).optional(),
     stages: z.array(StageSchema).min(1),
     maxConcurrentStages: z.number().int().positive().optional(),
+    exitPredicates: ExitPredicatesSchema.optional(),
   })
   .superRefine((pipeline, ctx) => {
     const stageNames = new Set(pipeline.stages.map((s) => s.name));
@@ -155,19 +226,40 @@ export const ConfiguredPipelineSchema = z
       }
       const routes = stage.routes;
       if (routes) {
-        for (const ref of routes.when.stages) {
+        for (const ref of predicateReferencedStages(routes.when)) {
           if (!stageNames.has(ref)) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
-              path: ["stages", i, "routes", "when", "stages"],
+              path: ["stages", i, "routes", "when"],
               message: `Stage "${stage.name}" routes references unknown stage "${ref}".`,
             });
           }
           if (ref === stage.name) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
-              path: ["stages", i, "routes", "when", "stages"],
+              path: ["stages", i, "routes", "when"],
               message: `Stage "${stage.name}" cannot route to itself.`,
+            });
+          }
+        }
+      }
+    }
+
+    // exitPredicates references must point to known stage names too.
+    if (pipeline.exitPredicates) {
+      const branches: Array<{ key: keyof ExitPredicates; predicate?: Predicate }> = [
+        { key: "done", predicate: pipeline.exitPredicates.done },
+        { key: "stalled", predicate: pipeline.exitPredicates.stalled },
+        { key: "blocksMerge", predicate: pipeline.exitPredicates.blocksMerge },
+      ];
+      for (const { key, predicate } of branches) {
+        if (!predicate) continue;
+        for (const ref of predicateReferencedStages(predicate)) {
+          if (!stageNames.has(ref)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["exitPredicates", key],
+              message: `exitPredicates.${key} references unknown stage "${ref}".`,
             });
           }
         }
@@ -223,12 +315,7 @@ export function configuredPipelineToRuntime(key: string, configured: ConfiguredP
     }
 
     const routes: StageRoutes | undefined = stage.routes
-      ? {
-          when: {
-            kind: stage.routes.when.kind,
-            stages: [...stage.routes.when.stages],
-          } as StageRoutePredicate,
-        }
+      ? { when: normalizeRoutePredicate(stage.routes.when) }
       : undefined;
 
     return {
@@ -253,5 +340,32 @@ export function configuredPipelineToRuntime(key: string, configured: ConfiguredP
     ...(configured.maxConcurrentStages !== undefined
       ? { maxConcurrentStages: configured.maxConcurrentStages }
       : {}),
+    ...(configured.exitPredicates ? { exitPredicates: { ...configured.exitPredicates } } : {}),
   };
+}
+
+/**
+ * Normalize a parsed route predicate into the canonical typed `Predicate`
+ * DSL. Legacy `StageRoutePredicate` shapes (`allSucceeded`/`anySucceeded`/
+ * `anyFailed`) are rewritten into their typed equivalents so the runtime
+ * Pipeline only ever holds typed predicates.
+ */
+function normalizeRoutePredicate(predicate: z.infer<typeof RoutePredicateSchema>): Predicate {
+  switch (predicate.kind) {
+    case "allSucceeded":
+      return { kind: "all_pass", stages: [...predicate.stages] };
+    case "anySucceeded":
+      return { kind: "any_pass", stages: [...predicate.stages] };
+    case "anyFailed":
+      return {
+        kind: "or",
+        predicates: predicate.stages.map((stage) => ({
+          kind: "stage_verdict",
+          stage,
+          verdict: "fail",
+        })),
+      };
+    default:
+      return predicate;
+  }
 }

--- a/packages/core/src/pipeline/dag.ts
+++ b/packages/core/src/pipeline/dag.ts
@@ -17,11 +17,13 @@
  */
 
 import type { PipelineEffect } from "./events.js";
+import { evaluate, predicateReferencedStages } from "./predicate-evaluator.js";
 import { iso, patchRun } from "./reducer-helpers.js";
 import {
+  type AnyPredicate,
+  type PredicateCtx,
   type RunState,
   type Stage,
-  type StageRoutePredicate,
   type StageState,
   isTerminalStageStatus,
 } from "./types.js";
@@ -59,7 +61,7 @@ export function scheduleAfterChange(run: RunState, now: number): ScheduleResult 
       const state = current.stages[stageDef.name];
       if (state.status !== "pending") continue;
       if (!areDepsSatisfiedForStart(stageDef, current.stages)) continue;
-      if (!evaluateRoutes(stageDef, current.stages)) continue;
+      if (!evaluateRoutes(stageDef, current)) continue;
       startEffects.push({
         type: "START_STAGE",
         runId: current.runId,
@@ -98,7 +100,7 @@ function applyEligibleSkips(run: RunState, now: number): { run: RunState; newlyS
       if (!arePreconditionsTerminal(stageDef, current.stages)) continue;
 
       const shouldSkip = stageDef.routes
-        ? !evaluatePredicate(stageDef.routes.when, current.stages)
+        ? !evaluatePredicateForRun(stageDef.routes.when, current)
         : !areAllDepsSucceeded(stageDef, current.stages);
 
       if (shouldSkip) {
@@ -119,7 +121,7 @@ function applyEligibleSkips(run: RunState, now: number): { run: RunState; newlyS
 function arePreconditionsTerminal(stage: Stage, stages: Record<string, StageState>): boolean {
   if (!areDepsTerminal(stage, stages)) return false;
   if (stage.routes) {
-    for (const ref of stage.routes.when.stages) {
+    for (const ref of predicateReferencedStages(stage.routes.when)) {
       const refState = stages[ref];
       if (!refState || !isTerminalStageStatus(refState.status)) return false;
     }
@@ -146,37 +148,41 @@ function areAllDepsSucceeded(stage: Stage, stages: Record<string, StageState>): 
 }
 
 /**
- * Eligible-to-start: every `dependsOn` must be `succeeded` (default) so the
- * scheduler doesn't optimistically start a stage whose upstream skipped or
- * failed. Routes are evaluated separately by `evaluateRoutes`.
+ * Eligible-to-start: when a stage has no `routes`, every `dependsOn` must be
+ * `succeeded` so the scheduler doesn't optimistically start a stage whose
+ * upstream skipped or failed.
+ *
+ * When `routes` IS set, the user is opting into custom activation semantics
+ * — recovery branches with `routes.when` referencing `anyFailed` upstream
+ * are the canonical case. In that mode we only require deps to be terminal
+ * (already ensured by `arePreconditionsTerminal`) and let the routes
+ * predicate make the final call.
  */
 function areDepsSatisfiedForStart(stage: Stage, stages: Record<string, StageState>): boolean {
+  if (stage.routes) {
+    return areDepsTerminal(stage, stages);
+  }
   return areAllDepsSucceeded(stage, stages);
 }
 
-function evaluateRoutes(stage: Stage, stages: Record<string, StageState>): boolean {
+function evaluateRoutes(stage: Stage, run: RunState): boolean {
   if (!stage.routes) return true;
-  return evaluatePredicate(stage.routes.when, stages);
+  return evaluatePredicateForRun(stage.routes.when, run);
 }
 
 /**
- * Pure predicate evaluator over the runtime stage states. Stages referenced
- * here are guaranteed by config validation to exist in the pipeline; missing
- * entries are treated as non-terminal (i.e. `false` for everything except
- * `anyFailed` short-circuits) so an unevaluable predicate never green-lights.
+ * Routes-time evaluation. Wraps the global predicate evaluator with a
+ * minimal `PredicateCtx` — the scheduler doesn't have access to durable
+ * cross-run history, and findings are surfaced from `run.findings`. The
+ * scheduler is invoked from the reducer too, so this stays pure.
  */
-function evaluatePredicate(
-  predicate: StageRoutePredicate,
-  stages: Record<string, StageState>,
-): boolean {
-  switch (predicate.kind) {
-    case "allSucceeded":
-      return predicate.stages.every((name) => stages[name]?.status === "succeeded");
-    case "anySucceeded":
-      return predicate.stages.some((name) => stages[name]?.status === "succeeded");
-    case "anyFailed":
-      return predicate.stages.some((name) => stages[name]?.status === "failed");
-  }
+function evaluatePredicateForRun(predicate: AnyPredicate, run: RunState): boolean {
+  const ctx: PredicateCtx = {
+    run,
+    history: [],
+    findings: run.findings ?? [],
+  };
+  return evaluate(predicate, ctx);
 }
 
 /**
@@ -198,15 +204,13 @@ export function findFirstStageCycle(
   stages: ReadonlyArray<{
     name: string;
     dependsOn?: string[];
-    routes?: { when: { stages: string[] } };
+    routes?: { when: AnyPredicate };
   }>,
 ): string[] | null {
   const adjacency = new Map<string, string[]>();
   for (const stage of stages) {
-    const edges = new Set<string>([
-      ...(stage.dependsOn ?? []),
-      ...(stage.routes?.when.stages ?? []),
-    ]);
+    const routesRefs = stage.routes ? predicateReferencedStages(stage.routes.when) : [];
+    const edges = new Set<string>([...(stage.dependsOn ?? []), ...routesRefs]);
     adjacency.set(stage.name, [...edges]);
   }
   const WHITE = 0;

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -28,6 +28,12 @@ export {
 
 export { findFirstStageCycle, scheduleAfterChange, type ScheduleResult } from "./dag.js";
 
+export {
+  evaluate as evaluatePredicate,
+  isV0Default,
+  predicateReferencedStages,
+} from "./predicate-evaluator.js";
+
 export { buildStagePrompt, type StagePromptInput } from "./stage-prompt.js";
 
 export {

--- a/packages/core/src/pipeline/predicate-evaluator.ts
+++ b/packages/core/src/pipeline/predicate-evaluator.ts
@@ -1,0 +1,193 @@
+/**
+ * Pure predicate evaluator for the typed Predicate DSL.
+ *
+ * Used by:
+ *  - The DAG scheduler (`dag.ts`) to decide whether a stage's `routes.when`
+ *    predicate is satisfied and the stage should run vs skip.
+ *  - The reducer (`reducer.ts`) to decide the run's exit state (`done` /
+ *    `stalled`) and merge-block status when `pipeline.exitPredicates` is
+ *    configured.
+ *
+ * Purity: no I/O, no Date.now(), no module-level state. Every input is in
+ * `PredicateCtx`. Stages referenced by name are looked up in `ctx.run.stages`;
+ * unknown names degrade to `false` for positive checks (we never green-light
+ * on missing data) but `not()` flips that to `true` — config validation
+ * catches dangling names at load time so the runtime never sees them.
+ */
+
+import type {
+  AnyPredicate,
+  Artifact,
+  Predicate,
+  PredicateCtx,
+  Severity,
+  StageState,
+  Verdict,
+} from "./types.js";
+
+/**
+ * Evaluate a predicate against a snapshot context. Returns `true` when the
+ * predicate is satisfied. `v0_default` always returns `false` — the reducer
+ * detects that kind and falls through to the hardcoded v0 rules instead of
+ * relying on this return value.
+ */
+export function evaluate(predicate: AnyPredicate, ctx: PredicateCtx): boolean {
+  const normalized = normalizeLegacy(predicate);
+  return evaluateTyped(normalized, ctx);
+}
+
+/**
+ * Collect every stage name a predicate references. Used by config-load cycle
+ * detection and engine-side preflight validation so unknown stages surface
+ * before the predicate is ever evaluated at runtime.
+ */
+export function predicateReferencedStages(predicate: AnyPredicate): string[] {
+  const out = new Set<string>();
+  visitTyped(normalizeLegacy(predicate), (p) => {
+    switch (p.kind) {
+      case "all_pass":
+      case "any_pass":
+      case "majority_pass":
+        for (const s of p.stages) out.add(s);
+        break;
+      case "stage_verdict":
+      case "stage_retried_at_least":
+        out.add(p.stage);
+        break;
+      case "no_open_findings":
+      case "finding_count_below":
+        if (p.stage) out.add(p.stage);
+        break;
+      default:
+        break;
+    }
+  });
+  return [...out];
+}
+
+/**
+ * `true` when the predicate is `{kind: "v0_default"}` at the top level. The
+ * reducer consults this to decide whether the configured branch is asking
+ * for the v0 hardcoded rule (e.g. `exitPredicates.done = {kind: "v0_default"}`).
+ * Composite predicates that embed `v0_default` inside an `and`/`or`/`not`
+ * branch return `false` here — those are treated as ordinary predicates
+ * whose `v0_default` leaf evaluates to `false`.
+ */
+export function isV0Default(predicate: AnyPredicate): boolean {
+  return "kind" in predicate && predicate.kind === "v0_default";
+}
+
+function evaluateTyped(predicate: Predicate, ctx: PredicateCtx): boolean {
+  switch (predicate.kind) {
+    case "all_pass":
+      return predicate.stages.every((name) => isSucceeded(ctx.run.stages[name]));
+    case "any_pass":
+      return predicate.stages.some((name) => isSucceeded(ctx.run.stages[name]));
+    case "majority_pass": {
+      if (predicate.stages.length === 0) return false;
+      const passed = predicate.stages.filter((name) => isSucceeded(ctx.run.stages[name])).length;
+      return passed * 2 > predicate.stages.length;
+    }
+    case "no_open_findings":
+      return countFindings(ctx.findings, predicate.stage, undefined) === 0;
+    case "finding_count_below":
+      return countFindings(ctx.findings, predicate.stage, predicate.severity) < predicate.max;
+    case "loop_rounds_at_least":
+      return ctx.run.loopRounds >= predicate.n;
+    case "stage_retried_at_least": {
+      const stage = ctx.run.stages[predicate.stage];
+      if (!stage) return false;
+      return stage.attempt >= predicate.n;
+    }
+    case "stage_verdict": {
+      const stage = ctx.run.stages[predicate.stage];
+      if (!stage) return false;
+      return effectiveVerdict(stage) === predicate.verdict;
+    }
+    case "and":
+      return predicate.predicates.every((p) => evaluateTyped(p, ctx));
+    case "or":
+      return predicate.predicates.some((p) => evaluateTyped(p, ctx));
+    case "not":
+      return !evaluateTyped(predicate.predicate, ctx);
+    case "v0_default":
+      return false;
+  }
+}
+
+function visitTyped(predicate: Predicate, fn: (p: Predicate) => void): void {
+  fn(predicate);
+  if (predicate.kind === "and" || predicate.kind === "or") {
+    for (const child of predicate.predicates) visitTyped(child, fn);
+  } else if (predicate.kind === "not") {
+    visitTyped(predicate.predicate, fn);
+  }
+}
+
+/**
+ * Normalize the legacy 3-kind `StageRoutePredicate` shape into the typed
+ * `Predicate` DSL so the evaluator has a single switch to maintain.
+ *
+ * `allSucceeded` / `anySucceeded` map straight onto `all_pass` / `any_pass`
+ * (the legacy semantics were always "status === succeeded"). `anyFailed`
+ * maps to `or` of `stage_verdict: fail` per listed stage — `effectiveVerdict`
+ * already treats `status === "failed"` as verdict "fail" so the runtime
+ * behavior is preserved.
+ */
+function normalizeLegacy(predicate: AnyPredicate): Predicate {
+  if (!("kind" in predicate)) {
+    return predicate as Predicate;
+  }
+  switch (predicate.kind) {
+    case "allSucceeded":
+      return { kind: "all_pass", stages: predicate.stages };
+    case "anySucceeded":
+      return { kind: "any_pass", stages: predicate.stages };
+    case "anyFailed":
+      return {
+        kind: "or",
+        predicates: predicate.stages.map((stage) => ({
+          kind: "stage_verdict",
+          stage,
+          verdict: "fail",
+        })),
+      };
+    default:
+      return predicate as Predicate;
+  }
+}
+
+function isSucceeded(stage: StageState | undefined): boolean {
+  return stage?.status === "succeeded";
+}
+
+/**
+ * Map a stage's lifecycle status onto a Verdict so `stage_verdict` queries
+ * work even for stages that didn't carry an explicit `verdict` field:
+ *  - explicit `verdict` always wins
+ *  - `succeeded` ⇒ "pass"
+ *  - `failed`    ⇒ "fail"
+ *  - everything else (pending/running/skipped/outdated) ⇒ "neutral"
+ */
+function effectiveVerdict(stage: StageState): Verdict {
+  if (stage.verdict) return stage.verdict;
+  if (stage.status === "succeeded") return "pass";
+  if (stage.status === "failed") return "fail";
+  return "neutral";
+}
+
+function countFindings(
+  findings: ReadonlyArray<Artifact>,
+  stageName: string | undefined,
+  severity: Severity | undefined,
+): number {
+  let count = 0;
+  for (const a of findings) {
+    if (a.kind !== "finding") continue;
+    if (a.status !== "open") continue;
+    if (stageName && a.stageName !== stageName) continue;
+    if (severity && a.severity !== severity) continue;
+    count += 1;
+  }
+  return count;
+}

--- a/packages/core/src/pipeline/reducer.ts
+++ b/packages/core/src/pipeline/reducer.ts
@@ -14,6 +14,7 @@
 
 import { scheduleAfterChange } from "./dag.js";
 import type { PipelineEffect, PipelineEvent, ReducerResult } from "./events.js";
+import { evaluate, isV0Default } from "./predicate-evaluator.js";
 import {
   deriveLoopStateFromRun,
   invalidTransition,
@@ -25,10 +26,13 @@ import {
   terminateRunFromState,
 } from "./reducer-helpers.js";
 import {
+  type Artifact,
   type ArtifactInput,
   type EngineState,
   type LoopStateName,
   type Pipeline,
+  type Predicate,
+  type PredicateCtx,
   type RunId,
   type RunState,
   type RunTerminationReason,
@@ -133,7 +137,15 @@ function reduceTriggerFired(state: EngineState, event: TriggerFiredEvent): Reduc
       },
       ...skipObservations(runState.runId, sched.newlySkipped, runState),
     ];
-    return terminateRunFromState(stateWithRun, runState, "completed", now, "done", preceding);
+    const decision = decideRunExit(runState, stateWithRun);
+    return terminateRunFromState(
+      stateWithRun,
+      runState,
+      decision.reason,
+      now,
+      decision.loopState,
+      preceding,
+    );
   }
 
   const nextState: EngineState = {
@@ -271,7 +283,7 @@ function reduceStageCompleted(state: EngineState, event: StageCompletedEvent): R
     artifacts: [...stage.artifacts, ...newArtifacts.map((a) => a.artifactId)],
   };
 
-  return finalizeStageCompletion(state, run, stageName, updatedStage, newArtifacts, "success", now);
+  return finalizeStageCompletion(state, run, stageName, updatedStage, newArtifacts, now);
 }
 
 interface StageFailedEvent {
@@ -302,7 +314,7 @@ function reduceStageFailed(state: EngineState, event: StageFailedEvent): Reducer
     errorMessage,
   };
 
-  return finalizeStageCompletion(state, run, stageName, updatedStage, [], "failure", now);
+  return finalizeStageCompletion(state, run, stageName, updatedStage, [], now);
 }
 
 interface NewShaEvent {
@@ -562,11 +574,13 @@ function finalizeStageCompletion(
   run: RunState,
   stageName: string,
   updatedStage: StageState,
-  newArtifacts: ReturnType<typeof materializeArtifact>[],
-  outcome: "success" | "failure",
+  newArtifacts: Artifact[],
   now: number,
 ): ReducerResult {
-  const updatedRun = patchRun(run, { [stageName]: updatedStage }, now);
+  const updatedRun = patchRunWithFindings(
+    patchRun(run, { [stageName]: updatedStage }, now),
+    newArtifacts,
+  );
 
   const effects: PipelineEffect[] = [];
 
@@ -593,35 +607,23 @@ function finalizeStageCompletion(
     },
   });
 
-  // Stage failure terminates the run as `stalled` (existing v0 behavior).
-  // Mid-flight or pending stages get cleaned up by terminateRunFromState
-  // (running → outdated, pending → skipped) so we don't leak inflight work
-  // onto the parallel branches that may still be running.
-  if (outcome === "failure") {
-    return terminateRunFromState(
-      replaceRun(state, updatedRun),
-      updatedRun,
-      "stage_failure",
-      now,
-      "stalled",
-      effects,
-    );
-  }
-
-  // Success path: the DAG scheduler may cascade-skip downstream stages whose
-  // routes are now unsatisfied, and may immediately schedule the next batch
-  // of parallel-eligible stages. Cascade-driven terminality is checked AFTER
-  // the cascade — only this can carry the run to `done` in one reducer step.
+  // Failure-tolerant scheduling: STAGE_FAILED no longer immediately
+  // terminates the run. `scheduleAfterChange` cascade-skips stages whose
+  // `dependsOn` is no longer satisfiable AND starts any recovery branch
+  // whose `routes` predicate now matches the failure. The run only
+  // terminates when every stage has reached a terminal status (then we
+  // evaluate `exitPredicates` / v0 fallback to choose `done` vs `stalled`).
   const sched = scheduleAfterChange(updatedRun, now);
   effects.push(...skipObservations(run.runId, sched.newlySkipped, sched.run));
 
   if (sched.allTerminal) {
+    const decision = decideRunExit(sched.run, state);
     return terminateRunFromState(
       replaceRun(state, sched.run),
       sched.run,
-      "completed",
+      decision.reason,
       now,
-      "done",
+      decision.loopState,
       effects,
     );
   }
@@ -630,4 +632,76 @@ function finalizeStageCompletion(
   effects.push(...sched.startEffects);
 
   return { state: replaceRun(state, sched.run), effects };
+}
+
+/**
+ * Append new finding artifacts to `run.findings`. JSON-kind artifacts are
+ * not mirrored — the predicate DSL's findings-aware kinds reason about
+ * the finding subtype only.
+ */
+function patchRunWithFindings(run: RunState, artifacts: Artifact[]): RunState {
+  const findings = artifacts.filter((a) => a.kind === "finding");
+  if (findings.length === 0) return run;
+  return { ...run, findings: [...(run.findings ?? []), ...findings] };
+}
+
+interface ExitDecision {
+  reason: RunTerminationReason;
+  loopState: LoopStateName;
+}
+
+/**
+ * Decide how the run terminates once every stage is in a terminal status.
+ *
+ * Order of consideration:
+ *  1. `pipeline.exitPredicates.done` (if set and not `v0_default`): when it
+ *     evaluates `true`, terminate as `done`/`completed`.
+ *  2. `pipeline.exitPredicates.stalled` (if set and not `v0_default`): when
+ *     it evaluates `true`, terminate as `stalled`/`stage_failure`.
+ *  3. v0 default: any `failed` stage → `stalled`/`stage_failure`, else `done`/`completed`.
+ *
+ * The reducer is pure — it consults `state.historySummaries` for the run's
+ * loop key so `loop_rounds_at_least` and history-aware composites have a
+ * real ledger rather than an empty snapshot.
+ */
+function decideRunExit(run: RunState, state: EngineState): ExitDecision {
+  const exits = run.pipelineConfigSnapshot.exitPredicates;
+  const ctx: PredicateCtx = {
+    run,
+    history: state.historySummaries[loopKey(run.sessionId, run.pipelineName)] ?? [],
+    findings: run.findings ?? [],
+  };
+
+  const doneMatched = matchesConfiguredPredicate(exits?.done, ctx);
+  if (doneMatched === true) {
+    return { reason: "completed", loopState: "done" };
+  }
+  const stalledMatched = matchesConfiguredPredicate(exits?.stalled, ctx);
+  if (stalledMatched === true) {
+    return { reason: "stage_failure", loopState: "stalled" };
+  }
+
+  // Either no exitPredicates configured, both configured branches said
+  // `false`, or one/both opted into `v0_default` explicitly. Fall through.
+  return v0DefaultExitDecision(run);
+}
+
+/**
+ * `undefined`/`v0_default` → `null` (caller falls through to v0 rules).
+ * Any other predicate is evaluated normally and returns `true`/`false`.
+ */
+function matchesConfiguredPredicate(
+  predicate: Predicate | undefined,
+  ctx: PredicateCtx,
+): boolean | null {
+  if (!predicate) return null;
+  if (isV0Default(predicate)) return null;
+  return evaluate(predicate, ctx);
+}
+
+function v0DefaultExitDecision(run: RunState): ExitDecision {
+  const anyFailed = Object.values(run.stages).some((s) => s.status === "failed");
+  return anyFailed
+    ? { reason: "stage_failure", loopState: "stalled" }
+    : { reason: "completed", loopState: "done" };
 }

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -103,31 +103,78 @@ export interface StageBudget {
 }
 
 /**
- * Hardcoded predicate forms for v1.1. The typed predicate DSL (and richer
- * `exitPredicates`) lands in v1.3 — this union is intentionally minimal so the
- * scheduler can ship without committing to a DSL surface yet.
+ * Legacy v1.1 hardcoded predicate forms. New configs should use the typed
+ * `Predicate` DSL; these three kinds remain accepted at the schema layer and
+ * are normalized into their typed equivalents at config load:
+ *  - `allSucceeded` → `all_pass`
+ *  - `anySucceeded` → `any_pass`
+ *  - `anyFailed`    → `or` of `stage_verdict: "fail"` per listed stage
  *
- * All forms reference stage names within the same pipeline. Validation at
- * config load rejects unknown names; the scheduler trusts the input here.
- *
- * **Known limitation in v1.1: `anyFailed` is reachable only via cascade-skip,
- * not for "run-on-failure" recovery branches.** The reducer terminates the
- * run as `stalled` immediately on any STAGE_FAILED, so a downstream stage
- * with `routes.when.kind === "anyFailed"` whose predicate would evaluate
- * `true` never gets a chance to run — `terminateRunFromState` marks it
- * `skipped` first. Operators can still use `anyFailed` to express "skip
- * this stage if any upstream failed" semantics in conjunction with other
- * predicates, but rollback/cleanup-on-failure stages aren't supported until
- * failure-tolerant scheduling lands in v1.2/v1.3.
+ * Runtime code (reducer, evaluator) handles both shapes so manually
+ * constructed `Pipeline` values that still use the legacy shapes keep
+ * working without a migration.
  */
 export type StageRoutePredicate =
   | { kind: "allSucceeded"; stages: string[] }
   | { kind: "anySucceeded"; stages: string[] }
   | { kind: "anyFailed"; stages: string[] };
 
+/**
+ * Typed predicate DSL — the canonical shape for routes activation and the
+ * `exitPredicates` (done / stalled / blocksMerge) decisions.
+ *
+ * Evaluated by `predicate-evaluator.ts` over a `PredicateCtx` of
+ * `{ run, history, findings }`. The evaluator is pure (no I/O) so the same
+ * predicate can be assessed at scheduling time (dag.ts, with only `run`),
+ * at exit time (reducer.ts, with full ctx), or at observation time.
+ *
+ * Semantics for stage-set predicates (`all_pass`, `any_pass`, `majority_pass`)
+ * treat "pass" as `status === "succeeded"`, matching the legacy
+ * `allSucceeded`/`anySucceeded` behavior. Verdict-based judgement uses the
+ * separate `stage_verdict` kind so the two axes don't collide.
+ */
+export type Predicate =
+  | { kind: "all_pass"; stages: string[] }
+  | { kind: "any_pass"; stages: string[] }
+  | { kind: "majority_pass"; stages: string[] }
+  | { kind: "no_open_findings"; stage?: string }
+  | {
+      kind: "finding_count_below";
+      max: number;
+      stage?: string;
+      severity?: Severity;
+    }
+  | { kind: "loop_rounds_at_least"; n: number }
+  | { kind: "stage_retried_at_least"; stage: string; n: number }
+  | { kind: "stage_verdict"; stage: string; verdict: Verdict }
+  | { kind: "and"; predicates: Predicate[] }
+  | { kind: "or"; predicates: Predicate[] }
+  | { kind: "not"; predicate: Predicate }
+  | { kind: "v0_default" };
+
+/**
+ * Any predicate shape the engine accepts at runtime — the typed `Predicate`
+ * DSL plus the legacy `StageRoutePredicate` forms for back-compat with
+ * hand-constructed `Pipeline` values.
+ */
+export type AnyPredicate = Predicate | StageRoutePredicate;
+
 export interface StageRoutes {
   /** Evaluated once every referenced upstream stage reaches a terminal state. */
-  when: StageRoutePredicate;
+  when: AnyPredicate;
+}
+
+export interface ExitPredicates {
+  /** Run terminates as `done` when this predicate is true after every stage is terminal. */
+  done?: Predicate;
+  /** Run terminates as `stalled` when this predicate is true after every stage is terminal. */
+  stalled?: Predicate;
+  /**
+   * Engine-level "this run blocks merge". Not enforced inside the reducer;
+   * the SCM integration consults the evaluator with the run's current
+   * snapshot to decide whether to surface a merge block.
+   */
+  blocksMerge?: Predicate;
 }
 
 export interface Stage {
@@ -173,6 +220,14 @@ export interface Pipeline {
    * are unaffected (they don't shell out untrusted code from the PR).
    */
   allowForkPRs?: boolean;
+  /**
+   * Optional typed-predicate decisions for run exit and merge blocking. When
+   * absent, the reducer falls back to the v0 hardcoded rules ("done" when
+   * every stage reached a non-failed terminal status; "stalled" when any
+   * stage failed). When any branch is set to `{kind: "v0_default"}`, it
+   * explicitly opts into v0 behavior for that branch only.
+   */
+  exitPredicates?: ExitPredicates;
 }
 
 // ============================================================================
@@ -296,6 +351,15 @@ export interface RunState {
   loopRounds: number;
   /** Keyed by stage name. v0 has at most one entry per stage. */
   stages: Record<string, StageState>;
+  /**
+   * Denormalized materialized findings for predicate evaluation. The reducer
+   * appends new finding artifacts here as STAGE_COMPLETED events arrive so
+   * the predicate evaluator (used at routes evaluation and exit decision
+   * time) can answer `no_open_findings` / `finding_count_below` without
+   * reading the store. JSON artifacts are not mirrored here — they aren't
+   * findings. Capped only by what stages emit.
+   */
+  findings?: Artifact[];
   createdAt: string;
   updatedAt: string;
 }
@@ -347,6 +411,30 @@ export function emptyEngineState(): EngineState {
     currentRunByLoop: {},
     historySummaries: {},
   };
+}
+
+// ============================================================================
+// Predicate evaluation context
+// ============================================================================
+
+/**
+ * Inputs to the typed-predicate evaluator (`predicate-evaluator.ts`). All
+ * fields are read-only snapshots — the evaluator is pure and must never
+ * mutate them.
+ *
+ * - `run` is the current run state being decided over (stages, attempts,
+ *   loopRounds).
+ * - `history` is the per-loop run summary ledger, oldest first. Predicates
+ *   like cross-run stability checks consult this. Routes-time evaluation
+ *   (in the scheduler) passes an empty array; only the reducer's exit
+ *   decision has access to durable history.
+ * - `findings` are the materialized finding artifacts the engine has
+ *   accumulated for this run. `RunState.findings` is the canonical source.
+ */
+export interface PredicateCtx {
+  run: RunState;
+  history: ReadonlyArray<RunSummary>;
+  findings: ReadonlyArray<Artifact>;
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #196.

## Summary

Replaces the v1.1 hardcoded 3-form route predicate (`allSucceeded` / `anySucceeded` / `anyFailed`) with a typed `Predicate` DSL, adds `Pipeline.exitPredicates` for done / stalled / blocksMerge decisions, and fixes the documented limitation where any `STAGE_FAILED` terminated the run as `stalled` — recovery branches that route on upstream failure are now reachable.

## What changed

- **`packages/core/src/pipeline/types.ts`** — discriminated `Predicate` union (12 kinds: `all_pass`, `any_pass`, `majority_pass`, `no_open_findings`, `finding_count_below`, `loop_rounds_at_least`, `stage_retried_at_least`, `stage_verdict`, `and`, `or`, `not`, `v0_default`), `Pipeline.exitPredicates: { done?; stalled?; blocksMerge? }`, `PredicateCtx`. Legacy `StageRoutePredicate` shapes are retained as an accepted runtime alias and normalized at schema parse time.
- **`packages/core/src/pipeline/predicate-evaluator.ts`** (new) — pure `evaluate(predicate, ctx)` over `{ run, history, findings }`. Handles all 12 kinds, recursive composition (`and`/`or`/`not`), and the legacy 3 shapes via internal normalization. `predicateReferencedStages` walks the tree for cycle detection and config validation.
- **`packages/core/src/pipeline/reducer.ts`** — `STAGE_FAILED` no longer immediately terminates the run; instead the failure is applied, the DAG scheduler runs (cascade-skipping unrouted downstream stages, starting recovery branches whose routes now match), and the run only terminates when every stage is terminal. The exit decision consults `pipeline.exitPredicates.done` / `stalled` (with `v0_default` falling through), defaulting to the v0 hardcoded rule (any failure → stalled).
- **`packages/core/src/pipeline/dag.ts`** — `areDepsSatisfiedForStart` distinguishes routes-driven (deps just need to be terminal) from default activation (deps must succeed). Routes evaluation now goes through the global evaluator. `findFirstStageCycle` walks `predicateReferencedStages` so cycle detection handles recursive predicates.
- **`packages/core/src/pipeline/config-schema.ts`** — recursive `PredicateSchema` (`z.lazy`), legacy `LegacyRoutePredicateSchema` for back-compat, `ExitPredicatesSchema`. `configuredPipelineToRuntime` normalizes legacy → typed at parse time so runtime code only sees the canonical form.
- **`RunState.findings`** — denormalized finding artifacts accumulated by the reducer so the evaluator can answer `no_open_findings` / `finding_count_below` purely (no store reads inside the reducer).

## Acceptance criteria

- [x] Predicate evaluator is pure (no I/O); composition tested (`and`/`or`/`not`, nested, legacy shapes).
- [x] `exitPredicates` override v0 rules when configured; `{kind: "v0_default"}` opts back into v0 explicitly.
- [x] Recovery branches: a stage whose route matches an upstream failure now runs instead of being skipped + terminating the run.
- [x] Existing 3 route forms remain valid (parse as the equivalent typed predicate at config load; evaluator also accepts them directly).
- [x] Tests per predicate kind, composition, and recovery-branch end-to-end (`packages/core/src/__tests__/pipeline-predicate-evaluator.test.ts`, `pipeline-exit-and-recovery.test.ts`).

## Behavior change

The v1.1 reducer terminated the run on the first `STAGE_FAILED`, cancelling any running sibling on a parallel branch. With failure-tolerant scheduling, running siblings keep going until they complete naturally; the run exit fires only when every stage is terminal. Two existing parallel-branch tests in `pipeline-dag.test.ts` / `pipeline-reducer.test.ts` that asserted the v0 immediate-termination behavior were updated to either:
- assert the new behavior (siblings keep running; run resolves once all-terminal), or
- preserve the original `outdated` end-state by chaining `STAGE_FAILED` + `RUN_CANCELLED` to explicitly terminate.

## Test plan

- [x] `pnpm --filter @aoagents/ao-core test` — 1384/1384 passing.
- [x] `pnpm --filter @aoagents/ao-core typecheck` clean.
- [x] `pnpm build` (full repo) clean.
- [x] `pnpm lint` — 0 errors (54 pre-existing warnings, none in changed files).
- [x] Integration tests: 206 passed, 3 skipped (pre-existing).
- [x] Pre-existing failures (unchanged by this PR): tracker-linear (Composio SDK not installed), 2 CLI tests (path-equality on macOS, `ao pipeline run` mock missing `getOneShotPipelineEngine` — introduced by #194). Verified each fails on pristine `pipelines` HEAD too.

Depends on #192; independent of #194/#195.