### PR TITLE
fix(pipelines): inject PR context into reviewer stages (#215)

### DIFF
--- a/packages/cli/src/lib/create-session-manager.ts
+++ b/packages/cli/src/lib/create-session-manager.ts
@@ -134,6 +134,9 @@ export async function getLifecycleManager(
       agentExecutor,
       initialState: hydrateEngineState(store),
       onObservation: routePipelineObservation,
+      // Wire worker session lookups so the engine can build `PrContext`
+      // (head SHA + PR number/URL/branches) for agent stages — see #215.
+      getSession: (sessionId) => sessionManager.get(sessionId),
     });
     // Reconcile stages left in `running` from a previous process: their
     // in-flight executor handles are gone, so dispatch STAGE_FAILED to let
@@ -180,5 +183,8 @@ export async function getOneShotPipelineEngine(
     agentExecutor,
     initialState: hydrateEngineState(store),
     onObservation: routePipelineObservation,
+    // Wire worker session lookups so the engine can build `PrContext`
+    // (head SHA + PR number/URL/branches) for agent stages — see #215.
+    getSession: (sessionId) => sessionManager.get(sessionId),
   });
 }

--- a/packages/core/src/__tests__/pipeline-agent-executor.test.ts
+++ b/packages/core/src/__tests__/pipeline-agent-executor.test.ts
@@ -386,3 +386,84 @@ describe("agent executor — cancelStage", () => {
     await expect(exec.cancelStage(handle)).resolves.toBeUndefined();
   });
 });
+
+describe("agent executor — prContext threading (#215)", () => {
+  it("threads prContext.headSha into spawn as checkoutSha and renders the PR Context block", async () => {
+    const mock = makeMockSessionManager();
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+
+    await exec.startStage(
+      makeStartInput({
+        prContext: {
+          prNumber: 42,
+          url: "https://github.com/acme/widget/pull/42",
+          headSha: "dfd6560abcdef0123456789abcdef0123456789a",
+          headBranch: "feat/foo",
+          baseBranch: "main",
+          isFromFork: false,
+        },
+      }),
+    );
+
+    expect(mock.spawn).toHaveBeenCalledTimes(1);
+    const spawnArgs = mock.spawn.mock.calls[0]?.[0] as SessionSpawnConfig;
+    // Defect 1: worktree must be pinned to the PR head SHA.
+    expect(spawnArgs.checkoutSha).toBe("dfd6560abcdef0123456789abcdef0123456789a");
+    // Defect 4: the prompt must carry the PR identity + a diff command.
+    expect(spawnArgs.prompt).toContain("## PR Context");
+    expect(spawnArgs.prompt).toContain("PR: #42");
+    expect(spawnArgs.prompt).toContain("https://github.com/acme/widget/pull/42");
+    expect(spawnArgs.prompt).toContain("Head branch: feat/foo");
+    expect(spawnArgs.prompt).toContain("Base branch: main");
+    expect(spawnArgs.prompt).toContain("Head SHA: dfd6560abcdef0123456789abcdef0123456789a");
+    expect(spawnArgs.prompt).toContain("git diff origin/main...HEAD");
+  });
+
+  it("omits the PR Context block and leaves checkoutSha unset when prContext is absent", async () => {
+    const mock = makeMockSessionManager();
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+
+    await exec.startStage(makeStartInput()); // no prContext — manual / orchestrator trigger
+
+    const spawnArgs = mock.spawn.mock.calls[0]?.[0] as SessionSpawnConfig;
+    expect(spawnArgs.checkoutSha).toBeUndefined();
+    expect(spawnArgs.prompt).not.toContain("## PR Context");
+    expect(spawnArgs.prompt).not.toContain("Head SHA");
+  });
+
+  it("uses baseSha in the diff command when present, in preference to baseBranch", async () => {
+    const mock = makeMockSessionManager();
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+
+    await exec.startStage(
+      makeStartInput({
+        prContext: {
+          headSha: "abc1234",
+          baseSha: "base5678",
+          baseBranch: "main",
+        },
+      }),
+    );
+
+    const spawnArgs = mock.spawn.mock.calls[0]?.[0] as SessionSpawnConfig;
+    expect(spawnArgs.prompt).toContain("git diff base5678...HEAD");
+    expect(spawnArgs.prompt).not.toContain("git diff origin/main...HEAD");
+  });
+
+  it("surfaces the fork warning line when isFromFork is true", async () => {
+    const mock = makeMockSessionManager();
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+
+    await exec.startStage(
+      makeStartInput({
+        prContext: {
+          headSha: "deadbeef",
+          isFromFork: true,
+        },
+      }),
+    );
+
+    const spawnArgs = mock.spawn.mock.calls[0]?.[0] as SessionSpawnConfig;
+    expect(spawnArgs.prompt).toContain("Fork PR: yes");
+  });
+});

