### PR TITLE
feat(pipeline): T1 domain contract + config schema

### DIFF
--- a/backend/internal/pipeline/config.go
+++ b/backend/internal/pipeline/config.go
@@ -260,6 +260,12 @@ func executorFieldRules(kind ExecutorKind) (allowed map[string]bool, required ma
 	}
 }
 
+// executorFieldNames is the fixed order executor fields are reported in, so
+// cross-kind rejection and missing-required issues come out deterministically.
+var executorFieldNames = []string{
+	"plugin", "mode", "command", "args", "env", "cwd", "name", "config",
+}
+
 func executorPresentFields(e StageExecutor) map[string]bool {
 	return map[string]bool{
 		"plugin":  e.Plugin != "",
@@ -291,13 +297,13 @@ func validateExecutor(e StageExecutor, path string) []Issue {
 	}
 
 	present := executorPresentFields(e)
-	for name, isPresent := range present {
-		if isPresent && !allowed[name] {
+	for _, name := range executorFieldNames {
+		if present[name] && !allowed[name] {
 			add("field %q is not valid for executor kind %q", name, e.Kind)
 		}
 	}
-	for name := range required {
-		if !present[name] {
+	for _, name := range executorFieldNames {
+		if required[name] && !present[name] {
 			add("executor kind %q requires field %q", e.Kind, name)
 		}
 	}

--- a/backend/internal/pipeline/config.go
+++ b/backend/internal/pipeline/config.go
@@ -244,7 +244,7 @@ func validatePipelineConfig(p *Pipeline) []Issue {
 // executorFieldRules returns which StageExecutor fields are allowed at all
 // for kind, and which of those are required. ok is false for an unknown
 // kind.
-func executorFieldRules(kind ExecutorKind) (allowed map[string]bool, required map[string]bool, ok bool) {
+func executorFieldRules(kind ExecutorKind) (allowed, required map[string]bool, ok bool) {
 	switch kind {
 	case ExecutorAgent:
 		return map[string]bool{"plugin": true, "mode": true, "config": true},

--- a/backend/internal/pipeline/config.go
+++ b/backend/internal/pipeline/config.go
@@ -1,0 +1,317 @@
+package pipeline
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Issue is one validation failure, pointing at the offending location in the
+// definition document (e.g. "stages[2].dependsOn").
+type Issue struct {
+	Path    string
+	Message string
+}
+
+// ValidationError collects every Issue found while validating a pipeline
+// definition. The old Zod schema's superRefine surfaced a single
+// consolidated failure across every rule violated; ValidationError preserves
+// that so a config author sees every problem in one pass instead of
+// fixing-and-reloading one error at a time.
+type ValidationError struct {
+	Issues []Issue
+}
+
+// Error joins every issue, one per line, formatted "path: message".
+func (e *ValidationError) Error() string {
+	var b strings.Builder
+	for i, issue := range e.Issues {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(issue.Path)
+		b.WriteString(": ")
+		b.WriteString(issue.Message)
+	}
+	return b.String()
+}
+
+// ParseDefinition decodes a single-document YAML pipeline definition
+// (v1 config format: one pipeline per document, authored in an editor and
+// stored in SQLite, unlike the old map-of-pipelines agent-orchestrator.yaml
+// file format), validates it, and returns the normalized *Pipeline.
+//
+// ID is never part of the YAML document; it is assigned by the store when
+// the definition is saved (a later task). Name is required (there is no map
+// key to default it from, unlike the old format). Scope defaults to
+// ScopeWorker when omitted.
+//
+// Unknown top-level or nested keys are rejected (strict decoding), and every
+// validation rule failure is collected into a single *ValidationError rather
+// than stopping at the first one.
+func ParseDefinition(src []byte) (*Pipeline, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(src))
+	dec.KnownFields(true)
+
+	var p Pipeline
+	if err := dec.Decode(&p); err != nil {
+		return nil, fmt.Errorf("parse pipeline definition: %w", err)
+	}
+	if p.Scope == "" {
+		p.Scope = ScopeWorker
+	}
+
+	if issues := validatePipelineConfig(&p); len(issues) > 0 {
+		return nil, &ValidationError{Issues: issues}
+	}
+	return &p, nil
+}
+
+// ValidateDAG rejects a runtime Pipeline whose DependsOn + routes.when
+// referenced-stages graph contains a cycle. ParseDefinition already enforces
+// this (via validatePipelineConfig, which calls the same cycle detector),
+// but programmatic callers that construct a Pipeline directly (tests, a
+// later engine's in-process pipeline construction) bypass ParseDefinition
+// and would otherwise deadlock the run silently: every cycle member stays
+// pending forever because its preconditions never all reach a terminal
+// state.
+func ValidateDAG(p *Pipeline) error {
+	cycle := FindFirstStageCycle(p.Stages)
+	if cycle == nil {
+		return nil
+	}
+	return fmt.Errorf("pipeline %q has a stage dependency cycle: %s", p.Name, strings.Join(cycle, " -> "))
+}
+
+// validatePipelineConfig runs every config-load validation rule and returns
+// every issue found (nil when the config is valid).
+func validatePipelineConfig(p *Pipeline) []Issue {
+	var issues []Issue
+	add := func(path, message string) {
+		issues = append(issues, Issue{Path: path, Message: message})
+	}
+	addf := func(path, format string, args ...any) {
+		add(path, fmt.Sprintf(format, args...))
+	}
+
+	// Rule 1: name non-empty.
+	if strings.TrimSpace(p.Name) == "" {
+		add("name", "name must not be empty")
+	}
+
+	// Rule 2: scope empty/worker only; other known scopes are deferred to
+	// phase 2, unknown values are rejected outright.
+	if p.Scope != "" && p.Scope != ScopeWorker {
+		if p.Scope.IsKnown() {
+			addf("scope", "scope %q is deferred to phase 2", p.Scope)
+		} else {
+			addf("scope", "unknown scope %q", p.Scope)
+		}
+	}
+
+	// Rule 3: at least one stage; unique, non-empty stage names.
+	if len(p.Stages) == 0 {
+		add("stages", "pipeline must declare at least one stage")
+	}
+	stageNames := make(map[string]bool, len(p.Stages))
+	seenNames := make(map[string]bool, len(p.Stages))
+	for i, stage := range p.Stages {
+		if strings.TrimSpace(stage.Name) == "" {
+			add(fmt.Sprintf("stages[%d].name", i), "stage name must not be empty")
+		} else {
+			stageNames[stage.Name] = true
+		}
+		if seenNames[stage.Name] {
+			addf(fmt.Sprintf("stages[%d].name", i), "duplicate stage name %q: every stage in a pipeline must have a unique name", stage.Name)
+		}
+		seenNames[stage.Name] = true
+	}
+
+	// Rule 6 (pipeline-level part): maxConcurrentStages >= 1.
+	if p.MaxConcurrentStages != nil && *p.MaxConcurrentStages < 1 {
+		add("maxConcurrentStages", "maxConcurrentStages must be >= 1")
+	}
+
+	for i, stage := range p.Stages {
+		base := fmt.Sprintf("stages[%d]", i)
+
+		// Rule 4: trigger.on values must be known v1 events.
+		for j, evt := range stage.Trigger.On {
+			if !evt.IsKnown() {
+				addf(fmt.Sprintf("%s.trigger.on[%d]", base, j), "unknown trigger event %q", evt)
+			}
+		}
+
+		// Rule 5: executor per-kind required fields + cross-kind rejection.
+		issues = append(issues, validateExecutor(stage.Executor, base+".executor")...)
+
+		// Rule 6 (stage-level): numeric bounds.
+		if stage.Policy != nil && stage.Policy.StallWindow != nil && *stage.Policy.StallWindow < 0 {
+			add(base+".policy.stallWindow", "stallWindow must be >= 0")
+		}
+		if stage.Budget != nil {
+			if stage.Budget.MaxUSD != nil && *stage.Budget.MaxUSD < 0 {
+				add(base+".budget.maxUsd", "maxUsd must be >= 0")
+			}
+			if stage.Budget.MaxDurationMs != nil && *stage.Budget.MaxDurationMs < 0 {
+				add(base+".budget.maxDurationMs", "maxDurationMs must be >= 0")
+			}
+		}
+		if stage.TimeoutMs != nil && *stage.TimeoutMs < 0 {
+			add(base+".timeoutMs", "timeoutMs must be >= 0")
+		}
+		if stage.Retries != nil && *stage.Retries < 0 {
+			add(base+".retries", "retries must be >= 0")
+		}
+		if stage.MaxLoopRounds != nil && *stage.MaxLoopRounds < 1 {
+			add(base+".maxLoopRounds", "maxLoopRounds must be >= 1")
+		}
+
+		// Rule 7: dependsOn entries non-empty, reference known stages, no
+		// self-reference.
+		for _, dep := range stage.DependsOn {
+			if strings.TrimSpace(dep) == "" {
+				add(base+".dependsOn", "dependsOn entries must not be empty")
+				continue
+			}
+			if dep == stage.Name {
+				addf(base+".dependsOn", "Stage %q cannot depend on itself.", stage.Name)
+				continue
+			}
+			if !stageNames[dep] {
+				addf(base+".dependsOn", "Stage %q depends on unknown stage %q.", stage.Name, dep)
+			}
+		}
+
+		// Rule 8: routes.when recursive predicate validation + referenced
+		// stages must exist and not be the stage itself.
+		if stage.Routes != nil {
+			path := base + ".routes.when"
+			issues = append(issues, stage.Routes.When.Validate(path)...)
+			for _, ref := range stage.Routes.When.ReferencedStages() {
+				if ref == stage.Name {
+					addf(path, "Stage %q cannot route to itself.", stage.Name)
+					continue
+				}
+				if !stageNames[ref] {
+					addf(path, "Stage %q routes references unknown stage %q.", stage.Name, ref)
+				}
+			}
+		}
+
+		// Rule 10: workspace is empty, shared-ro, or isolated-rw.
+		if !stage.Workspace.IsKnown() {
+			addf(base+".workspace", "unknown workspace %q", stage.Workspace)
+		}
+	}
+
+	// Rule 9: exitPredicates.{done,stalled,blocksMerge} recursive predicate
+	// validation + referenced stages must exist.
+	if p.ExitPredicates != nil {
+		branches := []struct {
+			key       string
+			predicate *Predicate
+		}{
+			{"done", p.ExitPredicates.Done},
+			{"stalled", p.ExitPredicates.Stalled},
+			{"blocksMerge", p.ExitPredicates.BlocksMerge},
+		}
+		for _, branch := range branches {
+			if branch.predicate == nil {
+				continue
+			}
+			path := "exitPredicates." + branch.key
+			issues = append(issues, branch.predicate.Validate(path)...)
+			for _, ref := range branch.predicate.ReferencedStages() {
+				if !stageNames[ref] {
+					addf(path, "exitPredicates.%s references unknown stage %q.", branch.key, ref)
+				}
+			}
+		}
+	}
+
+	// Rule 11: cycle detection, run last so structural issues above surface
+	// alongside it rather than being masked by an early return.
+	if cycle := FindFirstStageCycle(p.Stages); cycle != nil {
+		addf("stages", "Pipeline has a stage dependency cycle: %s.", strings.Join(cycle, " -> "))
+	}
+
+	return issues
+}
+
+// executorFieldRules returns which StageExecutor fields are allowed at all
+// for kind, and which of those are required. ok is false for an unknown
+// kind.
+func executorFieldRules(kind ExecutorKind) (allowed map[string]bool, required map[string]bool, ok bool) {
+	switch kind {
+	case ExecutorAgent:
+		return map[string]bool{"plugin": true, "mode": true, "config": true},
+			map[string]bool{"plugin": true, "mode": true}, true
+	case ExecutorCommand:
+		return map[string]bool{"command": true, "args": true, "env": true, "cwd": true},
+			map[string]bool{"command": true}, true
+	case ExecutorBuiltin:
+		return map[string]bool{"name": true, "config": true},
+			map[string]bool{"name": true}, true
+	default:
+		return nil, nil, false
+	}
+}
+
+func executorPresentFields(e StageExecutor) map[string]bool {
+	return map[string]bool{
+		"plugin":  e.Plugin != "",
+		"mode":    e.Mode != "",
+		"command": e.Command != "",
+		"args":    len(e.Args) > 0,
+		"env":     len(e.Env) > 0,
+		"cwd":     e.Cwd != "",
+		"name":    e.Name != "",
+		"config":  len(e.Config) > 0,
+	}
+}
+
+// validateExecutor validates a StageExecutor against its declared Kind,
+// enforcing per-kind required fields and rejecting fields that belong to a
+// different kind (e.g. Command set on an agent executor). Rejecting
+// cross-kind fields is a deliberate improvement over the old Zod schema,
+// which silently stripped unrecognized fields at the schema boundary.
+func validateExecutor(e StageExecutor, path string) []Issue {
+	var issues []Issue
+	add := func(format string, args ...any) {
+		issues = append(issues, Issue{Path: path, Message: fmt.Sprintf(format, args...)})
+	}
+
+	allowed, required, ok := executorFieldRules(e.Kind)
+	if !ok {
+		add("unknown executor kind %q", e.Kind)
+		return issues
+	}
+
+	present := executorPresentFields(e)
+	for name, isPresent := range present {
+		if isPresent && !allowed[name] {
+			add("field %q is not valid for executor kind %q", name, e.Kind)
+		}
+	}
+	for name := range required {
+		if !present[name] {
+			add("executor kind %q requires field %q", e.Kind, name)
+		}
+	}
+
+	switch e.Kind {
+	case ExecutorAgent:
+		if e.Mode != "" && !e.Mode.IsKnown() {
+			add("unknown task mode %q", e.Mode)
+		}
+	case ExecutorBuiltin:
+		if e.Name != "" && !e.Name.IsKnown() {
+			add("unknown builtin name %q", e.Name)
+		}
+	}
+
+	return issues
+}

--- a/backend/internal/pipeline/config_test.go
+++ b/backend/internal/pipeline/config_test.go
@@ -1,0 +1,567 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const fullFeaturedYAML = `
+name: review-pipeline
+scope: worker
+maxConcurrentStages: 2
+allowForkPRs: true
+stages:
+  - name: lint
+    trigger:
+      on: [pr.opened, pr.updated]
+    executor:
+      kind: command
+      command: "make lint"
+      args: ["--fix"]
+      env:
+        CI: "true"
+      cwd: "scripts"
+    task:
+      prompt: "run lint"
+    policy:
+      blocksMerge: true
+      stallWindow: 3
+    budget:
+      maxUsd: 1.5
+      maxDurationMs: 60000
+    timeoutMs: 120000
+    retries: 2
+    maxLoopRounds: 5
+    workspace: isolated-rw
+  - name: review
+    trigger:
+      on: [pr.opened]
+    executor:
+      kind: agent
+      plugin: claude-code
+      mode: review
+      config:
+        temperature: 0.2
+    task:
+      prompt: "review the diff"
+      outputSchema:
+        type: object
+    dependsOn: [lint]
+    workspace: shared-ro
+  - name: route
+    trigger:
+      on: [manual]
+    executor:
+      kind: builtin
+      name: router
+      config:
+        target: worker
+    dependsOn: [review]
+    routes:
+      when:
+        kind: and
+        predicates:
+          - kind: stage_verdict
+            stage: review
+            verdict: pass
+          - kind: not
+            predicate:
+              kind: finding_count_below
+              max: 0
+              severity: error
+exitPredicates:
+  done:
+    kind: all_pass
+    stages: [lint, review]
+  stalled:
+    kind: loop_rounds_at_least
+    n: 5
+  blocksMerge:
+    kind: or
+    predicates:
+      - kind: stage_verdict
+        stage: review
+        verdict: fail
+      - kind: finding_count_below
+        max: 0
+        stage: review
+        severity: warning
+`
+
+func TestParseDefinition_FullFeaturedRoundTrip(t *testing.T) {
+	p, err := ParseDefinition([]byte(fullFeaturedYAML))
+	if err != nil {
+		t.Fatalf("ParseDefinition failed: %v", err)
+	}
+
+	if p.Name != "review-pipeline" {
+		t.Errorf("Name = %q, want review-pipeline", p.Name)
+	}
+	if p.Scope != ScopeWorker {
+		t.Errorf("Scope = %q, want worker", p.Scope)
+	}
+	if p.MaxConcurrentStages == nil || *p.MaxConcurrentStages != 2 {
+		t.Errorf("MaxConcurrentStages = %v, want 2", p.MaxConcurrentStages)
+	}
+	if p.AllowForkPRs == nil || !*p.AllowForkPRs {
+		t.Errorf("AllowForkPRs = %v, want true", p.AllowForkPRs)
+	}
+	if len(p.Stages) != 3 {
+		t.Fatalf("len(Stages) = %d, want 3", len(p.Stages))
+	}
+
+	lint := p.Stages[0]
+	if lint.Name != "lint" {
+		t.Errorf("Stages[0].Name = %q, want lint", lint.Name)
+	}
+	if lint.Executor.Kind != ExecutorCommand || lint.Executor.Command != "make lint" {
+		t.Errorf("lint.Executor = %+v", lint.Executor)
+	}
+	if len(lint.Executor.Args) != 1 || lint.Executor.Args[0] != "--fix" {
+		t.Errorf("lint.Executor.Args = %v", lint.Executor.Args)
+	}
+	if lint.Executor.Env["CI"] != "true" {
+		t.Errorf("lint.Executor.Env = %v", lint.Executor.Env)
+	}
+	if lint.Executor.Cwd != "scripts" {
+		t.Errorf("lint.Executor.Cwd = %q", lint.Executor.Cwd)
+	}
+	if lint.Policy == nil || lint.Policy.BlocksMerge == nil || !*lint.Policy.BlocksMerge {
+		t.Errorf("lint.Policy.BlocksMerge = %+v", lint.Policy)
+	}
+	if lint.Policy == nil || lint.Policy.StallWindow == nil || *lint.Policy.StallWindow != 3 {
+		t.Errorf("lint.Policy.StallWindow = %+v", lint.Policy)
+	}
+	if lint.Budget == nil || lint.Budget.MaxUSD == nil || *lint.Budget.MaxUSD != 1.5 {
+		t.Errorf("lint.Budget.MaxUSD = %+v", lint.Budget)
+	}
+	if lint.Budget == nil || lint.Budget.MaxDurationMs == nil || *lint.Budget.MaxDurationMs != 60000 {
+		t.Errorf("lint.Budget.MaxDurationMs = %+v", lint.Budget)
+	}
+	if lint.TimeoutMs == nil || *lint.TimeoutMs != 120000 {
+		t.Errorf("lint.TimeoutMs = %v", lint.TimeoutMs)
+	}
+	if lint.Retries == nil || *lint.Retries != 2 {
+		t.Errorf("lint.Retries = %v", lint.Retries)
+	}
+	if lint.MaxLoopRounds == nil || *lint.MaxLoopRounds != 5 {
+		t.Errorf("lint.MaxLoopRounds = %v", lint.MaxLoopRounds)
+	}
+	if lint.Workspace != WorkspaceIsolatedRW {
+		t.Errorf("lint.Workspace = %q", lint.Workspace)
+	}
+
+	review := p.Stages[1]
+	if review.Executor.Kind != ExecutorAgent || review.Executor.Plugin != "claude-code" || review.Executor.Mode != ModeReview {
+		t.Errorf("review.Executor = %+v", review.Executor)
+	}
+	if review.Executor.Config["temperature"] != 0.2 {
+		t.Errorf("review.Executor.Config = %v", review.Executor.Config)
+	}
+	if len(review.DependsOn) != 1 || review.DependsOn[0] != "lint" {
+		t.Errorf("review.DependsOn = %v", review.DependsOn)
+	}
+	if review.Workspace != WorkspaceSharedRO {
+		t.Errorf("review.Workspace = %q", review.Workspace)
+	}
+
+	route := p.Stages[2]
+	if route.Executor.Kind != ExecutorBuiltin || route.Executor.Name != BuiltinRouter {
+		t.Errorf("route.Executor = %+v", route.Executor)
+	}
+	if len(route.DependsOn) != 1 || route.DependsOn[0] != "review" {
+		t.Errorf("route.DependsOn = %v", route.DependsOn)
+	}
+	if route.Routes == nil || route.Routes.When.Kind != PredicateAnd || len(route.Routes.When.Predicates) != 2 {
+		t.Fatalf("route.Routes = %+v", route.Routes)
+	}
+	if route.Routes.When.Predicates[1].Kind != PredicateNot ||
+		route.Routes.When.Predicates[1].Predicate.Kind != PredicateFindingCountBelow {
+		t.Errorf("route.Routes.When.Predicates[1] = %+v", route.Routes.When.Predicates[1])
+	}
+
+	if p.ExitPredicates == nil {
+		t.Fatal("ExitPredicates is nil")
+	}
+	if p.ExitPredicates.Done == nil || p.ExitPredicates.Done.Kind != PredicateAllPass ||
+		len(p.ExitPredicates.Done.Stages) != 2 {
+		t.Errorf("ExitPredicates.Done = %+v", p.ExitPredicates.Done)
+	}
+	if p.ExitPredicates.Stalled == nil || p.ExitPredicates.Stalled.Kind != PredicateLoopRoundsAtLeast ||
+		p.ExitPredicates.Stalled.N == nil || *p.ExitPredicates.Stalled.N != 5 {
+		t.Errorf("ExitPredicates.Stalled = %+v", p.ExitPredicates.Stalled)
+	}
+	if p.ExitPredicates.BlocksMerge == nil || p.ExitPredicates.BlocksMerge.Kind != PredicateOr ||
+		len(p.ExitPredicates.BlocksMerge.Predicates) != 2 {
+		t.Errorf("ExitPredicates.BlocksMerge = %+v", p.ExitPredicates.BlocksMerge)
+	}
+
+	// JSON marshal/unmarshal round trip (T3 stores JSON snapshots).
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var roundTripped Pipeline
+	if err := json.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if !reflect.DeepEqual(*p, roundTripped) {
+		t.Fatalf("JSON round trip mismatch:\noriginal:     %+v\nround-tripped: %+v", *p, roundTripped)
+	}
+}
+
+func TestParseDefinition_Invalid(t *testing.T) {
+	base := func(body string) string {
+		return "name: p\nstages:\n" + body
+	}
+	simpleStage := `  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: command
+      command: "echo hi"
+`
+
+	cases := []struct {
+		name        string
+		yaml        string
+		wantPathSub string
+		wantMsgSub  string
+	}{
+		{
+			name:        "missing name",
+			yaml:        "stages:\n" + simpleStage,
+			wantPathSub: "name",
+			wantMsgSub:  "must not be empty",
+		},
+		{
+			name:        "bad scope (deferred to phase 2)",
+			yaml:        "name: p\nscope: orchestrator\nstages:\n" + simpleStage,
+			wantPathSub: "scope",
+			wantMsgSub:  "deferred to phase 2",
+		},
+		{
+			name:        "bad scope (unknown value)",
+			yaml:        "name: p\nscope: bogus\nstages:\n" + simpleStage,
+			wantPathSub: "scope",
+			wantMsgSub:  "unknown scope",
+		},
+		{
+			name:        "empty stages",
+			yaml:        "name: p\nstages: []\n",
+			wantPathSub: "stages",
+			wantMsgSub:  "at least one stage",
+		},
+		{
+			name: "duplicate stage name",
+			yaml: base(simpleStage + `  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: command
+      command: "echo hi"
+`),
+			wantPathSub: "stages[1].name",
+			wantMsgSub:  "duplicate stage name",
+		},
+		{
+			name: "unknown trigger event",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [bogus.event]
+    executor:
+      kind: command
+      command: "echo hi"
+`),
+			wantPathSub: "trigger.on",
+			wantMsgSub:  "unknown trigger event",
+		},
+		{
+			name: "unknown executor kind",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: bogus
+`),
+			wantPathSub: "executor",
+			wantMsgSub:  "unknown executor kind",
+		},
+		{
+			name: "agent missing plugin/mode",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: agent
+`),
+			wantPathSub: "executor",
+			wantMsgSub:  "requires field",
+		},
+		{
+			name: "agent with command field set (cross-kind)",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: agent
+      plugin: claude-code
+      mode: review
+      command: "echo hi"
+`),
+			wantPathSub: "executor",
+			wantMsgSub:  `not valid for executor kind "agent"`,
+		},
+		{
+			name: "command missing command",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: command
+`),
+			wantPathSub: "executor",
+			wantMsgSub:  "requires field",
+		},
+		{
+			name: "builtin bad name",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: builtin
+      name: bogus
+`),
+			wantPathSub: "executor",
+			wantMsgSub:  "unknown builtin name",
+		},
+		{
+			name: "negative retries",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: command
+      command: "echo hi"
+    retries: -1
+`),
+			wantPathSub: "retries",
+			wantMsgSub:  "must be >= 0",
+		},
+		{
+			name: "maxLoopRounds 0",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: command
+      command: "echo hi"
+    maxLoopRounds: 0
+`),
+			wantPathSub: "maxLoopRounds",
+			wantMsgSub:  "must be >= 1",
+		},
+		{
+			name: "unknown dependsOn",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: command
+      command: "echo hi"
+    dependsOn: [ghost]
+`),
+			wantPathSub: "dependsOn",
+			wantMsgSub:  `depends on unknown stage "ghost"`,
+		},
+		{
+			name: "self dependsOn",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: command
+      command: "echo hi"
+    dependsOn: [s1]
+`),
+			wantPathSub: "dependsOn",
+			wantMsgSub:  "cannot depend on itself",
+		},
+		{
+			name: "routes references unknown stage",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: command
+      command: "echo hi"
+    routes:
+      when:
+        kind: stage_verdict
+        stage: ghost
+        verdict: pass
+`),
+			wantPathSub: "routes.when",
+			wantMsgSub:  `routes references unknown stage "ghost"`,
+		},
+		{
+			name: "routes self-reference",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: command
+      command: "echo hi"
+    routes:
+      when:
+        kind: stage_verdict
+        stage: s1
+        verdict: pass
+`),
+			wantPathSub: "routes.when",
+			wantMsgSub:  "cannot route to itself",
+		},
+		{
+			name: "exitPredicates references unknown stage",
+			yaml: base(simpleStage) + `exitPredicates:
+  done:
+    kind: stage_verdict
+    stage: ghost
+    verdict: pass
+`,
+			wantPathSub: "exitPredicates.done",
+			wantMsgSub:  `references unknown stage "ghost"`,
+		},
+		{
+			name: "bad workspace",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: command
+      command: "echo hi"
+    workspace: bogus
+`),
+			wantPathSub: "workspace",
+			wantMsgSub:  "unknown workspace",
+		},
+		{
+			name:       "unknown top-level YAML key",
+			yaml:       "name: p\nbogusTopLevel: true\nstages:\n" + simpleStage,
+			wantMsgSub: "bogusTopLevel",
+		},
+		{
+			name: "unknown stage key",
+			yaml: base(`  - name: s1
+    trigger:
+      on: [manual]
+    executor:
+      kind: command
+      command: "echo hi"
+    bogusStageKey: true
+`),
+			wantMsgSub: "bogusStageKey",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseDefinition([]byte(tc.yaml))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsgSub) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantMsgSub)
+			}
+			if tc.wantPathSub != "" {
+				var verr *ValidationError
+				ok := asValidationError(err, &verr)
+				if !ok {
+					t.Fatalf("expected *ValidationError, got %T: %v", err, err)
+				}
+				var found bool
+				for _, issue := range verr.Issues {
+					if strings.Contains(issue.Path, tc.wantPathSub) && strings.Contains(issue.Message, tc.wantMsgSub) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("no issue matched path substring %q / message substring %q; got %+v",
+						tc.wantPathSub, tc.wantMsgSub, verr.Issues)
+				}
+			}
+		})
+	}
+}
+
+// asValidationError is a small errors.As shim kept local to the test so the
+// table above stays readable.
+func asValidationError(err error, target **ValidationError) bool {
+	if ve, ok := err.(*ValidationError); ok {
+		*target = ve
+		return true
+	}
+	return false
+}
+
+func TestParseDefinition_MultipleIssuesSurfaceTogether(t *testing.T) {
+	yaml := "stages: []\n"
+	_, err := ParseDefinition([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	verr, ok := err.(*ValidationError)
+	if !ok {
+		t.Fatalf("expected *ValidationError, got %T: %v", err, err)
+	}
+	if len(verr.Issues) < 2 {
+		t.Fatalf("expected at least 2 issues (missing name + empty stages), got %+v", verr.Issues)
+	}
+	var sawName, sawStages bool
+	for _, issue := range verr.Issues {
+		if issue.Path == "name" {
+			sawName = true
+		}
+		if issue.Path == "stages" {
+			sawStages = true
+		}
+	}
+	if !sawName || !sawStages {
+		t.Fatalf("expected issues at both 'name' and 'stages', got %+v", verr.Issues)
+	}
+}
+
+func TestValidateDAG(t *testing.T) {
+	t.Run("acyclic passes", func(t *testing.T) {
+		p := &Pipeline{
+			Name: "p",
+			Stages: []Stage{
+				{Name: "a"},
+				{Name: "b", DependsOn: []string{"a"}},
+			},
+		}
+		if err := ValidateDAG(p); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("cyclic fails", func(t *testing.T) {
+		p := &Pipeline{
+			Name: "p",
+			Stages: []Stage{
+				{Name: "a", DependsOn: []string{"b"}},
+				{Name: "b", DependsOn: []string{"a"}},
+			},
+		}
+		err := ValidateDAG(p)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "a -> b -> a") {
+			t.Fatalf("error %q missing cycle path", err.Error())
+		}
+	})
+}

--- a/backend/internal/pipeline/config_test.go
+++ b/backend/internal/pipeline/config_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -500,11 +501,7 @@ func TestParseDefinition_Invalid(t *testing.T) {
 // asValidationError is a small errors.As shim kept local to the test so the
 // table above stays readable.
 func asValidationError(err error, target **ValidationError) bool {
-	if ve, ok := err.(*ValidationError); ok {
-		*target = ve
-		return true
-	}
-	return false
+	return errors.As(err, target)
 }
 
 func TestParseDefinition_MultipleIssuesSurfaceTogether(t *testing.T) {
@@ -513,8 +510,8 @@ func TestParseDefinition_MultipleIssuesSurfaceTogether(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	verr, ok := err.(*ValidationError)
-	if !ok {
+	var verr *ValidationError
+	if !errors.As(err, &verr) {
 		t.Fatalf("expected *ValidationError, got %T: %v", err, err)
 	}
 	if len(verr.Issues) < 2 {

--- a/backend/internal/pipeline/dag.go
+++ b/backend/internal/pipeline/dag.go
@@ -1,0 +1,108 @@
+package pipeline
+
+// FindFirstStageCycle finds the first cycle in the graph formed by every
+// stage's DependsOn edges unioned with its Routes.When.ReferencedStages()
+// edges, and returns it as [a, b, ..., a] (first and last element equal).
+// Returns nil when the graph is acyclic.
+//
+// Both edge kinds contribute because the scheduler (a later task) waits for
+// either kind of reference to reach a terminal state before evaluating a
+// stage, so a cycle in either graph deadlocks the run identically. A
+// routes-only cycle is just as fatal as a dependsOn-only cycle.
+//
+// Trivial self-loops ([x, x]) are skipped: the explicit self-reference
+// validation in config.go owns that error with a clearer message. Only
+// multi-node cycles are reported here.
+//
+// Traversal order is deterministic: stages are visited in declaration order,
+// and each stage's edges are visited dependsOn-first then routes-refs,
+// deduplicated preserving first-seen order (matching the old TypeScript
+// implementation's Set-based edge union). This makes the returned cycle's
+// path stable and readable ("a -> b -> c -> a") rather than dependent on map
+// iteration order.
+func FindFirstStageCycle(stages []Stage) []string {
+	adjacency := make(map[string][]string, len(stages))
+	for _, stage := range stages {
+		var routesRefs []string
+		if stage.Routes != nil {
+			routesRefs = stage.Routes.When.ReferencedStages()
+		}
+		seen := make(map[string]bool, len(stage.DependsOn)+len(routesRefs))
+		edges := make([]string, 0, len(stage.DependsOn)+len(routesRefs))
+		for _, dep := range stage.DependsOn {
+			if !seen[dep] {
+				seen[dep] = true
+				edges = append(edges, dep)
+			}
+		}
+		for _, ref := range routesRefs {
+			if !seen[ref] {
+				seen[ref] = true
+				edges = append(edges, ref)
+			}
+		}
+		adjacency[stage.Name] = edges
+	}
+
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int, len(stages))
+	for _, stage := range stages {
+		color[stage.Name] = white
+	}
+
+	type frame struct {
+		node string
+		iter int
+	}
+
+	for _, start := range stages {
+		if color[start.Name] != white {
+			continue
+		}
+		stack := []frame{{node: start.Name, iter: 0}}
+		path := []string{start.Name}
+		color[start.Name] = gray
+
+		for len(stack) > 0 {
+			top := &stack[len(stack)-1]
+			neighbors := adjacency[top.node]
+			if top.iter >= len(neighbors) {
+				color[top.node] = black
+				stack = stack[:len(stack)-1]
+				path = path[:len(path)-1]
+				continue
+			}
+			next := neighbors[top.iter]
+			top.iter++
+
+			switch color[next] {
+			case gray:
+				cycleStart := indexOf(path, next)
+				if cycleStart == len(path)-1 {
+					// Trivial self-loop; owned by explicit self-ref validation.
+					continue
+				}
+				cycle := append([]string{}, path[cycleStart:]...)
+				return append(cycle, next)
+			case white:
+				color[next] = gray
+				path = append(path, next)
+				stack = append(stack, frame{node: next, iter: 0})
+			}
+		}
+	}
+	return nil
+}
+
+func indexOf(path []string, name string) int {
+	for i, n := range path {
+		if n == name {
+			return i
+		}
+	}
+	return -1
+}

--- a/backend/internal/pipeline/dag_test.go
+++ b/backend/internal/pipeline/dag_test.go
@@ -1,0 +1,118 @@
+package pipeline
+
+import (
+	"reflect"
+	"testing"
+)
+
+func dependsOnStage(name string, deps ...string) Stage {
+	return Stage{Name: name, DependsOn: deps}
+}
+
+func routesStage(name string, routeTo ...string) Stage {
+	return Stage{
+		Name: name,
+		Routes: &StageRoutes{
+			When: Predicate{Kind: PredicateAllPass, Stages: routeTo},
+		},
+	}
+}
+
+func TestFindFirstStageCycle(t *testing.T) {
+	t.Run("diamond has no cycle", func(t *testing.T) {
+		stages := []Stage{
+			dependsOnStage("a"),
+			dependsOnStage("b", "a"),
+			dependsOnStage("c", "a"),
+			dependsOnStage("d", "b", "c"),
+		}
+		if got := FindFirstStageCycle(stages); got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("direct two-node cycle", func(t *testing.T) {
+		stages := []Stage{
+			dependsOnStage("a", "b"),
+			dependsOnStage("b", "a"),
+		}
+		got := FindFirstStageCycle(stages)
+		want := []string{"a", "b", "a"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("transitive three-node cycle in declaration order", func(t *testing.T) {
+		stages := []Stage{
+			dependsOnStage("a", "c"),
+			dependsOnStage("b", "a"),
+			dependsOnStage("c", "b"),
+		}
+		got := FindFirstStageCycle(stages)
+		want := []string{"a", "c", "b", "a"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("routes-edge-only cycle is detected", func(t *testing.T) {
+		stages := []Stage{
+			routesStage("a", "b"),
+			routesStage("b", "a"),
+		}
+		got := FindFirstStageCycle(stages)
+		want := []string{"a", "b", "a"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("trivial self-loop is skipped", func(t *testing.T) {
+		stages := []Stage{
+			dependsOnStage("a", "a"),
+			dependsOnStage("b"),
+		}
+		if got := FindFirstStageCycle(stages); got != nil {
+			t.Fatalf("expected nil (self-loop owned by self-ref validation), got %v", got)
+		}
+	})
+
+	t.Run("disconnected components, one with a cycle", func(t *testing.T) {
+		stages := []Stage{
+			dependsOnStage("x"),
+			dependsOnStage("y"),
+			dependsOnStage("a", "b"),
+			dependsOnStage("b", "a"),
+		}
+		got := FindFirstStageCycle(stages)
+		want := []string{"a", "b", "a"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("disconnected components, none with a cycle", func(t *testing.T) {
+		stages := []Stage{
+			dependsOnStage("x"),
+			dependsOnStage("y", "x"),
+			dependsOnStage("a"),
+			dependsOnStage("b", "a"),
+		}
+		if got := FindFirstStageCycle(stages); got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("mixed dependsOn and routes edges form the cycle", func(t *testing.T) {
+		stages := []Stage{
+			dependsOnStage("a", "b"),
+			routesStage("b", "a"),
+		}
+		got := FindFirstStageCycle(stages)
+		want := []string{"a", "b", "a"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+}

--- a/backend/internal/pipeline/events.go
+++ b/backend/internal/pipeline/events.go
@@ -1,0 +1,283 @@
+package pipeline
+
+import "time"
+
+// Event and Effect are the input/output of the pipeline reducer (a later
+// task). They are never parsed from YAML/JSON config; they are constructed
+// in-process by the engine driver. The reducer is pure: every Event carries
+// a driver-stamped Now, and the reducer must not read the clock itself.
+//
+// Both are sealed interfaces (an unexported marker method) so the union of
+// concrete types is closed to this package; callers switch over Type().
+//
+// Ported from the old TypeScript events.ts, excluding USER_FOLLOWUP and
+// FOLLOWUP_REPLY (conversational follow-up), which are phase 2.
+
+// EventType names a concrete Event's kind for switch dispatch.
+type EventType string
+
+// Known event types.
+const (
+	EventTriggerFired          EventType = "TRIGGER_FIRED"
+	EventStageStarted          EventType = "STAGE_STARTED"
+	EventStageCompleted        EventType = "STAGE_COMPLETED"
+	EventStageFailed           EventType = "STAGE_FAILED"
+	EventNewSHADetected        EventType = "NEW_SHA_DETECTED"
+	EventRunCancelled          EventType = "RUN_CANCELLED"
+	EventRunResumed            EventType = "RUN_RESUMED"
+	EventConfigChanged         EventType = "CONFIG_CHANGED"
+	EventArtifactStatusChanged EventType = "ARTIFACT_STATUS_CHANGED"
+	EventTick                  EventType = "TICK"
+)
+
+// Event is any driver-constructed input to the reducer.
+type Event interface {
+	// Type reports the event's concrete kind.
+	Type() EventType
+	// isPipelineEvent seals the interface to this package.
+	isPipelineEvent()
+}
+
+// TriggerFired starts a new pipeline run: a trigger event fired for a
+// session at a given head SHA. The driver allocates RunID and one
+// StageRunID per stage up front so the reducer never needs to generate IDs.
+type TriggerFired struct {
+	Now time.Time
+
+	Trigger   StageTriggerEvent
+	SessionID string
+	Pipeline  Pipeline
+	HeadSHA   string
+
+	RunID       RunID
+	StageRunIDs map[string]StageRunID
+}
+
+// Type implements Event.
+func (TriggerFired) Type() EventType  { return EventTriggerFired }
+func (TriggerFired) isPipelineEvent() {}
+
+// StageStarted reports that a stage's executor has begun running.
+type StageStarted struct {
+	Now time.Time
+
+	RunID     RunID
+	StageName string
+}
+
+// Type implements Event.
+func (StageStarted) Type() EventType  { return EventStageStarted }
+func (StageStarted) isPipelineEvent() {}
+
+// StageCompleted reports that a stage's executor finished, carrying its
+// verdict (zero value means no verdict reported) and any artifacts it
+// produced.
+type StageCompleted struct {
+	Now time.Time
+
+	RunID     RunID
+	StageName string
+	Verdict   Verdict
+	Artifacts []ArtifactInput
+}
+
+// Type implements Event.
+func (StageCompleted) Type() EventType  { return EventStageCompleted }
+func (StageCompleted) isPipelineEvent() {}
+
+// StageFailed reports that a stage's executor errored out.
+type StageFailed struct {
+	Now time.Time
+
+	RunID        RunID
+	StageName    string
+	ErrorMessage string
+}
+
+// Type implements Event.
+func (StageFailed) Type() EventType  { return EventStageFailed }
+func (StageFailed) isPipelineEvent() {}
+
+// NewSHADetected reports that the driver observed a new head SHA for a
+// session's pipeline loop, which (re)triggers the loop.
+type NewSHADetected struct {
+	Now time.Time
+
+	SessionID    string
+	PipelineName string
+	SHA          string
+}
+
+// Type implements Event.
+func (NewSHADetected) Type() EventType  { return EventNewSHADetected }
+func (NewSHADetected) isPipelineEvent() {}
+
+// RunCancelled cancels an in-flight run for the given reason.
+type RunCancelled struct {
+	Now time.Time
+
+	RunID  RunID
+	Reason RunTerminationReason
+}
+
+// Type implements Event.
+func (RunCancelled) Type() EventType  { return EventRunCancelled }
+func (RunCancelled) isPipelineEvent() {}
+
+// RunResumed re-arms a run's failed stages with freshly driver-allocated
+// StageRunIDs so the new attempt has non-colliding identity.
+type RunResumed struct {
+	Now time.Time
+
+	RunID       RunID
+	StageRunIDs map[string]StageRunID
+}
+
+// Type implements Event.
+func (RunResumed) Type() EventType  { return EventRunResumed }
+func (RunResumed) isPipelineEvent() {}
+
+// ConfigChanged reports that a session's pipeline definition changed while
+// a run was in flight; the reducer terminates the affected run.
+type ConfigChanged struct {
+	Now time.Time
+
+	SessionID    string
+	PipelineName string
+}
+
+// Type implements Event.
+func (ConfigChanged) Type() EventType  { return EventConfigChanged }
+func (ConfigChanged) isPipelineEvent() {}
+
+// ArtifactStatusChanged reports a user/agent action changing one artifact's
+// status (e.g. dismissing a finding).
+type ArtifactStatusChanged struct {
+	Now time.Time
+
+	RunID      RunID
+	StageRunID StageRunID
+	ArtifactID ArtifactID
+	Status     ArtifactStatus
+	// Actor is an optional human label (e.g. reviewer id) for audit
+	// observation.
+	Actor string
+}
+
+// Type implements Event.
+func (ArtifactStatusChanged) Type() EventType  { return EventArtifactStatusChanged }
+func (ArtifactStatusChanged) isPipelineEvent() {}
+
+// Tick is a driver heartbeat with no payload beyond the stamped clock,
+// letting the reducer re-evaluate time-based conditions (timeouts, stall
+// windows) without a state-changing input.
+type Tick struct {
+	Now time.Time
+}
+
+// Type implements Event.
+func (Tick) Type() EventType  { return EventTick }
+func (Tick) isPipelineEvent() {}
+
+// EffectType names a concrete Effect's kind for switch dispatch.
+type EffectType string
+
+// Known effect types.
+const (
+	EffectStartStage           EffectType = "START_STAGE"
+	EffectCancelStage          EffectType = "CANCEL_STAGE"
+	EffectPersistRun           EffectType = "PERSIST_RUN"
+	EffectPersistLoopState     EffectType = "PERSIST_LOOP_STATE"
+	EffectAppendArtifacts      EffectType = "APPEND_ARTIFACTS"
+	EffectUpdateArtifactStatus EffectType = "UPDATE_ARTIFACT_STATUS"
+	EffectEmitObservation      EffectType = "EMIT_OBSERVATION"
+)
+
+// Effect is any command the reducer emits for the engine driver to execute
+// after a reduce() call. Ported from the old TypeScript events.ts, excluding
+// APPEND_THREAD_MESSAGE and SEND_FOLLOWUP (conversational follow-up), which
+// are phase 2.
+type Effect interface {
+	// Type reports the effect's concrete kind.
+	Type() EffectType
+	// isPipelineEffect seals the interface to this package.
+	isPipelineEffect()
+}
+
+// StartStage instructs the driver to spawn stage's executor.
+type StartStage struct {
+	RunID      RunID
+	StageRunID StageRunID
+	Stage      Stage
+}
+
+// Type implements Effect.
+func (StartStage) Type() EffectType  { return EffectStartStage }
+func (StartStage) isPipelineEffect() {}
+
+// CancelStage instructs the driver to tear down a running stage's executor.
+type CancelStage struct {
+	RunID      RunID
+	StageRunID StageRunID
+	StageName  string
+}
+
+// Type implements Effect.
+func (CancelStage) Type() EffectType  { return EffectCancelStage }
+func (CancelStage) isPipelineEffect() {}
+
+// PersistRun instructs the driver to durably write the given RunState.
+type PersistRun struct {
+	RunState RunState
+}
+
+// Type implements Effect.
+func (PersistRun) Type() EffectType  { return EffectPersistRun }
+func (PersistRun) isPipelineEffect() {}
+
+// PersistLoopState instructs the driver to durably write the given
+// LoopState.
+type PersistLoopState struct {
+	RunID     RunID
+	LoopState LoopState
+}
+
+// Type implements Effect.
+func (PersistLoopState) Type() EffectType  { return EffectPersistLoopState }
+func (PersistLoopState) isPipelineEffect() {}
+
+// AppendArtifacts instructs the driver to durably append the given
+// artifacts to the run/stage-run's artifact log.
+type AppendArtifacts struct {
+	RunID      RunID
+	StageRunID StageRunID
+	Artifacts  []Artifact
+}
+
+// Type implements Effect.
+func (AppendArtifacts) Type() EffectType  { return EffectAppendArtifacts }
+func (AppendArtifacts) isPipelineEffect() {}
+
+// UpdateArtifactStatus instructs the driver to durably update one
+// artifact's status.
+type UpdateArtifactStatus struct {
+	RunID      RunID
+	StageRunID StageRunID
+	ArtifactID ArtifactID
+	Status     ArtifactStatus
+}
+
+// Type implements Effect.
+func (UpdateArtifactStatus) Type() EffectType  { return EffectUpdateArtifactStatus }
+func (UpdateArtifactStatus) isPipelineEffect() {}
+
+// EmitObservation instructs the driver to emit a named observation/telemetry
+// event with free-form data.
+type EmitObservation struct {
+	Name string
+	Data map[string]any
+}
+
+// Type implements Effect.
+func (EmitObservation) Type() EffectType  { return EffectEmitObservation }
+func (EmitObservation) isPipelineEffect() {}

--- a/backend/internal/pipeline/ids.go
+++ b/backend/internal/pipeline/ids.go
@@ -8,8 +8,8 @@ package pipeline
 // These ID types are distinct string types, mirroring the domain package's
 // convention, so they can't be swapped at a call site by accident.
 type (
-	// PipelineID identifies a pipeline definition.
-	PipelineID string
+	// ID identifies a pipeline definition.
+	ID string
 	// RunID identifies one execution of a pipeline.
 	RunID string
 	// StageRunID identifies one execution attempt of a stage within a run.

--- a/backend/internal/pipeline/ids.go
+++ b/backend/internal/pipeline/ids.go
@@ -1,0 +1,20 @@
+// Package pipeline holds the domain vocabulary for the pipelines feature: the
+// stage/predicate/event/effect shapes, YAML config parsing and validation,
+// and DAG cycle detection. It intentionally contains no reducer, scheduler,
+// predicate evaluator, executors, store, engine, HTTP, or CLI code; those
+// land in later tasks that build on this contract.
+package pipeline
+
+// These ID types are distinct string types, mirroring the domain package's
+// convention, so they can't be swapped at a call site by accident.
+type (
+	// PipelineID identifies a pipeline definition.
+	PipelineID string
+	// RunID identifies one execution of a pipeline.
+	RunID string
+	// StageRunID identifies one execution attempt of a stage within a run.
+	StageRunID string
+	// ArtifactID identifies one artifact (finding or JSON blob) produced by a
+	// stage run.
+	ArtifactID string
+)

--- a/backend/internal/pipeline/predicate.go
+++ b/backend/internal/pipeline/predicate.go
@@ -74,7 +74,7 @@ type Predicate struct {
 // predicateFieldRules returns which of the union fields are allowed at all
 // for kind, and which of those are required, keyed by the JSON field name.
 // The second return value is false for an unknown kind.
-func predicateFieldRules(kind PredicateKind) (allowed map[string]bool, required map[string]bool, ok bool) {
+func predicateFieldRules(kind PredicateKind) (allowed, required map[string]bool, ok bool) {
 	switch kind {
 	case PredicateAllPass, PredicateAnyPass, PredicateMajorityPass:
 		return map[string]bool{"stages": true}, map[string]bool{"stages": true}, true

--- a/backend/internal/pipeline/predicate.go
+++ b/backend/internal/pipeline/predicate.go
@@ -100,6 +100,12 @@ func predicateFieldRules(kind PredicateKind) (allowed map[string]bool, required 
 	}
 }
 
+// predicateFieldNames is the fixed order union fields are reported in, so
+// cross-kind rejection issues come out deterministically.
+var predicateFieldNames = []string{
+	"stages", "stage", "severity", "max", "n", "verdict", "predicates", "predicate",
+}
+
 // presentFields reports which union fields carry a non-zero value on p.
 func (p *Predicate) presentFields() map[string]bool {
 	return map[string]bool{
@@ -142,8 +148,9 @@ func (p *Predicate) Validate(path string) []Issue {
 		return issues
 	}
 
-	for name, isPresent := range p.presentFields() {
-		if isPresent && !allowed[name] {
+	present := p.presentFields()
+	for _, name := range predicateFieldNames {
+		if present[name] && !allowed[name] {
 			addf("field %q is not valid for predicate kind %q", name, p.Kind)
 		}
 	}

--- a/backend/internal/pipeline/predicate.go
+++ b/backend/internal/pipeline/predicate.go
@@ -1,0 +1,257 @@
+package pipeline
+
+import "fmt"
+
+// PredicateKind names a leaf or composite form in the typed predicate DSL.
+//
+// This is a deliberately narrower set than the old TypeScript DSL: it drops
+// "v0_default" (the legacy hardcoded-rule escape hatch) and the legacy
+// allSucceeded/anySucceeded/anyFailed shapes (both superseded by the typed
+// forms), and drops the pipeline-v3 workstream predicates
+// (all_workstream_workers_in_state, all_workstream_workers_match,
+// workstream_member_count), which are phase 2.
+type PredicateKind string
+
+// Known predicate kinds.
+const (
+	PredicateAllPass             PredicateKind = "all_pass"
+	PredicateAnyPass             PredicateKind = "any_pass"
+	PredicateMajorityPass        PredicateKind = "majority_pass"
+	PredicateNoOpenFindings      PredicateKind = "no_open_findings"
+	PredicateFindingCountBelow   PredicateKind = "finding_count_below"
+	PredicateLoopRoundsAtLeast   PredicateKind = "loop_rounds_at_least"
+	PredicateStageRetriedAtLeast PredicateKind = "stage_retried_at_least"
+	PredicateStageVerdict        PredicateKind = "stage_verdict"
+	PredicateAnd                 PredicateKind = "and"
+	PredicateOr                  PredicateKind = "or"
+	PredicateNot                 PredicateKind = "not"
+)
+
+// AllPredicateKinds lists every known predicate kind.
+var AllPredicateKinds = []PredicateKind{
+	PredicateAllPass, PredicateAnyPass, PredicateMajorityPass,
+	PredicateNoOpenFindings, PredicateFindingCountBelow, PredicateLoopRoundsAtLeast,
+	PredicateStageRetriedAtLeast, PredicateStageVerdict,
+	PredicateAnd, PredicateOr, PredicateNot,
+}
+
+// IsKnown reports whether k is a known predicate kind.
+func (k PredicateKind) IsKnown() bool {
+	for _, known := range AllPredicateKinds {
+		if k == known {
+			return true
+		}
+	}
+	return false
+}
+
+// Predicate is a single tagged struct covering every kind in the typed
+// predicate DSL, since it is parsed straight out of YAML/JSON as a recursive
+// union. Only the fields relevant to Kind are meaningful; Validate rejects
+// fields set on the wrong kind.
+type Predicate struct {
+	Kind PredicateKind `json:"kind" yaml:"kind"`
+
+	// Stages: all_pass, any_pass, majority_pass.
+	Stages []string `json:"stages,omitempty" yaml:"stages,omitempty"`
+	// Stage: no_open_findings (optional), finding_count_below (optional),
+	// stage_retried_at_least (required), stage_verdict (required).
+	Stage string `json:"stage,omitempty" yaml:"stage,omitempty"`
+	// Severity: finding_count_below (optional).
+	Severity Severity `json:"severity,omitempty" yaml:"severity,omitempty"`
+	// Max: finding_count_below (required).
+	Max *int `json:"max,omitempty" yaml:"max,omitempty"`
+	// N: loop_rounds_at_least (required), stage_retried_at_least (required).
+	N *int `json:"n,omitempty" yaml:"n,omitempty"`
+	// Verdict: stage_verdict (required).
+	Verdict Verdict `json:"verdict,omitempty" yaml:"verdict,omitempty"`
+	// Predicates: and, or (required, length >= 1).
+	Predicates []Predicate `json:"predicates,omitempty" yaml:"predicates,omitempty"`
+	// Predicate: not (required).
+	Predicate *Predicate `json:"predicate,omitempty" yaml:"predicate,omitempty"`
+}
+
+// predicateFieldRules returns which of the union fields are allowed at all
+// for kind, and which of those are required, keyed by the JSON field name.
+// The second return value is false for an unknown kind.
+func predicateFieldRules(kind PredicateKind) (allowed map[string]bool, required map[string]bool, ok bool) {
+	switch kind {
+	case PredicateAllPass, PredicateAnyPass, PredicateMajorityPass:
+		return map[string]bool{"stages": true}, map[string]bool{"stages": true}, true
+	case PredicateNoOpenFindings:
+		return map[string]bool{"stage": true}, nil, true
+	case PredicateFindingCountBelow:
+		return map[string]bool{"max": true, "stage": true, "severity": true},
+			map[string]bool{"max": true}, true
+	case PredicateLoopRoundsAtLeast:
+		return map[string]bool{"n": true}, map[string]bool{"n": true}, true
+	case PredicateStageRetriedAtLeast:
+		return map[string]bool{"stage": true, "n": true},
+			map[string]bool{"stage": true, "n": true}, true
+	case PredicateStageVerdict:
+		return map[string]bool{"stage": true, "verdict": true},
+			map[string]bool{"stage": true, "verdict": true}, true
+	case PredicateAnd, PredicateOr:
+		return map[string]bool{"predicates": true}, map[string]bool{"predicates": true}, true
+	case PredicateNot:
+		return map[string]bool{"predicate": true}, map[string]bool{"predicate": true}, true
+	default:
+		return nil, nil, false
+	}
+}
+
+// presentFields reports which union fields carry a non-zero value on p.
+func (p *Predicate) presentFields() map[string]bool {
+	return map[string]bool{
+		"stages":     len(p.Stages) > 0,
+		"stage":      p.Stage != "",
+		"severity":   p.Severity != "",
+		"max":        p.Max != nil,
+		"n":          p.N != nil,
+		"verdict":    p.Verdict != "",
+		"predicates": len(p.Predicates) > 0,
+		"predicate":  p.Predicate != nil,
+	}
+}
+
+// childPath appends name to base with a "." separator, omitting the
+// separator when base is empty (top of the document).
+func childPath(base, name string) string {
+	if base == "" {
+		return name
+	}
+	return base + "." + name
+}
+
+// Validate recursively validates p, hand-written equivalent of the old
+// Zod z.lazy recursive schema. path is the location of p within its
+// containing document (e.g. "routes.when" or "exitPredicates.done"); nested
+// issues get index/field suffixes appended (e.g. "routes.when.predicates[1].predicate").
+//
+// Per kind, this checks required fields are present and valid, and rejects
+// fields that belong to another kind. An unknown kind is a single issue.
+func (p *Predicate) Validate(path string) []Issue {
+	var issues []Issue
+	addf := func(format string, args ...any) {
+		issues = append(issues, Issue{Path: path, Message: fmt.Sprintf(format, args...)})
+	}
+
+	allowed, _, ok := predicateFieldRules(p.Kind)
+	if !ok {
+		addf("unknown predicate kind %q", p.Kind)
+		return issues
+	}
+
+	for name, isPresent := range p.presentFields() {
+		if isPresent && !allowed[name] {
+			addf("field %q is not valid for predicate kind %q", name, p.Kind)
+		}
+	}
+
+	switch p.Kind {
+	case PredicateAllPass, PredicateAnyPass, PredicateMajorityPass:
+		if len(p.Stages) == 0 {
+			addf("%q requires at least one stage", p.Kind)
+		}
+		for i, s := range p.Stages {
+			if s == "" {
+				issues = append(issues, Issue{
+					Path:    childPath(path, fmt.Sprintf("stages[%d]", i)),
+					Message: "stage name must not be empty",
+				})
+			}
+		}
+	case PredicateNoOpenFindings:
+		// Stage is optional; nothing further to check.
+	case PredicateFindingCountBelow:
+		if p.Max == nil {
+			addf("finding_count_below requires max")
+		} else if *p.Max < 0 {
+			addf("finding_count_below max must be >= 0")
+		}
+		if p.Severity != "" && !p.Severity.IsKnown() {
+			addf("unknown severity %q", p.Severity)
+		}
+	case PredicateLoopRoundsAtLeast:
+		if p.N == nil {
+			addf("loop_rounds_at_least requires n")
+		} else if *p.N < 1 {
+			addf("loop_rounds_at_least n must be >= 1")
+		}
+	case PredicateStageRetriedAtLeast:
+		if p.Stage == "" {
+			addf("stage_retried_at_least requires stage")
+		}
+		if p.N == nil {
+			addf("stage_retried_at_least requires n")
+		} else if *p.N < 1 {
+			addf("stage_retried_at_least n must be >= 1")
+		}
+	case PredicateStageVerdict:
+		if p.Stage == "" {
+			addf("stage_verdict requires stage")
+		}
+		if p.Verdict == "" {
+			addf("stage_verdict requires verdict")
+		} else if !p.Verdict.IsKnown() {
+			addf("unknown verdict %q", p.Verdict)
+		}
+	case PredicateAnd, PredicateOr:
+		if len(p.Predicates) == 0 {
+			addf("%q requires at least one predicate", p.Kind)
+		}
+		for i := range p.Predicates {
+			issues = append(issues, p.Predicates[i].Validate(childPath(path, fmt.Sprintf("predicates[%d]", i)))...)
+		}
+	case PredicateNot:
+		if p.Predicate == nil {
+			addf("not requires predicate")
+		} else {
+			issues = append(issues, p.Predicate.Validate(childPath(path, "predicate"))...)
+		}
+	}
+
+	return issues
+}
+
+// ReferencedStages returns the deduped list of stage names p references,
+// collected across the whole predicate tree (and/or/not recurse). Order is
+// first-seen (depth-first, left to right), matching the old TypeScript
+// predicateReferencedStages, which built the same set via insertion order.
+func (p *Predicate) ReferencedStages() []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(stage string) {
+		if stage == "" || seen[stage] {
+			return
+		}
+		seen[stage] = true
+		out = append(out, stage)
+	}
+	var visit func(pr *Predicate)
+	visit = func(pr *Predicate) {
+		if pr == nil {
+			return
+		}
+		switch pr.Kind {
+		case PredicateAllPass, PredicateAnyPass, PredicateMajorityPass:
+			for _, s := range pr.Stages {
+				add(s)
+			}
+		case PredicateStageVerdict, PredicateStageRetriedAtLeast:
+			add(pr.Stage)
+		case PredicateNoOpenFindings, PredicateFindingCountBelow:
+			if pr.Stage != "" {
+				add(pr.Stage)
+			}
+		case PredicateAnd, PredicateOr:
+			for i := range pr.Predicates {
+				visit(&pr.Predicates[i])
+			}
+		case PredicateNot:
+			visit(pr.Predicate)
+		}
+	}
+	visit(p)
+	return out
+}

--- a/backend/internal/pipeline/predicate_test.go
+++ b/backend/internal/pipeline/predicate_test.go
@@ -1,0 +1,250 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+func intp(n int) *int { return &n }
+
+func TestPredicateValidate_Valid(t *testing.T) {
+	cases := map[string]Predicate{
+		"all_pass":                      {Kind: PredicateAllPass, Stages: []string{"a", "b"}},
+		"any_pass":                      {Kind: PredicateAnyPass, Stages: []string{"a"}},
+		"majority_pass":                 {Kind: PredicateMajorityPass, Stages: []string{"a", "b", "c"}},
+		"no_open_findings (bare)":       {Kind: PredicateNoOpenFindings},
+		"no_open_findings (with stage)": {Kind: PredicateNoOpenFindings, Stage: "a"},
+		"finding_count_below (bare)":    {Kind: PredicateFindingCountBelow, Max: intp(0)},
+		"finding_count_below (full)": {
+			Kind: PredicateFindingCountBelow, Max: intp(3), Stage: "a", Severity: SeverityWarning,
+		},
+		"loop_rounds_at_least":   {Kind: PredicateLoopRoundsAtLeast, N: intp(1)},
+		"stage_retried_at_least": {Kind: PredicateStageRetriedAtLeast, Stage: "a", N: intp(2)},
+		"stage_verdict":          {Kind: PredicateStageVerdict, Stage: "a", Verdict: VerdictPass},
+		"and": {
+			Kind: PredicateAnd,
+			Predicates: []Predicate{
+				{Kind: PredicateAllPass, Stages: []string{"a"}},
+				{Kind: PredicateStageVerdict, Stage: "b", Verdict: VerdictFail},
+			},
+		},
+		"or": {
+			Kind: PredicateOr,
+			Predicates: []Predicate{
+				{Kind: PredicateNoOpenFindings},
+				{Kind: PredicateLoopRoundsAtLeast, N: intp(2)},
+			},
+		},
+		"not": {
+			Kind:      PredicateNot,
+			Predicate: &Predicate{Kind: PredicateAllPass, Stages: []string{"a"}},
+		},
+		"deeply nested composite": {
+			Kind: PredicateAnd,
+			Predicates: []Predicate{
+				{
+					Kind: PredicateOr,
+					Predicates: []Predicate{
+						{Kind: PredicateStageVerdict, Stage: "a", Verdict: VerdictPass},
+						{
+							Kind:      PredicateNot,
+							Predicate: &Predicate{Kind: PredicateNoOpenFindings, Stage: "b"},
+						},
+					},
+				},
+				{Kind: PredicateLoopRoundsAtLeast, N: intp(3)},
+			},
+		},
+	}
+
+	for name, p := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := p
+			if issues := p.Validate(""); len(issues) != 0 {
+				t.Fatalf("expected no issues, got %+v", issues)
+			}
+		})
+	}
+}
+
+func TestPredicateValidate_Invalid(t *testing.T) {
+	cases := []struct {
+		name        string
+		predicate   Predicate
+		wantPathSub string
+		wantMsgSub  string
+	}{
+		{
+			name:        "unknown kind",
+			predicate:   Predicate{Kind: "bogus"},
+			wantPathSub: "",
+			wantMsgSub:  "unknown predicate kind",
+		},
+		{
+			name:       "empty stages on all_pass",
+			predicate:  Predicate{Kind: PredicateAllPass, Stages: []string{}},
+			wantMsgSub: "requires at least one stage",
+		},
+		{
+			name:        "empty string stage entry",
+			predicate:   Predicate{Kind: PredicateAnyPass, Stages: []string{"a", ""}},
+			wantPathSub: "stages[1]",
+			wantMsgSub:  "must not be empty",
+		},
+		{
+			name:       "missing max",
+			predicate:  Predicate{Kind: PredicateFindingCountBelow},
+			wantMsgSub: "requires max",
+		},
+		{
+			name:       "negative max",
+			predicate:  Predicate{Kind: PredicateFindingCountBelow, Max: intp(-1)},
+			wantMsgSub: "must be >= 0",
+		},
+		{
+			name:       "n=0 on loop_rounds_at_least",
+			predicate:  Predicate{Kind: PredicateLoopRoundsAtLeast, N: intp(0)},
+			wantMsgSub: "must be >= 1",
+		},
+		{
+			name:       "missing verdict",
+			predicate:  Predicate{Kind: PredicateStageVerdict, Stage: "a"},
+			wantMsgSub: "requires verdict",
+		},
+		{
+			name:       "empty predicates on and",
+			predicate:  Predicate{Kind: PredicateAnd},
+			wantMsgSub: "requires at least one predicate",
+		},
+		{
+			name:       "empty predicates on or",
+			predicate:  Predicate{Kind: PredicateOr, Predicates: []Predicate{}},
+			wantMsgSub: "requires at least one predicate",
+		},
+		{
+			name:       "missing predicate on not",
+			predicate:  Predicate{Kind: PredicateNot},
+			wantMsgSub: "requires predicate",
+		},
+		{
+			name:       "cross-kind field set (all_pass with n)",
+			predicate:  Predicate{Kind: PredicateAllPass, Stages: []string{"a"}, N: intp(1)},
+			wantMsgSub: `not valid for predicate kind "all_pass"`,
+		},
+		{
+			name: "nested composite with invalid leaf",
+			predicate: Predicate{
+				Kind: PredicateOr,
+				Predicates: []Predicate{
+					{Kind: PredicateNoOpenFindings},
+					{
+						Kind:      PredicateNot,
+						Predicate: &Predicate{Kind: PredicateLoopRoundsAtLeast}, // missing n
+					},
+				},
+			},
+			wantPathSub: "predicates[1].predicate",
+			wantMsgSub:  "requires n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues := tc.predicate.Validate("")
+			if len(issues) == 0 {
+				t.Fatalf("expected issues, got none")
+			}
+			var found bool
+			for _, issue := range issues {
+				if strings.Contains(issue.Message, tc.wantMsgSub) &&
+					(tc.wantPathSub == "" || strings.Contains(issue.Path, tc.wantPathSub)) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("no issue matched path substring %q / message substring %q; got %+v",
+					tc.wantPathSub, tc.wantMsgSub, issues)
+			}
+		})
+	}
+}
+
+func TestPredicateReferencedStages(t *testing.T) {
+	cases := []struct {
+		name      string
+		predicate Predicate
+		want      []string
+	}{
+		{
+			name:      "all_pass collects stages",
+			predicate: Predicate{Kind: PredicateAllPass, Stages: []string{"a", "b"}},
+			want:      []string{"a", "b"},
+		},
+		{
+			name:      "stage_verdict collects stage",
+			predicate: Predicate{Kind: PredicateStageVerdict, Stage: "a", Verdict: VerdictPass},
+			want:      []string{"a"},
+		},
+		{
+			name:      "stage_retried_at_least collects stage",
+			predicate: Predicate{Kind: PredicateStageRetriedAtLeast, Stage: "a", N: intp(1)},
+			want:      []string{"a"},
+		},
+		{
+			name:      "no_open_findings includes optional stage when set",
+			predicate: Predicate{Kind: PredicateNoOpenFindings, Stage: "a"},
+			want:      []string{"a"},
+		},
+		{
+			name:      "no_open_findings omits stage when unset",
+			predicate: Predicate{Kind: PredicateNoOpenFindings},
+			want:      nil,
+		},
+		{
+			name:      "finding_count_below includes optional stage when set",
+			predicate: Predicate{Kind: PredicateFindingCountBelow, Max: intp(1), Stage: "b"},
+			want:      []string{"b"},
+		},
+		{
+			name: "nested and/or/not dedups across the tree, first-seen order",
+			predicate: Predicate{
+				Kind: PredicateAnd,
+				Predicates: []Predicate{
+					{Kind: PredicateAllPass, Stages: []string{"a", "b"}},
+					{
+						Kind: PredicateOr,
+						Predicates: []Predicate{
+							{Kind: PredicateStageVerdict, Stage: "b", Verdict: VerdictFail},
+							{
+								Kind:      PredicateNot,
+								Predicate: &Predicate{Kind: PredicateStageRetriedAtLeast, Stage: "c", N: intp(1)},
+							},
+						},
+					},
+					{Kind: PredicateAllPass, Stages: []string{"a"}},
+				},
+			},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name:      "loop_rounds_at_least references nothing",
+			predicate: Predicate{Kind: PredicateLoopRoundsAtLeast, N: intp(1)},
+			want:      nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.predicate.ReferencedStages()
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/pipeline/schema.go
+++ b/backend/internal/pipeline/schema.go
@@ -1,0 +1,21 @@
+package pipeline
+
+import _ "embed"
+
+// configSchemaJSON is the JSON Schema (draft 2020-12) mirror of the YAML
+// pipeline definition document accepted by ParseDefinition. It is consumed
+// by the definitions editor (a later task) for client-side validation and
+// autocomplete; correctness here matters more than cleverness, so it is kept
+// as a hand-written, readable file (schema.json) rather than generated.
+//
+//go:embed schema.json
+var configSchemaJSON []byte
+
+// ConfigJSONSchema returns a copy of the embedded JSON Schema document
+// describing the YAML pipeline definition format. Callers get their own
+// copy so they can't mutate the embedded original.
+func ConfigJSONSchema() []byte {
+	out := make([]byte, len(configSchemaJSON))
+	copy(out, configSchemaJSON)
+	return out
+}

--- a/backend/internal/pipeline/schema.json
+++ b/backend/internal/pipeline/schema.json
@@ -1,0 +1,273 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-orchestrator.dev/schema/pipeline-definition.json",
+  "title": "Pipeline definition",
+  "description": "A single pipeline definition document (v1: one pipeline per YAML document, authored in the definitions editor and stored in SQLite). Mirrors backend/internal/pipeline/types.go; kept in sync by hand.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable pipeline name. Required; there is no map key to default it from."
+    },
+    "scope": {
+      "type": "string",
+      "enum": ["worker"],
+      "description": "Pipeline-v3 scope. Only \"worker\" is accepted in v1; \"orchestrator\" and \"workstream\" are deferred to phase 2."
+    },
+    "stages": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/stage" }
+    },
+    "maxConcurrentStages": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Defaults to 1 (serial execution) when unset."
+    },
+    "allowForkPRs": {
+      "type": "boolean",
+      "description": "Opt in to running command-executor stages for fork PRs. Defaults to false."
+    },
+    "exitPredicates": { "$ref": "#/$defs/exitPredicates" }
+  },
+  "required": ["name", "stages"],
+  "additionalProperties": false,
+
+  "$defs": {
+    "stage": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "trigger": { "$ref": "#/$defs/stageTrigger" },
+        "executor": { "$ref": "#/$defs/stageExecutor" },
+        "task": { "$ref": "#/$defs/taskSpec" },
+        "policy": { "$ref": "#/$defs/stagePolicy" },
+        "budget": { "$ref": "#/$defs/stageBudget" },
+        "timeoutMs": { "type": "integer", "minimum": 0 },
+        "retries": { "type": "integer", "minimum": 0 },
+        "maxLoopRounds": { "type": "integer", "minimum": 1 },
+        "dependsOn": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "routes": { "$ref": "#/$defs/stageRoutes" },
+        "workspace": {
+          "type": "string",
+          "enum": ["shared-ro", "isolated-rw"]
+        }
+      },
+      "required": ["name", "trigger", "executor"],
+      "additionalProperties": false
+    },
+
+    "stageTrigger": {
+      "type": "object",
+      "properties": {
+        "on": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["pr.opened", "pr.updated", "pr.merge_ready", "pr.merged", "manual"]
+          }
+        }
+      },
+      "required": ["on"],
+      "additionalProperties": false
+    },
+
+    "stageExecutor": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "agent" },
+            "plugin": { "type": "string", "minLength": 1 },
+            "mode": { "type": "string", "enum": ["review", "code", "answer"] },
+            "config": { "type": "object" }
+          },
+          "required": ["kind", "plugin", "mode"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "command" },
+            "command": { "type": "string", "minLength": 1 },
+            "args": { "type": "array", "items": { "type": "string" } },
+            "env": { "type": "object", "additionalProperties": { "type": "string" } },
+            "cwd": { "type": "string" }
+          },
+          "required": ["kind", "command"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "builtin" },
+            "name": { "type": "string", "enum": ["router", "compose"] },
+            "config": { "type": "object" }
+          },
+          "required": ["kind", "name"],
+          "additionalProperties": false
+        }
+      ]
+    },
+
+    "taskSpec": {
+      "type": "object",
+      "properties": {
+        "prompt": { "type": "string" },
+        "outputSchema": { "type": "object" },
+        "inputs": { "type": "object" }
+      },
+      "additionalProperties": false
+    },
+
+    "stagePolicy": {
+      "type": "object",
+      "properties": {
+        "blocksMerge": { "type": "boolean" },
+        "stallWindow": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+
+    "stageBudget": {
+      "type": "object",
+      "properties": {
+        "maxUsd": { "type": "number", "minimum": 0 },
+        "maxDurationMs": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+
+    "stageRoutes": {
+      "type": "object",
+      "properties": {
+        "when": { "$ref": "#/$defs/predicate" }
+      },
+      "required": ["when"],
+      "additionalProperties": false
+    },
+
+    "exitPredicates": {
+      "type": "object",
+      "properties": {
+        "done": { "$ref": "#/$defs/predicate" },
+        "stalled": { "$ref": "#/$defs/predicate" },
+        "blocksMerge": { "$ref": "#/$defs/predicate" }
+      },
+      "additionalProperties": false
+    },
+
+    "predicate": {
+      "description": "Typed predicate DSL node. Recursive union discriminated on \"kind\".",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "all_pass" },
+            "stages": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+          },
+          "required": ["kind", "stages"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "any_pass" },
+            "stages": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+          },
+          "required": ["kind", "stages"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "majority_pass" },
+            "stages": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+          },
+          "required": ["kind", "stages"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "no_open_findings" },
+            "stage": { "type": "string", "minLength": 1 }
+          },
+          "required": ["kind"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "finding_count_below" },
+            "max": { "type": "integer", "minimum": 0 },
+            "stage": { "type": "string", "minLength": 1 },
+            "severity": { "type": "string", "enum": ["error", "warning", "info"] }
+          },
+          "required": ["kind", "max"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "loop_rounds_at_least" },
+            "n": { "type": "integer", "minimum": 1 }
+          },
+          "required": ["kind", "n"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "stage_retried_at_least" },
+            "stage": { "type": "string", "minLength": 1 },
+            "n": { "type": "integer", "minimum": 1 }
+          },
+          "required": ["kind", "stage", "n"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "stage_verdict" },
+            "stage": { "type": "string", "minLength": 1 },
+            "verdict": { "type": "string", "enum": ["pass", "fail", "neutral"] }
+          },
+          "required": ["kind", "stage", "verdict"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "and" },
+            "predicates": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/predicate" } }
+          },
+          "required": ["kind", "predicates"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "or" },
+            "predicates": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/predicate" } }
+          },
+          "required": ["kind", "predicates"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "not" },
+            "predicate": { "$ref": "#/$defs/predicate" }
+          },
+          "required": ["kind", "predicate"],
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}

--- a/backend/internal/pipeline/schema_test.go
+++ b/backend/internal/pipeline/schema_test.go
@@ -1,0 +1,59 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestConfigJSONSchema_ParsesAsJSON(t *testing.T) {
+	var doc map[string]any
+	if err := json.Unmarshal(ConfigJSONSchema(), &doc); err != nil {
+		t.Fatalf("embedded schema.json is not valid JSON: %v", err)
+	}
+	if doc["$schema"] != "https://json-schema.org/draft/2020-12/schema" {
+		t.Fatalf("expected draft 2020-12 $schema, got %v", doc["$schema"])
+	}
+}
+
+func TestConfigJSONSchema_ReturnsCopy(t *testing.T) {
+	a := ConfigJSONSchema()
+	b := ConfigJSONSchema()
+	if len(a) == 0 {
+		t.Fatal("expected non-empty schema")
+	}
+	a[0] = 'X'
+	if string(a[:1]) == string(b[:1]) {
+		t.Fatal("expected mutating one copy to not affect another")
+	}
+}
+
+// TestConfigJSONSchema_CoversEnums is a cheap drift guard: every Go enum
+// constant this package defines for the config surface must appear
+// somewhere in the schema text, so a new predicate kind / executor kind /
+// trigger event added to the Go enums doesn't silently go undocumented in
+// the schema the definitions editor consumes.
+func TestConfigJSONSchema_CoversEnums(t *testing.T) {
+	schema := string(ConfigJSONSchema())
+
+	for _, k := range AllPredicateKinds {
+		if !strings.Contains(schema, string(k)) {
+			t.Errorf("schema missing predicate kind %q", k)
+		}
+	}
+	for _, k := range AllExecutorKinds {
+		if !strings.Contains(schema, string(k)) {
+			t.Errorf("schema missing executor kind %q", k)
+		}
+	}
+	for _, e := range AllStageTriggerEvents {
+		if !strings.Contains(schema, string(e)) {
+			t.Errorf("schema missing trigger event %q", e)
+		}
+	}
+	for _, key := range []string{"name", "stages"} {
+		if !strings.Contains(schema, `"`+key+`"`) {
+			t.Errorf("schema missing required top-level key %q", key)
+		}
+	}
+}

--- a/backend/internal/pipeline/types.go
+++ b/backend/internal/pipeline/types.go
@@ -358,7 +358,7 @@ func (k ArtifactKind) IsKnown() bool {
 //     stage at the same SHA, destroyed on terminal status. Safe for stages
 //     that write files.
 //
-// The empty string means "unset" — the default is resolved later (by the
+// The empty string means "unset": the default is resolved later (by the
 // scheduler/executor task, not this package) based on the stage's executor
 // kind.
 type WorkspaceMode string

--- a/backend/internal/pipeline/types.go
+++ b/backend/internal/pipeline/types.go
@@ -1,0 +1,711 @@
+package pipeline
+
+import "time"
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+// StageTriggerEvent names an event a stage's trigger reacts to.
+//
+// v1 scope is worker-only ("pr.*" and "manual"). The old TypeScript source
+// also defined "orchestrator.*" and "workstream.*" trigger families for
+// pipeline-v3 scopes; those are phase 2 and intentionally not defined here.
+// Validation is table-driven off AllStageTriggerEvents, so adding the phase 2
+// values later is a one-line change to that table, not a schema rewrite.
+type StageTriggerEvent string
+
+// Known v1 stage trigger events.
+const (
+	TriggerPROpened     StageTriggerEvent = "pr.opened"
+	TriggerPRUpdated    StageTriggerEvent = "pr.updated"
+	TriggerPRMergeReady StageTriggerEvent = "pr.merge_ready"
+	TriggerPRMerged     StageTriggerEvent = "pr.merged"
+	TriggerManual       StageTriggerEvent = "manual"
+)
+
+// AllStageTriggerEvents lists every trigger event known in v1.
+var AllStageTriggerEvents = []StageTriggerEvent{
+	TriggerPROpened, TriggerPRUpdated, TriggerPRMergeReady, TriggerPRMerged, TriggerManual,
+}
+
+// IsKnown reports whether e is one of the v1 stage trigger events.
+func (e StageTriggerEvent) IsKnown() bool {
+	for _, k := range AllStageTriggerEvents {
+		if e == k {
+			return true
+		}
+	}
+	return false
+}
+
+// PipelineScope mirrors the pipeline-v3 spec's three scopes. v1 config
+// validation accepts only the empty string (which defaults to
+// ScopeWorker) or ScopeWorker itself; ScopeOrchestrator and ScopeWorkstream
+// are declared here so the type is future-proof but are rejected at
+// validation time with a "deferred to phase 2" message.
+type PipelineScope string
+
+// Known pipeline scopes. Only ScopeWorker is accepted by v1 validation.
+const (
+	ScopeWorker       PipelineScope = "worker"
+	ScopeOrchestrator PipelineScope = "orchestrator"
+	ScopeWorkstream   PipelineScope = "workstream"
+)
+
+// AllPipelineScopes lists every scope defined by the spec, including the
+// phase 2 scopes that v1 validation rejects.
+var AllPipelineScopes = []PipelineScope{ScopeWorker, ScopeOrchestrator, ScopeWorkstream}
+
+// IsKnown reports whether s is one of the scopes defined by the spec
+// (regardless of whether v1 validation currently accepts it).
+func (s PipelineScope) IsKnown() bool {
+	for _, k := range AllPipelineScopes {
+		if s == k {
+			return true
+		}
+	}
+	return false
+}
+
+// TaskMode is a mode an agent plugin advertises support for and a stage's
+// agent executor requests.
+type TaskMode string
+
+// Known task modes.
+const (
+	ModeReview TaskMode = "review"
+	ModeCode   TaskMode = "code"
+	ModeAnswer TaskMode = "answer"
+)
+
+// AllTaskModes lists every known task mode.
+var AllTaskModes = []TaskMode{ModeReview, ModeCode, ModeAnswer}
+
+// IsKnown reports whether m is a known task mode.
+func (m TaskMode) IsKnown() bool {
+	for _, k := range AllTaskModes {
+		if m == k {
+			return true
+		}
+	}
+	return false
+}
+
+// ExecutorKind names how a stage runs: an agent session, a shelled-out
+// command, or an engine-internal builtin.
+type ExecutorKind string
+
+// Known executor kinds.
+const (
+	ExecutorAgent   ExecutorKind = "agent"
+	ExecutorCommand ExecutorKind = "command"
+	ExecutorBuiltin ExecutorKind = "builtin"
+)
+
+// AllExecutorKinds lists every known executor kind.
+var AllExecutorKinds = []ExecutorKind{ExecutorAgent, ExecutorCommand, ExecutorBuiltin}
+
+// IsKnown reports whether k is a known executor kind.
+func (k ExecutorKind) IsKnown() bool {
+	for _, known := range AllExecutorKinds {
+		if k == known {
+			return true
+		}
+	}
+	return false
+}
+
+// BuiltinName names an engine-internal builtin executor. Builtins run inside
+// the engine process; they never spawn a session or shell out.
+type BuiltinName string
+
+// Known builtin executors.
+const (
+	BuiltinRouter  BuiltinName = "router"
+	BuiltinCompose BuiltinName = "compose"
+)
+
+// AllBuiltinNames lists every known builtin executor name.
+var AllBuiltinNames = []BuiltinName{BuiltinRouter, BuiltinCompose}
+
+// IsKnown reports whether n is a known builtin executor name.
+func (n BuiltinName) IsKnown() bool {
+	for _, k := range AllBuiltinNames {
+		if n == k {
+			return true
+		}
+	}
+	return false
+}
+
+// Severity classifies a finding artifact's importance.
+type Severity string
+
+// Known severities.
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+	SeverityInfo    Severity = "info"
+)
+
+// AllSeverities lists every known severity.
+var AllSeverities = []Severity{SeverityError, SeverityWarning, SeverityInfo}
+
+// IsKnown reports whether s is a known severity.
+func (s Severity) IsKnown() bool {
+	for _, k := range AllSeverities {
+		if s == k {
+			return true
+		}
+	}
+	return false
+}
+
+// Verdict is a stage's pass/fail/neutral judgement, distinct from its
+// lifecycle StageStatus.
+type Verdict string
+
+// Known verdicts.
+const (
+	VerdictPass    Verdict = "pass"
+	VerdictFail    Verdict = "fail"
+	VerdictNeutral Verdict = "neutral"
+)
+
+// AllVerdicts lists every known verdict.
+var AllVerdicts = []Verdict{VerdictPass, VerdictFail, VerdictNeutral}
+
+// IsKnown reports whether v is a known verdict.
+func (v Verdict) IsKnown() bool {
+	for _, k := range AllVerdicts {
+		if v == k {
+			return true
+		}
+	}
+	return false
+}
+
+// StageStatus is a stage run's lifecycle status.
+type StageStatus string
+
+// Known stage statuses.
+const (
+	StageStatusPending   StageStatus = "pending"
+	StageStatusRunning   StageStatus = "running"
+	StageStatusSucceeded StageStatus = "succeeded"
+	StageStatusFailed    StageStatus = "failed"
+	StageStatusSkipped   StageStatus = "skipped"
+	StageStatusOutdated  StageStatus = "outdated"
+)
+
+// AllStageStatuses lists every known stage status.
+var AllStageStatuses = []StageStatus{
+	StageStatusPending, StageStatusRunning, StageStatusSucceeded,
+	StageStatusFailed, StageStatusSkipped, StageStatusOutdated,
+}
+
+// IsKnown reports whether s is a known stage status.
+func (s StageStatus) IsKnown() bool {
+	for _, k := range AllStageStatuses {
+		if s == k {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTerminal reports whether s is a terminal stage status: succeeded,
+// failed, skipped, or outdated.
+func (s StageStatus) IsTerminal() bool {
+	switch s {
+	case StageStatusSucceeded, StageStatusFailed, StageStatusSkipped, StageStatusOutdated:
+		return true
+	default:
+		return false
+	}
+}
+
+// LoopStateName is the persistent per-session pipeline loop's lifecycle
+// state (tier 3 of the three-tier exit model: stage exit -> run exit ->
+// loop exit).
+type LoopStateName string
+
+// Known loop states.
+const (
+	LoopRunning         LoopStateName = "running"
+	LoopAwaitingContext LoopStateName = "awaiting_context"
+	LoopDone            LoopStateName = "done"
+	LoopStalled         LoopStateName = "stalled"
+	LoopTerminated      LoopStateName = "terminated"
+)
+
+// AllLoopStateNames lists every known loop state.
+var AllLoopStateNames = []LoopStateName{
+	LoopRunning, LoopAwaitingContext, LoopDone, LoopStalled, LoopTerminated,
+}
+
+// IsKnown reports whether s is a known loop state.
+func (s LoopStateName) IsKnown() bool {
+	for _, k := range AllLoopStateNames {
+		if s == k {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTerminal reports whether s is a terminal loop state: done, stalled, or
+// terminated.
+func (s LoopStateName) IsTerminal() bool {
+	switch s {
+	case LoopDone, LoopStalled, LoopTerminated:
+		return true
+	default:
+		return false
+	}
+}
+
+// RunTerminationReason explains why a pipeline run terminated (tier 2 of the
+// three-tier exit model).
+type RunTerminationReason string
+
+// Known run termination reasons.
+const (
+	TerminationCompleted    RunTerminationReason = "completed"
+	TerminationStageFailure RunTerminationReason = "stage_failure"
+	TerminationManualCancel RunTerminationReason = "manual_cancel"
+	TerminationConfigChange RunTerminationReason = "config_change"
+	TerminationOutdated     RunTerminationReason = "outdated"
+	TerminationWorkerDead   RunTerminationReason = "worker_dead"
+	// TerminationConverged marks stall-window convergence: the last
+	// stallWindow consecutive runs in this loop produced the same set of
+	// finding fingerprints, so the loop hit a fixpoint and terminates as
+	// stalled rather than ping-ponging indefinitely.
+	TerminationConverged RunTerminationReason = "converged"
+)
+
+// AllRunTerminationReasons lists every known run termination reason.
+var AllRunTerminationReasons = []RunTerminationReason{
+	TerminationCompleted, TerminationStageFailure, TerminationManualCancel,
+	TerminationConfigChange, TerminationOutdated, TerminationWorkerDead, TerminationConverged,
+}
+
+// IsKnown reports whether r is a known run termination reason.
+func (r RunTerminationReason) IsKnown() bool {
+	for _, k := range AllRunTerminationReasons {
+		if r == k {
+			return true
+		}
+	}
+	return false
+}
+
+// ArtifactStatus is an artifact's lifecycle status.
+type ArtifactStatus string
+
+// Known artifact statuses.
+const (
+	ArtifactStatusOpen        ArtifactStatus = "open"
+	ArtifactStatusDismissed   ArtifactStatus = "dismissed"
+	ArtifactStatusSentToAgent ArtifactStatus = "sent_to_agent"
+	ArtifactStatusResolved    ArtifactStatus = "resolved"
+)
+
+// AllArtifactStatuses lists every known artifact status.
+var AllArtifactStatuses = []ArtifactStatus{
+	ArtifactStatusOpen, ArtifactStatusDismissed, ArtifactStatusSentToAgent, ArtifactStatusResolved,
+}
+
+// IsKnown reports whether s is a known artifact status.
+func (s ArtifactStatus) IsKnown() bool {
+	for _, k := range AllArtifactStatuses {
+		if s == k {
+			return true
+		}
+	}
+	return false
+}
+
+// ArtifactKind distinguishes a finding artifact from a free-form JSON
+// artifact.
+type ArtifactKind string
+
+// Known artifact kinds.
+const (
+	ArtifactKindFinding ArtifactKind = "finding"
+	ArtifactKindJSON    ArtifactKind = "json"
+)
+
+// AllArtifactKinds lists every known artifact kind.
+var AllArtifactKinds = []ArtifactKind{ArtifactKindFinding, ArtifactKindJSON}
+
+// IsKnown reports whether k is a known artifact kind.
+func (k ArtifactKind) IsKnown() bool {
+	for _, known := range AllArtifactKinds {
+		if k == known {
+			return true
+		}
+	}
+	return false
+}
+
+// WorkspaceMode is the workspace class a stage runs in.
+//
+//   - WorkspaceSharedRO (default for agent/builtin): one detached worktree per
+//     run, shared by every shared-ro stage. Not expected to be mutated.
+//   - WorkspaceIsolatedRW (default for command): fresh detached worktree per
+//     stage at the same SHA, destroyed on terminal status. Safe for stages
+//     that write files.
+//
+// The empty string means "unset" — the default is resolved later (by the
+// scheduler/executor task, not this package) based on the stage's executor
+// kind.
+type WorkspaceMode string
+
+// Known workspace modes.
+const (
+	WorkspaceSharedRO   WorkspaceMode = "shared-ro"
+	WorkspaceIsolatedRW WorkspaceMode = "isolated-rw"
+)
+
+// AllWorkspaceModes lists every known non-empty workspace mode.
+var AllWorkspaceModes = []WorkspaceMode{WorkspaceSharedRO, WorkspaceIsolatedRW}
+
+// IsKnown reports whether m is empty (unset) or a known workspace mode.
+func (m WorkspaceMode) IsKnown() bool {
+	if m == "" {
+		return true
+	}
+	for _, k := range AllWorkspaceModes {
+		if m == k {
+			return true
+		}
+	}
+	return false
+}
+
+// FindingsFilename is the file stages drop in {workspacePath}/.ao/ for
+// findings discovery by convention.
+const FindingsFilename = "pipeline-findings.jsonl"
+
+// ============================================================================
+// Pipeline configuration
+// ============================================================================
+
+// StageTrigger lists the events that fire a stage.
+type StageTrigger struct {
+	On []StageTriggerEvent `json:"on" yaml:"on"`
+}
+
+// StageExecutor is a single tagged struct covering all three executor kinds
+// (agent, command, builtin) since it is parsed straight out of YAML. Config
+// validation enforces the required fields per Kind and rejects fields that
+// belong to another kind (e.g. Command set on an agent executor is an
+// error), which gives clearer editor feedback than the old Zod schema (which
+// silently stripped unknown fields).
+type StageExecutor struct {
+	Kind ExecutorKind `json:"kind" yaml:"kind"`
+
+	// Agent fields (Kind == ExecutorAgent).
+	Plugin string   `json:"plugin,omitempty" yaml:"plugin,omitempty"`
+	Mode   TaskMode `json:"mode,omitempty" yaml:"mode,omitempty"`
+
+	// Command fields (Kind == ExecutorCommand).
+	Command string            `json:"command,omitempty" yaml:"command,omitempty"`
+	Args    []string          `json:"args,omitempty" yaml:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
+	// Cwd is the working directory relative to the stage workspace.
+	Cwd string `json:"cwd,omitempty" yaml:"cwd,omitempty"`
+
+	// Builtin field (Kind == ExecutorBuiltin).
+	Name BuiltinName `json:"name,omitempty" yaml:"name,omitempty"`
+
+	// Config is shared by the agent and builtin kinds: free-form executor
+	// config (e.g. builtin "router"/"compose" options, or agent-plugin
+	// specific settings).
+	Config map[string]any `json:"config,omitempty" yaml:"config,omitempty"`
+}
+
+// TaskSpec is the task fed to a stage's executor.
+type TaskSpec struct {
+	// Prompt is injected into the spawned agent session, or is the main
+	// script body for a command executor.
+	Prompt string `json:"prompt,omitempty" yaml:"prompt,omitempty"`
+	// OutputSchema optionally describes the expected JSON outputs of the
+	// stage.
+	OutputSchema map[string]any `json:"outputSchema,omitempty" yaml:"outputSchema,omitempty"`
+	// Inputs are free-form named inputs available to the stage.
+	Inputs map[string]any `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+}
+
+// StagePolicy configures merge-blocking and stall-convergence behavior for a
+// stage.
+type StagePolicy struct {
+	BlocksMerge *bool `json:"blocksMerge,omitempty" yaml:"blocksMerge,omitempty"`
+	// StallWindow is the convergence window: the number of recent runs whose
+	// findings must be unchanged for the loop to be considered stalled.
+	StallWindow *int `json:"stallWindow,omitempty" yaml:"stallWindow,omitempty"`
+}
+
+// StageBudget caps a stage's spend and wall-clock duration.
+type StageBudget struct {
+	MaxUSD        *float64 `json:"maxUsd,omitempty" yaml:"maxUsd,omitempty"`
+	MaxDurationMs *int64   `json:"maxDurationMs,omitempty" yaml:"maxDurationMs,omitempty"`
+}
+
+// StageRoutes is a stage's conditional activation predicate. When set and
+// the predicate evaluates to false (after every referenced upstream stage is
+// terminal), the stage is marked skipped instead of started. When unset, the
+// default is "all dependsOn stages must have succeeded".
+type StageRoutes struct {
+	When Predicate `json:"when" yaml:"when"`
+}
+
+// ExitPredicates are the optional typed-predicate decisions for a run's exit
+// and merge-blocking state.
+type ExitPredicates struct {
+	// Done: the run terminates as "done" when this predicate is true after
+	// every stage reaches a terminal state.
+	Done *Predicate `json:"done,omitempty" yaml:"done,omitempty"`
+	// Stalled: the run terminates as "stalled" when this predicate is true
+	// after every stage reaches a terminal state.
+	Stalled *Predicate `json:"stalled,omitempty" yaml:"stalled,omitempty"`
+	// BlocksMerge: engine-level "this run blocks merge" decision, consulted
+	// by the SCM integration; not enforced by the reducer itself.
+	BlocksMerge *Predicate `json:"blocksMerge,omitempty" yaml:"blocksMerge,omitempty"`
+}
+
+// Stage is one node in a pipeline's DAG.
+type Stage struct {
+	Name     string        `json:"name" yaml:"name"`
+	Trigger  StageTrigger  `json:"trigger" yaml:"trigger"`
+	Executor StageExecutor `json:"executor" yaml:"executor"`
+	Task     TaskSpec      `json:"task,omitempty" yaml:"task,omitempty"`
+
+	Policy *StagePolicy `json:"policy,omitempty" yaml:"policy,omitempty"`
+	Budget *StageBudget `json:"budget,omitempty" yaml:"budget,omitempty"`
+
+	// TimeoutMs is advisory; the engine treats it as a hint, not a hard cap.
+	TimeoutMs *int64 `json:"timeoutMs,omitempty" yaml:"timeoutMs,omitempty"`
+	Retries   *int   `json:"retries,omitempty" yaml:"retries,omitempty"`
+	// MaxLoopRounds is a per-stage loop cap (locked decision: not
+	// pipeline-global).
+	MaxLoopRounds *int `json:"maxLoopRounds,omitempty" yaml:"maxLoopRounds,omitempty"`
+
+	// DependsOn lists stage names this stage waits for before it can be
+	// evaluated. The named stages must reach a terminal status before the
+	// scheduler considers this stage. Unknown names and cycles are rejected
+	// at config load.
+	DependsOn []string `json:"dependsOn,omitempty" yaml:"dependsOn,omitempty"`
+
+	// Routes is this stage's conditional activation predicate. See
+	// StageRoutes for semantics.
+	Routes *StageRoutes `json:"routes,omitempty" yaml:"routes,omitempty"`
+
+	// Workspace is this stage's workspace class. Empty means "use the
+	// default for the executor kind", resolved later. See WorkspaceMode.
+	Workspace WorkspaceMode `json:"workspace,omitempty" yaml:"workspace,omitempty"`
+}
+
+// Pipeline is a full pipeline definition: the DAG of stages plus
+// pipeline-level policy.
+type Pipeline struct {
+	// ID is assigned by the store when the definition is saved; it is never
+	// part of the authored YAML document.
+	ID   PipelineID `json:"id" yaml:"-"`
+	Name string     `json:"name" yaml:"name"`
+
+	// Scope mirrors the pipeline-v3 spec (see PipelineScope). v1 accepts
+	// only the empty string or ScopeWorker; ScopeOrchestrator and
+	// ScopeWorkstream are deferred to phase 2.
+	Scope PipelineScope `json:"scope,omitempty" yaml:"scope,omitempty"`
+
+	Stages []Stage `json:"stages" yaml:"stages"`
+
+	// MaxConcurrentStages defaults to 1 when unset; the engine enforces
+	// serial execution in that case.
+	MaxConcurrentStages *int `json:"maxConcurrentStages,omitempty" yaml:"maxConcurrentStages,omitempty"`
+
+	// AllowForkPRs opts in to running command-executor stages for pull
+	// requests opened from forks. Defaults to false: fork-PR command stages
+	// are skipped before any subprocess is spawned. Only applies to the
+	// command executor.
+	AllowForkPRs *bool `json:"allowForkPRs,omitempty" yaml:"allowForkPRs,omitempty"`
+
+	// ExitPredicates optionally overrides the v0 hardcoded run-exit rules.
+	ExitPredicates *ExitPredicates `json:"exitPredicates,omitempty" yaml:"exitPredicates,omitempty"`
+}
+
+// ============================================================================
+// Runtime state
+// ============================================================================
+//
+// The types below describe engine runtime state (RunState, LoopState, ...).
+// They are JSON-serialized for persistence but are never parsed from YAML
+// config, so they carry only json tags.
+
+// StageState is one stage's runtime state within a run.
+type StageState struct {
+	StageRunID StageRunID   `json:"stageRunId"`
+	Status     StageStatus  `json:"status"`
+	Attempt    int          `json:"attempt"`
+	Verdict    Verdict      `json:"verdict,omitempty"`
+	Artifacts  []ArtifactID `json:"artifacts,omitempty"`
+
+	StartedAt   *time.Time `json:"startedAt,omitempty"`
+	CompletedAt *time.Time `json:"completedAt,omitempty"`
+
+	ErrorMessage string `json:"errorMessage,omitempty"`
+}
+
+// RunState is one pipeline run's full runtime state.
+type RunState struct {
+	RunID        RunID      `json:"runId"`
+	PipelineID   PipelineID `json:"pipelineId"`
+	PipelineName string     `json:"pipelineName"`
+	SessionID    string     `json:"sessionId"`
+
+	// PipelineConfigSnapshot is frozen at run-create; config changes during
+	// a run terminate the run rather than mutating it in place.
+	PipelineConfigSnapshot Pipeline `json:"pipelineConfigSnapshot"`
+
+	HeadSHA string `json:"headSha"`
+
+	LoopState         LoopStateName        `json:"loopState"`
+	TerminationReason RunTerminationReason `json:"terminationReason,omitempty"`
+	LoopRounds        int                  `json:"loopRounds"`
+
+	// Stages is keyed by stage name. v1 has at most one entry per stage.
+	Stages map[string]StageState `json:"stages"`
+
+	// Findings are denormalized materialized finding artifacts, appended as
+	// STAGE_COMPLETED events arrive, so predicate evaluation can answer
+	// no_open_findings/finding_count_below without reading the store. JSON
+	// artifacts are not mirrored here.
+	Findings []Artifact `json:"findings,omitempty"`
+
+	// Fingerprints are finding fingerprints accumulated during the run, used
+	// by stall-window convergence detection.
+	Fingerprints []string `json:"fingerprints,omitempty"`
+
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// LoopState is the persistent per-session, per-pipeline loop's runtime
+// state.
+type LoopState struct {
+	SessionID    string        `json:"sessionId"`
+	PipelineName string        `json:"pipelineName"`
+	LoopState    LoopStateName `json:"loopState"`
+	LoopRounds   int           `json:"loopRounds"`
+	LastSHA      string        `json:"lastSha"`
+	CurrentRunID RunID         `json:"currentRunId,omitempty"`
+	UpdatedAt    time.Time     `json:"updatedAt"`
+}
+
+// RunSummary is a compact run record used for stalled-detection across runs.
+type RunSummary struct {
+	RunID             RunID                `json:"runId"`
+	LoopState         LoopStateName        `json:"loopState"`
+	TerminationReason RunTerminationReason `json:"terminationReason,omitempty"`
+	HeadSHA           string               `json:"headSha"`
+	LoopRounds        int                  `json:"loopRounds"`
+	// Fingerprints is the sorted, deduped list of artifact fingerprints from
+	// the run, used by convergence detection.
+	Fingerprints []string  `json:"fingerprints"`
+	CreatedAt    time.Time `json:"createdAt"`
+}
+
+// EngineState is the engine-global state. Multiple in-flight runs may exist
+// at once (e.g. an old run is being torn down while a new SHA spawns its
+// replacement), so runs are keyed by RunID. Per-loop indices are kept
+// separately from the per-run details.
+type EngineState struct {
+	Runs map[RunID]RunState `json:"runs"`
+	// CurrentRunByLoop maps a loop key ("sessionId:pipelineName") to the
+	// currently-active RunID.
+	CurrentRunByLoop map[string]RunID `json:"currentRunByLoop"`
+	// HistorySummaries maps a loop key to its ordered run history (oldest
+	// first), used by convergence detection.
+	HistorySummaries map[string][]RunSummary `json:"historySummaries"`
+}
+
+// LoopKey returns the key used to index a session+pipeline loop in
+// EngineState.CurrentRunByLoop and EngineState.HistorySummaries.
+func LoopKey(sessionID, pipelineName string) string {
+	return sessionID + ":" + pipelineName
+}
+
+// EmptyEngineState returns a zero-value EngineState with initialized maps.
+func EmptyEngineState() EngineState {
+	return EngineState{
+		Runs:             map[RunID]RunState{},
+		CurrentRunByLoop: map[string]RunID{},
+		HistorySummaries: map[string][]RunSummary{},
+	}
+}
+
+// PredicateCtx is the input to the predicate evaluator (built in a later
+// task). All fields are read-only snapshots.
+//
+// Unlike the old TypeScript PredicateCtx, there is no workstream field in
+// v1: pipeline-v3 workstream scope is deferred to phase 2, and the
+// workstream-only predicate kinds were dropped from the DSL (see
+// predicate.go).
+type PredicateCtx struct {
+	Run      *RunState
+	History  []RunSummary
+	Findings []Artifact
+}
+
+// ============================================================================
+// Artifacts
+// ============================================================================
+
+// ArtifactInput is the payload a stage reports for one artifact: either a
+// finding or a free-form JSON blob. It carries no envelope fields (those are
+// assigned by the engine when the artifact is persisted; see Artifact).
+type ArtifactInput struct {
+	Kind ArtifactKind `json:"kind"`
+
+	// Finding fields (Kind == ArtifactKindFinding).
+	FilePath    string `json:"filePath,omitempty"`
+	StartLine   int    `json:"startLine,omitempty"`
+	EndLine     int    `json:"endLine,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	// Category is a free-form label, e.g. "security" | "correctness" |
+	// "style" | ... | "general".
+	Category string   `json:"category,omitempty"`
+	Severity Severity `json:"severity,omitempty"`
+	// Confidence is in [0.0, 1.0].
+	Confidence float64 `json:"confidence,omitempty"`
+	// AnchorSignature is a structural anchor (function/class name) for
+	// fingerprint stability.
+	AnchorSignature string `json:"anchorSignature,omitempty"`
+
+	// JSON field (Kind == ArtifactKindJSON).
+	Data map[string]any `json:"data,omitempty"`
+}
+
+// Artifact is a persisted ArtifactInput plus its engine-assigned envelope.
+type Artifact struct {
+	ArtifactInput
+
+	ArtifactID    ArtifactID `json:"artifactId"`
+	PipelineRunID RunID      `json:"pipelineRunId"`
+	StageRunID    StageRunID `json:"stageRunId"`
+	StageName     string     `json:"stageName"`
+
+	Fingerprint string         `json:"fingerprint,omitempty"`
+	Status      ArtifactStatus `json:"status"`
+
+	CreatedAt     time.Time  `json:"createdAt"`
+	SentToAgentAt *time.Time `json:"sentToAgentAt,omitempty"`
+
+	// BelowConfidenceThreshold is set when the finding's confidence is below
+	// the pipeline/stage threshold.
+	BelowConfidenceThreshold bool `json:"belowConfidenceThreshold,omitempty"`
+}

--- a/backend/internal/pipeline/types.go
+++ b/backend/internal/pipeline/types.go
@@ -39,28 +39,28 @@ func (e StageTriggerEvent) IsKnown() bool {
 	return false
 }
 
-// PipelineScope mirrors the pipeline-v3 spec's three scopes. v1 config
+// Scope mirrors the pipeline-v3 spec's three scopes. v1 config
 // validation accepts only the empty string (which defaults to
 // ScopeWorker) or ScopeWorker itself; ScopeOrchestrator and ScopeWorkstream
 // are declared here so the type is future-proof but are rejected at
 // validation time with a "deferred to phase 2" message.
-type PipelineScope string
+type Scope string
 
 // Known pipeline scopes. Only ScopeWorker is accepted by v1 validation.
 const (
-	ScopeWorker       PipelineScope = "worker"
-	ScopeOrchestrator PipelineScope = "orchestrator"
-	ScopeWorkstream   PipelineScope = "workstream"
+	ScopeWorker       Scope = "worker"
+	ScopeOrchestrator Scope = "orchestrator"
+	ScopeWorkstream   Scope = "workstream"
 )
 
-// AllPipelineScopes lists every scope defined by the spec, including the
+// AllScopes lists every scope defined by the spec, including the
 // phase 2 scopes that v1 validation rejects.
-var AllPipelineScopes = []PipelineScope{ScopeWorker, ScopeOrchestrator, ScopeWorkstream}
+var AllScopes = []Scope{ScopeWorker, ScopeOrchestrator, ScopeWorkstream}
 
 // IsKnown reports whether s is one of the scopes defined by the spec
 // (regardless of whether v1 validation currently accepts it).
-func (s PipelineScope) IsKnown() bool {
-	for _, k := range AllPipelineScopes {
+func (s Scope) IsKnown() bool {
+	for _, k := range AllScopes {
 		if s == k {
 			return true
 		}
@@ -513,13 +513,13 @@ type Stage struct {
 type Pipeline struct {
 	// ID is assigned by the store when the definition is saved; it is never
 	// part of the authored YAML document.
-	ID   PipelineID `json:"id" yaml:"-"`
-	Name string     `json:"name" yaml:"name"`
+	ID   ID     `json:"id" yaml:"-"`
+	Name string `json:"name" yaml:"name"`
 
-	// Scope mirrors the pipeline-v3 spec (see PipelineScope). v1 accepts
+	// Scope mirrors the pipeline-v3 spec (see Scope). v1 accepts
 	// only the empty string or ScopeWorker; ScopeOrchestrator and
 	// ScopeWorkstream are deferred to phase 2.
-	Scope PipelineScope `json:"scope,omitempty" yaml:"scope,omitempty"`
+	Scope Scope `json:"scope,omitempty" yaml:"scope,omitempty"`
 
 	Stages []Stage `json:"stages" yaml:"stages"`
 
@@ -561,10 +561,10 @@ type StageState struct {
 
 // RunState is one pipeline run's full runtime state.
 type RunState struct {
-	RunID        RunID      `json:"runId"`
-	PipelineID   PipelineID `json:"pipelineId"`
-	PipelineName string     `json:"pipelineName"`
-	SessionID    string     `json:"sessionId"`
+	RunID        RunID  `json:"runId"`
+	PipelineID   ID     `json:"pipelineId"`
+	PipelineName string `json:"pipelineName"`
+	SessionID    string `json:"sessionId"`
 
 	// PipelineConfigSnapshot is frozen at run-create; config changes during
 	// a run terminate the run rather than mutating it in place.

--- a/backend/internal/pipeline/validation.go
+++ b/backend/internal/pipeline/validation.go
@@ -1,0 +1,59 @@
+package pipeline
+
+import "fmt"
+
+// TaskModeResolver reports the task modes an agent plugin supports. This is
+// a narrow seam standing in for the old TypeScript PluginRegistry: the Go
+// rewrite has no plugin registry yet, so a later task wires a real
+// implementation (backed by the agent layer) into ValidateAgentModes.
+//
+// ok=false means the plugin is unknown (not registered at all), distinct
+// from a plugin that is registered but supports no modes (empty modes,
+// ok=true).
+type TaskModeResolver interface {
+	SupportedTaskModes(plugin string) (modes []TaskMode, ok bool)
+}
+
+// ValidateAgentModes validates that every agent-executor stage in p routes
+// to a plugin resolver knows about, and that the plugin supports the
+// stage's requested TaskMode. Non-agent stages (command, builtin) are
+// ignored.
+//
+// Returns the first failure, mirroring the old TypeScript
+// validatePipelineAgentModes, which threw PipelineConfigError on the first
+// bad stage rather than collecting every failure (unlike config validation,
+// which collects everything: this check runs after config load, against a
+// resolver whose contents aren't known until runtime).
+func ValidateAgentModes(p *Pipeline, resolver TaskModeResolver) error {
+	for _, stage := range p.Stages {
+		if stage.Executor.Kind != ExecutorAgent {
+			continue
+		}
+		plugin := stage.Executor.Plugin
+		mode := stage.Executor.Mode
+
+		supported, ok := resolver.SupportedTaskModes(plugin)
+		if !ok {
+			return fmt.Errorf(
+				"pipeline %q stage %q references unknown agent plugin %q",
+				p.Name, stage.Name, plugin,
+			)
+		}
+		if !containsMode(supported, mode) {
+			return fmt.Errorf(
+				"pipeline %q stage %q requires agent %q to support task mode %q, but its manifest declares supportedTaskModes=%v",
+				p.Name, stage.Name, plugin, mode, supported,
+			)
+		}
+	}
+	return nil
+}
+
+func containsMode(modes []TaskMode, mode TaskMode) bool {
+	for _, m := range modes {
+		if m == mode {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/pipeline/validation_test.go
+++ b/backend/internal/pipeline/validation_test.go
@@ -1,0 +1,115 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+type fakeTaskModeResolver map[string][]TaskMode
+
+func (r fakeTaskModeResolver) SupportedTaskModes(plugin string) ([]TaskMode, bool) {
+	modes, ok := r[plugin]
+	return modes, ok
+}
+
+func agentStage(name, plugin string, mode TaskMode) Stage {
+	return Stage{
+		Name: name,
+		Executor: StageExecutor{
+			Kind:   ExecutorAgent,
+			Plugin: plugin,
+			Mode:   mode,
+		},
+	}
+}
+
+func TestValidateAgentModes(t *testing.T) {
+	resolver := fakeTaskModeResolver{
+		"claude-code": {ModeReview, ModeCode},
+		"codex":       {ModeAnswer},
+		"no-modes":    {},
+	}
+
+	t.Run("accepts a supported mode", func(t *testing.T) {
+		p := &Pipeline{
+			Name:   "p",
+			Stages: []Stage{agentStage("review", "claude-code", ModeReview)},
+		}
+		if err := ValidateAgentModes(p, resolver); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("rejects unknown plugin", func(t *testing.T) {
+		p := &Pipeline{
+			Name:   "p",
+			Stages: []Stage{agentStage("review", "nonexistent", ModeReview)},
+		}
+		err := ValidateAgentModes(p, resolver)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "unknown agent plugin") {
+			t.Fatalf("error %q missing 'unknown agent plugin'", err.Error())
+		}
+	})
+
+	t.Run("rejects unsupported mode", func(t *testing.T) {
+		p := &Pipeline{
+			Name:   "p",
+			Stages: []Stage{agentStage("answer-stage", "claude-code", ModeAnswer)},
+		}
+		err := ValidateAgentModes(p, resolver)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		msg := err.Error()
+		for _, want := range []string{"claude-code", "answer", "review", "code"} {
+			if !strings.Contains(msg, want) {
+				t.Fatalf("error %q missing %q", msg, want)
+			}
+		}
+	})
+
+	t.Run("empty supported list rejects", func(t *testing.T) {
+		p := &Pipeline{
+			Name:   "p",
+			Stages: []Stage{agentStage("stage", "no-modes", ModeReview)},
+		}
+		err := ValidateAgentModes(p, resolver)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("command and builtin stages are ignored", func(t *testing.T) {
+		p := &Pipeline{
+			Name: "p",
+			Stages: []Stage{
+				{Name: "cmd", Executor: StageExecutor{Kind: ExecutorCommand, Command: "echo hi"}},
+				{Name: "builtin", Executor: StageExecutor{Kind: ExecutorBuiltin, Name: BuiltinRouter}},
+			},
+		}
+		if err := ValidateAgentModes(p, resolver); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("multi-stage pipeline fails on first mismatch", func(t *testing.T) {
+		p := &Pipeline{
+			Name: "p",
+			Stages: []Stage{
+				agentStage("ok", "claude-code", ModeReview),
+				agentStage("bad", "codex", ModeReview),
+				agentStage("also-bad", "nonexistent", ModeReview),
+			},
+		}
+		err := ValidateAgentModes(p, resolver)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), `stage "bad"`) {
+			t.Fatalf("expected error to name the first failing stage 'bad', got %q", err.Error())
+		}
+	})
+}


### PR DESCRIPTION
Closes #226

T1 of the Pipelines v1 reimplementation (spec: PIPELINES_REIMPL_SPEC.md, sections 5, 8, 9, 10). New package backend/internal/pipeline with the pure domain contract only; no reducer, scheduler, evaluator, executors, store, engine, HTTP, or CLI (later tasks).

## What is in here

- **IDs and enums** (`ids.go`, `types.go`): PipelineID/RunID/StageRunID/ArtifactID as distinct string types; StageTriggerEvent (5 v1 events), PipelineScope, TaskMode, ExecutorKind, BuiltinName, Severity, Verdict, StageStatus and LoopStateName with IsTerminal(), RunTerminationReason, ArtifactStatus, WorkspaceMode; all with AllXxx sets and IsKnown() so phase 2 additions (orchestrator.*/workstream.* triggers, followups) are one-line extensions.
- **Config shapes** (`types.go`): Pipeline, Stage, StageTrigger, StageExecutor, TaskSpec, StagePolicy, StageBudget, StageRoutes, ExitPredicates. Discriminated unions (executor, predicate) are single tagged structs with kind tags plus runtime validation, per spec section 9 note 2.
- **Runtime state shapes** (`types.go`): RunState, StageState, LoopState, RunSummary, EngineState (+ LoopKey/EmptyEngineState), PredicateCtx, Artifact/ArtifactInput; JSON tags match the old ISO shapes so T3 can snapshot them.
- **Predicate DSL** (`predicate.go`): all_pass, any_pass, majority_pass, no_open_findings, finding_count_below, loop_rounds_at_least, stage_retried_at_least, stage_verdict, and/or/not. Hand-written recursive Validate with path-annotated issues (the Go replacement for the old Zod z.lazy schema, spec section 9 note 1) and ReferencedStages() (port of predicateReferencedStages).
- **Events/effects** (`events.go`): sealed Event/Effect interfaces with the 10 v1 events and 7 v1 effects; every event carries a driver-stamped Now so the reducer stays pure.
- **Config parsing** (`config.go`): ParseDefinition for single-document YAML (strict decode via KnownFields), collecting every violation into one ValidationError (rules ported from the old superRefine: duplicate/unknown/self stage refs, per-kind executor fields, numeric bounds, scope/trigger gating, exitPredicates refs). ValidateDAG for programmatically built Pipelines.
- **Cycle detection** (`dag.go`): FindFirstStageCycle port; combined dependsOn + routes-refs graph, iterative DFS, first cycle in declaration order, trivial self-loops left to the self-reference checks.
- **Agent-mode check** (`validation.go`): ValidateAgentModes ported against a narrow TaskModeResolver seam, since the Go rewrite has no plugin registry; T4/T5 wire the real resolver.
- **JSON-schema mirror** (`schema.go` + `schema.json`): hand-written draft 2020-12 schema of the YAML definition document, embedded and exposed via ConfigJSONSchema() for the T9 definitions editor. A drift-guard test asserts every Go enum constant appears in the schema.

## Intentional deviations from the old TypeScript

- Single-document YAML per definition with required `name` (definitions are SQLite CRUD rows in v1; the old map-keyed `pipelines:` file format and key-derived name/id are dropped per spec sections 3 and 4b).
- Dropped, per spec: `v0_default`, legacy allSucceeded/anySucceeded/anyFailed normalization, workstream predicates, followup events/effects.
- Kept `stage_retried_at_least`: it is part of the old typed DSL and the T2 evaluator's contract, even though the spec's short DSL list omits it.
- `allowForkPRs` is accepted in config (the old Zod schema forgot it even though the runtime type had it).
- Cross-kind fields on executors/predicates are rejected with named issues instead of silently stripped (better editor UX; server-side validation is the editor's source of truth per spec 4b).
- Scope accepts only `worker` (or empty) in v1; `orchestrator`/`workstream` are rejected with a "deferred to phase 2" message.

## Tests

83 subtests: YAML round-trip (all three executor kinds, nested composite predicates, all exit branches) plus JSON re-round-trip; one rejection case per validation rule plus a consolidated multi-issue case; predicate parse/validate incl. deep nesting and path assertions; cycle detection (direct, transitive, routes-only edge, self-loop exclusion, diamond, disconnected); agent-mode resolver cases; schema drift guard.

`gofmt` clean, `go vet ./...` clean, `go build ./...` and `go test ./internal/pipeline/` green. Full `go test ./...` matches the base branch (4 pre-existing local failures in internal/cli/spawn_test.go from a daemon dependency, unrelated; this package is not imported anywhere yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)