### PR TITLE
feat(pipelines): Pipeline Workbench UI + REST + sendFollowUpToTask (#198)

### DIFF
--- a/packages/core/src/__tests__/pipeline-followup.test.ts
+++ b/packages/core/src/__tests__/pipeline-followup.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Coverage for the v2 reducer events that back the Pipeline Workbench:
+ * ARTIFACT_STATUS_CHANGED, USER_FOLLOWUP, FOLLOWUP_REPLY.
+ *
+ * Pure reducer assertions only — no engine, no store I/O. Web-side effect
+ * routing lives in packages/web/src/lib/pipelines.ts and is covered by the
+ * component tests.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  asPipelineId,
+  asRunId,
+  asStageRunId,
+  emptyEngineState,
+  reduce,
+  type EngineState,
+  type Pipeline,
+  type PipelineEvent,
+  type ArtifactId,
+  type StageRunId,
+} from "../pipeline/index.js";
+
+const NOW = 1_700_000_000_000;
+
+function makePipeline(): Pipeline {
+  return {
+    id: asPipelineId("pl-1"),
+    name: "default",
+    stages: [
+      {
+        name: "review",
+        trigger: { on: ["pr.opened"] },
+        executor: { kind: "agent", plugin: "codex", mode: "review" },
+        task: { prompt: "review" },
+      },
+    ],
+    maxConcurrentStages: 1,
+  };
+}
+
+function bootstrapRunWithFinding(): EngineState {
+  const runId = asRunId("run-1");
+  const stageRunIds = { review: asStageRunId("sr-1") };
+  const trigger: PipelineEvent = {
+    type: "TRIGGER_FIRED",
+    now: NOW,
+    trigger: "pr.opened",
+    sessionId: "ses-1",
+    pipeline: makePipeline(),
+    headSha: "sha-aaa",
+    runId,
+    stageRunIds,
+  };
+  const after = reduce(emptyEngineState(), trigger).state;
+  const started = reduce(after, {
+    type: "STAGE_STARTED",
+    now: NOW,
+    runId,
+    stageName: "review",
+  });
+  const finished = reduce(started.state, {
+    type: "STAGE_COMPLETED",
+    now: NOW,
+    runId,
+    stageName: "review",
+    verdict: "neutral",
+    artifacts: [
+      {
+        kind: "finding",
+        filePath: "src/foo.ts",
+        startLine: 5,
+        endLine: 7,
+        title: "use const",
+        description: "...",
+        category: "style",
+        severity: "info",
+        confidence: 0.8,
+      },
+    ],
+  });
+  return finished.state;
+}
+
+describe("pipeline reducer — v2 workbench events", () => {
+  it("ARTIFACT_STATUS_CHANGED emits UPDATE_ARTIFACT_STATUS + PERSIST_RUN and mirrors run.findings", () => {
+    const state = bootstrapRunWithFinding();
+    const run = Object.values(state.runs)[0];
+    const finding = run.findings?.[0];
+    expect(finding?.status).toBe("open");
+    const result = reduce(state, {
+      type: "ARTIFACT_STATUS_CHANGED",
+      now: NOW + 1,
+      runId: run.runId,
+      stageRunId: run.stages.review.stageRunId,
+      artifactId: finding!.artifactId as ArtifactId,
+      status: "dismissed",
+      actor: "app-rev-1",
+    });
+    const types = result.effects.map((e) => e.type);
+    expect(types).toContain("UPDATE_ARTIFACT_STATUS");
+    expect(types).toContain("PERSIST_RUN");
+    expect(types).toContain("EMIT_OBSERVATION");
+    const nextRun = result.state.runs[run.runId];
+    expect(nextRun.findings?.[0].status).toBe("dismissed");
+  });
+
+  it("USER_FOLLOWUP is rejected on a terminal run", () => {
+    const state = bootstrapRunWithFinding();
+    const run = Object.values(state.runs)[0];
+    // Single-stage pipeline auto-terminates after STAGE_COMPLETED.
+    expect(run.loopState).toBe("done");
+    const result = reduce(state, {
+      type: "USER_FOLLOWUP",
+      now: NOW + 1,
+      runId: run.runId,
+      stageRunId: run.stages.review.stageRunId,
+      stageName: "review",
+      message: "hi",
+    });
+    const types = result.effects.map((e) => e.type);
+    expect(types).toContain("EMIT_OBSERVATION");
+    expect(types).not.toContain("APPEND_THREAD_MESSAGE");
+    expect(types).not.toContain("SEND_FOLLOWUP");
+  });
+
+  it("USER_FOLLOWUP on a running run emits APPEND_THREAD_MESSAGE + SEND_FOLLOWUP + observation", () => {
+    const runId = asRunId("run-2");
+    const stageRunIds: Record<string, StageRunId> = {
+      a: asStageRunId("sr-a"),
+      b: asStageRunId("sr-b"),
+    };
+    const pipeline: Pipeline = {
+      ...makePipeline(),
+      stages: [
+        {
+          name: "a",
+          trigger: { on: ["pr.opened"] },
+          executor: { kind: "agent", plugin: "codex", mode: "review" },
+          task: { prompt: "a" },
+        },
+        {
+          name: "b",
+          trigger: { on: ["pr.opened"] },
+          executor: { kind: "agent", plugin: "codex", mode: "review" },
+          task: { prompt: "b" },
+          dependsOn: ["a"],
+        },
+      ],
+    };
+    const after = reduce(emptyEngineState(), {
+      type: "TRIGGER_FIRED",
+      now: NOW,
+      trigger: "pr.opened",
+      sessionId: "ses-2",
+      pipeline,
+      headSha: "sha-xx",
+      runId,
+      stageRunIds,
+    }).state;
+    const result = reduce(after, {
+      type: "USER_FOLLOWUP",
+      now: NOW + 1,
+      runId,
+      stageRunId: stageRunIds.a,
+      stageName: "a",
+      message: "more context please",
+      reviewerId: "ses-rev-1",
+    });
+    const types = result.effects.map((e) => e.type);
+    expect(types).toContain("APPEND_THREAD_MESSAGE");
+    expect(types).toContain("SEND_FOLLOWUP");
+    expect(types).toContain("EMIT_OBSERVATION");
+  });
+
+  it("FOLLOWUP_REPLY appends the agent message to the thread", () => {
+    const state = bootstrapRunWithFinding();
+    const run = Object.values(state.runs)[0];
+    const result = reduce(state, {
+      type: "FOLLOWUP_REPLY",
+      now: NOW + 2,
+      runId: run.runId,
+      stageRunId: run.stages.review.stageRunId,
+      stageName: "review",
+      reply: "ack",
+    });
+    const append = result.effects.find((e) => e.type === "APPEND_THREAD_MESSAGE");
+    if (append?.type !== "APPEND_THREAD_MESSAGE") throw new Error("expected append");
+    expect(append.role).toBe("agent");
+    expect(append.content).toBe("ack");
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -508,6 +508,10 @@ export type {
   PipelineStore,
   PersistedStageRun,
   PipelineLayout,
+  // Follow-up + chat thread (v2)
+  FollowUpContext,
+  FollowUpResult,
+  ThreadMessage,
 } from "./pipeline/index.js";
 
 export type {
@@ -529,6 +533,7 @@ export type {
   WorkspaceClass,
   WorkspaceSnapshot,
   GuardCheckResult,
+  FollowUpDeliveryDeps,
 } from "./pipeline/index.js";
 
 export {

--- a/packages/core/src/pipeline/engine.ts
+++ b/packages/core/src/pipeline/engine.ts
@@ -106,6 +106,13 @@ export interface PipelineEngineDeps {
    * (most v0.x tests) need not wire this up.
    */
   builtin?: BuiltinDispatcherDeps;
+  /**
+   * Optional follow-up delivery. When the reducer emits SEND_FOLLOWUP, the
+   * engine calls this so the appropriate agent plugin can drop the message
+   * into the existing task (Codex: `codex exec --continue`). When omitted,
+   * the effect is a no-op and the dashboard surfaces "chat unavailable".
+   */
+  followUp?: FollowUpDeliveryDeps;
   /** Optional initial state (e.g. restored from disk on startup). Defaults to empty. */
   initialState?: EngineState;
   /** Override clock for tests. */
@@ -122,6 +129,32 @@ export interface PipelineEngineDeps {
     event: { name: string; data: Record<string, unknown> },
     context: ObservationContext,
   ) => void;
+}
+
+/**
+ * Deliver a follow-up message to an existing worker session. The engine asks
+ * the session manager for the session, then forwards to the matching agent
+ * plugin's `sendFollowUpToTask`. Implementations live in `cli/lib` (CLI) and
+ * `web/lib` (web) so the engine itself stays free of plugin-registry I/O.
+ */
+export interface FollowUpDeliveryDeps {
+  /**
+   * Deliver the message. Implementation MUST:
+   *   - resolve the session by id;
+   *   - confirm the worker workspace still exists (worker-alive pre-send);
+   *   - call the agent plugin's `sendFollowUpToTask`;
+   *   - throw on missing workspace so the engine can surface
+   *     `pipeline.followup.workspace_gone` and the dashboard returns 410.
+   */
+  deliver(input: {
+    sessionId: string;
+    runId: RunId;
+    stageRunId: StageRunId;
+    stageName: string;
+    pipelineName: string;
+    message: string;
+    reviewerId?: string;
+  }): Promise<{ reply?: string }>;
 }
 
 export interface StartRunInput {
@@ -227,7 +260,8 @@ export function hydrateEngineState(store: PipelineStore): EngineState {
 }
 
 export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
-  const { store, registry, agentExecutor, commandExecutor, builtin, now = Date.now } = deps;
+  const { store, registry, agentExecutor, commandExecutor, builtin, followUp, now = Date.now } =
+    deps;
   const onObservation = deps.onObservation;
 
   let state: EngineState = deps.initialState ?? emptyEngineState();
@@ -314,6 +348,28 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
 
       case "APPEND_ARTIFACTS":
         store.appendArtifacts(effect.runId, effect.stageRunId, effect.artifacts);
+        break;
+
+      case "UPDATE_ARTIFACT_STATUS":
+        store.updateArtifactStatus(
+          effect.runId,
+          effect.stageRunId,
+          effect.artifactId,
+          effect.status,
+        );
+        break;
+
+      case "APPEND_THREAD_MESSAGE":
+        store.appendThreadMessage(effect.runId, effect.stageRunId, {
+          role: effect.role,
+          content: effect.content,
+          ts: new Date(now()).toISOString(),
+          ...(effect.reviewerId ? { reviewerId: effect.reviewerId } : {}),
+        });
+        break;
+
+      case "SEND_FOLLOWUP":
+        await deliverFollowUp(effect);
         break;
 
       case "START_STAGE": {
@@ -572,6 +628,70 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
         stageName: stage.name,
         errorMessage:
           err instanceof Error ? err.message : `command executor failed: ${String(err)}`,
+      });
+    }
+  }
+
+  async function deliverFollowUp(effect: {
+    runId: RunId;
+    stageRunId: StageRunId;
+    stageName: string;
+    sessionId: string;
+    message: string;
+    reviewerId?: string;
+  }): Promise<void> {
+    if (!followUp) {
+      await executeEffect({
+        type: "EMIT_OBSERVATION",
+        event: {
+          name: "pipeline.followup.unavailable",
+          data: {
+            runId: effect.runId,
+            stageRunId: effect.stageRunId,
+            stageName: effect.stageName,
+            sessionId: effect.sessionId,
+          },
+        },
+      });
+      return;
+    }
+
+    const run = state.runs[effect.runId];
+    const pipelineName = run?.pipelineName ?? "";
+    try {
+      const result = await followUp.deliver({
+        sessionId: effect.sessionId,
+        runId: effect.runId,
+        stageRunId: effect.stageRunId,
+        stageName: effect.stageName,
+        pipelineName,
+        message: effect.message,
+        ...(effect.reviewerId ? { reviewerId: effect.reviewerId } : {}),
+      });
+      if (result.reply !== undefined && result.reply.length > 0) {
+        await dispatchInline({
+          type: "FOLLOWUP_REPLY",
+          now: now(),
+          runId: effect.runId,
+          stageRunId: effect.stageRunId,
+          stageName: effect.stageName,
+          reply: result.reply,
+        });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await executeEffect({
+        type: "EMIT_OBSERVATION",
+        event: {
+          name: "pipeline.followup.delivery_failed",
+          data: {
+            runId: effect.runId,
+            stageRunId: effect.stageRunId,
+            stageName: effect.stageName,
+            sessionId: effect.sessionId,
+            error: message,
+          },
+        },
       });
     }
   }

--- a/packages/core/src/pipeline/events.ts
+++ b/packages/core/src/pipeline/events.ts
@@ -7,7 +7,9 @@
 
 import type {
   Artifact,
+  ArtifactId,
   ArtifactInput,
+  ArtifactStatus,
   EngineState,
   LoopState,
   Pipeline,
@@ -19,6 +21,12 @@ import type {
   StageTriggerEvent,
   Verdict,
 } from "./types.js";
+
+/** Stable identity for a stage-run follow-up thread. */
+export interface ThreadKey {
+  runId: RunId;
+  stageRunId: StageRunId;
+}
 
 interface EventBase {
   /** Driver-stamped timestamp (epoch ms). Reducer must not read the clock. */
@@ -80,6 +88,31 @@ export type PipelineEvent =
       sessionId: string;
       pipelineName: string;
     })
+  | (EventBase & {
+      type: "ARTIFACT_STATUS_CHANGED";
+      runId: RunId;
+      stageRunId: StageRunId;
+      artifactId: ArtifactId;
+      status: ArtifactStatus;
+      /** Optional human label, e.g. reviewer id, for audit observation. */
+      actor?: string;
+    })
+  | (EventBase & {
+      type: "USER_FOLLOWUP";
+      runId: RunId;
+      stageRunId: StageRunId;
+      stageName: string;
+      message: string;
+      /** Reviewer surface id for thread persistence + observation. */
+      reviewerId?: string;
+    })
+  | (EventBase & {
+      type: "FOLLOWUP_REPLY";
+      runId: RunId;
+      stageRunId: StageRunId;
+      stageName: string;
+      reply: string;
+    })
   | (EventBase & { type: "TICK" });
 
 export type PipelineEffect =
@@ -92,6 +125,30 @@ export type PipelineEffect =
       runId: RunId;
       stageRunId: StageRunId;
       artifacts: Artifact[];
+    }
+  | {
+      type: "UPDATE_ARTIFACT_STATUS";
+      runId: RunId;
+      stageRunId: StageRunId;
+      artifactId: ArtifactId;
+      status: ArtifactStatus;
+    }
+  | {
+      type: "APPEND_THREAD_MESSAGE";
+      runId: RunId;
+      stageRunId: StageRunId;
+      role: "user" | "agent" | "system";
+      content: string;
+      reviewerId?: string;
+    }
+  | {
+      type: "SEND_FOLLOWUP";
+      runId: RunId;
+      stageRunId: StageRunId;
+      stageName: string;
+      sessionId: string;
+      message: string;
+      reviewerId?: string;
     }
   | {
       type: "EMIT_OBSERVATION";

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -85,6 +85,7 @@ export {
   type PipelineEngineDeps,
   type StartRunInput,
   type ObservationContext,
+  type FollowUpDeliveryDeps,
 } from "./engine.js";
 
 export {

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -21,6 +21,8 @@ export {
   artifactsDirForRun,
   artifactsFilePath,
   loopFilePath,
+  threadsDirForRun,
+  threadFilePath,
   type PipelineLayout,
 } from "./paths.js";
 

--- a/packages/core/src/pipeline/paths.ts
+++ b/packages/core/src/pipeline/paths.ts
@@ -21,6 +21,7 @@ export interface PipelineLayout {
   stagesDir: string;
   artifactsDir: string;
   loopsDir: string;
+  threadsDir: string;
 }
 
 export function pipelineLayout(root: string): PipelineLayout {
@@ -30,6 +31,7 @@ export function pipelineLayout(root: string): PipelineLayout {
     stagesDir: join(root, "stages"),
     artifactsDir: join(root, "artifacts"),
     loopsDir: join(root, "loops"),
+    threadsDir: join(root, "threads"),
   };
 }
 
@@ -51,4 +53,12 @@ export function artifactsFilePath(root: string, runId: RunId, stageRunId: StageR
 
 export function loopFilePath(root: string, runId: RunId): string {
   return join(root, "loops", `${runId}.json`);
+}
+
+export function threadsDirForRun(root: string, runId: RunId): string {
+  return join(root, "threads", runId);
+}
+
+export function threadFilePath(root: string, runId: RunId, stageRunId: StageRunId): string {
+  return join(threadsDirForRun(root, runId), `${stageRunId}.jsonl`);
 }

--- a/packages/core/src/pipeline/reducer.ts
+++ b/packages/core/src/pipeline/reducer.ts
@@ -808,7 +808,7 @@ function reduceArtifactStatusChanged(
 
   const findings = run.findings ?? [];
   const idx = findings.findIndex((a) => a.artifactId === artifactId);
-  let updatedRun: RunState = run;
+  let updatedRun: RunState;
   if (idx >= 0) {
     const next = findings.slice();
     next[idx] = { ...findings[idx], status };
@@ -859,7 +859,7 @@ interface UserFollowupEvent {
  * reducer accepts both; the dashboard already filters by stage availability.
  */
 function reduceUserFollowup(state: EngineState, event: UserFollowupEvent): ReducerResult {
-  const { runId, stageRunId, stageName, message, reviewerId, now } = event;
+  const { runId, stageRunId, stageName, message, reviewerId, now: _now } = event;
   const run = state.runs[runId];
   if (!run) return invalidTransition(state, `USER_FOLLOWUP for unknown runId=${runId}`);
   if (isTerminalLoopState(run.loopState)) {

--- a/packages/core/src/pipeline/reducer.ts
+++ b/packages/core/src/pipeline/reducer.ts
@@ -27,7 +27,9 @@ import {
 } from "./reducer-helpers.js";
 import {
   type Artifact,
+  type ArtifactId,
   type ArtifactInput,
+  type ArtifactStatus,
   type EngineState,
   type LoopStateName,
   type Pipeline,
@@ -62,6 +64,12 @@ export function reduce(state: EngineState, event: PipelineEvent): ReducerResult 
       return reduceRunResumed(state, event);
     case "CONFIG_CHANGED":
       return reduceConfigChanged(state, event);
+    case "ARTIFACT_STATUS_CHANGED":
+      return reduceArtifactStatusChanged(state, event);
+    case "USER_FOLLOWUP":
+      return reduceUserFollowup(state, event);
+    case "FOLLOWUP_REPLY":
+      return reduceFollowupReply(state, event);
     case "TICK":
       return { state, effects: [] };
   }
@@ -769,4 +777,167 @@ function isConverged(state: EngineState, run: RunState): boolean {
     if (priorKey !== current) return false;
   }
   return true;
+}
+
+interface ArtifactStatusChangedEvent {
+  now: number;
+  runId: RunId;
+  stageRunId: StageRunId;
+  artifactId: ArtifactId;
+  status: ArtifactStatus;
+  actor?: string;
+}
+
+/**
+ * Update a single artifact's status (dismiss / reopen / mark resolved). The
+ * reducer mirrors the change into `run.findings` so the predicate evaluator
+ * sees the current status without re-reading the store, then emits
+ * `UPDATE_ARTIFACT_STATUS` so the engine rewrites the JSONL.
+ *
+ * `sent_to_agent` is set by the router builtin and the SEND_FOLLOWUP effect,
+ * not by user actions. The reducer accepts it here so the engine can stamp
+ * it through the same event channel.
+ */
+function reduceArtifactStatusChanged(
+  state: EngineState,
+  event: ArtifactStatusChangedEvent,
+): ReducerResult {
+  const { runId, stageRunId, artifactId, status, actor, now } = event;
+  const run = state.runs[runId];
+  if (!run) return invalidTransition(state, `ARTIFACT_STATUS_CHANGED for unknown runId=${runId}`);
+
+  const findings = run.findings ?? [];
+  const idx = findings.findIndex((a) => a.artifactId === artifactId);
+  let updatedRun: RunState = run;
+  if (idx >= 0) {
+    const next = findings.slice();
+    next[idx] = { ...findings[idx], status };
+    updatedRun = { ...run, findings: next, updatedAt: iso(now) };
+  } else {
+    updatedRun = { ...run, updatedAt: iso(now) };
+  }
+
+  const effects: PipelineEffect[] = [
+    {
+      type: "UPDATE_ARTIFACT_STATUS",
+      runId,
+      stageRunId,
+      artifactId,
+      status,
+    },
+    { type: "PERSIST_RUN", runState: updatedRun },
+    {
+      type: "EMIT_OBSERVATION",
+      event: {
+        name: "pipeline.artifact.status_changed",
+        data: { runId, stageRunId, artifactId, status, ...(actor ? { actor } : {}) },
+      },
+    },
+  ];
+
+  return { state: replaceRun(state, updatedRun), effects };
+}
+
+interface UserFollowupEvent {
+  now: number;
+  runId: RunId;
+  stageRunId: StageRunId;
+  stageName: string;
+  message: string;
+  reviewerId?: string;
+}
+
+/**
+ * Persist a user follow-up to the thread JSONL and emit a SEND_FOLLOWUP effect
+ * for the engine to deliver to the agent. The reply lands later as
+ * FOLLOWUP_REPLY (an event, not a synchronous return) so the engine doesn't
+ * block the reducer on subprocess I/O.
+ *
+ * Guard: follow-up is only meaningful while the run is non-terminal and the
+ * stage is in a state where the agent can still consume context (running
+ * stages or terminal stages whose `loopState` is `awaiting_context`). The
+ * reducer accepts both; the dashboard already filters by stage availability.
+ */
+function reduceUserFollowup(state: EngineState, event: UserFollowupEvent): ReducerResult {
+  const { runId, stageRunId, stageName, message, reviewerId, now } = event;
+  const run = state.runs[runId];
+  if (!run) return invalidTransition(state, `USER_FOLLOWUP for unknown runId=${runId}`);
+  if (isTerminalLoopState(run.loopState)) {
+    return invalidTransition(
+      state,
+      `USER_FOLLOWUP requires non-terminal run; got ${run.loopState} for ${runId}`,
+    );
+  }
+  const stage = run.stages[stageName];
+  if (!stage) {
+    return invalidTransition(state, `USER_FOLLOWUP for unknown stage=${stageName}`);
+  }
+
+  const effects: PipelineEffect[] = [
+    {
+      type: "APPEND_THREAD_MESSAGE",
+      runId,
+      stageRunId,
+      role: "user",
+      content: message,
+      ...(reviewerId ? { reviewerId } : {}),
+    },
+    {
+      type: "SEND_FOLLOWUP",
+      runId,
+      stageRunId,
+      stageName,
+      sessionId: run.sessionId,
+      message,
+      ...(reviewerId ? { reviewerId } : {}),
+    },
+    {
+      type: "EMIT_OBSERVATION",
+      event: {
+        name: "pipeline.followup.sent",
+        data: {
+          runId,
+          stageRunId,
+          stageName,
+          sessionId: run.sessionId,
+          ...(reviewerId ? { reviewerId } : {}),
+        },
+      },
+    },
+  ];
+
+  return { state, effects };
+}
+
+interface FollowupReplyEvent {
+  now: number;
+  runId: RunId;
+  stageRunId: StageRunId;
+  stageName: string;
+  reply: string;
+}
+
+function reduceFollowupReply(state: EngineState, event: FollowupReplyEvent): ReducerResult {
+  const { runId, stageRunId, stageName, reply, now: _now } = event;
+  const run = state.runs[runId];
+  if (!run) return invalidTransition(state, `FOLLOWUP_REPLY for unknown runId=${runId}`);
+
+  const effects: PipelineEffect[] = [
+    {
+      type: "APPEND_THREAD_MESSAGE",
+      runId,
+      stageRunId,
+      role: "agent",
+      content: reply,
+    },
+    {
+      type: "EMIT_OBSERVATION",
+      event: {
+        name: "pipeline.followup.reply",
+        data: { runId, stageRunId, stageName, sessionId: run.sessionId },
+      },
+    },
+  ];
+
+  return { state, effects };
 }

--- a/packages/core/src/pipeline/store.ts
+++ b/packages/core/src/pipeline/store.ts
@@ -40,14 +40,19 @@ import {
   pipelineLayout,
   runFilePath,
   stageFilePath,
+  threadFilePath,
+  threadsDirForRun,
 } from "./paths.js";
 import type {
   Artifact,
+  ArtifactId,
+  ArtifactStatus,
   LoopState,
   RunId,
   RunState,
   StageRunId,
   StageState,
+  ThreadMessage,
 } from "./types.js";
 
 export interface PersistedStageRun extends StageState {
@@ -74,6 +79,22 @@ export interface PipelineStore {
 
   saveLoopState(runId: RunId, loopState: LoopState): void;
   loadLoopState(runId: RunId): LoopState | null;
+
+  /**
+   * Update a single artifact's status. Reads the JSONL, mutates the matching
+   * record, and atomically rewrites the file. No-op when the artifact is
+   * missing — the engine surfaces that via the invalidTransition observation
+   * already.
+   */
+  updateArtifactStatus(
+    runId: RunId,
+    stageRunId: StageRunId,
+    artifactId: ArtifactId,
+    status: ArtifactStatus,
+  ): void;
+
+  appendThreadMessage(runId: RunId, stageRunId: StageRunId, msg: ThreadMessage): void;
+  listThreadMessages(runId: RunId, stageRunId: StageRunId): ThreadMessage[];
 }
 
 /**
@@ -205,6 +226,50 @@ export function createPipelineStore(
 
     loadLoopState(runId) {
       return readJsonOrNull<LoopState>(loopFilePath(root, runId));
+    },
+
+    updateArtifactStatus(runId, stageRunId, artifactId, status) {
+      const path = artifactsFilePath(root, runId, stageRunId);
+      if (!existsSync(path)) return;
+      const body = readFileSync(path, "utf-8");
+      let changed = false;
+      const out: Artifact[] = [];
+      for (const line of body.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        const a = JSON.parse(trimmed) as Artifact;
+        if (a.artifactId === artifactId && a.status !== status) {
+          out.push({ ...a, status });
+          changed = true;
+        } else {
+          out.push(a);
+        }
+      }
+      if (!changed) return;
+      const rewritten = out.map((a) => JSON.stringify(a)).join("\n") + "\n";
+      atomicWriteFileSync(path, rewritten);
+    },
+
+    appendThreadMessage(runId, stageRunId, msg) {
+      ensureDir(threadsDirForRun(root, runId));
+      appendFileSync(
+        threadFilePath(root, runId, stageRunId),
+        JSON.stringify(msg) + "\n",
+        "utf-8",
+      );
+    },
+
+    listThreadMessages(runId, stageRunId) {
+      const path = threadFilePath(root, runId, stageRunId);
+      if (!existsSync(path)) return [];
+      const body = readFileSync(path, "utf-8");
+      const out: ThreadMessage[] = [];
+      for (const line of body.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        out.push(JSON.parse(trimmed) as ThreadMessage);
+      }
+      return out;
     },
   };
 }

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -502,3 +502,43 @@ export interface TaskContext {
 export interface BuiltinTaskContext extends TaskContext {
   sendToSession: (sessionId: string, message: string) => Promise<void>;
 }
+
+// ============================================================================
+// Conversational follow-up (Agent.sendFollowUpToTask)
+// ============================================================================
+
+/**
+ * Context handed to `Agent.sendFollowUpToTask`. The workspace path is the
+ * worker session's workspace (not the pipeline run's project root). When the
+ * worktree has been removed, callers must surface `ReviewerWorkspaceGone`
+ * (HTTP 410 from the dashboard) — implementations must NOT fall back to the
+ * project root.
+ */
+export interface FollowUpContext {
+  sessionId: string;
+  workspacePath: string;
+  pipelineRunId: RunId;
+  stageRunId: StageRunId;
+  pipelineName: string;
+  stageName: string;
+}
+
+export interface FollowUpResult {
+  /** Optional agent reply captured synchronously. */
+  reply?: string;
+  /** Internal agent thread id, if the agent surfaces one. */
+  agentThreadId?: string;
+}
+
+/**
+ * One persisted message in a stage-run follow-up thread. Stored at
+ * `pipelines/threads/{runId}/{stageRunId}.jsonl`, one JSON record per line.
+ */
+export interface ThreadMessage {
+  role: "user" | "agent" | "system";
+  content: string;
+  /** ISO-8601 timestamp. */
+  ts: string;
+  /** Optional reviewer id surface label, e.g. `{sessionPrefix}-rev-N`. */
+  reviewerId?: string;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,14 @@
 import type { ObservabilityLevel } from "./observability.js";
 import type { ConfiguredPipeline } from "./pipeline/config-schema.js";
+import type {
+  FollowUpContext as PipelineFollowUpContext,
+  FollowUpResult as PipelineFollowUpResult,
+  ThreadMessage as PipelineThreadMessage,
+} from "./pipeline/types.js";
+
+export type FollowUpContext = PipelineFollowUpContext;
+export type FollowUpResult = PipelineFollowUpResult;
+export type ThreadMessage = PipelineThreadMessage;
 
 /**
  * Agent Orchestrator — Core Type Definitions
@@ -555,7 +564,24 @@ export interface Agent {
    * it is exercised by `ao spawn`. Throw with an actionable error message.
    */
   preflight?(context: PreflightContext): Promise<void>;
+
+  /**
+   * Optional: deliver a user follow-up message into an existing agent task
+   * (the linked worker session for a pipeline stage in `awaiting_context`).
+   *
+   * Implementations should NOT spawn a new session. Codex implements this via
+   * `codex exec --continue` against the existing rollout file in the workspace;
+   * agents without an equivalent capability omit the method.
+   *
+   * The pipeline engine routes USER_FOLLOWUP events through this method; the
+   * dashboard shows "chat unavailable" gracefully when an agent doesn't
+   * implement it.
+   */
+  sendFollowUpToTask?(ctx: FollowUpContext, message: string): Promise<FollowUpResult>;
 }
+
+// FollowUpContext / FollowUpResult / ThreadMessage live in pipeline/types.ts
+// and are re-exported at the top of this file via `export type`.
 
 export interface AgentLaunchConfig {
   sessionId: SessionId;

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -16,6 +16,8 @@ import {
   type ActivityState,
   type ActivityDetection,
   type CostEstimate,
+  type FollowUpContext,
+  type FollowUpResult,
   type PluginModule,
   type ProcessProbeResult,
   type ProjectConfig,
@@ -837,6 +839,43 @@ function createCodexAgent(): Agent {
 
     async setupWorkspaceHooks(_workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
       // PATH wrappers are installed by session-manager for all agents.
+    },
+
+    /**
+     * Deliver a pipeline follow-up message into the existing Codex task via
+     * `codex exec --continue`. Runs as a one-shot, headless invocation that
+     * reuses the latest thread for the workspace — no new session, no tmux.
+     *
+     * The engine surfaces failures (missing binary, dead worker, missing
+     * workspace) by throwing; the dashboard maps "workspace gone" to HTTP 410
+     * `ReviewerWorkspaceGone` and never falls back to the project root.
+     */
+    async sendFollowUpToTask(ctx: FollowUpContext, message: string): Promise<FollowUpResult> {
+      const cwd = ctx.workspacePath;
+      const binary = resolvedBinary ?? "codex";
+      try {
+        // `codex exec` runs a single turn against the latest thread when
+        // --continue is passed. `--skip-git-repo-check` lets the engine talk
+        // to checkouts that may be detached/worktree-style without aborting.
+        const { stdout } = await execFileAsync(
+          binary,
+          ["exec", "--continue", "--skip-git-repo-check", "--", message],
+          {
+            cwd,
+            env: { ...process.env, CODEX_DISABLE_UPDATE_CHECK: "1" },
+            // Codex follow-ups are short; long replies arrive via the JSONL.
+            timeout: 60_000,
+            maxBuffer: 10 * 1024 * 1024,
+            shell: false,
+            windowsHide: true,
+          },
+        );
+        const reply = (stdout ?? "").trim();
+        return reply.length > 0 ? { reply } : {};
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`codex exec --continue failed: ${message}`, { cause: err });
+      }
     },
 
     async postLaunchSetup(_session: Session): Promise<void> {

--- a/packages/web/src/app/api/pipelines/events/route.ts
+++ b/packages/web/src/app/api/pipelines/events/route.ts
@@ -1,0 +1,70 @@
+import { type NextRequest } from "next/server";
+
+import { listRunsAcrossProjects } from "@/lib/pipelines";
+
+/**
+ * GET /api/pipelines/events — Server-Sent Events stream of pipeline runs.
+ *
+ * Cadence: 5s (C-14 — must match the existing dashboard polling interval).
+ * Each tick emits a single `data: <json>\n\n` frame with the full run list,
+ * scoped by ?project when provided.
+ *
+ * Why pull-based SSE rather than push? Pipeline state is persisted as
+ * flat JSON files by the CLI's running engine; the dashboard process does
+ * not own state, so it polls the store. This matches `useSessionEvents`'s
+ * coarse 5s cadence.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const projectFilter = searchParams.get("project") ?? undefined;
+  const project = projectFilter && projectFilter !== "all" ? projectFilter : undefined;
+
+  const encoder = new TextEncoder();
+  let cancelled = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (data: unknown) => {
+        try {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+        } catch {
+          cancelled = true;
+        }
+      };
+
+      const tick = async () => {
+        if (cancelled) return;
+        try {
+          const snapshot = await listRunsAcrossProjects(project);
+          send({ kind: "snapshot", ts: Date.now(), runs: snapshot.runs });
+        } catch (err) {
+          send({
+            kind: "error",
+            ts: Date.now(),
+            error: err instanceof Error ? err.message : "snapshot failed",
+          });
+        }
+        if (cancelled) return;
+        timer = setTimeout(() => void tick(), 5_000);
+      };
+
+      // Emit a hello frame so clients see the connection open immediately.
+      send({ kind: "hello", ts: Date.now() });
+      await tick();
+    },
+    cancel() {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/packages/web/src/app/api/pipelines/runs/[runId]/artifacts/[artifactId]/route.ts
+++ b/packages/web/src/app/api/pipelines/runs/[runId]/artifacts/[artifactId]/route.ts
@@ -1,0 +1,110 @@
+import { type NextRequest } from "next/server";
+
+import { getCorrelationId, jsonWithCorrelation } from "@/lib/observability";
+import {
+  asRunId,
+  asStageRunId,
+  dismissArtifact,
+  reopenArtifact,
+  markArtifactSent,
+  listRunsAcrossProjects,
+  describeRunWithStages,
+} from "@/lib/pipelines";
+import type { ArtifactId, ArtifactStatus } from "@aoagents/ao-core";
+
+/**
+ * PATCH /api/pipelines/runs/:runId/artifacts/:artifactId — change an
+ * artifact's status. Body: `{ status: "dismissed" | "open" | "sent_to_agent",
+ * stageRunId, actor? }`. Flow:
+ *
+ *  - `dismissed` → user-suppressed finding (Workbench dismiss button)
+ *  - `open`      → reopen a previously dismissed finding
+ *  - `sent_to_agent` → mark as forwarded (set by router builtin in normal
+ *    pipelines; exposed here so the dashboard's manual send button stamps
+ *    the same status when SCM compose dispatches a single finding)
+ *
+ * The request body's `stageRunId` is the artifact's parent stage run; the
+ * route validates it against the persisted artifact list to refuse mismatched
+ * ids. All mutations flow through `ARTIFACT_STATUS_CHANGED` engine events,
+ * not direct store writes (per #198 acceptance).
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string; artifactId: string }> },
+) {
+  const correlationId = getCorrelationId(request);
+  const { runId: runIdStr, artifactId } = await params;
+  const runId = asRunId(runIdStr);
+
+  let body: { status?: string; stageRunId?: string; actor?: string };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return jsonWithCorrelation({ error: "Invalid JSON body" }, { status: 400 }, correlationId);
+  }
+  const status = body.status as ArtifactStatus | undefined;
+  if (status !== "dismissed" && status !== "open" && status !== "sent_to_agent") {
+    return jsonWithCorrelation(
+      { error: "status must be one of: dismissed, open, sent_to_agent" },
+      { status: 400 },
+      correlationId,
+    );
+  }
+  if (!body.stageRunId) {
+    return jsonWithCorrelation({ error: "stageRunId required" }, { status: 400 }, correlationId);
+  }
+  const stageRunId = asStageRunId(body.stageRunId);
+
+  // Resolve project from the run
+  const url = new URL(request.url);
+  let projectId = url.searchParams.get("project") ?? undefined;
+  if (!projectId) {
+    const { runs } = await listRunsAcrossProjects();
+    const found = runs.find((r) => r.runId === runId);
+    if (!found) {
+      return jsonWithCorrelation({ error: "Run not found" }, { status: 404 }, correlationId);
+    }
+    projectId = found.projectId;
+  }
+
+  // Validate stageRunId belongs to this run + has the artifact
+  const detail = await describeRunWithStages(projectId, runId);
+  if (!detail) {
+    return jsonWithCorrelation({ error: "Run not found" }, { status: 404 }, correlationId);
+  }
+  const stage = detail.stages.find((s) => s.stageRunId === stageRunId);
+  if (!stage) {
+    return jsonWithCorrelation(
+      { error: "stageRunId not in this run" },
+      { status: 400 },
+      correlationId,
+    );
+  }
+  if (!stage.artifacts.some((a) => a.artifactId === artifactId)) {
+    return jsonWithCorrelation(
+      { error: "artifactId not in this stage" },
+      { status: 404 },
+      correlationId,
+    );
+  }
+
+  try {
+    const input = {
+      projectId,
+      runId,
+      stageRunId,
+      artifactId: artifactId as ArtifactId,
+      ...(body.actor ? { actor: body.actor } : {}),
+    };
+    if (status === "dismissed") await dismissArtifact(input);
+    else if (status === "open") await reopenArtifact(input);
+    else await markArtifactSent(input);
+    return jsonWithCorrelation({ ok: true, status }, { status: 200 }, correlationId);
+  } catch (err) {
+    return jsonWithCorrelation(
+      { error: err instanceof Error ? err.message : "Status update failed" },
+      { status: 500 },
+      correlationId,
+    );
+  }
+}

--- a/packages/web/src/app/api/pipelines/runs/[runId]/cancel/route.ts
+++ b/packages/web/src/app/api/pipelines/runs/[runId]/cancel/route.ts
@@ -1,0 +1,37 @@
+import { type NextRequest } from "next/server";
+
+import { getCorrelationId, jsonWithCorrelation } from "@/lib/observability";
+import { asRunId, cancelRun, listRunsAcrossProjects } from "@/lib/pipelines";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> },
+) {
+  const correlationId = getCorrelationId(request);
+  const { runId: runIdStr } = await params;
+  const runId = asRunId(runIdStr);
+  const url = new URL(request.url);
+  let projectId = url.searchParams.get("project") ?? undefined;
+
+  try {
+    if (!projectId) {
+      const { runs } = await listRunsAcrossProjects();
+      const found = runs.find((r) => r.runId === runId);
+      if (!found) {
+        return jsonWithCorrelation({ error: "Run not found" }, { status: 404 }, correlationId);
+      }
+      projectId = found.projectId;
+    }
+    const updated = await cancelRun({ projectId, runId });
+    if (!updated) {
+      return jsonWithCorrelation({ error: "Run not found" }, { status: 404 }, correlationId);
+    }
+    return jsonWithCorrelation({ run: updated }, { status: 200 }, correlationId);
+  } catch (err) {
+    return jsonWithCorrelation(
+      { error: err instanceof Error ? err.message : "Cancel failed" },
+      { status: 500 },
+      correlationId,
+    );
+  }
+}

--- a/packages/web/src/app/api/pipelines/runs/[runId]/resume/route.ts
+++ b/packages/web/src/app/api/pipelines/runs/[runId]/resume/route.ts
@@ -1,0 +1,37 @@
+import { type NextRequest } from "next/server";
+
+import { getCorrelationId, jsonWithCorrelation } from "@/lib/observability";
+import { asRunId, resumeRun, listRunsAcrossProjects } from "@/lib/pipelines";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> },
+) {
+  const correlationId = getCorrelationId(request);
+  const { runId: runIdStr } = await params;
+  const runId = asRunId(runIdStr);
+  const url = new URL(request.url);
+  let projectId = url.searchParams.get("project") ?? undefined;
+
+  try {
+    if (!projectId) {
+      const { runs } = await listRunsAcrossProjects();
+      const found = runs.find((r) => r.runId === runId);
+      if (!found) {
+        return jsonWithCorrelation({ error: "Run not found" }, { status: 404 }, correlationId);
+      }
+      projectId = found.projectId;
+    }
+    const updated = await resumeRun({ projectId, runId });
+    if (!updated) {
+      return jsonWithCorrelation({ error: "Run not found" }, { status: 404 }, correlationId);
+    }
+    return jsonWithCorrelation({ run: updated }, { status: 200 }, correlationId);
+  } catch (err) {
+    return jsonWithCorrelation(
+      { error: err instanceof Error ? err.message : "Resume failed" },
+      { status: 500 },
+      correlationId,
+    );
+  }
+}

--- a/packages/web/src/app/api/pipelines/runs/[runId]/route.ts
+++ b/packages/web/src/app/api/pipelines/runs/[runId]/route.ts
@@ -1,0 +1,50 @@
+import { type NextRequest } from "next/server";
+
+import { getCorrelationId, jsonWithCorrelation } from "@/lib/observability";
+import { asRunId, describeRunWithStages, listRunsAcrossProjects } from "@/lib/pipelines";
+
+/**
+ * GET /api/pipelines/runs/:runId — full run detail with stages, artifacts,
+ * and per-stage thread counts. `?project=` is required for direct lookup,
+ * but if omitted we fall back to scanning each project until the runId
+ * resolves (one read per project — cheap because the store lists each
+ * directory once).
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> },
+) {
+  const correlationId = getCorrelationId(request);
+  const { runId: runIdStr } = await params;
+  const runId = asRunId(runIdStr);
+  const { searchParams } = new URL(request.url);
+  const project = searchParams.get("project");
+
+  try {
+    if (project) {
+      const detail = await describeRunWithStages(project, runId);
+      if (!detail) {
+        return jsonWithCorrelation({ error: "Run not found" }, { status: 404 }, correlationId);
+      }
+      return jsonWithCorrelation({ run: detail }, { status: 200 }, correlationId);
+    }
+
+    // No project filter — search every project.
+    const { runs } = await listRunsAcrossProjects();
+    const summary = runs.find((r) => r.runId === runId);
+    if (!summary) {
+      return jsonWithCorrelation({ error: "Run not found" }, { status: 404 }, correlationId);
+    }
+    const detail = await describeRunWithStages(summary.projectId, runId);
+    if (!detail) {
+      return jsonWithCorrelation({ error: "Run not found" }, { status: 404 }, correlationId);
+    }
+    return jsonWithCorrelation({ run: detail }, { status: 200 }, correlationId);
+  } catch (err) {
+    return jsonWithCorrelation(
+      { error: err instanceof Error ? err.message : "Failed to load run" },
+      { status: 500 },
+      correlationId,
+    );
+  }
+}

--- a/packages/web/src/app/api/pipelines/runs/[runId]/stages/[stageRunId]/thread/route.ts
+++ b/packages/web/src/app/api/pipelines/runs/[runId]/stages/[stageRunId]/thread/route.ts
@@ -1,0 +1,122 @@
+import { type NextRequest } from "next/server";
+
+import { getCorrelationId, jsonWithCorrelation } from "@/lib/observability";
+import {
+  asRunId,
+  asStageRunId,
+  describeRunWithStages,
+  listRunsAcrossProjects,
+  listThread,
+  sendFollowUp,
+  ReviewerWorkspaceGoneError,
+} from "@/lib/pipelines";
+
+/** GET — list messages in the per-stage thread JSONL. */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string; stageRunId: string }> },
+) {
+  const correlationId = getCorrelationId(request);
+  const { runId: runIdStr, stageRunId: stageRunIdStr } = await params;
+  const runId = asRunId(runIdStr);
+  const stageRunId = asStageRunId(stageRunIdStr);
+  const url = new URL(request.url);
+  let projectId = url.searchParams.get("project") ?? undefined;
+
+  try {
+    if (!projectId) {
+      const { runs } = await listRunsAcrossProjects();
+      const found = runs.find((r) => r.runId === runId);
+      if (!found) {
+        return jsonWithCorrelation({ error: "Run not found" }, { status: 404 }, correlationId);
+      }
+      projectId = found.projectId;
+    }
+    const messages = await listThread(projectId, runId, stageRunId);
+    return jsonWithCorrelation({ messages }, { status: 200 }, correlationId);
+  } catch (err) {
+    return jsonWithCorrelation(
+      { error: err instanceof Error ? err.message : "Failed to load thread" },
+      { status: 500 },
+      correlationId,
+    );
+  }
+}
+
+/**
+ * POST — send a follow-up message into the stage's agent task. Routes through
+ * `USER_FOLLOWUP` → reducer → `SEND_FOLLOWUP` → `Agent.sendFollowUpToTask`.
+ *
+ * Returns 410 `ReviewerWorkspaceGone` when the worker workspace is no longer
+ * on disk (per the v2 spec — NO project-root fallback).
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string; stageRunId: string }> },
+) {
+  const correlationId = getCorrelationId(request);
+  const { runId: runIdStr, stageRunId: stageRunIdStr } = await params;
+  const runId = asRunId(runIdStr);
+  const stageRunId = asStageRunId(stageRunIdStr);
+
+  let body: { message?: string; reviewerId?: string };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return jsonWithCorrelation({ error: "Invalid JSON body" }, { status: 400 }, correlationId);
+  }
+  const message = (body.message ?? "").trim();
+  if (!message) {
+    return jsonWithCorrelation({ error: "message is required" }, { status: 400 }, correlationId);
+  }
+
+  const url = new URL(request.url);
+  let projectId = url.searchParams.get("project") ?? undefined;
+  if (!projectId) {
+    const { runs } = await listRunsAcrossProjects();
+    const found = runs.find((r) => r.runId === runId);
+    if (!found) {
+      return jsonWithCorrelation({ error: "Run not found" }, { status: 404 }, correlationId);
+    }
+    projectId = found.projectId;
+  }
+
+  // Resolve stage name so we can dispatch USER_FOLLOWUP.
+  const detail = await describeRunWithStages(projectId, runId);
+  if (!detail) {
+    return jsonWithCorrelation({ error: "Run not found" }, { status: 404 }, correlationId);
+  }
+  const stage = detail.stages.find((s) => s.stageRunId === stageRunId);
+  if (!stage) {
+    return jsonWithCorrelation(
+      { error: "stageRunId not in this run" },
+      { status: 400 },
+      correlationId,
+    );
+  }
+
+  try {
+    await sendFollowUp({
+      projectId,
+      runId,
+      stageRunId,
+      stageName: stage.stageName,
+      message,
+      ...(body.reviewerId ? { reviewerId: body.reviewerId } : {}),
+    });
+    return jsonWithCorrelation({ ok: true }, { status: 200 }, correlationId);
+  } catch (err) {
+    if (err instanceof ReviewerWorkspaceGoneError) {
+      return jsonWithCorrelation(
+        { error: err.message, code: "ReviewerWorkspaceGone" },
+        { status: 410 },
+        correlationId,
+      );
+    }
+    return jsonWithCorrelation(
+      { error: err instanceof Error ? err.message : "Follow-up failed" },
+      { status: 500 },
+      correlationId,
+    );
+  }
+}

--- a/packages/web/src/app/api/pipelines/runs/route.ts
+++ b/packages/web/src/app/api/pipelines/runs/route.ts
@@ -1,0 +1,23 @@
+import { type NextRequest } from "next/server";
+
+import { getCorrelationId, jsonWithCorrelation } from "@/lib/observability";
+import { listRunsAcrossProjects } from "@/lib/pipelines";
+
+/** GET /api/pipelines/runs — list pipeline runs (optionally scoped by ?project=). */
+export async function GET(request: NextRequest) {
+  const correlationId = getCorrelationId(request);
+  const { searchParams } = new URL(request.url);
+  const projectFilter = searchParams.get("project") ?? undefined;
+  try {
+    const { runs } = await listRunsAcrossProjects(
+      projectFilter && projectFilter !== "all" ? projectFilter : undefined,
+    );
+    return jsonWithCorrelation({ runs }, { status: 200 }, correlationId);
+  } catch (err) {
+    return jsonWithCorrelation(
+      { error: err instanceof Error ? err.message : "Failed to list pipeline runs" },
+      { status: 500 },
+      correlationId,
+    );
+  }
+}

--- a/packages/web/src/app/pipelines/page.tsx
+++ b/packages/web/src/app/pipelines/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+
+import { PipelineWorkbench } from "@/components/PipelineWorkbench";
+import { listRunsAcrossProjects } from "@/lib/pipelines";
+import { resolveDashboardProjectFilter } from "@/lib/dashboard-page-data";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata(props: {
+  searchParams: Promise<{ project?: string }>;
+}): Promise<Metadata> {
+  const searchParams = await props.searchParams;
+  const projectFilter = resolveDashboardProjectFilter(searchParams.project);
+  const label = projectFilter && projectFilter !== "all" ? projectFilter : "all projects";
+  return { title: { absolute: `ao | pipelines · ${label}` } };
+}
+
+export default async function PipelinesPage(props: {
+  searchParams: Promise<{ project?: string }>;
+}) {
+  const searchParams = await props.searchParams;
+  const projectFilter = resolveDashboardProjectFilter(searchParams.project);
+  const filter = projectFilter && projectFilter !== "all" ? projectFilter : undefined;
+  const initial = await listRunsAcrossProjects(filter);
+
+  return <PipelineWorkbench initialRuns={initial.runs} projectFilter={filter ?? null} />;
+}

--- a/packages/web/src/app/reviews/page.tsx
+++ b/packages/web/src/app/reviews/page.tsx
@@ -1,0 +1,15 @@
+import { redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * `/reviews` is the legacy v1 surface — replaced by `/pipelines` in v2. We
+ * keep a permanent redirect so external bookmarks and tab links don't
+ * 404 during the transition.
+ */
+export default async function ReviewsRedirect(props: {
+  searchParams: Promise<{ project?: string }>;
+}) {
+  const { project } = await props.searchParams;
+  redirect(project ? `/pipelines?project=${encodeURIComponent(project)}` : "/pipelines");
+}

--- a/packages/web/src/components/ChatPanel.tsx
+++ b/packages/web/src/components/ChatPanel.tsx
@@ -28,7 +28,7 @@ interface ChatPanelProps {
  * Worktree-gone (HTTP 410 `ReviewerWorkspaceGone`) surfaces inline — no
  * project-root fallback.
  */
-export function ChatPanel(props: ChatPanelProps): JSX.Element {
+export function ChatPanel(props: ChatPanelProps) {
   const { runId, stageRunId, projectId, followUpAvailable, stageActive, reviewerId } = props;
   const [messages, setMessages] = useState<ThreadMessage[]>([]);
   const [draft, setDraft] = useState("");
@@ -52,7 +52,6 @@ export function ChatPanel(props: ChatPanelProps): JSX.Element {
     void refresh();
     const timer = setInterval(() => void refresh(), 5_000);
     return () => clearInterval(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runId, stageRunId, projectId]);
 
   const send = async (): Promise<void> => {

--- a/packages/web/src/components/ChatPanel.tsx
+++ b/packages/web/src/components/ChatPanel.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { ThreadMessage } from "@aoagents/ao-core";
+
+import { cn } from "@/lib/cn";
+
+interface ChatPanelProps {
+  runId: string;
+  stageRunId: string;
+  stageName: string;
+  projectId: string;
+  /** Whether the agent for this stage supports `sendFollowUpToTask`. */
+  followUpAvailable: boolean;
+  /** Whether the stage is currently in `awaiting_context` (where chat is enabled). */
+  stageActive: boolean;
+  /** Optional human-readable reviewer label (`{sessionPrefix}-rev-N`) to stamp into the thread. */
+  reviewerId?: string;
+}
+
+/**
+ * Conversational follow-up panel for an `awaiting_context` stage. Polls the
+ * thread JSONL at the same 5s cadence the rest of the dashboard uses (C-14).
+ * Messages POST through `/api/pipelines/runs/:runId/stages/:stageRunId/thread`,
+ * which dispatches `USER_FOLLOWUP` into the reducer.
+ *
+ * Worktree-gone (HTTP 410 `ReviewerWorkspaceGone`) surfaces inline — no
+ * project-root fallback.
+ */
+export function ChatPanel(props: ChatPanelProps): JSX.Element {
+  const { runId, stageRunId, projectId, followUpAvailable, stageActive, reviewerId } = props;
+  const [messages, setMessages] = useState<ThreadMessage[]>([]);
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [workspaceGone, setWorkspaceGone] = useState(false);
+
+  const refresh = async (): Promise<void> => {
+    try {
+      const url = `/api/pipelines/runs/${encodeURIComponent(runId)}/stages/${encodeURIComponent(stageRunId)}/thread?project=${encodeURIComponent(projectId)}`;
+      const res = await fetch(url, { cache: "no-store" });
+      if (!res.ok) return;
+      const body = (await res.json()) as { messages?: ThreadMessage[] };
+      if (Array.isArray(body.messages)) setMessages(body.messages);
+    } catch {
+      // Polling failures are non-fatal — next 5s tick retries.
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    const timer = setInterval(() => void refresh(), 5_000);
+    return () => clearInterval(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runId, stageRunId, projectId]);
+
+  const send = async (): Promise<void> => {
+    const message = draft.trim();
+    if (!message || sending) return;
+    setSending(true);
+    setError(null);
+    setWorkspaceGone(false);
+    try {
+      const url = `/api/pipelines/runs/${encodeURIComponent(runId)}/stages/${encodeURIComponent(stageRunId)}/thread?project=${encodeURIComponent(projectId)}`;
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message, ...(reviewerId ? { reviewerId } : {}) }),
+      });
+      if (res.status === 410) {
+        setWorkspaceGone(true);
+        return;
+      }
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      setDraft("");
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Send failed");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (!followUpAvailable) {
+    return (
+      <div className="rounded border border-dashed border-[var(--color-border-muted)] p-3 text-center text-[11px] text-[var(--color-text-tertiary)]">
+        Chat unavailable — this agent doesn&apos;t implement <code>sendFollowUpToTask</code>.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-card)] p-2">
+      <ol className="flex max-h-64 flex-col gap-1.5 overflow-auto" aria-label="Follow-up thread">
+        {messages.length === 0 && (
+          <li className="text-[11px] text-[var(--color-text-tertiary)]">
+            No messages yet.
+          </li>
+        )}
+        {messages.map((m, i) => (
+          <li
+            key={`${m.ts}-${i}`}
+            className={cn(
+              "rounded p-2 text-[11px] leading-relaxed",
+              m.role === "user"
+                ? "bg-[var(--color-accent-subtle)] text-[var(--color-text-primary)]"
+                : m.role === "agent"
+                  ? "bg-[var(--color-bg-subtle)] text-[var(--color-text-secondary)]"
+                  : "bg-[var(--color-bg-subtle)] text-[var(--color-text-tertiary)]",
+            )}
+          >
+            <p className="mb-0.5 font-mono text-[9px] uppercase tracking-wide text-[var(--color-text-muted)]">
+              {m.role}
+              {m.reviewerId ? ` · ${m.reviewerId}` : ""} · {new Date(m.ts).toLocaleTimeString()}
+            </p>
+            <p className="whitespace-pre-wrap break-words">{m.content}</p>
+          </li>
+        ))}
+      </ol>
+
+      <textarea
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        rows={2}
+        disabled={!stageActive || sending}
+        placeholder={
+          stageActive ? "Send a follow-up… (Enter to send, Shift+Enter newline)" : "Chat disabled — stage not awaiting context."
+        }
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            void send();
+          }
+        }}
+        className="rounded border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] p-2 font-mono text-[11px] text-[var(--color-text-primary)] focus:border-[var(--color-accent)] focus:outline-none disabled:opacity-50"
+      />
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] text-[var(--color-text-tertiary)]">
+          {workspaceGone && (
+            <span className="text-[var(--color-status-error)]">
+              Worker workspace gone (410) — cannot deliver. No fallback to project root.
+            </span>
+          )}
+          {!workspaceGone && error && (
+            <span className="text-[var(--color-status-error)]">{error}</span>
+          )}
+        </span>
+        <button
+          type="button"
+          onClick={() => void send()}
+          disabled={!stageActive || sending || !draft.trim()}
+          className="rounded border border-[var(--color-accent)] bg-[var(--color-accent)] px-3 py-0.5 font-mono text-[10px] text-[var(--color-text-on-accent)] disabled:opacity-50"
+        >
+          {sending ? "Sending…" : "Send"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/FindingRow.tsx
+++ b/packages/web/src/components/FindingRow.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+
+import type { ArtifactStatus, Severity } from "@aoagents/ao-core";
+
+import { cn } from "@/lib/cn";
+
+export interface FindingArtifactView {
+  artifactId: string;
+  stageRunId: string;
+  status: ArtifactStatus;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  title: string;
+  description: string;
+  severity: Severity;
+  category: string;
+  confidence: number;
+}
+
+interface FindingRowProps {
+  runId: string;
+  projectId: string;
+  finding: FindingArtifactView;
+  onStatusChanged?(next: ArtifactStatus): void;
+}
+
+/**
+ * Per-finding row inside a stage card. Three actions: dismiss / reopen / send.
+ * Each action POSTs the corresponding artifact-status mutation; the
+ * surrounding card refreshes via the SSE feed.
+ */
+export function FindingRow(props: FindingRowProps): JSX.Element {
+  const { runId, projectId, finding, onStatusChanged } = props;
+  const [busy, setBusy] = useState<"dismiss" | "reopen" | "send" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const dispatchStatus = async (status: ArtifactStatus) => {
+    if (busy) return;
+    const action = status === "dismissed" ? "dismiss" : status === "open" ? "reopen" : "send";
+    setBusy(action);
+    setError(null);
+    try {
+      const url = `/api/pipelines/runs/${encodeURIComponent(runId)}/artifacts/${encodeURIComponent(finding.artifactId)}?project=${encodeURIComponent(projectId)}`;
+      const res = await fetch(url, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status, stageRunId: finding.stageRunId }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      onStatusChanged?.(status);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Action failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const isDismissed = finding.status === "dismissed";
+  const isSent = finding.status === "sent_to_agent";
+
+  return (
+    <div
+      className={cn(
+        "rounded border border-[var(--color-border-muted)] bg-[var(--color-bg-card)] p-2",
+        isDismissed && "opacity-60",
+      )}
+      data-artifact-id={finding.artifactId}
+    >
+      <div className="flex items-baseline gap-2">
+        <span
+          className={cn(
+            "rounded-full px-1.5 py-px font-mono text-[10px] uppercase tracking-wide",
+            severityClass(finding.severity),
+          )}
+        >
+          {finding.severity}
+        </span>
+        <span className="font-mono text-[10px] text-[var(--color-text-secondary)]">
+          {finding.filePath}:{finding.startLine}
+          {finding.endLine !== finding.startLine ? `-${finding.endLine}` : ""}
+        </span>
+        <span className="ml-auto font-mono text-[10px] text-[var(--color-text-tertiary)]">
+          {Math.round(finding.confidence * 100)}%
+        </span>
+      </div>
+      <p className="mt-1 text-[12px] font-semibold text-[var(--color-text-primary)]">
+        {finding.title}
+      </p>
+      <p className="mt-0.5 text-[11px] text-[var(--color-text-secondary)]">
+        {finding.description}
+      </p>
+
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        {!isDismissed && (
+          <button
+            type="button"
+            onClick={() => void dispatchStatus("dismissed")}
+            disabled={busy !== null}
+            className="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-subtle)] px-2 py-0.5 font-mono text-[10px] text-[var(--color-text-secondary)] hover:border-[var(--color-text-tertiary)] disabled:opacity-50"
+          >
+            {busy === "dismiss" ? "Dismissing…" : "Dismiss"}
+          </button>
+        )}
+        {isDismissed && (
+          <button
+            type="button"
+            onClick={() => void dispatchStatus("open")}
+            disabled={busy !== null}
+            className="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-subtle)] px-2 py-0.5 font-mono text-[10px] text-[var(--color-text-secondary)] hover:border-[var(--color-text-tertiary)] disabled:opacity-50"
+          >
+            {busy === "reopen" ? "Reopening…" : "Reopen"}
+          </button>
+        )}
+        {!isDismissed && !isSent && (
+          <button
+            type="button"
+            onClick={() => void dispatchStatus("sent_to_agent")}
+            disabled={busy !== null}
+            className="rounded border border-[var(--color-accent)] bg-[var(--color-accent-subtle)] px-2 py-0.5 font-mono text-[10px] text-[var(--color-text-primary)] hover:bg-[var(--color-accent)] disabled:opacity-50"
+          >
+            {busy === "send" ? "Sending…" : "Send to worker"}
+          </button>
+        )}
+        {isSent && (
+          <span className="font-mono text-[10px] text-[var(--color-status-ready)]">
+            ✓ sent
+          </span>
+        )}
+        {error && (
+          <span className="font-mono text-[10px] text-[var(--color-status-error)]">{error}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function severityClass(s: Severity): string {
+  switch (s) {
+    case "error":
+      return "bg-[var(--color-status-error)] text-[var(--color-text-on-accent)]";
+    case "warning":
+      return "bg-[var(--color-status-waiting)] text-[var(--color-text-on-accent)]";
+    case "info":
+    default:
+      return "bg-[var(--color-bg-subtle)] text-[var(--color-text-secondary)]";
+  }
+}

--- a/packages/web/src/components/FindingRow.tsx
+++ b/packages/web/src/components/FindingRow.tsx
@@ -32,7 +32,7 @@ interface FindingRowProps {
  * Each action POSTs the corresponding artifact-status mutation; the
  * surrounding card refreshes via the SSE feed.
  */
-export function FindingRow(props: FindingRowProps): JSX.Element {
+export function FindingRow(props: FindingRowProps) {
   const { runId, projectId, finding, onStatusChanged } = props;
   const [busy, setBusy] = useState<"dismiss" | "reopen" | "send" | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/packages/web/src/components/PipelineFilterBar.tsx
+++ b/packages/web/src/components/PipelineFilterBar.tsx
@@ -15,7 +15,7 @@ interface PipelineFilterBarProps {
  * Filter bar — pipeline-name multi-select + "show dismissed" toggle.
  * No external UI libs (C-01), only Tailwind + CSS-variable colors (C-02/C-05).
  */
-export function PipelineFilterBar(props: PipelineFilterBarProps): JSX.Element {
+export function PipelineFilterBar(props: PipelineFilterBarProps) {
   const { filters, availablePipelines, onChange } = props;
 
   const togglePipeline = (name: string) => {

--- a/packages/web/src/components/PipelineFilterBar.tsx
+++ b/packages/web/src/components/PipelineFilterBar.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+export interface PipelineFilters {
+  pipelineNames: string[];
+  showDismissed: boolean;
+}
+
+interface PipelineFilterBarProps {
+  filters: PipelineFilters;
+  availablePipelines: string[];
+  onChange(next: PipelineFilters): void;
+}
+
+/**
+ * Filter bar — pipeline-name multi-select + "show dismissed" toggle.
+ * No external UI libs (C-01), only Tailwind + CSS-variable colors (C-02/C-05).
+ */
+export function PipelineFilterBar(props: PipelineFilterBarProps): JSX.Element {
+  const { filters, availablePipelines, onChange } = props;
+
+  const togglePipeline = (name: string) => {
+    const set = new Set(filters.pipelineNames);
+    if (set.has(name)) set.delete(name);
+    else set.add(name);
+    onChange({ ...filters, pipelineNames: [...set] });
+  };
+
+  const clear = () => onChange({ pipelineNames: [], showDismissed: false });
+  const showingAll = filters.pipelineNames.length === 0;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-b border-[var(--color-border-default)] bg-[var(--color-bg-card)] px-4 py-2">
+      <span className="text-[10px] uppercase tracking-wide text-[var(--color-text-tertiary)]">
+        Pipelines:
+      </span>
+      {availablePipelines.length === 0 && (
+        <span className="text-[11px] text-[var(--color-text-muted)]">(none yet)</span>
+      )}
+      {availablePipelines.map((name) => {
+        const active = filters.pipelineNames.includes(name);
+        return (
+          <button
+            key={name}
+            type="button"
+            onClick={() => togglePipeline(name)}
+            aria-pressed={active}
+            className={
+              active
+                ? "rounded-full border border-[var(--color-accent)] bg-[var(--color-accent-subtle)] px-2 py-0.5 font-mono text-[11px] text-[var(--color-text-primary)]"
+                : "rounded-full border border-[var(--color-border-muted)] bg-[var(--color-bg-subtle)] px-2 py-0.5 font-mono text-[11px] text-[var(--color-text-secondary)] hover:border-[var(--color-border-default)]"
+            }
+          >
+            {name}
+          </button>
+        );
+      })}
+      {!showingAll && (
+        <button
+          type="button"
+          onClick={clear}
+          className="ml-1 text-[10px] text-[var(--color-text-muted)] underline-offset-2 hover:underline"
+        >
+          clear
+        </button>
+      )}
+
+      <span className="ml-auto inline-flex items-center gap-1 text-[10px] text-[var(--color-text-tertiary)]">
+        <input
+          type="checkbox"
+          checked={filters.showDismissed}
+          onChange={(e) => onChange({ ...filters, showDismissed: e.target.checked })}
+        />
+        Show dismissed findings
+      </span>
+    </div>
+  );
+}

--- a/packages/web/src/components/PipelineRunCard.tsx
+++ b/packages/web/src/components/PipelineRunCard.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+
+import type { PipelineRunSummary } from "@/hooks/usePipelineEvents";
+import { cn } from "@/lib/cn";
+
+interface PipelineRunCardProps {
+  run: PipelineRunSummary;
+  onExpand?: () => void;
+}
+
+/**
+ * Card view of a single pipeline run. Compact in the Kanban column; clicking
+ * the header expands it inline to show per-stage status dots. Findings,
+ * artifact actions, and the chat panel live in a separate detail view to keep
+ * the column scannable.
+ */
+export function PipelineRunCard({ run, onExpand }: PipelineRunCardProps): JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+  const stageNames = Object.keys(run.stageStatuses);
+
+  return (
+    <article
+      className={cn(
+        "rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-card)] p-2.5 shadow-sm",
+        run.hasOpenFindings && "border-[var(--color-status-waiting)]",
+      )}
+      data-run-id={run.runId}
+    >
+      <button
+        type="button"
+        onClick={() => {
+          setExpanded((v) => !v);
+          onExpand?.();
+        }}
+        className="flex w-full items-baseline gap-2 text-left"
+        aria-expanded={expanded}
+      >
+        <span className="font-mono text-[11px] font-semibold text-[var(--color-text-primary)]">
+          {run.pipelineName}
+        </span>
+        <span className="font-mono text-[10px] text-[var(--color-text-muted)]">
+          {run.sessionId}
+        </span>
+        <span className="ml-auto font-mono text-[10px] text-[var(--color-text-tertiary)]">
+          rounds {run.loopRounds}
+        </span>
+      </button>
+      <p className="mt-1 font-mono text-[10px] text-[var(--color-text-tertiary)]">
+        {run.headSha.length > 12 ? run.headSha.slice(0, 12) : run.headSha} · updated{" "}
+        {new Date(run.updatedAt).toLocaleTimeString()}
+      </p>
+      <ul className="mt-1.5 flex flex-wrap items-center gap-1.5" aria-label="stage statuses">
+        {stageNames.map((name) => (
+          <StageDot key={name} stageName={name} status={run.stageStatuses[name] ?? "pending"} />
+        ))}
+      </ul>
+      {run.hasOpenFindings && (
+        <p className="mt-1.5 text-[10px] text-[var(--color-status-waiting)]">
+          ● open findings
+        </p>
+      )}
+      {expanded && (
+        <p className="mt-2 text-[10px] text-[var(--color-text-tertiary)]">
+          <a
+            href={`/pipelines/${encodeURIComponent(run.runId)}?project=${encodeURIComponent(run.projectId)}`}
+            className="underline-offset-2 hover:underline"
+          >
+            View run details →
+          </a>
+        </p>
+      )}
+    </article>
+  );
+}
+
+interface StageDotProps {
+  stageName: string;
+  status: string;
+}
+
+function StageDot({ stageName, status }: StageDotProps): JSX.Element {
+  const tone = stageStatusTone(status);
+  return (
+    <li
+      className="inline-flex items-center gap-1 font-mono text-[10px]"
+      title={`${stageName}: ${status}`}
+      aria-label={`stage ${stageName} ${status}`}
+    >
+      <span className={cn("h-2 w-2 rounded-full", tone)} />
+      <span className="text-[var(--color-text-secondary)]">{stageName}</span>
+    </li>
+  );
+}
+
+function stageStatusTone(status: string): string {
+  switch (status) {
+    case "succeeded":
+      return "bg-[var(--color-status-ready)]";
+    case "running":
+      return "bg-[var(--color-status-working)]";
+    case "failed":
+      return "bg-[var(--color-status-error)]";
+    case "skipped":
+      return "bg-[var(--color-text-tertiary)]";
+    case "outdated":
+      return "bg-[var(--color-text-muted)]";
+    case "pending":
+    default:
+      return "bg-[var(--color-text-muted)]";
+  }
+}

--- a/packages/web/src/components/PipelineRunCard.tsx
+++ b/packages/web/src/components/PipelineRunCard.tsx
@@ -16,7 +16,7 @@ interface PipelineRunCardProps {
  * artifact actions, and the chat panel live in a separate detail view to keep
  * the column scannable.
  */
-export function PipelineRunCard({ run, onExpand }: PipelineRunCardProps): JSX.Element {
+export function PipelineRunCard({ run, onExpand }: PipelineRunCardProps) {
   const [expanded, setExpanded] = useState(false);
   const stageNames = Object.keys(run.stageStatuses);
 
@@ -80,7 +80,7 @@ interface StageDotProps {
   status: string;
 }
 
-function StageDot({ stageName, status }: StageDotProps): JSX.Element {
+function StageDot({ stageName, status }: StageDotProps) {
   const tone = stageStatusTone(status);
   return (
     <li

--- a/packages/web/src/components/PipelineWorkbench.tsx
+++ b/packages/web/src/components/PipelineWorkbench.tsx
@@ -60,7 +60,7 @@ const COLUMNS: readonly KanbanColumn[] = [
  * so first paint shows real data, and the SSE snapshot replaces it once the
  * EventSource connects.
  */
-export function PipelineWorkbench(props: PipelineWorkbenchProps): JSX.Element {
+export function PipelineWorkbench(props: PipelineWorkbenchProps) {
   const { initialRuns, projectFilter } = props;
   const live = usePipelineEvents({ project: projectFilter ?? undefined });
   const runs = live.lastSnapshotAt !== null ? live.runs : initialRuns;

--- a/packages/web/src/components/PipelineWorkbench.tsx
+++ b/packages/web/src/components/PipelineWorkbench.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type { LoopStateName } from "@aoagents/ao-core";
+
+import { usePipelineEvents, type PipelineRunSummary } from "@/hooks/usePipelineEvents";
+import { PipelineFilterBar, type PipelineFilters } from "@/components/PipelineFilterBar";
+import { PipelineRunCard } from "@/components/PipelineRunCard";
+import { cn } from "@/lib/cn";
+
+interface PipelineWorkbenchProps {
+  initialRuns: PipelineRunSummary[];
+  projectFilter: string | null;
+}
+
+interface KanbanColumn {
+  state: LoopStateName;
+  title: string;
+  description: string;
+  toneClass: string;
+}
+
+const COLUMNS: readonly KanbanColumn[] = [
+  {
+    state: "running",
+    title: "Running",
+    description: "Stage executing",
+    toneClass: "border-l-[var(--color-status-working)]",
+  },
+  {
+    state: "awaiting_context",
+    title: "Awaiting context",
+    description: "Stage paused for input",
+    toneClass: "border-l-[var(--color-status-waiting)]",
+  },
+  {
+    state: "done",
+    title: "Done",
+    description: "All stages succeeded",
+    toneClass: "border-l-[var(--color-status-ready)]",
+  },
+  {
+    state: "stalled",
+    title: "Stalled",
+    description: "Failed stages — resume to retry",
+    toneClass: "border-l-[var(--color-status-error)]",
+  },
+  {
+    state: "terminated",
+    title: "Terminated",
+    description: "Cancelled or superseded",
+    toneClass: "border-l-[var(--color-text-tertiary)]",
+  },
+] as const;
+
+/**
+ * Workbench — 5-column Kanban grouped by `loopState`. Live updates via the
+ * pipeline SSE feed (5s cadence, C-14). The initial run list is server-rendered
+ * so first paint shows real data, and the SSE snapshot replaces it once the
+ * EventSource connects.
+ */
+export function PipelineWorkbench(props: PipelineWorkbenchProps): JSX.Element {
+  const { initialRuns, projectFilter } = props;
+  const live = usePipelineEvents({ project: projectFilter ?? undefined });
+  const runs = live.lastSnapshotAt !== null ? live.runs : initialRuns;
+
+  const [filters, setFilters] = useState<PipelineFilters>({
+    pipelineNames: [],
+    showDismissed: false,
+  });
+
+  const filteredRuns = useMemo(() => {
+    if (filters.pipelineNames.length === 0) return runs;
+    const allowed = new Set(filters.pipelineNames);
+    return runs.filter((r) => allowed.has(r.pipelineName));
+  }, [runs, filters.pipelineNames]);
+
+  const columns = useMemo(() => {
+    const grouped = new Map<LoopStateName, PipelineRunSummary[]>();
+    for (const col of COLUMNS) grouped.set(col.state, []);
+    for (const run of filteredRuns) {
+      grouped.get(run.loopState)?.push(run);
+    }
+    return COLUMNS.map((col) => ({ ...col, runs: grouped.get(col.state) ?? [] }));
+  }, [filteredRuns]);
+
+  const pipelineNames = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of runs) set.add(r.pipelineName);
+    return [...set].sort();
+  }, [runs]);
+
+  return (
+    <div className="flex h-full min-h-screen flex-col bg-[var(--color-bg-page)] text-[var(--color-text-primary)]">
+      <header className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-card)] px-6 py-4">
+        <h1 className="text-base font-semibold tracking-tight">Pipeline Workbench</h1>
+        <p className="mt-1 text-xs text-[var(--color-text-tertiary)]">
+          {projectFilter ? `Project ${projectFilter}` : "All projects"} ·{" "}
+          {runs.length} run{runs.length === 1 ? "" : "s"} ·{" "}
+          {live.lastSnapshotAt ? "live" : "loading…"}
+          {live.loadError ? ` · ${live.loadError}` : ""}
+        </p>
+      </header>
+
+      <PipelineFilterBar
+        filters={filters}
+        availablePipelines={pipelineNames}
+        onChange={setFilters}
+      />
+
+      <main className="grid min-h-0 flex-1 grid-cols-1 gap-3 overflow-auto px-3 py-3 md:grid-cols-5">
+        {columns.map((col) => (
+          <section
+            key={col.state}
+            className={cn(
+              "flex min-h-[200px] flex-col rounded-md border-l-2 bg-[var(--color-bg-subtle)] p-2",
+              col.toneClass,
+            )}
+            aria-label={`${col.title} column`}
+            data-loop-state={col.state}
+          >
+            <header className="px-1 pb-2">
+              <h2 className="text-[11px] font-semibold uppercase tracking-wide text-[var(--color-text-secondary)]">
+                {col.title}{" "}
+                <span className="ml-1 rounded-full bg-[var(--color-bg-card)] px-1.5 py-px font-mono text-[10px] text-[var(--color-text-muted)]">
+                  {col.runs.length}
+                </span>
+              </h2>
+              <p className="mt-0.5 text-[10px] text-[var(--color-text-tertiary)]">
+                {col.description}
+              </p>
+            </header>
+            <div className="flex flex-1 flex-col gap-2">
+              {col.runs.map((run) => (
+                <PipelineRunCard key={run.runId} run={run} />
+              ))}
+              {col.runs.length === 0 && (
+                <div className="rounded border border-dashed border-[var(--color-border-muted)] p-3 text-center text-[10px] text-[var(--color-text-tertiary)]">
+                  Empty
+                </div>
+              )}
+            </div>
+          </section>
+        ))}
+      </main>
+    </div>
+  );
+}

--- a/packages/web/src/components/RunHistoryTimeline.tsx
+++ b/packages/web/src/components/RunHistoryTimeline.tsx
@@ -21,7 +21,7 @@ interface RunHistoryTimelineProps {
  * dot represents one run, colored by terminal `loopState`. Hovering reveals
  * runId + duration.
  */
-export function RunHistoryTimeline({ entries }: RunHistoryTimelineProps): JSX.Element {
+export function RunHistoryTimeline({ entries }: RunHistoryTimelineProps) {
   if (entries.length === 0) {
     return (
       <p className="text-[11px] text-[var(--color-text-tertiary)]">No prior runs.</p>

--- a/packages/web/src/components/RunHistoryTimeline.tsx
+++ b/packages/web/src/components/RunHistoryTimeline.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { LoopStateName } from "@aoagents/ao-core";
+
+import { cn } from "@/lib/cn";
+
+export interface RunHistoryEntry {
+  runId: string;
+  loopState: LoopStateName;
+  loopRounds: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface RunHistoryTimelineProps {
+  entries: RunHistoryEntry[];
+}
+
+/**
+ * Compact horizontal timeline of past runs for a session+pipeline loop. Each
+ * dot represents one run, colored by terminal `loopState`. Hovering reveals
+ * runId + duration.
+ */
+export function RunHistoryTimeline({ entries }: RunHistoryTimelineProps): JSX.Element {
+  if (entries.length === 0) {
+    return (
+      <p className="text-[11px] text-[var(--color-text-tertiary)]">No prior runs.</p>
+    );
+  }
+  return (
+    <ol
+      className="flex flex-wrap items-center gap-1"
+      aria-label="Pipeline run history"
+    >
+      {entries.map((entry) => (
+        <li key={entry.runId} className="inline-flex items-center gap-1">
+          <span
+            className={cn("h-2 w-2 rounded-full", toneFor(entry.loopState))}
+            title={`${entry.runId} · ${entry.loopState} · round ${entry.loopRounds}`}
+            aria-label={`run ${entry.runId} ${entry.loopState}`}
+          />
+          <span className="font-mono text-[10px] text-[var(--color-text-tertiary)]">
+            #{entry.loopRounds}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function toneFor(state: LoopStateName): string {
+  switch (state) {
+    case "running":
+      return "bg-[var(--color-status-working)]";
+    case "awaiting_context":
+      return "bg-[var(--color-status-waiting)]";
+    case "done":
+      return "bg-[var(--color-status-ready)]";
+    case "stalled":
+      return "bg-[var(--color-status-error)]";
+    case "terminated":
+    default:
+      return "bg-[var(--color-text-tertiary)]";
+  }
+}

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -18,6 +18,7 @@ import { cn } from "@/lib/cn";
 import { getSessionTitle } from "@/lib/format";
 import { CICheckList } from "./CIBadge";
 import { getSizeLabel } from "./PRStatus";
+import { SessionPipelineStrip } from "./SessionPipelineStrip";
 import { projectSessionHashPath, projectSessionPath } from "@/lib/routes";
 
 /**
@@ -628,6 +629,8 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
             </p>
           </div>
         )}
+
+        <SessionPipelineStrip sessionId={session.id} projectId={session.projectId} />
 
         {rateLimited && pr?.state === "open" && (
           <div className="px-[10px] pb-[5px]">

--- a/packages/web/src/components/SessionPipelineStrip.tsx
+++ b/packages/web/src/components/SessionPipelineStrip.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { PipelineRunSummary } from "@/hooks/usePipelineEvents";
+import { cn } from "@/lib/cn";
+
+interface SessionPipelineStripProps {
+  sessionId: string;
+  projectId: string;
+}
+
+/**
+ * Per-stage status dots strip for a session's linked pipeline runs. Renders
+ * compactly under the session id on every `SessionCard` — one row per active
+ * pipeline run, one dot per stage. Empty when the session has no pipeline
+ * runs (the strip stays out of layout entirely).
+ *
+ * Polls `/api/pipelines/runs` at the 5s dashboard cadence (C-14). Skips
+ * setState after unmount via the `cancelled` flag.
+ */
+export function SessionPipelineStrip(props: SessionPipelineStripProps): JSX.Element | null {
+  const { sessionId, projectId } = props;
+  const [runs, setRuns] = useState<PipelineRunSummary[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async (): Promise<void> => {
+      try {
+        const url = `/api/pipelines/runs?project=${encodeURIComponent(projectId)}`;
+        const res = await fetch(url, { cache: "no-store" });
+        if (!res.ok) return;
+        const body = (await res.json()) as { runs?: PipelineRunSummary[] };
+        if (cancelled) return;
+        setRuns(
+          (body.runs ?? []).filter((r) => r.sessionId === sessionId),
+        );
+      } catch {
+        // transient failure — next tick retries
+      }
+    };
+    void tick();
+    const timer = setInterval(() => void tick(), 5_000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [sessionId, projectId]);
+
+  if (runs.length === 0) return null;
+
+  return (
+    <div className="px-[10px] pb-[5px]" data-testid="session-pipeline-strip">
+      {runs.map((run) => (
+        <div
+          key={run.runId}
+          className="mt-1 flex flex-wrap items-center gap-1.5"
+          aria-label={`pipeline ${run.pipelineName}`}
+        >
+          <span className="font-mono text-[10px] text-[var(--color-text-tertiary)]">
+            {run.pipelineName}
+          </span>
+          {Object.entries(run.stageStatuses).map(([name, status]) => (
+            <span
+              key={name}
+              className={cn("inline-block h-1.5 w-1.5 rounded-full", toneFor(status))}
+              title={`${name}: ${status}`}
+              aria-label={`stage ${name} ${status}`}
+            />
+          ))}
+          <a
+            href={`/pipelines?project=${encodeURIComponent(projectId)}`}
+            className="ml-auto font-mono text-[10px] text-[var(--color-text-muted)] underline-offset-2 hover:underline"
+          >
+            view
+          </a>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function toneFor(status: string): string {
+  switch (status) {
+    case "succeeded":
+      return "bg-[var(--color-status-ready)]";
+    case "running":
+      return "bg-[var(--color-status-working)]";
+    case "failed":
+      return "bg-[var(--color-status-error)]";
+    case "skipped":
+      return "bg-[var(--color-text-tertiary)]";
+    case "outdated":
+      return "bg-[var(--color-text-muted)]";
+    default:
+      return "bg-[var(--color-text-muted)]";
+  }
+}

--- a/packages/web/src/components/SessionPipelineStrip.tsx
+++ b/packages/web/src/components/SessionPipelineStrip.tsx
@@ -19,7 +19,7 @@ interface SessionPipelineStripProps {
  * Polls `/api/pipelines/runs` at the 5s dashboard cadence (C-14). Skips
  * setState after unmount via the `cancelled` flag.
  */
-export function SessionPipelineStrip(props: SessionPipelineStripProps): JSX.Element | null {
+export function SessionPipelineStrip(props: SessionPipelineStripProps) {
   const { sessionId, projectId } = props;
   const [runs, setRuns] = useState<PipelineRunSummary[]>([]);
 

--- a/packages/web/src/components/__tests__/ChatPanel.test.tsx
+++ b/packages/web/src/components/__tests__/ChatPanel.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ChatPanel } from "../ChatPanel";
+
+describe("ChatPanel", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ messages: [] }),
+    });
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('shows "chat unavailable" when the agent has no follow-up support', () => {
+    render(
+      <ChatPanel
+        runId="run-1"
+        stageRunId="sr-1"
+        stageName="review"
+        projectId="demo"
+        followUpAvailable={false}
+        stageActive={true}
+      />,
+    );
+    expect(screen.getByText(/Chat unavailable/i)).toBeInTheDocument();
+  });
+
+  it("posts a follow-up message when the user clicks Send", async () => {
+    render(
+      <ChatPanel
+        runId="run-1"
+        stageRunId="sr-1"
+        stageName="review"
+        projectId="demo"
+        followUpAvailable={true}
+        stageActive={true}
+        reviewerId="app-rev-1"
+      />,
+    );
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "please continue" } });
+    fireEvent.click(screen.getByText("Send"));
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/\/thread\?project=demo/),
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+  });
+
+  it("surfaces a 410 ReviewerWorkspaceGone error inline", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 410,
+      json: async () => ({ error: "gone", code: "ReviewerWorkspaceGone" }),
+    });
+    render(
+      <ChatPanel
+        runId="run-1"
+        stageRunId="sr-1"
+        stageName="review"
+        projectId="demo"
+        followUpAvailable={true}
+        stageActive={true}
+      />,
+    );
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "hi" } });
+    fireEvent.click(screen.getByText("Send"));
+    await waitFor(() =>
+      expect(screen.getByText(/Worker workspace gone/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/packages/web/src/components/__tests__/FindingRow.test.tsx
+++ b/packages/web/src/components/__tests__/FindingRow.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FindingRow, type FindingArtifactView } from "../FindingRow";
+
+const baseFinding: FindingArtifactView = {
+  artifactId: "art-1",
+  stageRunId: "sr-1",
+  status: "open",
+  filePath: "src/foo.ts",
+  startLine: 10,
+  endLine: 12,
+  title: "Use const",
+  description: "Avoid mutable bindings",
+  severity: "warning",
+  category: "style",
+  confidence: 0.92,
+};
+
+describe("FindingRow", () => {
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("PATCHes the artifact when Dismiss is clicked", async () => {
+    const onChanged = vi.fn();
+    render(
+      <FindingRow
+        runId="run-1"
+        projectId="demo"
+        finding={baseFinding}
+        onStatusChanged={onChanged}
+      />,
+    );
+    fireEvent.click(screen.getByText("Dismiss"));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toMatch(/\/api\/pipelines\/runs\/run-1\/artifacts\/art-1/);
+    expect((init as RequestInit | undefined)?.method).toBe("PATCH");
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({ status: "dismissed", stageRunId: "sr-1" });
+    expect(onChanged).toHaveBeenCalledWith("dismissed");
+  });
+
+  it("shows Reopen instead of Dismiss when already dismissed", () => {
+    render(
+      <FindingRow
+        runId="run-1"
+        projectId="demo"
+        finding={{ ...baseFinding, status: "dismissed" }}
+      />,
+    );
+    expect(screen.getByText("Reopen")).toBeInTheDocument();
+    expect(screen.queryByText("Dismiss")).not.toBeInTheDocument();
+  });
+
+  it("surfaces the error returned by the server", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "store write failed" }),
+    });
+    render(<FindingRow runId="run-1" projectId="demo" finding={baseFinding} />);
+    fireEvent.click(screen.getByText("Dismiss"));
+    await waitFor(() =>
+      expect(screen.getByText(/store write failed/)).toBeInTheDocument(),
+    );
+  });
+});

--- a/packages/web/src/components/__tests__/PipelineFilterBar.test.tsx
+++ b/packages/web/src/components/__tests__/PipelineFilterBar.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PipelineFilterBar, type PipelineFilters } from "../PipelineFilterBar";
+
+const baseFilters: PipelineFilters = { pipelineNames: [], showDismissed: false };
+
+describe("PipelineFilterBar", () => {
+  it("renders one chip per pipeline name and toggles selection", () => {
+    const onChange = vi.fn();
+    render(
+      <PipelineFilterBar
+        filters={baseFilters}
+        availablePipelines={["code_review", "lint"]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByText("code_review"));
+    expect(onChange).toHaveBeenCalledWith({
+      pipelineNames: ["code_review"],
+      showDismissed: false,
+    });
+  });
+
+  it("shows the clear button when filters are active", () => {
+    const onChange = vi.fn();
+    render(
+      <PipelineFilterBar
+        filters={{ pipelineNames: ["lint"], showDismissed: false }}
+        availablePipelines={["code_review", "lint"]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByText("clear"));
+    expect(onChange).toHaveBeenCalledWith({ pipelineNames: [], showDismissed: false });
+  });
+
+  it("toggles the show-dismissed checkbox", () => {
+    const onChange = vi.fn();
+    render(
+      <PipelineFilterBar
+        filters={baseFilters}
+        availablePipelines={[]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(onChange).toHaveBeenCalledWith({ pipelineNames: [], showDismissed: true });
+  });
+});

--- a/packages/web/src/components/__tests__/PipelineRunCard.test.tsx
+++ b/packages/web/src/components/__tests__/PipelineRunCard.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PipelineRunCard } from "../PipelineRunCard";
+import type { PipelineRunSummary } from "@/hooks/usePipelineEvents";
+
+function makeRun(overrides: Partial<PipelineRunSummary> = {}): PipelineRunSummary {
+  return {
+    runId: "run-abc",
+    pipelineId: "pl-1",
+    pipelineName: "code_review",
+    sessionId: "app-3",
+    projectId: "demo",
+    loopState: "running",
+    loopRounds: 1,
+    headSha: "abc123def456",
+    createdAt: "2026-06-04T12:00:00.000Z",
+    updatedAt: "2026-06-04T12:01:00.000Z",
+    stageCount: 2,
+    stageStatuses: { review: "running", router: "pending" },
+    hasOpenFindings: false,
+    ...overrides,
+  };
+}
+
+describe("PipelineRunCard", () => {
+  it("renders pipeline + session ids and the truncated head sha", () => {
+    render(<PipelineRunCard run={makeRun()} />);
+    expect(screen.getByText("code_review")).toBeInTheDocument();
+    expect(screen.getByText("app-3")).toBeInTheDocument();
+    expect(screen.getByText(/abc123def456/)).toBeInTheDocument();
+  });
+
+  it("renders per-stage dots labelled by status", () => {
+    render(<PipelineRunCard run={makeRun()} />);
+    expect(screen.getByLabelText("stage review running")).toBeInTheDocument();
+    expect(screen.getByLabelText("stage router pending")).toBeInTheDocument();
+  });
+
+  it("expands to reveal a detail link when clicked", () => {
+    render(<PipelineRunCard run={makeRun()} />);
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    expect(screen.getByText("View run details →")).toBeInTheDocument();
+  });
+
+  it("surfaces a hint when the run has open findings", () => {
+    render(<PipelineRunCard run={makeRun({ hasOpenFindings: true })} />);
+    expect(screen.getByText(/open findings/)).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/__tests__/PipelineWorkbench.test.tsx
+++ b/packages/web/src/components/__tests__/PipelineWorkbench.test.tsx
@@ -2,10 +2,11 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { PipelineWorkbench } from "../PipelineWorkbench";
+import type * as PipelineEventsModule from "@/hooks/usePipelineEvents";
 import type { PipelineRunSummary } from "@/hooks/usePipelineEvents";
 
 vi.mock("@/hooks/usePipelineEvents", async () => {
-  const actual = await vi.importActual<typeof import("@/hooks/usePipelineEvents")>(
+  const actual = await vi.importActual<typeof PipelineEventsModule>(
     "@/hooks/usePipelineEvents",
   );
   return {

--- a/packages/web/src/components/__tests__/PipelineWorkbench.test.tsx
+++ b/packages/web/src/components/__tests__/PipelineWorkbench.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PipelineWorkbench } from "../PipelineWorkbench";
+import type { PipelineRunSummary } from "@/hooks/usePipelineEvents";
+
+vi.mock("@/hooks/usePipelineEvents", async () => {
+  const actual = await vi.importActual<typeof import("@/hooks/usePipelineEvents")>(
+    "@/hooks/usePipelineEvents",
+  );
+  return {
+    ...actual,
+    usePipelineEvents: () => ({ runs: [], loadError: null, lastSnapshotAt: null }),
+  };
+});
+
+function run(state: PipelineRunSummary["loopState"], runId: string): PipelineRunSummary {
+  return {
+    runId,
+    pipelineId: "pl-1",
+    pipelineName: "code_review",
+    sessionId: "app-1",
+    projectId: "demo",
+    loopState: state,
+    loopRounds: 1,
+    headSha: "abc",
+    createdAt: "2026-06-04T12:00:00.000Z",
+    updatedAt: "2026-06-04T12:01:00.000Z",
+    stageCount: 1,
+    stageStatuses: { review: "succeeded" },
+    hasOpenFindings: false,
+  };
+}
+
+describe("PipelineWorkbench", () => {
+  it("renders one column per loopState with the right run distribution", () => {
+    render(
+      <PipelineWorkbench
+        initialRuns={[
+          run("running", "r1"),
+          run("awaiting_context", "r2"),
+          run("done", "r3"),
+          run("stalled", "r4"),
+          run("terminated", "r5"),
+          run("running", "r6"),
+        ]}
+        projectFilter={null}
+      />,
+    );
+    expect(screen.getByRole("region", { name: /Running column/i })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /Awaiting context column/i })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /Done column/i })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /Stalled column/i })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /Terminated column/i })).toBeInTheDocument();
+  });
+
+  it("shows an empty hint in columns with no runs", () => {
+    render(<PipelineWorkbench initialRuns={[]} projectFilter={null} />);
+    expect(screen.getAllByText("Empty").length).toBeGreaterThan(0);
+  });
+});

--- a/packages/web/src/components/__tests__/RunHistoryTimeline.test.tsx
+++ b/packages/web/src/components/__tests__/RunHistoryTimeline.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RunHistoryTimeline } from "../RunHistoryTimeline";
+
+describe("RunHistoryTimeline", () => {
+  it("renders an empty hint when there are no prior runs", () => {
+    render(<RunHistoryTimeline entries={[]} />);
+    expect(screen.getByText("No prior runs.")).toBeInTheDocument();
+  });
+
+  it("renders one dot per entry with status accessible labels", () => {
+    render(
+      <RunHistoryTimeline
+        entries={[
+          {
+            runId: "run-1",
+            loopState: "done",
+            loopRounds: 1,
+            createdAt: "2026-06-04T12:00:00.000Z",
+            updatedAt: "2026-06-04T12:01:00.000Z",
+          },
+          {
+            runId: "run-2",
+            loopState: "stalled",
+            loopRounds: 2,
+            createdAt: "2026-06-04T12:02:00.000Z",
+            updatedAt: "2026-06-04T12:03:00.000Z",
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByLabelText("run run-1 done")).toBeInTheDocument();
+    expect(screen.getByLabelText("run run-2 stalled")).toBeInTheDocument();
+    expect(screen.getByText("#2")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/__tests__/SessionPipelineStrip.test.tsx
+++ b/packages/web/src/components/__tests__/SessionPipelineStrip.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SessionPipelineStrip } from "../SessionPipelineStrip";
+
+describe("SessionPipelineStrip", () => {
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        runs: [
+          {
+            runId: "run-1",
+            pipelineId: "pl",
+            pipelineName: "code_review",
+            sessionId: "app-1",
+            projectId: "demo",
+            loopState: "running",
+            loopRounds: 1,
+            headSha: "abc",
+            createdAt: "2026-06-04T12:00:00.000Z",
+            updatedAt: "2026-06-04T12:01:00.000Z",
+            stageCount: 2,
+            stageStatuses: { review: "running", router: "pending" },
+            hasOpenFindings: false,
+          },
+        ],
+      }),
+    });
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("renders status dots for linked pipeline runs", async () => {
+    render(<SessionPipelineStrip sessionId="app-1" projectId="demo" />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("stage review running")).toBeInTheDocument(),
+    );
+    expect(screen.getByLabelText("stage router pending")).toBeInTheDocument();
+    expect(screen.getByText("code_review")).toBeInTheDocument();
+  });
+
+  it("renders nothing when the session has no pipeline runs", () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ runs: [] }),
+    });
+    const { container } = render(<SessionPipelineStrip sessionId="app-2" projectId="demo" />);
+    expect(container.querySelector("[data-testid='session-pipeline-strip']")).toBeNull();
+  });
+});

--- a/packages/web/src/hooks/usePipelineEvents.ts
+++ b/packages/web/src/hooks/usePipelineEvents.ts
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useReducer, useRef } from "react";
+
+import type { LoopStateName } from "@aoagents/ao-core";
+
+/**
+ * Minimal pipeline-run summary view that mirrors what
+ * `/api/pipelines/runs` returns. Keeping the type local (rather than
+ * importing from `@/lib/pipelines`) avoids a Next.js client/server boundary
+ * import — `server-only` modules cannot be pulled into client code.
+ */
+export interface PipelineRunSummary {
+  runId: string;
+  pipelineId: string;
+  pipelineName: string;
+  sessionId: string;
+  projectId: string;
+  loopState: LoopStateName;
+  loopRounds: number;
+  headSha: string;
+  createdAt: string;
+  updatedAt: string;
+  stageCount: number;
+  stageStatuses: Record<string, string>;
+  hasOpenFindings: boolean;
+}
+
+interface PipelineEventsState {
+  runs: PipelineRunSummary[];
+  loadError: string | null;
+  lastSnapshotAt: number | null;
+}
+
+type Action =
+  | { type: "snapshot"; runs: PipelineRunSummary[]; ts: number }
+  | { type: "error"; message: string };
+
+function reducer(state: PipelineEventsState, action: Action): PipelineEventsState {
+  switch (action.type) {
+    case "snapshot":
+      return {
+        runs: action.runs,
+        loadError: null,
+        lastSnapshotAt: action.ts,
+      };
+    case "error":
+      return { ...state, loadError: action.message };
+  }
+}
+
+export interface UsePipelineEventsOptions {
+  /** Optional project filter — passes through to `/api/pipelines/events?project=`. */
+  project?: string;
+  /** When false, disables the SSE connection entirely (e.g. SSR or hidden tab). */
+  enabled?: boolean;
+}
+
+/**
+ * Subscribe to `/api/pipelines/events`. The server emits a snapshot every 5s
+ * (C-14); this hook surfaces the latest snapshot plus any transient error.
+ *
+ * Reconnects automatically on transient errors — the SSE EventSource API
+ * already retries on connection loss. We layer a thin error reporter on top so
+ * the UI can show "stale" / "disconnected" affordances.
+ */
+export function usePipelineEvents(options: UsePipelineEventsOptions = {}): PipelineEventsState {
+  const { project, enabled = true } = options;
+  const [state, dispatch] = useReducer(reducer, {
+    runs: [],
+    loadError: null,
+    lastSnapshotAt: null,
+  });
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const url = project
+      ? `/api/pipelines/events?project=${encodeURIComponent(project)}`
+      : "/api/pipelines/events";
+
+    const es = new EventSource(url);
+    esRef.current = es;
+
+    es.onmessage = (ev) => {
+      try {
+        const frame = JSON.parse(ev.data) as
+          | { kind: "snapshot"; ts: number; runs: PipelineRunSummary[] }
+          | { kind: "hello"; ts: number }
+          | { kind: "error"; ts: number; error: string };
+        if (frame.kind === "snapshot") {
+          dispatch({ type: "snapshot", runs: frame.runs, ts: frame.ts });
+        } else if (frame.kind === "error") {
+          dispatch({ type: "error", message: frame.error });
+        }
+      } catch (err) {
+        // A torn frame should not kill the stream; surface and keep listening.
+        dispatch({
+          type: "error",
+          message: err instanceof Error ? err.message : "Failed to parse pipeline SSE frame",
+        });
+      }
+    };
+
+    es.onerror = () => {
+      dispatch({ type: "error", message: "pipeline events disconnected" });
+      // EventSource auto-retries; no manual reconnect needed.
+    };
+
+    return () => {
+      es.close();
+      esRef.current = null;
+    };
+  }, [project, enabled]);
+
+  return state;
+}

--- a/packages/web/src/lib/pipelines.ts
+++ b/packages/web/src/lib/pipelines.ts
@@ -1,0 +1,507 @@
+import "server-only";
+
+import { existsSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+import {
+  asRunId,
+  asStageRunId,
+  createPipelineStore,
+  getProjectPipelinesDir,
+  hydrateEngineState,
+  loopKey,
+  isTerminalLoopState,
+  reduce,
+  type Agent,
+  type ArtifactId,
+  type ArtifactStatus,
+  type FollowUpContext,
+  type LoopStateName,
+  type PipelineEffect,
+  type PipelineEvent,
+  type PipelineStore,
+  type PluginRegistry,
+  type ProjectConfig,
+  type RunId,
+  type RunState,
+  type Session,
+  type StageRunId,
+  type ThreadMessage,
+} from "@aoagents/ao-core";
+
+import { getServices } from "@/lib/services";
+
+/**
+ * Error thrown when a follow-up is requested but the linked worker workspace
+ * no longer exists. The dashboard surfaces this as HTTP 410 `ReviewerWorkspaceGone`
+ * per the v2 spec — there is NO project-root fallback.
+ */
+export class ReviewerWorkspaceGoneError extends Error {
+  constructor(workspacePath: string) {
+    super(`Reviewer workspace no longer exists: ${workspacePath}`);
+    this.name = "ReviewerWorkspaceGone";
+  }
+}
+
+/** Resolve the per-project pipeline store. */
+export function getPipelineStore(projectId: string): PipelineStore {
+  return createPipelineStore(getProjectPipelinesDir(projectId));
+}
+
+interface PipelineActionDeps {
+  store: PipelineStore;
+  registry: PluginRegistry;
+  projects: Record<string, ProjectConfig>;
+  sessionManager: Awaited<ReturnType<typeof getServices>>["sessionManager"];
+  now?: () => number;
+}
+
+/**
+ * Apply a single pipeline event in the web process. Mirrors the CLI's
+ * one-shot `applyEvent`: the running `ao start` process owns the real engine,
+ * but read+write actions from the dashboard (dismiss / reopen / cancel /
+ * resume / follow-up) persist through the same reducer surface so artifacts
+ * and threads stay consistent.
+ *
+ * Effects executed here:
+ *  - persistence (PERSIST_RUN, PERSIST_LOOP_STATE, APPEND_ARTIFACTS,
+ *    UPDATE_ARTIFACT_STATUS, APPEND_THREAD_MESSAGE) — straight store writes
+ *  - SEND_FOLLOWUP — resolves the agent plugin and calls
+ *    `sendFollowUpToTask` against the linked worker session
+ *  - START_STAGE / CANCEL_STAGE — no-ops in the web path; the running CLI
+ *    engine handles them when it next ticks. The CLI's pipeline-service
+ *    warns about the same gap.
+ *  - EMIT_OBSERVATION — no-op (web has no observation router today).
+ */
+export async function applyPipelineEvent(
+  event: PipelineEvent,
+  deps: PipelineActionDeps,
+): Promise<void> {
+  const { store, registry, projects, sessionManager, now = Date.now } = deps;
+  const state = hydrateEngineState(store);
+  const result = reduce(state, event);
+
+  for (const effect of result.effects) {
+    await persistEffect(effect, { store, registry, projects, sessionManager, now });
+  }
+}
+
+async function persistEffect(
+  effect: PipelineEffect,
+  deps: PipelineActionDeps,
+): Promise<void> {
+  const { store, now = Date.now } = deps;
+  switch (effect.type) {
+    case "PERSIST_RUN":
+      store.saveRun(effect.runState);
+      for (const [stageName, stageState] of Object.entries(effect.runState.stages)) {
+        store.saveStage({ ...stageState, runId: effect.runState.runId, stageName });
+      }
+      return;
+    case "PERSIST_LOOP_STATE":
+      store.saveLoopState(effect.runId, effect.loopState);
+      return;
+    case "APPEND_ARTIFACTS":
+      store.appendArtifacts(effect.runId, effect.stageRunId, effect.artifacts);
+      return;
+    case "UPDATE_ARTIFACT_STATUS":
+      store.updateArtifactStatus(effect.runId, effect.stageRunId, effect.artifactId, effect.status);
+      return;
+    case "APPEND_THREAD_MESSAGE":
+      store.appendThreadMessage(effect.runId, effect.stageRunId, {
+        role: effect.role,
+        content: effect.content,
+        ts: new Date(now()).toISOString(),
+        ...(effect.reviewerId ? { reviewerId: effect.reviewerId } : {}),
+      });
+      return;
+    case "SEND_FOLLOWUP":
+      await deliverFollowUp(effect, deps);
+      return;
+    case "START_STAGE":
+    case "CANCEL_STAGE":
+    case "EMIT_OBSERVATION":
+      // The running CLI engine owns stage lifecycle; dashboard mutations
+      // don't reach into it. Observations are also not routed in the web.
+      return;
+  }
+}
+
+async function deliverFollowUp(
+  effect: Extract<PipelineEffect, { type: "SEND_FOLLOWUP" }>,
+  deps: PipelineActionDeps,
+): Promise<void> {
+  const { store, registry, projects, sessionManager } = deps;
+  const session = await resolveSession(effect.sessionId, sessionManager);
+  if (!session) {
+    throw new Error(`Worker session not found: ${effect.sessionId}`);
+  }
+  const workspacePath = session.workspacePath;
+  if (!workspacePath || !existsSync(workspacePath)) {
+    throw new ReviewerWorkspaceGoneError(workspacePath ?? "<unset>");
+  }
+  const project = projects[session.projectId];
+  if (!project) {
+    throw new Error(`Project not found for session: ${session.id}`);
+  }
+  const agent = resolveAgentForProject(registry, project);
+  if (!agent?.sendFollowUpToTask) {
+    throw new Error(`Agent "${agent?.name ?? "?"}" does not implement sendFollowUpToTask`);
+  }
+
+  const run = store.loadRun(effect.runId);
+  const stage = run?.stages[effect.stageName];
+
+  const ctx: FollowUpContext = {
+    sessionId: session.id,
+    workspacePath,
+    pipelineRunId: effect.runId,
+    stageRunId: effect.stageRunId,
+    pipelineName: run?.pipelineName ?? "",
+    stageName: effect.stageName,
+  };
+  // The reducer already persisted the user message and emitted the observation.
+  // Best-effort guard so the engine doesn't double-throw if the stage is gone.
+  if (!stage) {
+    throw new Error(`Stage "${effect.stageName}" not in run ${effect.runId}`);
+  }
+
+  const result = await agent.sendFollowUpToTask(ctx, effect.message);
+  if (result.reply && result.reply.length > 0) {
+    store.appendThreadMessage(effect.runId, effect.stageRunId, {
+      role: "agent",
+      content: result.reply,
+      ts: new Date(Date.now()).toISOString(),
+    });
+  }
+}
+
+async function resolveSession(
+  sessionId: string,
+  sessionManager: PipelineActionDeps["sessionManager"],
+): Promise<Session | null> {
+  const all = await sessionManager.list();
+  return all.find((s) => s.id === sessionId) ?? null;
+}
+
+function resolveAgentForProject(
+  registry: PluginRegistry,
+  project: ProjectConfig,
+): Agent | null {
+  const name = project.agent ?? "claude-code";
+  try {
+    return registry.get<Agent>("agent", name);
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// High-level helpers used by the API routes
+// ---------------------------------------------------------------------------
+
+export async function dismissArtifact(input: {
+  projectId: string;
+  runId: RunId;
+  stageRunId: StageRunId;
+  artifactId: ArtifactId;
+  actor?: string;
+}): Promise<void> {
+  return mutateArtifactStatus({ ...input, status: "dismissed" });
+}
+
+export async function reopenArtifact(input: {
+  projectId: string;
+  runId: RunId;
+  stageRunId: StageRunId;
+  artifactId: ArtifactId;
+  actor?: string;
+}): Promise<void> {
+  return mutateArtifactStatus({ ...input, status: "open" });
+}
+
+export async function markArtifactSent(input: {
+  projectId: string;
+  runId: RunId;
+  stageRunId: StageRunId;
+  artifactId: ArtifactId;
+}): Promise<void> {
+  return mutateArtifactStatus({ ...input, status: "sent_to_agent" });
+}
+
+async function mutateArtifactStatus(input: {
+  projectId: string;
+  runId: RunId;
+  stageRunId: StageRunId;
+  artifactId: ArtifactId;
+  status: ArtifactStatus;
+  actor?: string;
+}): Promise<void> {
+  const { config, registry, sessionManager } = await getServices();
+  const store = getPipelineStore(input.projectId);
+  await applyPipelineEvent(
+    {
+      type: "ARTIFACT_STATUS_CHANGED",
+      now: Date.now(),
+      runId: input.runId,
+      stageRunId: input.stageRunId,
+      artifactId: input.artifactId,
+      status: input.status,
+      ...(input.actor ? { actor: input.actor } : {}),
+    },
+    { store, registry, projects: config.projects, sessionManager },
+  );
+}
+
+export interface SendFollowUpInput {
+  projectId: string;
+  runId: RunId;
+  stageRunId: StageRunId;
+  stageName: string;
+  message: string;
+  reviewerId?: string;
+}
+
+export async function sendFollowUp(input: SendFollowUpInput): Promise<void> {
+  const { config, registry, sessionManager } = await getServices();
+  const store = getPipelineStore(input.projectId);
+  await applyPipelineEvent(
+    {
+      type: "USER_FOLLOWUP",
+      now: Date.now(),
+      runId: input.runId,
+      stageRunId: input.stageRunId,
+      stageName: input.stageName,
+      message: input.message,
+      ...(input.reviewerId ? { reviewerId: input.reviewerId } : {}),
+    },
+    { store, registry, projects: config.projects, sessionManager },
+  );
+}
+
+export interface CancelRunInput {
+  projectId: string;
+  runId: RunId;
+}
+
+export async function cancelRun(input: CancelRunInput): Promise<RunState | null> {
+  const { config, registry, sessionManager } = await getServices();
+  const store = getPipelineStore(input.projectId);
+  const run = store.loadRun(input.runId);
+  if (!run) return null;
+  if (isTerminalLoopState(run.loopState)) return run;
+  await applyPipelineEvent(
+    {
+      type: "RUN_CANCELLED",
+      now: Date.now(),
+      runId: input.runId,
+      reason: "manual_cancel",
+    },
+    { store, registry, projects: config.projects, sessionManager },
+  );
+  return store.loadRun(input.runId);
+}
+
+export interface ResumeRunInput {
+  projectId: string;
+  runId: RunId;
+}
+
+export async function resumeRun(input: ResumeRunInput): Promise<RunState | null> {
+  const { config, registry, sessionManager } = await getServices();
+  const store = getPipelineStore(input.projectId);
+  const run = store.loadRun(input.runId);
+  if (!run) return null;
+
+  const candidateStageNames = Object.entries(run.stages)
+    .filter(([, s]) => s.status === "failed" || s.status === "outdated")
+    .map(([name]) => name);
+  if (candidateStageNames.length === 0) return run;
+
+  const stageRunIds: Record<string, StageRunId> = {};
+  for (const name of candidateStageNames) {
+    stageRunIds[name] = asStageRunId(`sr-${randomUUID()}`);
+  }
+
+  await applyPipelineEvent(
+    {
+      type: "RUN_RESUMED",
+      now: Date.now(),
+      runId: input.runId,
+      stageRunIds,
+    },
+    { store, registry, projects: config.projects, sessionManager },
+  );
+  return store.loadRun(input.runId);
+}
+
+// ---------------------------------------------------------------------------
+// Read helpers
+// ---------------------------------------------------------------------------
+
+export interface RunSummaryView {
+  runId: RunId;
+  pipelineId: string;
+  pipelineName: string;
+  sessionId: string;
+  projectId: string;
+  loopState: LoopStateName;
+  loopRounds: number;
+  headSha: string;
+  createdAt: string;
+  updatedAt: string;
+  stageCount: number;
+  stageStatuses: Record<string, string>;
+  hasOpenFindings: boolean;
+}
+
+/**
+ * List all pipeline runs across configured projects. Pure read — no engine
+ * dispatch. The CLI's `ao start` is the source of truth for engine state;
+ * this just walks the persistent flat-file store under each project.
+ */
+export async function listRunsAcrossProjects(filterProjectId?: string): Promise<{
+  runs: RunSummaryView[];
+}> {
+  const { config } = await getServices();
+  const out: RunSummaryView[] = [];
+
+  const projectIds = filterProjectId
+    ? config.projects[filterProjectId]
+      ? [filterProjectId]
+      : []
+    : Object.keys(config.projects);
+
+  for (const projectId of projectIds) {
+    let runs: RunState[] = [];
+    try {
+      runs = getPipelineStore(projectId).listRuns();
+    } catch {
+      continue;
+    }
+    for (const run of runs) {
+      const stageStatuses: Record<string, string> = {};
+      for (const [name, s] of Object.entries(run.stages)) stageStatuses[name] = s.status;
+      const hasOpenFindings = (run.findings ?? []).some(
+        (a) => a.kind === "finding" && a.status === "open",
+      );
+      out.push({
+        runId: run.runId,
+        pipelineId: run.pipelineId,
+        pipelineName: run.pipelineName,
+        sessionId: run.sessionId,
+        projectId,
+        loopState: run.loopState,
+        loopRounds: run.loopRounds,
+        headSha: run.headSha,
+        createdAt: run.createdAt,
+        updatedAt: run.updatedAt,
+        stageCount: Object.keys(run.stages).length,
+        stageStatuses,
+        hasOpenFindings,
+      });
+    }
+  }
+
+  out.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  return { runs: out };
+}
+
+export interface StageView {
+  stageName: string;
+  stageRunId: StageRunId;
+  status: string;
+  attempt: number;
+  verdict?: string;
+  startedAt?: string;
+  completedAt?: string;
+  errorMessage?: string;
+  artifacts: Array<{
+    artifactId: ArtifactId;
+    kind: string;
+    status: ArtifactStatus;
+    [k: string]: unknown;
+  }>;
+}
+
+export interface RunDetailView extends RunSummaryView {
+  stages: StageView[];
+  /** Per-stage thread message counts. */
+  threadCounts: Record<string, number>;
+}
+
+export async function describeRunWithStages(
+  projectId: string,
+  runId: RunId,
+): Promise<RunDetailView | null> {
+  const store = getPipelineStore(projectId);
+  const run = store.loadRun(runId);
+  if (!run) return null;
+
+  const stages: StageView[] = [];
+  const threadCounts: Record<string, number> = {};
+  for (const [stageName, s] of Object.entries(run.stages)) {
+    const artifacts = store.listArtifacts(runId, s.stageRunId);
+    const view: StageView = {
+      stageName,
+      stageRunId: s.stageRunId,
+      status: s.status,
+      attempt: s.attempt,
+      ...(s.verdict ? { verdict: s.verdict } : {}),
+      ...(s.startedAt ? { startedAt: s.startedAt } : {}),
+      ...(s.completedAt ? { completedAt: s.completedAt } : {}),
+      ...(s.errorMessage ? { errorMessage: s.errorMessage } : {}),
+      artifacts: artifacts.map((a) => ({
+        ...a,
+        artifactId: a.artifactId,
+        kind: a.kind,
+        status: a.status,
+      })),
+    };
+    stages.push(view);
+    threadCounts[stageName] = store.listThreadMessages(runId, s.stageRunId).length;
+  }
+
+  const stageStatuses: Record<string, string> = {};
+  for (const [name, s] of Object.entries(run.stages)) stageStatuses[name] = s.status;
+  const hasOpenFindings = (run.findings ?? []).some(
+    (a) => a.kind === "finding" && a.status === "open",
+  );
+
+  return {
+    runId: run.runId,
+    pipelineId: run.pipelineId,
+    pipelineName: run.pipelineName,
+    sessionId: run.sessionId,
+    projectId,
+    loopState: run.loopState,
+    loopRounds: run.loopRounds,
+    headSha: run.headSha,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+    stageCount: Object.keys(run.stages).length,
+    stageStatuses,
+    hasOpenFindings,
+    stages,
+    threadCounts,
+  };
+}
+
+export async function listThread(
+  projectId: string,
+  runId: RunId,
+  stageRunId: StageRunId,
+): Promise<ThreadMessage[]> {
+  return getPipelineStore(projectId).listThreadMessages(runId, stageRunId);
+}
+
+/**
+ * Make a human-readable reviewer id surface label. Storage keeps the opaque
+ * stageRunId as the primary key; this is the dashboard-only display id.
+ */
+export function makeReviewerId(sessionPrefix: string, n: number): string {
+  return `${sessionPrefix}-rev-${n}`;
+}
+
+// Re-export so route handlers can branded-cast user input
+export { asRunId, asStageRunId, loopKey };

--- a/packages/web/src/lib/pipelines.ts
+++ b/packages/web/src/lib/pipelines.ts
@@ -373,7 +373,7 @@ export async function listRunsAcrossProjects(filterProjectId?: string): Promise<
     : Object.keys(config.projects);
 
   for (const projectId of projectIds) {
-    let runs: RunState[] = [];
+    let runs: RunState[];
     try {
       runs = getPipelineStore(projectId).listRuns();
     } catch {


### PR DESCRIPTION
Closes #198. Branched off `pipelines` (post-#190…#197).

## What lands
- **v2 `/pipelines` Workbench** — 5-column Kanban grouped by `loopState`. `page.tsx`, `PipelineWorkbench`, `PipelineRunCard`, `PipelineFilterBar`, `FindingRow`, `ChatPanel`, `RunHistoryTimeline`.
- **REST API under `/api/pipelines/`** — GET runs, GET runs/:id, SSE events (5s cadence — C-14); action endpoints PATCH artifacts/:id (dismiss/reopen/sent_to_agent), POST cancel/resume, POST stages/:stageRunId/thread (USER_FOLLOWUP), GET thread.
- **SSE hook** `usePipelineEvents` polling `/api/pipelines/events` every 5s.
- **`SessionCard` review strip** — `SessionPipelineStrip` mounts inside each session card and renders one row per linked pipeline run, dots per stage.
- **Conversational follow-up**:
  - Extended `Agent` with `sendFollowUpToTask?(ctx, message)` + `FollowUpContext` / `FollowUpResult` / `ThreadMessage`.
  - `agent-codex` implements via `codex exec --continue` in the worker's workspace.
  - Reducer events `USER_FOLLOWUP` → `SEND_FOLLOWUP` effect → `FOLLOWUP_REPLY`. Threads at `pipelines/threads/{runId}/{stageRunId}.jsonl`.
  - `PipelineEngineDeps.followUp` injection point lets CLI + web each wire their own delivery (no plugin-registry I/O in the engine itself).
- **Artifact actions** — `dismiss` / `reopen` / `sent_to_agent` flow through `ARTIFACT_STATUS_CHANGED` reducer events + `UPDATE_ARTIFACT_STATUS` effect; reducer mirrors into `RunState.findings` so predicate evaluation stays in sync.
- **Worker-alive pre-send check** — surfaces HTTP `410 ReviewerWorkspaceGone` with `code` in the body; **no project-root fallback**.
- **`/reviews` → `/pipelines` redirect** (back-compat).
- **Tests** — 4 reducer tests for the new events; 19 component smoke tests covering the new UI surface.

## Out of scope (carried forward)
- **Composed router findings + SCM `getPendingComments`** — the v0 router from #195 already bundles upstream findings and runs the worker-alive probe; same-file:line dedup against SCM comments + 60s SCM cache TTL is deferred to a follow-up PR. The Workbench-side plumbing (event flow, artifact statuses, send button) is already in place; only the SCM compose step is missing.
- **Human-readable reviewer IDs** — surfaced through `ThreadMessage.reviewerId` end-to-end; UI labeling defaults to the opaque `stageRunId` until the CLI's session-prefix-based id allocation lands.

## Verification
- `pnpm build` — clean (web + cli + core + every plugin).
- `pnpm typecheck` — clean across all 30 packages.
- `pnpm lint` — `0 errors, 54 warnings` (warnings are pre-existing).
- `pnpm --filter @aoagents/ao-core test pipeline-followup` — 4 passed.
- `pnpm --filter @aoagents/ao-web test` (new tests) — 19 passed across 7 files.

## Constraints respected
- Tailwind utility classes only — no inline `style=` (C-02).
- No external UI libs (C-01).
- Tests for every new component (C-12).
- Component files under 400 LOC (C-04).
- Dark theme preserved (C-05); CSS variables only.
- SSE cadence kept at 5s (C-14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)