--- a/packages/core/src/__tests__/pipeline-engine.test.ts
+++ b/packages/core/src/__tests__/pipeline-engine.test.ts
@@ -27,7 +27,14 @@ import {
   type TaskMode,
 } from "../pipeline/index.js";
 import { createPluginRegistry } from "../plugin-registry.js";
-import type { Agent, PluginManifest, PluginModule, PluginRegistry } from "../types.js";
+import type {
+  Agent,
+  PluginManifest,
+  PluginModule,
+  PluginRegistry,
+  Session,
+  SessionId,
+} from "../types.js";
 
 let storeRoot: string;
 
@@ -488,5 +495,180 @@ describe("pipeline engine — end-to-end", () => {
 
     expect(executor.startCalls).toHaveLength(2);
     expect(executor.startCalls[1]?.projectId).toBe("proj-b");
+  });
+});
+
+describe("pipeline engine — prContext threading (#215)", () => {
+  function makeSession(overrides: Partial<Session> = {}): Session {
+    return {
+      id: "ses-1" as SessionId,
+      projectId: "proj-a",
+      status: "working",
+      activity: "active",
+      activitySignal: {
+        state: "valid",
+        activity: "active",
+        source: "runtime",
+        timestamp: new Date(),
+      },
+      lifecycle: {
+        session: { state: "working", reason: undefined },
+        agent: { state: "active", reason: undefined },
+        ci: { state: "no_pr", reason: undefined },
+        review: { state: "no_pr", reason: undefined },
+        updatedAt: new Date(),
+      } as unknown as Session["lifecycle"],
+      branch: "feat/x",
+      issueId: null,
+      pr: null,
+      prs: [],
+      workspacePath: "/tmp/mock",
+      runtimeHandle: { id: "tmux-1", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+      ...overrides,
+    } as Session;
+  }
+
+  it("builds PrContext from run.headSha + worker session PRInfo and threads it into startInput", async () => {
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+    const workerSession = makeSession({
+      pr: {
+        number: 42,
+        url: "https://github.com/acme/widget/pull/42",
+        title: "feat: add foo",
+        owner: "acme",
+        repo: "widget",
+        branch: "feat/foo",
+        baseBranch: "main",
+        isDraft: false,
+        isFromFork: false,
+      },
+    });
+    const getSession = vi.fn(async () => workerSession);
+
+    const engine = createPipelineEngine({
+      store,
+      registry,
+      agentExecutor: executor,
+      getSession,
+    });
+
+    await engine.startRun({
+      pipeline: makePipeline(),
+      projectId: "proj-a",
+      sessionId: "ses-1",
+      headSha: "dfd6560abcdef0",
+    });
+
+    expect(executor.startCalls).toHaveLength(1);
+    const startInput = executor.startCalls[0]!;
+    expect(startInput.prContext).toBeDefined();
+    expect(startInput.prContext?.headSha).toBe("dfd6560abcdef0");
+    expect(startInput.prContext?.prNumber).toBe(42);
+    expect(startInput.prContext?.url).toBe("https://github.com/acme/widget/pull/42");
+    expect(startInput.prContext?.headBranch).toBe("feat/foo");
+    expect(startInput.prContext?.baseBranch).toBe("main");
+    expect(startInput.prContext?.isFromFork).toBe(false);
+    expect(getSession).toHaveBeenCalledWith("ses-1");
+  });
+
+  it("threads PrContext with headSha only when the worker session has no PR yet", async () => {
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+    const getSession = vi.fn(async () => makeSession({ pr: null }));
+
+    const engine = createPipelineEngine({
+      store,
+      registry,
+      agentExecutor: executor,
+      getSession,
+    });
+
+    await engine.startRun({
+      pipeline: makePipeline(),
+      projectId: "proj-a",
+      sessionId: "ses-1",
+      headSha: "abc1234",
+    });
+
+    const startInput = executor.startCalls[0]!;
+    expect(startInput.prContext).toEqual({ headSha: "abc1234" });
+  });
+
+  it("omits prContext entirely for manual triggers (sentinel headSha === \"manual\")", async () => {
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+    const getSession = vi.fn(async () => makeSession());
+
+    const engine = createPipelineEngine({
+      store,
+      registry,
+      agentExecutor: executor,
+      getSession,
+    });
+
+    await engine.startRun({
+      pipeline: makePipeline(),
+      projectId: "proj-a",
+      sessionId: "ses-1",
+      headSha: "manual",
+    });
+
+    expect(executor.startCalls[0]?.prContext).toBeUndefined();
+    expect(getSession).not.toHaveBeenCalled();
+  });
+
+  it("omits prContext when getSession is not wired (legacy / test engines)", async () => {
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+
+    const engine = createPipelineEngine({
+      store,
+      registry,
+      agentExecutor: executor,
+      // no getSession
+    });
+
+    await engine.startRun({
+      pipeline: makePipeline(),
+      projectId: "proj-a",
+      sessionId: "ses-1",
+      headSha: "abc1234",
+    });
+
+    expect(executor.startCalls[0]?.prContext).toBeUndefined();
+  });
+
+  it("swallows getSession errors and falls back to no prContext", async () => {
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+    const getSession = vi.fn(async () => {
+      throw new Error("session store unreachable");
+    });
+
+    const engine = createPipelineEngine({
+      store,
+      registry,
+      agentExecutor: executor,
+      getSession,
+    });
+
+    await engine.startRun({
+      pipeline: makePipeline(),
+      projectId: "proj-a",
+      sessionId: "ses-1",
+      headSha: "abc1234",
+    });
+
+    expect(executor.startCalls[0]?.prContext).toBeUndefined();
   });
 });

--- a/packages/core/src/pipeline/engine.ts
+++ b/packages/core/src/pipeline/engine.ts
@@ -30,7 +30,7 @@
 
 import { randomUUID } from "node:crypto";
 
-import type { PluginRegistry } from "../types.js";
+import type { PluginRegistry, Session } from "../types.js";
 import type { PipelineEffect, PipelineEvent } from "./events.js";
 import { reduce } from "./reducer.js";
 import type { PipelineStore } from "./store.js";
@@ -45,6 +45,7 @@ import {
   type EngineState,
   type Pipeline,
   type PipelineScope,
+  type PrContext,
   type RunId,
   type RunState,
   type RunSummary,
@@ -132,6 +133,16 @@ export interface PipelineEngineDeps {
     event: { name: string; data: Record<string, unknown> },
     context: ObservationContext,
   ) => void;
+  /**
+   * Look up a worker session by id when building `PrContext` for agent
+   * stages. Wired to `sessionManager.get` in production; absent in tests
+   * that don't exercise PR-triggered runs.
+   *
+   * When omitted, agent stages still run — they just don't get a
+   * `prContext` block in the prompt or a `checkoutSha` pin on the worktree,
+   * which is the correct fallback for manual / orchestrator-triggered runs.
+   */
+  getSession?: (sessionId: string) => Promise<Session | null>;
 }
 
 /**
@@ -272,6 +283,7 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
   const { store, registry, agentExecutor, commandExecutor, builtin, followUp, now = Date.now } =
     deps;
   const onObservation = deps.onObservation;
+  const getSession = deps.getSession;
 
   let state: EngineState = deps.initialState ?? emptyEngineState();
   /**
@@ -418,6 +430,7 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
         });
 
         const meta = runMetadata.get(run.runId);
+        const prContext = await buildPrContext(run);
         const startInput: StartStageInput = {
           pipelineName: run.pipelineName,
           projectId: meta?.projectId ?? "",
@@ -426,6 +439,7 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
           stage: effect.stage,
           loopRound: run.loopRounds,
           ...(meta?.issueId ? { issueId: meta.issueId } : {}),
+          ...(prContext ? { prContext } : {}),
         };
 
         try {
@@ -501,6 +515,48 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
    * BuiltinTaskContext; this engine code never constructs one directly so
    * `sendToSession` stays gated behind the dispatcher.
    */
+  /**
+   * Build a PrContext for the agent executor from `run.headSha` and the
+   * worker session's PRInfo (#215). Returns `undefined` when:
+   *   - `getSession` wasn't wired (test / non-PR engine),
+   *   - the worker session is gone (e.g. cancelled between dispatch + tick),
+   *   - `run.headSha` is the sentinel "manual" used by orchestrator-triggered
+   *     and manual runs that aren't pinned to a real commit,
+   *
+   * which is the right fallback: those runs have no SHA to pin to and no PR
+   * to describe, so the executor falls back to the pre-#215 behavior (worktree
+   * on `session/<id>`, no PR Context block in the prompt).
+   *
+   * Best-effort: failures are swallowed so prContext stays absent rather than
+   * crashing the stage.
+   */
+  async function buildPrContext(run: RunState): Promise<PrContext | undefined> {
+    if (!getSession) return undefined;
+    if (!run.headSha || run.headSha === "manual") return undefined;
+
+    let session: Session | null;
+    try {
+      session = await getSession(run.sessionId);
+    } catch {
+      return undefined;
+    }
+    if (!session) return undefined;
+
+    const pr = session.pr;
+    const ctx: PrContext = { headSha: run.headSha };
+    if (pr) {
+      ctx.prNumber = pr.number;
+      ctx.url = pr.url;
+      ctx.headBranch = pr.branch;
+      ctx.baseBranch = pr.baseBranch;
+      // `isFromFork` is `boolean | null` on PRInfo; thread through verbatim
+      // so the prompt can reflect "fork status unknown" when the SCM plugin
+      // can't tell.
+      ctx.isFromFork = pr.isFromFork;
+    }
+    return ctx;
+  }
+
   async function runBuiltinStage(
     run: RunState,
     stage: Stage,

--- a/packages/core/src/pipeline/executors/agent.ts
+++ b/packages/core/src/pipeline/executors/agent.ts
@@ -30,6 +30,7 @@ import { buildStagePrompt } from "../stage-prompt.js";
 import {
   PIPELINE_FINDINGS_FILENAME,
   type ArtifactInput,
+  type PrContext,
   type RunId,
   type Stage,
   type StageRunId,
@@ -52,6 +53,13 @@ export interface StartStageInput {
   issueId?: string;
   /** Loop counter from the engine. Surfaced in the prompt only. */
   loopRound?: number;
+  /**
+   * PR context for the run, threaded into both the prompt (so the agent
+   * knows what's being reviewed) and the spawn (so the worktree is pinned
+   * to the PR head SHA via `checkoutSha`). Absent for manual / orchestrator
+   * triggers that aren't scoped to a PR.
+   */
+  prContext?: PrContext;
 }
 
 /**
@@ -142,6 +150,7 @@ export function createAgentExecutor(deps: AgentExecutorDeps): AgentStageExecutor
       pipelineName: input.pipelineName,
       stage: input.stage,
       loopRound: input.loopRound,
+      ...(input.prContext ? { prContext: input.prContext } : {}),
     });
 
     let session;
@@ -151,6 +160,10 @@ export function createAgentExecutor(deps: AgentExecutorDeps): AgentStageExecutor
         issueId: input.issueId,
         prompt: stagePrompt,
         agent: input.stage.executor.plugin,
+        // Pin the worktree to the PR head SHA so the reviewer sees the
+        // diff being reviewed instead of `origin/<defaultBranch>` (#215).
+        // Workspaces that can't pin a commit (workspace-clone) ignore it.
+        ...(input.prContext?.headSha ? { checkoutSha: input.prContext.headSha } : {}),
       });
     } catch (err) {
       throw new AgentExecutorSpawnError(

--- a/packages/core/src/pipeline/stage-prompt.ts
+++ b/packages/core/src/pipeline/stage-prompt.ts
@@ -10,13 +10,21 @@
  * spawn-time `prompt` field. Keep it terse — agents read it once.
  */
 
-import { PIPELINE_FINDINGS_FILENAME, type Stage, type TaskMode } from "./types.js";
+import { PIPELINE_FINDINGS_FILENAME, type PrContext, type Stage, type TaskMode } from "./types.js";
 
 export interface StagePromptInput {
   pipelineName: string;
   stage: Stage;
   /** Loop counter from the engine — included so prompts surface progress. */
   loopRound?: number;
+  /**
+   * PR context the stage is executing against. Present for PR-triggered runs
+   * (e.g. reviewer stages) — emitted as a `## PR Context` block so the agent
+   * has the PR number, URL, head/base SHAs, branches, and a copy-pasteable
+   * `git diff` command. Absent for manual / orchestrator-triggered runs that
+   * are not scoped to a PR — in that case the block is omitted entirely.
+   */
+  prContext?: PrContext;
 }
 
 /**
@@ -26,7 +34,7 @@ export interface StagePromptInput {
  * agent doesn't need to know the absolute path.
  */
 export function buildStagePrompt(input: StagePromptInput): string {
-  const { pipelineName, stage, loopRound } = input;
+  const { pipelineName, stage, loopRound, prContext } = input;
   const mode = stage.executor.kind === "agent" ? stage.executor.mode : null;
   const lines: string[] = [];
 
@@ -37,6 +45,12 @@ export function buildStagePrompt(input: StagePromptInput): string {
   if (typeof loopRound === "number") lines.push(`Loop round: ${loopRound}`);
   if (stage.policy?.blocksMerge) {
     lines.push(`This stage's findings will block merge until they are resolved.`);
+  }
+
+  if (prContext) {
+    lines.push(``);
+    lines.push(`## PR Context`);
+    lines.push(...formatPrContext(prContext));
   }
 
   if (stage.task.prompt) {
@@ -58,6 +72,43 @@ export function buildStagePrompt(input: StagePromptInput): string {
   lines.push(formatFindingsInstructions(mode));
 
   return lines.join("\n");
+}
+
+function formatPrContext(ctx: PrContext): string[] {
+  const lines: string[] = [];
+
+  if (typeof ctx.prNumber === "number") lines.push(`PR: #${ctx.prNumber}`);
+  if (ctx.url) lines.push(`URL: ${ctx.url}`);
+  if (ctx.headBranch) lines.push(`Head branch: ${ctx.headBranch}`);
+  if (ctx.baseBranch) lines.push(`Base branch: ${ctx.baseBranch}`);
+  lines.push(`Head SHA: ${ctx.headSha}`);
+  if (ctx.baseSha) lines.push(`Base SHA: ${ctx.baseSha}`);
+  if (ctx.isFromFork === true) {
+    lines.push(`Fork PR: yes (head branch lives on a fork of the base repo)`);
+  }
+
+  // Pin the diff target so the agent doesn't have to guess. Prefer the
+  // explicit base SHA when present; otherwise use the base branch with
+  // three-dot syntax (`base...HEAD`) so the diff is from the merge-base,
+  // matching what GitHub shows in the PR's "Files changed" tab.
+  const diffBase = ctx.baseSha ?? (ctx.baseBranch ? `origin/${ctx.baseBranch}` : null);
+  if (diffBase) {
+    lines.push(``);
+    lines.push(
+      `Your worktree is already checked out at the PR head SHA (\`${ctx.headSha}\`). ` +
+        `Inspect the diff with:`,
+    );
+    lines.push("```bash");
+    lines.push(`git diff ${diffBase}...HEAD`);
+    lines.push("```");
+  } else {
+    lines.push(``);
+    lines.push(
+      `Your worktree is already checked out at the PR head SHA (\`${ctx.headSha}\`).`,
+    );
+  }
+
+  return lines;
 }
 
 function formatFindingsInstructions(mode: TaskMode | null): string {

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -35,6 +35,37 @@ export const asArtifactId = (id: string): ArtifactId => id as ArtifactId;
 /** Modes an agent plugin advertises in its manifest's `supportedTaskModes` field. */
 export type TaskMode = "review" | "code" | "answer";
 
+/**
+ * PR context threaded into agent stage executions so reviewer prompts know which
+ * commit/branch to look at and the worktree can be pinned to the PR's head SHA.
+ *
+ * Built by the engine from `RunState.headSha` + the worker session's `PRInfo`
+ * at START_STAGE time. Absent for manual / orchestrator-triggered runs that
+ * are not scoped to a PR.
+ */
+export interface PrContext {
+  /** PR number, when known. Absent if the worker session has no PR yet. */
+  prNumber?: number;
+  /** Canonical PR URL (web). */
+  url?: string;
+  /**
+   * Head commit the reviewer's worktree should be checked out at. Required —
+   * a `PrContext` only exists when the engine has a head SHA to pin to.
+   */
+  headSha: string;
+  /** Optional base SHA — typically the merge-base; absent unless the SCM plugin surfaces it. */
+  baseSha?: string;
+  /** PR head branch name (no `refs/` prefix). */
+  headBranch?: string;
+  /** PR base branch name. */
+  baseBranch?: string;
+  /**
+   * Whether the PR's head lives on a fork of the base repo. Mirrors
+   * `PRInfo.isFromFork`; `null` means the SCM plugin can't tell.
+   */
+  isFromFork?: boolean | null;
+}
+
 export type StageTriggerEvent =
   | "pr.opened"
   | "pr.updated"

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1313,6 +1313,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           sessionId,
           branch,
           worktreeDir: getProjectWorktreesDir(spawnConfig.projectId),
+          // Pipeline reviewer stages pass `checkoutSha` so the worktree
+          // starts at the PR head SHA rather than `origin/<defaultBranch>`.
+          ...(spawnConfig.checkoutSha ? { checkoutSha: spawnConfig.checkoutSha } : {}),
         });
         workspacePath = wsInfo.path;
         // Only register destroy when the path is inside a managed root —

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -398,6 +398,18 @@ export interface SessionSpawnConfig {
    * default branch when omitted.
    */
   workstreamBaseBranch?: string;
+  /**
+   * Pin the workspace to a specific commit after creation (detached HEAD).
+   *
+   * Set by the pipeline engine when spawning a reviewer session against an
+   * existing PR: without it, the reviewer worktree would come up on
+   * `session/<id> -> origin/<defaultBranch>` and "review the diff" would
+   * have no diff target.
+   *
+   * Workspace plugins that don't track commits (e.g. workspace-clone) treat
+   * this as a no-op.
+   */
+  checkoutSha?: string;
 }
 
 /**
@@ -760,6 +772,16 @@ export interface WorkspaceCreateConfig {
   branch: string;
   /** Override the base directory for worktrees (e.g. V2 project-scoped dir). */
   worktreeDir?: string;
+  /**
+   * Pin the workspace to this commit after creation (`git checkout --detach`).
+   *
+   * Used by the pipeline engine when spawning a reviewer session against an
+   * existing PR head SHA so the reviewer's worktree starts at the SHA being
+   * reviewed rather than the freshly-created session branch at HEAD of
+   * `origin/<defaultBranch>`. Workspace plugins that cannot pin to a commit
+   * (e.g. workspace-clone) treat this as a no-op.
+   */
+  checkoutSha?: string;
 }
 
 export interface WorkspaceInfo {

--- a/packages/integration-tests/src/pipeline-pr-trigger.integration.test.ts
+++ b/packages/integration-tests/src/pipeline-pr-trigger.integration.test.ts
@@ -99,17 +99,21 @@ function buildConfig(configPath: string): OrchestratorConfig {
 interface StubExecutor extends AgentStageExecutor {
   setNextOutcome(outcome: StageOutcome): void;
   inflightCount(): number;
+  startCalls(): readonly StartStageInput[];
 }
 
 function buildStubExecutor(): StubExecutor {
   let nextOutcome: StageOutcome = { status: "running" };
   const inflight = new Set<string>();
+  const calls: StartStageInput[] = [];
   return {
     setNextOutcome: (o) => {
       nextOutcome = o;
     },
     inflightCount: () => inflight.size,
+    startCalls: () => calls,
     async startStage(input: StartStageInput): Promise<RunningAgentStage> {
+      calls.push(input);
       inflight.add(input.stageRunId);
       return {
         runId: input.runId,
@@ -427,5 +431,50 @@ describe("pipeline trigger bridge (PR opened → engine starts run → done)", (
     // Persistence round-trip: a fresh store reads back the same terminal run.
     const reloaded = store.loadRun(finalRun.runId);
     expect(reloaded?.loopState).toBe("done");
+  });
+
+  it("threads PrContext (PR + head SHA) into the reviewer stage when getSession is wired (#215)", async () => {
+    // End-to-end check for Defects 4 + 1: the engine must hand the reviewer
+    // stage a `PrContext` it can use to (a) describe the PR in the prompt
+    // (Defect 4) and (b) pin the worktree to the head SHA (Defect 1).
+    const pr = makePR();
+    const config = buildConfig(join(tmpRoot, "agent-orchestrator.yaml"));
+    const session = makeSession(pr);
+    const scm = buildStubSCM(pr, "sha-init");
+    const registry = buildRegistry(scm, buildAgentManifest());
+    const sessionManager = buildSessionManager(session);
+    const executor = buildStubExecutor();
+    const store = createPipelineStore(join(tmpRoot, "pipelines"));
+
+    engine = createPipelineEngine({
+      store,
+      registry,
+      agentExecutor: executor,
+      initialState: hydrateEngineState(store),
+      getSession: (sessionId) => sessionManager.get(sessionId),
+    });
+
+    lifecycle = createLifecycleManager({
+      config,
+      registry,
+      sessionManager,
+      projectId: PROJECT_ID,
+      pipelineEngine: engine,
+    });
+
+    await lifecycle.check(SESSION_ID);
+
+    const calls = executor.startCalls();
+    expect(calls).toHaveLength(1);
+    const ctx = calls[0]!.prContext;
+    expect(ctx).toBeDefined();
+    // Defect 1: head SHA must arrive at the executor so spawn can pin the worktree.
+    expect(ctx?.headSha).toBe("sha-init");
+    // Defect 4: PR identity must reach the executor so the prompt has a diff target.
+    expect(ctx?.prNumber).toBe(99);
+    expect(ctx?.url).toBe("https://github.com/org/test-project/pull/99");
+    expect(ctx?.headBranch).toBe("feat/x");
+    expect(ctx?.baseBranch).toBe("main");
+    expect(ctx?.isFromFork).toBe(false);
   });
 });

--- a/packages/plugins/workspace-worktree/src/__tests__/index.test.ts
+++ b/packages/plugins/workspace-worktree/src/__tests__/index.test.ts
@@ -709,6 +709,77 @@ describe("workspace.create()", () => {
       { cwd: "/repo/path", windowsHide: true, timeout: 30_000 },
     );
   });
+
+  it("pins the worktree to checkoutSha after creation via git checkout --detach (#215)", async () => {
+    const ws = create();
+
+    mockOriginRemote(); // remote get-url + fetch
+    mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
+    mockGitSuccess(""); // worktree add -b ...
+    mockGitSuccess(""); // git fetch origin <sha> --quiet
+    mockGitSuccess(""); // git checkout --detach <sha>
+
+    await ws.create(makeCreateConfig({ checkoutSha: "dfd6560abcdef0" }));
+
+    // Fetch the SHA so it's reachable even if the local repo hasn't pulled
+    // the PR head yet.
+    expect(mockExecFileAsync).toHaveBeenCalledWith(
+      "git",
+      ["fetch", "origin", "dfd6560abcdef0", "--quiet"],
+      { cwd: "/repo/path", windowsHide: true, timeout: 30_000 },
+    );
+    // Detach onto the SHA inside the worktree.
+    expect(mockExecFileAsync).toHaveBeenCalledWith(
+      "git",
+      ["checkout", "--detach", "dfd6560abcdef0"],
+      {
+        cwd: "/mock-home/.worktrees/myproject/session-1",
+        windowsHide: true,
+        timeout: 30_000,
+      },
+    );
+  });
+
+  it("does not invoke checkout --detach when checkoutSha is absent", async () => {
+    const ws = create();
+
+    mockOriginRemote();
+    mockGitSuccess(""); // origin/main
+    mockGitSuccess(""); // worktree add
+
+    await ws.create(makeCreateConfig());
+
+    const checkoutCalls = mockExecFileAsync.mock.calls.filter(
+      (c) => Array.isArray(c[1]) && c[1][0] === "checkout",
+    );
+    expect(checkoutCalls).toHaveLength(0);
+  });
+
+  it("tears down the half-built worktree if pinning to checkoutSha fails", async () => {
+    const ws = create();
+
+    mockOriginRemote();
+    mockGitSuccess(""); // origin/main
+    mockGitSuccess(""); // worktree add -b
+    mockGitSuccess(""); // git fetch origin <sha> --quiet
+    mockGitError("unknown revision deadbeef"); // git checkout --detach
+    mockGitSuccess(""); // git worktree remove --force (cleanup)
+
+    await expect(
+      ws.create(makeCreateConfig({ checkoutSha: "deadbeef" })),
+    ).rejects.toThrow(/Failed to pin worktree .* to checkoutSha "deadbeef"/);
+
+    expect(mockExecFileAsync).toHaveBeenCalledWith(
+      "git",
+      [
+        "worktree",
+        "remove",
+        "--force",
+        "/mock-home/.worktrees/myproject/session-1",
+      ],
+      { cwd: "/repo/path", windowsHide: true, timeout: 30_000 },
+    );
+  });
 });
 
 describe("workspace.restore()", () => {

--- a/packages/plugins/workspace-worktree/src/index.ts
+++ b/packages/plugins/workspace-worktree/src/index.ts
@@ -348,7 +348,13 @@ export function create(config?: Record<string, unknown>): Workspace {
 
       const baseRef = await resolveBaseRef(repoPath, cfg.project.defaultBranch, { hasOrigin });
 
-      // Create worktree with a new branch
+      // Create worktree with a new branch.
+      //
+      // Note: when the caller passes `checkoutSha`, we still create the
+      // worktree on a fresh session branch first, then detach onto the
+      // requested SHA below. Going straight to `worktree add --detach <sha>`
+      // would skip branch creation and break the rest of AO's machinery —
+      // session-archive expects a session branch to be present.
       try {
         await git(repoPath, "worktree", "add", "-b", cfg.branch, worktreePath, baseRef);
       } catch (err: unknown) {
@@ -400,6 +406,43 @@ export function create(config?: Record<string, unknown>): Workspace {
           throw new Error(`Failed to create worktree for branch "${cfg.branch}": ${retryMsg}`, {
             cause: retryErr,
           });
+        }
+      }
+
+      // Pin the worktree to a specific commit when the caller requests it
+      // (pipeline reviewer stages — #215). The worktree is currently on the
+      // freshly-created session branch at HEAD of `baseRef`; detach to the
+      // requested SHA so `git diff` against the PR's base has a meaningful
+      // target. Fetch the SHA first so it's reachable even when the repo
+      // hasn't pulled the PR head yet (fork PRs, stale checkouts).
+      if (cfg.checkoutSha) {
+        if (hasOrigin) {
+          try {
+            await git(repoPath, "fetch", "origin", cfg.checkoutSha, "--quiet");
+          } catch {
+            // Fetch may fail for fork PRs without configured refspecs or
+            // when offline. Fall through to checkout — it succeeds when the
+            // SHA is already reachable, and fails loudly otherwise so the
+            // session-spawn caller can surface a clear error instead of
+            // silently leaving the worktree on the wrong commit.
+          }
+        }
+        try {
+          await git(worktreePath, "checkout", "--detach", cfg.checkoutSha);
+        } catch (err) {
+          // Tear down the half-built worktree so the next spawn can retry
+          // cleanly. Without this the registered worktree at the session
+          // branch would block a subsequent `worktree add` at the same path.
+          try {
+            await git(repoPath, "worktree", "remove", "--force", worktreePath);
+          } catch {
+            // Best-effort
+          }
+          const msg = err instanceof Error ? err.message : String(err);
+          throw new Error(
+            `Failed to pin worktree "${worktreePath}" to checkoutSha "${cfg.checkoutSha}": ${msg}`,
+            { cause: err },
+          );
         }
       }
 


### PR DESCRIPTION
Closes #215.

Fixes Defects 4 + 1 from end-to-end testing of the §3 smoke pipeline (discussion #212):

- **Defect 4** — Engine didn't inject PR context into the reviewer prompt. "Review the diff" had no diff target.
- **Defect 1** — Reviewer worktree came up on `session/<id> -> origin/<defaultBranch>` instead of the PR head SHA.

## Root cause

Both defects shared the same plumbing gap in `engine.ts` `START_STAGE`: `run.headSha` was on `RunState` but never threaded down to the executor, and the worker session's `PRInfo` was never composed into a context object the prompt or workspace could use.

## Shape of the fix

1. New `PrContext` type (`packages/core/src/pipeline/types.ts`) bundles head SHA + PRInfo fields.
2. `checkoutSha?: string` on `SessionSpawnConfig` and `WorkspaceCreateConfig`.
3. `workspace-worktree` fetches the SHA (when origin is configured) then `git checkout --detach`s onto it after branch creation. Failure tears down the half-built worktree so the next spawn can retry. `workspace-clone` is a graceful no-op (unused field).
4. Engine `START_STAGE` handler builds `PrContext` from `run.headSha` + the worker session's `pr` field (looked up via the new optional `getSession` dep, wired to `sessionManager.get` in production).
5. `buildStagePrompt` emits a `## PR Context` block with PR #, URL, head/base branches & SHAs, fork warning, and a copy-pasteable `git diff <base>...HEAD` command.

Manual / orchestrator triggers (no headSha or sentinel `"manual"`) return `undefined` from `buildPrContext`, preserving pre-#215 behavior.

## Test plan

- [x] Unit: engine builds PrContext from headSha + PRInfo and threads it into `StartStageInput` (5 cases: with-PR, no-PR, manual sentinel, no getSession, getSession throws)
- [x] Unit: agent executor passes `prContext.headSha` as `spawn.checkoutSha` and renders the `## PR Context` block (4 cases: full PR, no prContext, baseSha preferred over baseBranch, fork warning)
- [x] Unit: workspace-worktree fetches + `git checkout --detach`s onto checkoutSha; absent checkoutSha leaves the worktree alone; failed pin tears down the worktree
- [x] Integration: PR opened → bridge → engine → reviewer stage receives `prContext` with PR #, URL, branches, head SHA (`packages/integration-tests/src/pipeline-pr-trigger.integration.test.ts`)

## Verification

- `pnpm build` — clean
- `pnpm -r typecheck` — only pre-existing failures in `pipeline-engine-lifecycle.integration.test.ts` and `pipeline-pr-trigger.integration.test.ts` for missing `relaunchOrchestrator` on a SessionManager mock (confirmed pre-existing via `git stash`)
- `pnpm lint` — 0 errors
- `pnpm test`:
  - `@aoagents/ao-core` — 1570 passed
  - `@aoagents/ao-plugin-workspace-worktree` — 82 passed
  - `@aoagents/ao-integration-tests` — pipeline-pr-trigger 2 passed; pre-existing notifier-desktop failures left untouched

Base: `pipelines-staging`. PR back to `pipelines-staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)