### PR TITLE
fix(pipelines): empty findings = success; correct terminal reason

### DIFF
--- a/packages/core/src/__tests__/pipeline-agent-executor.test.ts
+++ b/packages/core/src/__tests__/pipeline-agent-executor.test.ts
@@ -298,20 +298,108 @@ describe("agent executor — pollStage", () => {
     expect(outcome.status).toBe("failed");
     if (outcome.status !== "failed") throw new Error("unreachable");
     expect(outcome.errorMessage).toContain("terminated without findings");
+    // Defect 3 regression: must not surface the initial `spawn_requested`
+    // lifecycle reason — fall back to activity-derived terminal reason.
+    expect(outcome.errorMessage).not.toContain("spawn_requested");
+    expect(outcome.errorMessage).toContain("reason=agent_process_exited");
   });
 
-  it("returns failed when session reaches `done` before findings are harvested", async () => {
-    // Regression: stages should never reach `done` ahead of findings — `done`
-    // is reserved for post-merge / explicit completion. Treating it as a still-
-    // running state would hang the stage forever.
-    const mock = makeMockSessionManager({ activity: "idle", status: "done" });
+  it("harvests findings as success even when the session has already exited", async () => {
+    // Defect 2 regression: the reviewer wrote findings (the contract's
+    // completion signal) and then exited. We must not short-circuit to
+    // failure before checking the findings file.
+    const mock = makeMockSessionManager({ activity: "exited", status: "killed" });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    writeFindingsFile(workspaceRoot, [
+      JSON.stringify({
+        kind: "finding",
+        filePath: "src/a.ts",
+        startLine: 1,
+        endLine: 1,
+        title: "t",
+        description: "d",
+        category: "c",
+        severity: "info",
+        confidence: 0.5,
+      }),
+    ]);
+
+    const outcome = await exec.pollStage(handle);
+    expect(outcome.status).toBe("completed");
+    if (outcome.status !== "completed") throw new Error("unreachable");
+    expect(outcome.artifacts).toHaveLength(1);
+    expect(mock.kill).toHaveBeenCalledWith(handle.sessionId, { reason: "auto_cleanup" });
+  });
+
+  it("harvests an empty findings file as success even when the session has already exited", async () => {
+    // Defect 2 regression: the file's existence — not its contents — is the
+    // completion signal. An empty file from a reviewer that found nothing must
+    // succeed, not fail, regardless of post-write session state.
+    const mock = makeMockSessionManager({ activity: "exited", status: "killed" });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    writeFindingsFile(workspaceRoot, []);
+
+    const outcome = await exec.pollStage(handle);
+    expect(outcome).toEqual({ status: "completed", artifacts: [] });
+    expect(mock.kill).toHaveBeenCalledWith(handle.sessionId, { reason: "auto_cleanup" });
+  });
+
+  it("reports a real terminal reason when lifecycle reason is a whitelisted terminal one", async () => {
+    const seedLifecycle = createInitialCanonicalLifecycle("worker", new Date());
+    seedLifecycle.session.state = "terminated";
+    seedLifecycle.session.reason = "manually_killed";
+    const mock = makeMockSessionManager({
+      activity: "idle",
+      status: "killed",
+      lifecycle: seedLifecycle,
+    });
     const exec = createAgentExecutor({ sessionManager: mock.sm });
     const handle = await exec.startStage(makeStartInput());
 
     const outcome = await exec.pollStage(handle);
     expect(outcome.status).toBe("failed");
     if (outcome.status !== "failed") throw new Error("unreachable");
-    expect(outcome.errorMessage).toContain("terminated without findings");
+    expect(outcome.errorMessage).toContain("reason=manually_killed");
+  });
+
+  it("falls back to `terminated` when lifecycle is terminal but the reason is not a terminal one", async () => {
+    // Mirrors the real Defect 3 scenario: lifecycle.state transitions to
+    // `terminated` but the reason field still carries the initial
+    // `spawn_requested` — we must not echo that misleading reason.
+    const seedLifecycle = createInitialCanonicalLifecycle("worker", new Date());
+    seedLifecycle.session.state = "terminated";
+    const mock = makeMockSessionManager({
+      activity: "idle",
+      status: "killed",
+      lifecycle: seedLifecycle,
+    });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    const outcome = await exec.pollStage(handle);
+    expect(outcome.status).toBe("failed");
+    if (outcome.status !== "failed") throw new Error("unreachable");
+    expect(outcome.errorMessage).not.toContain("spawn_requested");
+    expect(outcome.errorMessage).toContain("reason=terminated");
+  });
+
+  it("does not treat a healthy `done` status as failure when findings are still pending", async () => {
+    // Defect 2 fix: dropping the conservative `done`-as-failure clause means a
+    // session reporting `done` without a terminal lifecycle state and without
+    // findings is treated as still in flight — the next poll will harvest if
+    // the file appears, or surface a real terminal reason when the runtime
+    // actually dies.
+    const mock = makeMockSessionManager({ activity: "idle", status: "done" });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    const outcome = await exec.pollStage(handle);
+    expect(outcome).toEqual({ status: "running" });
+    expect(mock.kill).not.toHaveBeenCalled();
   });
 
   it("rejects findings whose confidence is outside [0, 1]", async () => {

--- a/packages/core/src/pipeline/executors/agent.ts
+++ b/packages/core/src/pipeline/executors/agent.ts
@@ -194,22 +194,22 @@ export function createAgentExecutor(deps: AgentExecutorDeps): AgentStageExecutor
       };
     }
 
-    // The runtime/lifecycle escaping `idle` (e.g. session crashed, was killed
-    // out-of-band, or the agent exited without producing findings) is treated
-    // as a failure. The session is already terminal; nothing more to harvest.
-    if (isFailedTerminalSession(session)) {
-      const reason = session.lifecycle?.session.reason ?? session.status;
-      return {
-        status: "failed",
-        errorMessage: `Stage "${handle.stageName}" session ${handle.sessionId} terminated without findings (reason=${reason})`,
-      };
-    }
-
+    // Harvest-first: the findings file's existence is the completion signal,
+    // per the stage-prompt contract. Check it before any terminal-state
+    // bailout so a reviewer that wrote findings and exited cleanly still has
+    // its work picked up. Only when findings are absent do we look at
+    // session state to decide between "still working" and "dead without
+    // delivering".
     const findingsPath = join(handle.workspacePath, STAGE_FINDINGS_RELATIVE_PATH);
     const findingsReady = existsSync(findingsPath);
-    const isIdle = session.activity === "idle";
 
-    if (!isIdle || !findingsReady) {
+    if (!findingsReady) {
+      if (isFailedTerminalSession(session)) {
+        return {
+          status: "failed",
+          errorMessage: `Stage "${handle.stageName}" session ${handle.sessionId} terminated without findings (reason=${resolveTerminalReason(session)})`,
+        };
+      }
       return { status: "running" };
     }
 
@@ -261,13 +261,35 @@ function isFailedTerminalSession(session: {
 }): boolean {
   if (session.activity === "exited") return true;
   if (session.lifecycle?.session.state === "terminated") return true;
-  // `done` is a healthy terminal — but for stages we never expect a session to
-  // reach `done` before findings are harvested, so treat it as a failure too.
-  // (Sessions only transition to `done` after PR merge / explicit completion.)
-  if (session.status === "killed" || session.status === "errored" || session.status === "done") {
-    return true;
-  }
+  if (session.status === "killed" || session.status === "errored") return true;
   return false;
+}
+
+// Whitelist of lifecycle reasons that actually correspond to a terminal
+// transition. `spawn_requested` and friends are *initial* lifecycle reasons —
+// reading the reason field blindly would surface them as the cause of
+// termination, which is misleading. Fall back to activity/state/status when the
+// raw reason isn't a real terminal one.
+const TERMINAL_REASONS: ReadonlySet<string> = new Set([
+  "manually_killed",
+  "runtime_lost",
+  "agent_process_exited",
+  "probe_failure",
+  "error_in_process",
+  "auto_cleanup",
+  "pr_merged",
+]);
+
+function resolveTerminalReason(session: {
+  status: string;
+  activity: string | null;
+  lifecycle?: { session: { state: string; reason?: string } };
+}): string {
+  const rawReason = session.lifecycle?.session.reason;
+  if (rawReason && TERMINAL_REASONS.has(rawReason)) return rawReason;
+  if (session.activity === "exited") return "agent_process_exited";
+  if (session.lifecycle?.session.state === "terminated") return "terminated";
+  return session.status;
 }
 
 interface ParseFindingsResult {


### PR DESCRIPTION
Closes #216.

Two coupled fixes in `agent.ts pollStage` from the §3 minimal-smoke RCA in #212.

## Defect 2 — Empty findings file misclassified as failure
`pollStage` was running `isFailedTerminalSession` **before** checking the findings file. A reviewer that wrote `.ao/pipeline-findings.jsonl` (empty or not) and exited cleanly never had its work harvested — the next poll saw the terminal session and short-circuited to failure.

**Fix**: re-order `pollStage`. `existsSync(findingsPath)` is now checked first. Findings present always wins, regardless of session state. The conservative `status === "done"` clause in `isFailedTerminalSession` is gone — short-lived reviewer agents reach `done` as a healthy terminal, and that's not a failure.

## Defect 3 — Wrong terminal reason "spawn_requested"
The failure path read `session.lifecycle?.session.reason` blindly. `spawn_requested` is the *initial* lifecycle reason — when a terminal session's lifecycle reason hadn't yet been transitioned, the executor surfaced that initial value as if it were the cause of termination.

**Fix**: new `resolveTerminalReason()` only echoes the raw reason when it's in the canonical terminal set:
`manually_killed, runtime_lost, agent_process_exited, probe_failure, error_in_process, auto_cleanup, pr_merged`.
Otherwise it derives one from activity (`exited` → `agent_process_exited`), lifecycle state (`terminated` → `terminated`), or session status as a last resort.

## Tests
Extended `pipeline-agent-executor.test.ts`:
- empty findings file → `completed` with `artifacts: []` (already covered, kept green)
- findings present + session activity `exited` → `completed` with artifacts (Defect 2)
- empty findings + session `exited` → `completed` with `[]` (Defect 2)
- no findings + lifecycle reason in terminal whitelist → failure echoes the real reason
- no findings + lifecycle state `terminated` but reason is `spawn_requested` → failure reports `terminated`, never `spawn_requested` (Defect 3)
- `status === "done"` + activity `idle` + no findings → `running` (was: failed)
- existing "session exited without findings" test now also asserts `reason=agent_process_exited` and **not** `spawn_requested`

## Acceptance
- [x] Empty findings file → stage succeeds with `artifacts: []`
- [x] Findings file present but session went terminal → still harvested as success
- [x] No findings + session terminal → fails with a real terminal reason, never `spawn_requested`
- [x] Existing agent-executor tests still green

Base: `pipelines-staging`.