### PR TITLE
fix(core): clear install hint when codex CLI is missing for code review

### DIFF
--- a/packages/core/src/__tests__/code-review-manager.test.ts
+++ b/packages/core/src/__tests__/code-review-manager.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createActivitySignal } from "../activity-signal.js";
+import { isWindows } from "../platform.js";
 import { createCodeReviewStore, type CodeReviewStore } from "../code-review-store.js";
 import {
   buildCodexCodeReviewArgs,
@@ -643,7 +644,7 @@ describe("runCodexCodeReview", () => {
     expect(args).not.toContain("--base");
   });
 
-  it.skipIf(process.platform === "win32")(
+  it.skipIf(isWindows())(
     "throws an install-hint error when the codex CLI is missing from PATH",
     async () => {
       const tmpRoot = join(tmpdir(), `ao-test-codex-missing-${randomUUID()}`);

--- a/packages/core/src/__tests__/code-review-manager.test.ts
+++ b/packages/core/src/__tests__/code-review-manager.test.ts
@@ -13,6 +13,7 @@ import {
   markOutdatedCodeReviewRunsForSession,
   parseReviewerOutput,
   prepareGitReviewerWorkspace,
+  runCodexCodeReview,
   sendCodeReviewFindingsToAgent,
   triggerCodeReviewForSession,
 } from "../code-review-manager.js";
@@ -641,6 +642,42 @@ describe("runCodexCodeReview", () => {
     expect(args).not.toContain("review");
     expect(args).not.toContain("--base");
   });
+
+  it.skipIf(process.platform === "win32")(
+    "throws an install-hint error when the codex CLI is missing from PATH",
+    async () => {
+      const tmpRoot = join(tmpdir(), `ao-test-codex-missing-${randomUUID()}`);
+      mkdirSync(tmpRoot, { recursive: true });
+      const originalPath = process.env["PATH"];
+      process.env["PATH"] = tmpRoot;
+
+      const run = store.createRun({
+        linkedSessionId: "app-1",
+        reviewerSessionId: "app-rev-missing",
+        status: "queued",
+      });
+
+      try {
+        await expect(
+          runCodexCodeReview({
+            config,
+            project: config.projects.app!,
+            session: makeSession({ workspacePath: tmpRoot }),
+            run,
+            workspacePath: tmpRoot,
+            baseRef: "main",
+          }),
+        ).rejects.toThrow(/Codex CLI .* was not found on PATH/);
+      } finally {
+        if (originalPath === undefined) {
+          delete process.env["PATH"];
+        } else {
+          process.env["PATH"] = originalPath;
+        }
+        rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("prepareGitReviewerWorkspace", () => {

--- a/packages/core/src/code-review-manager.ts
+++ b/packages/core/src/code-review-manager.ts
@@ -751,6 +751,12 @@ export async function runCodexCodeReview(
     const rawOutput = outputFileContents ?? (stdout.trim() || stderr.trim());
     return { rawOutput };
   } catch (error) {
+    if (isFsErrorWithCode(error, "ENOENT")) {
+      throw new Error(
+        "Codex CLI ('codex') was not found on PATH. AO's built-in reviewer requires the Codex CLI — install it from https://github.com/openai/codex (or `npm i -g @openai/codex`) and retry the review.",
+        { cause: error },
+      );
+    }
     const details =
       error instanceof Error && "stderr" in error && typeof error.stderr === "string"
         ? error.stderr.trim()


### PR DESCRIPTION
## Summary
- When the AO code reviewer (`executeCodeReviewRun` → `runCodexCodeReview`) is triggered but the `codex` CLI is not installed, the spawn fails with `ENOENT` and the review run is marked `failed` with terminationReason `Codex review failed: spawn codex ENOENT`.
- That message gives users no actionable signal — the actual fix is to install Codex CLI.
- Detect the `ENOENT` case explicitly and throw a message that names the missing binary and points at the install location. All other failures keep their existing wrapping.

## Test plan
- [x] New test in `code-review-manager.test.ts` clears `PATH` to an empty tmp dir and asserts `runCodexCodeReview` rejects with `/Codex CLI .* was not found on PATH/` (skipped on Windows where `shell: true` resolution differs).
- [x] `pnpm --filter @aoagents/ao-core typecheck`
- [x] `pnpm --filter @aoagents/ao-core test` — 1341 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to show a clear, actionable message when the Codex CLI is not found, guiding users to install it.

* **Tests**
  * Added tests covering behavior when the Codex CLI is absent and conditionally skip a platform-specific test on Windows to reduce false failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->