### PR TITLE
feat(pipeline): T2 engine core (reducer + DAG scheduler + predicate evaluator)

### DIFF
--- a/backend/internal/pipeline/engine_test_helpers_test.go
+++ b/backend/internal/pipeline/engine_test_helpers_test.go
@@ -1,0 +1,116 @@
+package pipeline
+
+import (
+	"testing"
+	"time"
+)
+
+// Shared constructors for the reducer / scheduler / evaluator tests.
+
+func intPtr(i int) *int { return &i }
+
+// testNow is a fixed clock; the reducer is pure so any stable value works.
+var testNow = time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+
+// stageDef builds a Stage with the given name and dependsOn edges.
+func stageDef(name string, dependsOn ...string) Stage {
+	return Stage{Name: name, DependsOn: dependsOn}
+}
+
+// withRoutes returns a copy of s with a routes.when predicate attached.
+func withRoutes(s Stage, when Predicate) Stage {
+	s.Routes = &StageRoutes{When: when}
+	return s
+}
+
+// pipelineOf builds a Pipeline from stages with an optional concurrency cap.
+func pipelineOf(name string, maxConcurrent int, stages ...Stage) Pipeline {
+	p := Pipeline{ID: "pl-1", Name: name, Stages: stages}
+	if maxConcurrent > 0 {
+		p.MaxConcurrentStages = intPtr(maxConcurrent)
+	}
+	return p
+}
+
+// stageRunIDsFor allocates one StageRunID per stage, mirroring the driver.
+func stageRunIDsFor(p Pipeline) map[string]StageRunID {
+	out := make(map[string]StageRunID, len(p.Stages))
+	for _, s := range p.Stages {
+		out[s.Name] = StageRunID("sr-" + s.Name)
+	}
+	return out
+}
+
+// runState builds a RunState with the given stage statuses (keyed by name).
+// Every stage gets a stable stageRunId and attempt 1 unless overridden later.
+func runState(runID RunID, p Pipeline, statuses map[string]StageStatus) RunState {
+	stages := make(map[string]StageState, len(p.Stages))
+	for _, s := range p.Stages {
+		st := StageState{StageRunID: StageRunID("sr-" + s.Name), Status: StageStatusPending, Attempt: 1}
+		if status, ok := statuses[s.Name]; ok {
+			st.Status = status
+		}
+		stages[s.Name] = st
+	}
+	return RunState{
+		RunID:                  runID,
+		PipelineID:             p.ID,
+		PipelineName:           p.Name,
+		SessionID:              "sess-1",
+		PipelineConfigSnapshot: p,
+		HeadSHA:                "sha-1",
+		LoopState:              LoopRunning,
+		LoopRounds:             1,
+		Stages:                 stages,
+		CreatedAt:              testNow,
+		UpdatedAt:              testNow,
+	}
+}
+
+// engineWith puts a single run into an otherwise-empty engine state, marking it
+// active for its loop key.
+func engineWith(run RunState) EngineState {
+	st := EmptyEngineState()
+	st.Runs[run.RunID] = run
+	st.CurrentRunByLoop[LoopKey(run.SessionID, run.PipelineName)] = run.RunID
+	return st
+}
+
+// effectsByType groups effects by their EffectType for assertion convenience.
+func effectsByType(effects []Effect) map[EffectType][]Effect {
+	out := map[EffectType][]Effect{}
+	for _, e := range effects {
+		out[e.Type()] = append(out[e.Type()], e)
+	}
+	return out
+}
+
+// startedStageNames returns the stage names of every START_STAGE effect, in
+// emission order.
+func startedStageNames(effects []Effect) []string {
+	var out []string
+	for _, e := range effects {
+		if s, ok := e.(StartStage); ok {
+			out = append(out, s.Stage.Name)
+		}
+	}
+	return out
+}
+
+// requireEffect fails the test unless exactly one effect of the given type is
+// present, returning it.
+func requireOneEffect[T Effect](t *testing.T, effects []Effect) T {
+	t.Helper()
+	var found T
+	count := 0
+	for _, e := range effects {
+		if v, ok := e.(T); ok {
+			found = v
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one %T effect, got %d", found, count)
+	}
+	return found
+}

--- a/backend/internal/pipeline/evaluator.go
+++ b/backend/internal/pipeline/evaluator.go
@@ -1,0 +1,160 @@
+package pipeline
+
+// Pure predicate evaluator for the typed Predicate DSL.
+//
+// Used by:
+//   - the DAG scheduler (scheduler.go) to decide whether a stage's
+//     routes.when predicate is satisfied and the stage should run vs skip, and
+//   - the reducer (reducer.go) to decide the run's exit state (done / stalled)
+//     when pipeline.exitPredicates is configured.
+//
+// Purity: no I/O, no clock reads, no package-level state. Every input is in
+// PredicateCtx. Stages referenced by name are looked up in ctx.Run.Stages;
+// unknown names degrade to false for positive checks (we never green-light on
+// missing data), but not() flips that to true. Config validation catches
+// dangling stage names at load time so the runtime never sees them.
+//
+// Ported from the old TypeScript predicate-evaluator.ts, minus the dropped
+// v0_default kind, the legacy allSucceeded/anySucceeded/anyFailed
+// normalization, and the deferred workstream predicates.
+
+// Evaluate reports whether p is satisfied against ctx.
+func Evaluate(p Predicate, ctx PredicateCtx) bool {
+	switch p.Kind {
+	case PredicateAllPass:
+		for _, name := range p.Stages {
+			if !isSucceeded(ctx.stage(name)) {
+				return false
+			}
+		}
+		return true
+	case PredicateAnyPass:
+		for _, name := range p.Stages {
+			if isSucceeded(ctx.stage(name)) {
+				return true
+			}
+		}
+		return false
+	case PredicateMajorityPass:
+		if len(p.Stages) == 0 {
+			return false
+		}
+		passed := 0
+		for _, name := range p.Stages {
+			if isSucceeded(ctx.stage(name)) {
+				passed++
+			}
+		}
+		return passed*2 > len(p.Stages)
+	case PredicateNoOpenFindings:
+		return countOpenFindings(ctx.Findings, p.Stage, "") == 0
+	case PredicateFindingCountBelow:
+		if p.Max == nil {
+			// Guarded by config validation; treat a missing bound as
+			// unsatisfiable rather than panicking.
+			return false
+		}
+		return countOpenFindings(ctx.Findings, p.Stage, p.Severity) < *p.Max
+	case PredicateLoopRoundsAtLeast:
+		if p.N == nil || ctx.Run == nil {
+			return false
+		}
+		return ctx.Run.LoopRounds >= *p.N
+	case PredicateStageRetriedAtLeast:
+		if p.N == nil {
+			return false
+		}
+		stage := ctx.stage(p.Stage)
+		if stage == nil {
+			return false
+		}
+		return stage.Attempt >= *p.N
+	case PredicateStageVerdict:
+		stage := ctx.stage(p.Stage)
+		if stage == nil {
+			return false
+		}
+		return effectiveVerdict(*stage) == p.Verdict
+	case PredicateAnd:
+		for i := range p.Predicates {
+			if !Evaluate(p.Predicates[i], ctx) {
+				return false
+			}
+		}
+		return true
+	case PredicateOr:
+		for i := range p.Predicates {
+			if Evaluate(p.Predicates[i], ctx) {
+				return true
+			}
+		}
+		return false
+	case PredicateNot:
+		if p.Predicate == nil {
+			return false
+		}
+		return !Evaluate(*p.Predicate, ctx)
+	default:
+		// Unknown kind: config validation rejects these before runtime, and we
+		// never green-light on data we don't understand.
+		return false
+	}
+}
+
+// stage looks up a stage's runtime state by name, returning nil when the run
+// or the stage is absent.
+func (ctx PredicateCtx) stage(name string) *StageState {
+	if ctx.Run == nil {
+		return nil
+	}
+	s, ok := ctx.Run.Stages[name]
+	if !ok {
+		return nil
+	}
+	return &s
+}
+
+func isSucceeded(s *StageState) bool {
+	return s != nil && s.Status == StageStatusSucceeded
+}
+
+// effectiveVerdict maps a stage's lifecycle status onto a Verdict so
+// stage_verdict queries work even for stages that carry no explicit verdict:
+// an explicit verdict always wins; succeeded => pass; failed => fail;
+// everything else (pending/running/skipped/outdated) => neutral.
+func effectiveVerdict(s StageState) Verdict {
+	if s.Verdict != "" {
+		return s.Verdict
+	}
+	switch s.Status {
+	case StageStatusSucceeded:
+		return VerdictPass
+	case StageStatusFailed:
+		return VerdictFail
+	default:
+		return VerdictNeutral
+	}
+}
+
+// countOpenFindings counts open finding artifacts, optionally filtered by
+// stage name and severity (empty filters match any).
+func countOpenFindings(findings []Artifact, stageName string, severity Severity) int {
+	count := 0
+	for i := range findings {
+		a := &findings[i]
+		if a.Kind != ArtifactKindFinding {
+			continue
+		}
+		if a.Status != ArtifactStatusOpen {
+			continue
+		}
+		if stageName != "" && a.StageName != stageName {
+			continue
+		}
+		if severity != "" && a.Severity != severity {
+			continue
+		}
+		count++
+	}
+	return count
+}

--- a/backend/internal/pipeline/evaluator_test.go
+++ b/backend/internal/pipeline/evaluator_test.go
@@ -1,0 +1,249 @@
+package pipeline
+
+import "testing"
+
+// stagesWith builds a bare run whose stages carry the given statuses (and
+// optional verdicts/attempts), for evaluator table tests.
+func evalRun(stages map[string]StageState, loopRounds int) *RunState {
+	return &RunState{Stages: stages, LoopRounds: loopRounds}
+}
+
+func openFinding(stage string, sev Severity) Artifact {
+	return Artifact{
+		ArtifactInput: ArtifactInput{Kind: ArtifactKindFinding, Severity: sev},
+		StageName:     stage,
+		Status:        ArtifactStatusOpen,
+	}
+}
+
+func TestEvaluate(t *testing.T) {
+	succeeded := StageState{Status: StageStatusSucceeded}
+	failed := StageState{Status: StageStatusFailed}
+	running := StageState{Status: StageStatusRunning}
+
+	tests := []struct {
+		name string
+		p    Predicate
+		ctx  PredicateCtx
+		want bool
+	}{
+		{
+			name: "all_pass true when every stage succeeded",
+			p:    Predicate{Kind: PredicateAllPass, Stages: []string{"a", "b"}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": succeeded, "b": succeeded}, 1)},
+			want: true,
+		},
+		{
+			name: "all_pass false when one failed",
+			p:    Predicate{Kind: PredicateAllPass, Stages: []string{"a", "b"}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": succeeded, "b": failed}, 1)},
+			want: false,
+		},
+		{
+			name: "all_pass false on missing stage (never green-light on missing data)",
+			p:    Predicate{Kind: PredicateAllPass, Stages: []string{"a", "ghost"}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": succeeded}, 1)},
+			want: false,
+		},
+		{
+			name: "any_pass true when one succeeded",
+			p:    Predicate{Kind: PredicateAnyPass, Stages: []string{"a", "b"}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": failed, "b": succeeded}, 1)},
+			want: true,
+		},
+		{
+			name: "any_pass false when none succeeded",
+			p:    Predicate{Kind: PredicateAnyPass, Stages: []string{"a", "b"}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": failed, "b": running}, 1)},
+			want: false,
+		},
+		{
+			name: "majority_pass true (2 of 3)",
+			p:    Predicate{Kind: PredicateMajorityPass, Stages: []string{"a", "b", "c"}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": succeeded, "b": succeeded, "c": failed}, 1)},
+			want: true,
+		},
+		{
+			name: "majority_pass false on exact tie (1 of 2)",
+			p:    Predicate{Kind: PredicateMajorityPass, Stages: []string{"a", "b"}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": succeeded, "b": failed}, 1)},
+			want: false,
+		},
+		{
+			name: "majority_pass false on empty stage list",
+			p:    Predicate{Kind: PredicateMajorityPass, Stages: []string{}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{}, 1)},
+			want: false,
+		},
+		{
+			name: "no_open_findings true with no findings",
+			p:    Predicate{Kind: PredicateNoOpenFindings},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{}, 1)},
+			want: true,
+		},
+		{
+			name: "no_open_findings false when an open finding exists",
+			p:    Predicate{Kind: PredicateNoOpenFindings},
+			ctx: PredicateCtx{
+				Run:      evalRun(map[string]StageState{}, 1),
+				Findings: []Artifact{openFinding("a", SeverityError)},
+			},
+			want: false,
+		},
+		{
+			name: "no_open_findings scoped to a stage ignores other stages",
+			p:    Predicate{Kind: PredicateNoOpenFindings, Stage: "a"},
+			ctx: PredicateCtx{
+				Run:      evalRun(map[string]StageState{}, 1),
+				Findings: []Artifact{openFinding("b", SeverityError)},
+			},
+			want: true,
+		},
+		{
+			name: "no_open_findings ignores dismissed findings",
+			p:    Predicate{Kind: PredicateNoOpenFindings},
+			ctx: PredicateCtx{
+				Run: evalRun(map[string]StageState{}, 1),
+				Findings: []Artifact{{
+					ArtifactInput: ArtifactInput{Kind: ArtifactKindFinding},
+					StageName:     "a", Status: ArtifactStatusDismissed,
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "finding_count_below true when count under max",
+			p:    Predicate{Kind: PredicateFindingCountBelow, Max: intPtr(2)},
+			ctx: PredicateCtx{
+				Run:      evalRun(map[string]StageState{}, 1),
+				Findings: []Artifact{openFinding("a", SeverityError)},
+			},
+			want: true,
+		},
+		{
+			name: "finding_count_below false when count equals max",
+			p:    Predicate{Kind: PredicateFindingCountBelow, Max: intPtr(1)},
+			ctx: PredicateCtx{
+				Run:      evalRun(map[string]StageState{}, 1),
+				Findings: []Artifact{openFinding("a", SeverityError)},
+			},
+			want: false,
+		},
+		{
+			name: "finding_count_below filters by severity",
+			p:    Predicate{Kind: PredicateFindingCountBelow, Max: intPtr(1), Severity: SeverityError},
+			ctx: PredicateCtx{
+				Run:      evalRun(map[string]StageState{}, 1),
+				Findings: []Artifact{openFinding("a", SeverityWarning), openFinding("a", SeverityWarning)},
+			},
+			want: true, // zero errors < 1 even though two warnings exist
+		},
+		{
+			name: "loop_rounds_at_least true",
+			p:    Predicate{Kind: PredicateLoopRoundsAtLeast, N: intPtr(3)},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{}, 3)},
+			want: true,
+		},
+		{
+			name: "loop_rounds_at_least false",
+			p:    Predicate{Kind: PredicateLoopRoundsAtLeast, N: intPtr(3)},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{}, 2)},
+			want: false,
+		},
+		{
+			name: "stage_retried_at_least true",
+			p:    Predicate{Kind: PredicateStageRetriedAtLeast, Stage: "a", N: intPtr(2)},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": {Status: StageStatusFailed, Attempt: 2}}, 1)},
+			want: true,
+		},
+		{
+			name: "stage_retried_at_least false on missing stage",
+			p:    Predicate{Kind: PredicateStageRetriedAtLeast, Stage: "ghost", N: intPtr(1)},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{}, 1)},
+			want: false,
+		},
+		{
+			name: "stage_verdict maps succeeded to pass",
+			p:    Predicate{Kind: PredicateStageVerdict, Stage: "a", Verdict: VerdictPass},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": succeeded}, 1)},
+			want: true,
+		},
+		{
+			name: "stage_verdict maps failed to fail",
+			p:    Predicate{Kind: PredicateStageVerdict, Stage: "a", Verdict: VerdictFail},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": failed}, 1)},
+			want: true,
+		},
+		{
+			name: "stage_verdict explicit verdict wins over status mapping",
+			p:    Predicate{Kind: PredicateStageVerdict, Stage: "a", Verdict: VerdictNeutral},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": {Status: StageStatusSucceeded, Verdict: VerdictNeutral}}, 1)},
+			want: true,
+		},
+		{
+			name: "stage_verdict running maps to neutral",
+			p:    Predicate{Kind: PredicateStageVerdict, Stage: "a", Verdict: VerdictNeutral},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": running}, 1)},
+			want: true,
+		},
+		{
+			name: "and true when both branches true",
+			p: Predicate{Kind: PredicateAnd, Predicates: []Predicate{
+				{Kind: PredicateAllPass, Stages: []string{"a"}},
+				{Kind: PredicateLoopRoundsAtLeast, N: intPtr(1)},
+			}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": succeeded}, 1)},
+			want: true,
+		},
+		{
+			name: "and false when one branch false",
+			p: Predicate{Kind: PredicateAnd, Predicates: []Predicate{
+				{Kind: PredicateAllPass, Stages: []string{"a"}},
+				{Kind: PredicateAllPass, Stages: []string{"b"}},
+			}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": succeeded, "b": failed}, 1)},
+			want: false,
+		},
+		{
+			name: "or true when one branch true",
+			p: Predicate{Kind: PredicateOr, Predicates: []Predicate{
+				{Kind: PredicateAllPass, Stages: []string{"a"}},
+				{Kind: PredicateAllPass, Stages: []string{"b"}},
+			}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": failed, "b": succeeded}, 1)},
+			want: true,
+		},
+		{
+			name: "not flips a false leaf to true (unknown stage)",
+			p:    Predicate{Kind: PredicateNot, Predicate: &Predicate{Kind: PredicateAllPass, Stages: []string{"ghost"}}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{}, 1)},
+			want: true,
+		},
+		{
+			name: "nested composite: (a AND (NOT b_pass)) OR loop>=5",
+			p: Predicate{Kind: PredicateOr, Predicates: []Predicate{
+				{Kind: PredicateAnd, Predicates: []Predicate{
+					{Kind: PredicateAllPass, Stages: []string{"a"}},
+					{Kind: PredicateNot, Predicate: &Predicate{Kind: PredicateAllPass, Stages: []string{"b"}}},
+				}},
+				{Kind: PredicateLoopRoundsAtLeast, N: intPtr(5)},
+			}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": succeeded, "b": failed}, 1)},
+			want: true,
+		},
+		{
+			name: "routes-time context with empty history still evaluates leaves",
+			p:    Predicate{Kind: PredicateAnyPass, Stages: []string{"a"}},
+			ctx:  PredicateCtx{Run: evalRun(map[string]StageState{"a": succeeded}, 1), History: nil},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Evaluate(tt.p, tt.ctx); got != tt.want {
+				t.Fatalf("Evaluate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/pipeline/fingerprint_test.go
+++ b/backend/internal/pipeline/fingerprint_test.go
@@ -1,0 +1,51 @@
+package pipeline
+
+import "testing"
+
+func TestComputeFindingFingerprint(t *testing.T) {
+	base := findingInput("x.go", "bug", "correctness", SeverityError)
+
+	t.Run("stable and 16 hex chars", func(t *testing.T) {
+		fp := computeFindingFingerprint(base, "review")
+		if len(fp) != 16 {
+			t.Fatalf("fingerprint length = %d, want 16", len(fp))
+		}
+		if fp != computeFindingFingerprint(base, "review") {
+			t.Fatal("fingerprint should be deterministic")
+		}
+	})
+
+	t.Run("stage name is part of the identity", func(t *testing.T) {
+		if computeFindingFingerprint(base, "review") == computeFindingFingerprint(base, "lint") {
+			t.Fatal("different stages must yield different fingerprints")
+		}
+	})
+
+	t.Run("anchorSignature overrides the line-range anchor", func(t *testing.T) {
+		withAnchor := base
+		withAnchor.AnchorSignature = "func Foo"
+		if computeFindingFingerprint(withAnchor, "review") == computeFindingFingerprint(base, "review") {
+			t.Fatal("anchor signature should change the fingerprint")
+		}
+		// Same anchor signature is stable even if the line range shifts.
+		moved := withAnchor
+		moved.StartLine, moved.EndLine = 99, 120
+		if computeFindingFingerprint(withAnchor, "review") != computeFindingFingerprint(moved, "review") {
+			t.Fatal("anchor-based fingerprint should be stable across line moves")
+		}
+	})
+
+	t.Run("materializeArtifact only fingerprints findings", func(t *testing.T) {
+		jsonArt := materializeArtifact(ArtifactInput{Kind: ArtifactKindJSON}, "r1", "sr-a", "a", 0, testNow)
+		if jsonArt.Fingerprint != "" {
+			t.Fatal("JSON artifacts must not carry a fingerprint")
+		}
+		finding := materializeArtifact(base, "r1", "sr-a", "a", 0, testNow)
+		if finding.Fingerprint == "" {
+			t.Fatal("finding artifacts must carry a fingerprint")
+		}
+		if finding.ArtifactID != "sr-a-0" {
+			t.Fatalf("artifactId = %v, want sr-a-0", finding.ArtifactID)
+		}
+	})
+}

--- a/backend/internal/pipeline/reducer.go
+++ b/backend/internal/pipeline/reducer.go
@@ -1,0 +1,531 @@
+package pipeline
+
+import "time"
+
+// Pure pipeline reducer.
+//
+// Signature: Reduce(state, event) -> (state', effects). The reducer is
+// synchronous and pure: it never reads the clock and never performs I/O. Every
+// event carries a driver-stamped Now so timestamps are fixed at enqueue time.
+// Effects are intent-only; the engine (a later task) executes them and feeds
+// results back as new events.
+//
+// Ported from the old TypeScript reducer.ts, minus the deferred USER_FOLLOWUP /
+// FOLLOWUP_REPLY events (phase 2) and the dropped v0_default exit-predicate
+// placeholder (greenfield).
+
+// Reduce applies event to state, returning the next state and the effects the
+// driver must execute. The input state is never mutated.
+func Reduce(state EngineState, event Event) (EngineState, []Effect) {
+	switch e := event.(type) {
+	case TriggerFired:
+		return reduceTriggerFired(state, e)
+	case StageStarted:
+		return reduceStageStarted(state, e)
+	case StageCompleted:
+		return reduceStageCompleted(state, e)
+	case StageFailed:
+		return reduceStageFailed(state, e)
+	case NewSHADetected:
+		return reduceNewSHADetected(state, e)
+	case RunCancelled:
+		return reduceRunCancelled(state, e)
+	case RunResumed:
+		return reduceRunResumed(state, e)
+	case ConfigChanged:
+		return reduceConfigChanged(state, e)
+	case ArtifactStatusChanged:
+		return reduceArtifactStatusChanged(state, e)
+	case Tick:
+		// Heartbeat: nothing time-based to re-evaluate in the pure reducer.
+		return state, nil
+	default:
+		return invalidTransition(state, "unknown event type")
+	}
+}
+
+func reduceTriggerFired(state EngineState, event TriggerFired) (EngineState, []Effect) {
+	now := event.Now
+	key := LoopKey(event.SessionID, event.Pipeline.Name)
+
+	if runID, ok := state.CurrentRunByLoop[key]; ok {
+		if _, running := state.Runs[runID]; running {
+			// An active run is already in flight for this loop; the driver must
+			// cancel it (NEW_SHA_DETECTED or RUN_CANCELLED) before a new run
+			// can start.
+			return state, nil
+		}
+	}
+
+	stages, ok := buildInitialStageStates(event.Pipeline, event.StageRunIDs)
+	if !ok {
+		return invalidTransition(state, "TRIGGER_FIRED missing stageRunIds for one or more stages")
+	}
+
+	priorRound := len(state.HistorySummaries[key])
+	isContinuation := event.Trigger == TriggerPRUpdated || event.Trigger == TriggerManual
+	loopRounds := priorRound
+	if isContinuation {
+		loopRounds = priorRound + 1
+	} else if loopRounds < 1 {
+		loopRounds = 1
+	}
+
+	initialRun := RunState{
+		RunID:                  event.RunID,
+		PipelineID:             event.Pipeline.ID,
+		PipelineName:           event.Pipeline.Name,
+		SessionID:              event.SessionID,
+		PipelineConfigSnapshot: event.Pipeline,
+		HeadSHA:                event.HeadSHA,
+		LoopState:              LoopRunning,
+		LoopRounds:             loopRounds,
+		Stages:                 stages,
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	// Run the DAG scheduler once at trigger time so vacuous routes get a single
+	// skip decision instead of sitting pending forever, and parallel-startable
+	// stages emit START_STAGE in one shot.
+	sched := scheduleAfterChange(initialRun, now)
+	runState := sched.run
+
+	createdObs := EmitObservation{
+		Name: "pipeline.run.created",
+		Data: map[string]any{
+			"runId":        event.RunID,
+			"pipelineName": event.Pipeline.Name,
+			"sessionId":    event.SessionID,
+			"trigger":      event.Trigger,
+			"headSha":      event.HeadSHA,
+			"loopRounds":   loopRounds,
+		},
+	}
+
+	// Cascade-skipping into a fully-terminal pipeline at trigger time is only
+	// possible with degenerate predicates. Terminate cleanly rather than
+	// leaving an orphaned record.
+	if sched.allTerminal {
+		stateWithRun := replaceRun(state, runState)
+		stateWithRun = withCurrentRun(stateWithRun, key, event.RunID)
+		preceding := append([]Effect{createdObs}, skipObservations(runState.RunID, sched.newlySkipped, runState)...)
+		decision := decideRunExit(runState, stateWithRun)
+		return terminateRunFromState(stateWithRun, runState, decision.reason, now, decision.loopState, preceding)
+	}
+
+	nextState := replaceRun(state, runState)
+	nextState = withCurrentRun(nextState, key, event.RunID)
+
+	effects := []Effect{
+		PersistRun{RunState: runState},
+		PersistLoopState{RunID: event.RunID, LoopState: deriveLoopStateFromRun(runState, now)},
+	}
+	effects = append(effects, sched.startEffects...)
+	effects = append(effects, createdObs)
+	effects = append(effects, skipObservations(runState.RunID, sched.newlySkipped, runState)...)
+
+	return nextState, effects
+}
+
+// withCurrentRun returns a copy of state with key pointing at runID in
+// CurrentRunByLoop (copy-on-write).
+func withCurrentRun(state EngineState, key string, runID RunID) EngineState {
+	current := make(map[string]RunID, len(state.CurrentRunByLoop)+1)
+	for k, v := range state.CurrentRunByLoop {
+		current[k] = v
+	}
+	current[key] = runID
+	state.CurrentRunByLoop = current
+	return state
+}
+
+// skipObservations builds pipeline.stage.terminated observations for stages the
+// DAG scheduler just skipped, mirroring the shape emitted by
+// finalizeStageCompletion so consumers need no per-source schema.
+func skipObservations(runID RunID, skippedNames []string, run RunState) []Effect {
+	out := make([]Effect, 0, len(skippedNames))
+	for _, name := range skippedNames {
+		artifactCount := 0
+		if s, ok := run.Stages[name]; ok {
+			artifactCount = len(s.Artifacts)
+		}
+		out = append(out, EmitObservation{
+			Name: "pipeline.stage.terminated",
+			Data: map[string]any{
+				"runId":         runID,
+				"stageName":     name,
+				"status":        StageStatusSkipped,
+				"artifactCount": artifactCount,
+			},
+		})
+	}
+	return out
+}
+
+func reduceStageStarted(state EngineState, event StageStarted) (EngineState, []Effect) {
+	now := event.Now
+	run, ok := state.Runs[event.RunID]
+	if !ok {
+		return invalidTransition(state, "STAGE_STARTED for unknown runId="+string(event.RunID))
+	}
+	stage, ok := run.Stages[event.StageName]
+	if !ok {
+		return invalidTransition(state, "STAGE_STARTED for unknown stage="+event.StageName)
+	}
+	if stage.Status != StageStatusPending {
+		return invalidTransition(state, "STAGE_STARTED requires pending; got "+string(stage.Status)+" for "+event.StageName)
+	}
+
+	started := now
+	updatedStage := stage
+	updatedStage.Status = StageStatusRunning
+	updatedStage.StartedAt = &started
+	updatedRun := patchRun(run, map[string]StageState{event.StageName: updatedStage}, now)
+
+	return replaceRun(state, updatedRun), []Effect{
+		PersistRun{RunState: updatedRun},
+		EmitObservation{
+			Name: "pipeline.stage.started",
+			// stageRunId rotates on every retry/revival, so it is the only
+			// field that uniquely identifies this execution: attempt is not
+			// enough now that outdated revival keeps the counter unchanged.
+			Data: map[string]any{
+				"runId":      event.RunID,
+				"stageName":  event.StageName,
+				"stageRunId": stage.StageRunID,
+				"attempt":    stage.Attempt,
+			},
+		},
+	}
+}
+
+func reduceStageCompleted(state EngineState, event StageCompleted) (EngineState, []Effect) {
+	now := event.Now
+	run, ok := state.Runs[event.RunID]
+	if !ok {
+		return invalidTransition(state, "STAGE_COMPLETED for unknown runId="+string(event.RunID))
+	}
+	stage, ok := run.Stages[event.StageName]
+	if !ok {
+		return invalidTransition(state, "STAGE_COMPLETED for unknown stage="+event.StageName)
+	}
+	if stage.Status != StageStatusRunning {
+		return invalidTransition(state, "STAGE_COMPLETED requires running; got "+string(stage.Status)+" for "+event.StageName)
+	}
+
+	newArtifacts := make([]Artifact, len(event.Artifacts))
+	newIDs := make([]ArtifactID, len(event.Artifacts))
+	for idx, input := range event.Artifacts {
+		a := materializeArtifact(input, event.RunID, stage.StageRunID, event.StageName, idx, now)
+		newArtifacts[idx] = a
+		newIDs[idx] = a.ArtifactID
+	}
+
+	completed := now
+	updatedStage := stage
+	updatedStage.Status = StageStatusSucceeded
+	updatedStage.CompletedAt = &completed
+	updatedStage.Verdict = event.Verdict
+	updatedStage.Artifacts = append(append([]ArtifactID{}, stage.Artifacts...), newIDs...)
+
+	return finalizeStageCompletion(state, run, event.StageName, updatedStage, newArtifacts, now)
+}
+
+func reduceStageFailed(state EngineState, event StageFailed) (EngineState, []Effect) {
+	now := event.Now
+	run, ok := state.Runs[event.RunID]
+	if !ok {
+		return invalidTransition(state, "STAGE_FAILED for unknown runId="+string(event.RunID))
+	}
+	stage, ok := run.Stages[event.StageName]
+	if !ok {
+		return invalidTransition(state, "STAGE_FAILED for unknown stage="+event.StageName)
+	}
+	if stage.Status != StageStatusRunning && stage.Status != StageStatusPending {
+		return invalidTransition(state, "STAGE_FAILED requires running|pending; got "+string(stage.Status)+" for "+event.StageName)
+	}
+
+	completed := now
+	updatedStage := stage
+	updatedStage.Status = StageStatusFailed
+	updatedStage.CompletedAt = &completed
+	updatedStage.ErrorMessage = event.ErrorMessage
+
+	return finalizeStageCompletion(state, run, event.StageName, updatedStage, nil, now)
+}
+
+// finalizeStageCompletion applies a stage's terminal status, materializes its
+// artifacts and fingerprints, re-runs the DAG scheduler for downstream stages,
+// and terminates the run (checking convergence then exit predicates) once every
+// stage is terminal. Shared by STAGE_COMPLETED and STAGE_FAILED.
+func finalizeStageCompletion(state EngineState, run RunState, stageName string, updatedStage StageState, newArtifacts []Artifact, now time.Time) (EngineState, []Effect) {
+	// Accumulate finding fingerprints onto the run so summarizeRun can return
+	// them at termination. Append rather than recompute so the reducer never
+	// re-reads stored artifacts.
+	var newFingerprints []string
+	var newFindings []Artifact
+	for i := range newArtifacts {
+		a := newArtifacts[i]
+		if a.Kind == ArtifactKindFinding {
+			if a.Fingerprint != "" {
+				newFingerprints = append(newFingerprints, a.Fingerprint)
+			}
+			newFindings = append(newFindings, a)
+		}
+	}
+
+	runWithFingerprints := run
+	if len(newFingerprints) > 0 {
+		runWithFingerprints.Fingerprints = append(append([]string{}, run.Fingerprints...), newFingerprints...)
+	}
+	updatedRun := patchRun(runWithFingerprints, map[string]StageState{stageName: updatedStage}, now)
+	// Mirror finding artifacts onto run.findings for the predicate evaluator.
+	if len(newFindings) > 0 {
+		updatedRun.Findings = append(append([]Artifact{}, run.Findings...), newFindings...)
+	}
+
+	var effects []Effect
+
+	if len(newArtifacts) > 0 {
+		effects = append(effects, AppendArtifacts{
+			RunID:      run.RunID,
+			StageRunID: updatedStage.StageRunID,
+			Artifacts:  newArtifacts,
+		})
+	}
+
+	effects = append(effects, EmitObservation{
+		Name: "pipeline.stage.terminated",
+		Data: map[string]any{
+			"runId":         run.RunID,
+			"stageName":     stageName,
+			"status":        updatedStage.Status,
+			"verdict":       updatedStage.Verdict,
+			"artifactCount": len(updatedStage.Artifacts),
+		},
+	})
+
+	// Failure-tolerant scheduling: STAGE_FAILED no longer immediately
+	// terminates the run. scheduleAfterChange cascade-skips stages whose
+	// dependsOn is no longer satisfiable AND starts any recovery branch whose
+	// routes predicate now matches the failure. The run terminates only once
+	// every stage is terminal.
+	sched := scheduleAfterChange(updatedRun, now)
+	effects = append(effects, skipObservations(run.RunID, sched.newlySkipped, sched.run)...)
+
+	if sched.allTerminal {
+		// Convergence detection runs BEFORE the regular exit decision: when the
+		// prior stallWindow-1 runs plus this one expose the same finding
+		// fingerprint set, terminate as converged -> stalled so a loop that hit
+		// a fixpoint doesn't ping-pong forever.
+		if isConverged(state, sched.run) {
+			return terminateRunFromState(replaceRun(state, sched.run), sched.run, TerminationConverged, now, LoopStalled, effects)
+		}
+		decision := decideRunExit(sched.run, state)
+		return terminateRunFromState(replaceRun(state, sched.run), sched.run, decision.reason, now, decision.loopState, effects)
+	}
+
+	// Not terminal: persist first, then start eligible stages.
+	out := make([]Effect, 0, len(effects)+1+len(sched.startEffects))
+	out = append(out, PersistRun{RunState: sched.run})
+	out = append(out, effects...)
+	out = append(out, sched.startEffects...)
+
+	return replaceRun(state, sched.run), out
+}
+
+func reduceNewSHADetected(state EngineState, event NewSHADetected) (EngineState, []Effect) {
+	key := LoopKey(event.SessionID, event.PipelineName)
+	runID, ok := state.CurrentRunByLoop[key]
+	if !ok {
+		return state, nil
+	}
+	run, ok := state.Runs[runID]
+	if !ok || run.HeadSHA == event.SHA {
+		return state, nil
+	}
+	// Run becomes outdated; the loop key is freed so the driver can spawn a new
+	// TRIGGER_FIRED for the new SHA.
+	return terminateRun(state, run, TerminationOutdated, event.Now, LoopTerminated)
+}
+
+func reduceRunCancelled(state EngineState, event RunCancelled) (EngineState, []Effect) {
+	run, ok := state.Runs[event.RunID]
+	if !ok {
+		return invalidTransition(state, "RUN_CANCELLED for unknown runId="+string(event.RunID))
+	}
+	if run.LoopState != LoopRunning && run.LoopState != LoopAwaitingContext {
+		return invalidTransition(state, "RUN_CANCELLED requires running|awaiting_context; got "+string(run.LoopState))
+	}
+	finalState := LoopTerminated
+	if event.Reason == TerminationStageFailure {
+		finalState = LoopStalled
+	}
+	return terminateRun(state, run, event.Reason, event.Now, finalState)
+}
+
+func reduceConfigChanged(state EngineState, event ConfigChanged) (EngineState, []Effect) {
+	key := LoopKey(event.SessionID, event.PipelineName)
+	runID, ok := state.CurrentRunByLoop[key]
+	if !ok {
+		return state, nil
+	}
+	run, ok := state.Runs[runID]
+	if !ok {
+		return state, nil
+	}
+	return terminateRun(state, run, TerminationConfigChange, event.Now, LoopTerminated)
+}
+
+func reduceArtifactStatusChanged(state EngineState, event ArtifactStatusChanged) (EngineState, []Effect) {
+	now := event.Now
+	run, ok := state.Runs[event.RunID]
+	if !ok {
+		return invalidTransition(state, "ARTIFACT_STATUS_CHANGED for unknown runId="+string(event.RunID))
+	}
+
+	updatedRun := run
+	idx := -1
+	for i := range run.Findings {
+		if run.Findings[i].ArtifactID == event.ArtifactID {
+			idx = i
+			break
+		}
+	}
+	if idx >= 0 {
+		findings := append([]Artifact{}, run.Findings...)
+		findings[idx].Status = event.Status
+		updatedRun.Findings = findings
+	}
+	updatedRun.UpdatedAt = now
+
+	effects := []Effect{
+		UpdateArtifactStatus{
+			RunID:      event.RunID,
+			StageRunID: event.StageRunID,
+			ArtifactID: event.ArtifactID,
+			Status:     event.Status,
+		},
+		PersistRun{RunState: updatedRun},
+		EmitObservation{
+			Name: "pipeline.artifact.status_changed",
+			Data: artifactStatusObsData(event),
+		},
+	}
+	return replaceRun(state, updatedRun), effects
+}
+
+func artifactStatusObsData(event ArtifactStatusChanged) map[string]any {
+	data := map[string]any{
+		"runId":      event.RunID,
+		"stageRunId": event.StageRunID,
+		"artifactId": event.ArtifactID,
+		"status":     event.Status,
+	}
+	if event.Actor != "" {
+		data["actor"] = event.Actor
+	}
+	return data
+}
+
+// buildInitialStageStates seeds one pending StageState per pipeline stage using
+// the driver-allocated stageRunIds. Returns false when any stage lacks an id.
+func buildInitialStageStates(pipeline Pipeline, stageRunIDs map[string]StageRunID) (map[string]StageState, bool) {
+	out := make(map[string]StageState, len(pipeline.Stages))
+	for _, stage := range pipeline.Stages {
+		id, ok := stageRunIDs[stage.Name]
+		if !ok || id == "" {
+			return nil, false
+		}
+		out[stage.Name] = StageState{
+			StageRunID: id,
+			Status:     StageStatusPending,
+			Attempt:    1,
+		}
+	}
+	return out, true
+}
+
+type exitDecision struct {
+	reason    RunTerminationReason
+	loopState LoopStateName
+}
+
+// decideRunExit chooses how a run terminates once every stage is terminal:
+//  1. exitPredicates.done true -> done/completed;
+//  2. exitPredicates.stalled true -> stalled/stage_failure;
+//  3. v0 default: any failed stage -> stalled/stage_failure, else done/completed.
+//
+// The reducer consults state.HistorySummaries for the run's loop key so
+// loop_rounds_at_least and history-aware composites have a real ledger.
+func decideRunExit(run RunState, state EngineState) exitDecision {
+	exits := run.PipelineConfigSnapshot.ExitPredicates
+	ctx := PredicateCtx{
+		Run:      &run,
+		History:  state.HistorySummaries[LoopKey(run.SessionID, run.PipelineName)],
+		Findings: run.Findings,
+	}
+
+	if exits != nil && exits.Done != nil && Evaluate(*exits.Done, ctx) {
+		return exitDecision{reason: TerminationCompleted, loopState: LoopDone}
+	}
+	if exits != nil && exits.Stalled != nil && Evaluate(*exits.Stalled, ctx) {
+		return exitDecision{reason: TerminationStageFailure, loopState: LoopStalled}
+	}
+	return v0DefaultExitDecision(run)
+}
+
+func v0DefaultExitDecision(run RunState) exitDecision {
+	for _, s := range run.Stages {
+		if s.Status == StageStatusFailed {
+			return exitDecision{reason: TerminationStageFailure, loopState: LoopStalled}
+		}
+	}
+	return exitDecision{reason: TerminationCompleted, loopState: LoopDone}
+}
+
+// isConverged reports whether the prior stallWindow-1 history summaries on this
+// loop plus the just-completed run all expose the same sorted-unique finding
+// fingerprint set. stallWindow is per-stage; the max across stages with the
+// policy set is used, and any stage with stallWindow >= 2 activates the check.
+// A window of 0 or 1 is meaningless (need at least two runs to detect
+// repetition) and disables the check.
+func isConverged(state EngineState, run RunState) bool {
+	window := 0
+	for _, stage := range run.PipelineConfigSnapshot.Stages {
+		if stage.Policy != nil && stage.Policy.StallWindow != nil && *stage.Policy.StallWindow > window {
+			window = *stage.Policy.StallWindow
+		}
+	}
+	if window < 2 {
+		return false
+	}
+
+	history := state.HistorySummaries[LoopKey(run.SessionID, run.PipelineName)]
+	if len(history) < window-1 {
+		return false
+	}
+
+	current := joinSortedUnique(run.Fingerprints)
+	recent := history[len(history)-(window-1):]
+	for i := range recent {
+		if joinSortedUnique(recent[i].Fingerprints) != current {
+			return false
+		}
+	}
+	return true
+}
+
+// joinSortedUnique renders a fingerprint set as a stable comparison key.
+func joinSortedUnique(in []string) string {
+	unique := sortedUnique(in)
+	out := ""
+	for i, s := range unique {
+		if i > 0 {
+			out += "|"
+		}
+		out += s
+	}
+	return out
+}

--- a/backend/internal/pipeline/reducer.go
+++ b/backend/internal/pipeline/reducer.go
@@ -117,10 +117,11 @@ func reduceTriggerFired(state EngineState, event TriggerFired) (EngineState, []E
 	nextState := replaceRun(state, runState)
 	nextState = withCurrentRun(nextState, key, event.RunID)
 
-	effects := []Effect{
+	effects := make([]Effect, 0, 3+len(sched.startEffects)+len(sched.newlySkipped))
+	effects = append(effects,
 		PersistRun{RunState: runState},
 		PersistLoopState{RunID: event.RunID, LoopState: deriveLoopStateFromRun(runState, now)},
-	}
+	)
 	effects = append(effects, sched.startEffects...)
 	effects = append(effects, createdObs)
 	effects = append(effects, skipObservations(runState.RunID, sched.newlySkipped, runState)...)

--- a/backend/internal/pipeline/reducer_helpers.go
+++ b/backend/internal/pipeline/reducer_helpers.go
@@ -1,0 +1,239 @@
+package pipeline
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// Internal helpers for the pipeline reducer.
+//
+// Pure: every function takes the driver-stamped clock as a parameter; nothing
+// here reads the clock or performs I/O. Ported from the old TypeScript
+// reducer-helpers.ts.
+
+// patchRun returns a copy of run with stageDelta merged into its stages map
+// and UpdatedAt bumped. The input run's map is never mutated.
+func patchRun(run RunState, stageDelta map[string]StageState, now time.Time) RunState {
+	stages := make(map[string]StageState, len(run.Stages)+len(stageDelta))
+	for k, v := range run.Stages {
+		stages[k] = v
+	}
+	for k, v := range stageDelta {
+		stages[k] = v
+	}
+	run.Stages = stages
+	run.UpdatedAt = now
+	return run
+}
+
+// replaceRun returns a copy of state with run stored under its RunID. The
+// input state's runs map is never mutated.
+func replaceRun(state EngineState, run RunState) EngineState {
+	runs := make(map[RunID]RunState, len(state.Runs))
+	for k, v := range state.Runs {
+		runs[k] = v
+	}
+	runs[run.RunID] = run
+	state.Runs = runs
+	return state
+}
+
+// deriveLoopStateFromRun projects a run onto its persistent LoopState record.
+// CurrentRunID is cleared once the run reaches a terminal loop state so the
+// driver can spawn a fresh run for the loop key.
+func deriveLoopStateFromRun(run RunState, now time.Time) LoopState {
+	current := run.RunID
+	if run.LoopState.IsTerminal() {
+		current = ""
+	}
+	return LoopState{
+		SessionID:    run.SessionID,
+		PipelineName: run.PipelineName,
+		LoopState:    run.LoopState,
+		LoopRounds:   run.LoopRounds,
+		LastSHA:      run.HeadSHA,
+		CurrentRunID: current,
+		UpdatedAt:    now,
+	}
+}
+
+// summarizeRun builds the compact cross-run history record. Fingerprints are
+// deduped and sorted so summaries are comparable across runs regardless of
+// discovery order.
+func summarizeRun(run RunState) RunSummary {
+	return RunSummary{
+		RunID:             run.RunID,
+		LoopState:         run.LoopState,
+		TerminationReason: run.TerminationReason,
+		HeadSHA:           run.HeadSHA,
+		LoopRounds:        run.LoopRounds,
+		Fingerprints:      sortedUnique(run.Fingerprints),
+		CreatedAt:         run.CreatedAt,
+	}
+}
+
+// sortedUnique returns the deduped, ascending-sorted copy of in. It always
+// returns a non-nil slice so JSON round-trips as [] rather than null, matching
+// the old TypeScript summaries.
+func sortedUnique(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// materializeArtifact promotes a stage-reported ArtifactInput into a persisted
+// Artifact, assigning the engine envelope (id, run/stage identity, open status,
+// createdAt) and, for findings, a stable fingerprint.
+func materializeArtifact(input ArtifactInput, runID RunID, stageRunID StageRunID, stageName string, index int, now time.Time) Artifact {
+	a := Artifact{
+		ArtifactInput: input,
+		ArtifactID:    ArtifactID(fmt.Sprintf("%s-%d", stageRunID, index)),
+		PipelineRunID: runID,
+		StageRunID:    stageRunID,
+		StageName:     stageName,
+		Status:        ArtifactStatusOpen,
+		CreatedAt:     now,
+	}
+	// Finding artifacts carry a stable fingerprint computed from the stage name
+	// + structural identity (filePath, anchor, category, title). This is what
+	// lets dismissals match across runs and drives stallWindow convergence
+	// detection.
+	if input.Kind == ArtifactKindFinding {
+		a.Fingerprint = computeFindingFingerprint(input, stageName)
+	}
+	return a
+}
+
+// computeFindingFingerprint hashes a finding's stage-scoped structural
+// identity. Ported verbatim from the old migrate.ts computeFindingFingerprint
+// (that file is otherwise dropped as greenfield): the anchor falls back to the
+// line range when no structural anchor signature is present, and the joined
+// parts are sha256'd and truncated to 16 hex chars.
+func computeFindingFingerprint(input ArtifactInput, stageName string) string {
+	anchor := input.AnchorSignature
+	if anchor == "" {
+		anchor = fmt.Sprintf("L%d:%d", input.StartLine, input.EndLine)
+	}
+	joined := stageName + "\x00" + input.FilePath + "\x00" + anchor + "\x00" + input.Category + "\x00" + input.Title
+	sum := sha256.Sum256([]byte(joined))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+// invalidTransition emits a single observation describing a rejected event and
+// leaves state untouched. Invalid events are logged, never fatal.
+func invalidTransition(state EngineState, message string) (EngineState, []Effect) {
+	return state, []Effect{
+		EmitObservation{
+			Name: "pipeline.invalid_transition",
+			Data: map[string]any{"message": message},
+		},
+	}
+}
+
+// terminateRunFromState terminates run with the given reason and final loop
+// state: non-terminal stages become outdated (if running) or skipped (if not),
+// running stages emit CANCEL_STAGE, the run is summarized into history, and the
+// loop key is freed when this run owned it. preceding effects are emitted ahead
+// of the cancel/persist/observation effects.
+func terminateRunFromState(state EngineState, run RunState, reason RunTerminationReason, now time.Time, finalLoopState LoopStateName, preceding []Effect) (EngineState, []Effect) {
+	var cancelEffects []Effect
+	terminatedStages := make(map[string]StageState, len(run.Stages))
+	for name, stage := range run.Stages {
+		if !stage.Status.IsTerminal() {
+			completed := now
+			next := stage
+			if stage.Status == StageStatusRunning {
+				next.Status = StageStatusOutdated
+			} else {
+				next.Status = StageStatusSkipped
+			}
+			next.CompletedAt = &completed
+			terminatedStages[name] = next
+			if stage.Status == StageStatusRunning {
+				cancelEffects = append(cancelEffects, CancelStage{
+					RunID:      run.RunID,
+					StageRunID: stage.StageRunID,
+					StageName:  name,
+				})
+			}
+		} else {
+			terminatedStages[name] = stage
+		}
+	}
+
+	finalRun := run
+	finalRun.Stages = terminatedStages
+	finalRun.LoopState = finalLoopState
+	finalRun.TerminationReason = reason
+	finalRun.UpdatedAt = now
+
+	key := LoopKey(run.SessionID, run.PipelineName)
+
+	// Append this run's summary to the loop's history (copy-on-write).
+	prior := state.HistorySummaries[key]
+	summaries := make([]RunSummary, len(prior), len(prior)+1)
+	copy(summaries, prior)
+	summaries = append(summaries, summarizeRun(finalRun))
+
+	histories := make(map[string][]RunSummary, len(state.HistorySummaries)+1)
+	for k, v := range state.HistorySummaries {
+		histories[k] = v
+	}
+	histories[key] = summaries
+
+	// Drop currentRunByLoop only when this run was the active one.
+	nextCurrent := make(map[string]RunID, len(state.CurrentRunByLoop))
+	for k, v := range state.CurrentRunByLoop {
+		if k == key && v == run.RunID {
+			continue
+		}
+		nextCurrent[k] = v
+	}
+
+	runs := make(map[RunID]RunState, len(state.Runs))
+	for k, v := range state.Runs {
+		runs[k] = v
+	}
+	runs[run.RunID] = finalRun
+
+	nextState := EngineState{
+		Runs:             runs,
+		CurrentRunByLoop: nextCurrent,
+		HistorySummaries: histories,
+	}
+
+	effects := make([]Effect, 0, len(preceding)+len(cancelEffects)+3)
+	effects = append(effects, preceding...)
+	effects = append(effects, cancelEffects...)
+	effects = append(effects,
+		PersistRun{RunState: finalRun},
+		PersistLoopState{RunID: run.RunID, LoopState: deriveLoopStateFromRun(finalRun, now)},
+		EmitObservation{
+			Name: "pipeline.run.terminated",
+			Data: map[string]any{
+				"runId":        run.RunID,
+				"pipelineName": run.PipelineName,
+				"reason":       reason,
+				"loopState":    finalLoopState,
+			},
+		},
+	)
+
+	return nextState, effects
+}
+
+// terminateRun is terminateRunFromState with no preceding effects.
+func terminateRun(state EngineState, run RunState, reason RunTerminationReason, now time.Time, finalLoopState LoopStateName) (EngineState, []Effect) {
+	return terminateRunFromState(state, run, reason, now, finalLoopState, nil)
+}

--- a/backend/internal/pipeline/reducer_resume.go
+++ b/backend/internal/pipeline/reducer_resume.go
@@ -1,0 +1,148 @@
+package pipeline
+
+// reduceRunResumed resumes a stalled/failed run: it resets every failed stage
+// back to pending with a fresh stageRunId (and incremented attempt, capped by
+// stage.Retries when set), revives externally-cancelled outdated stages
+// WITHOUT bumping attempt (they never really failed), re-pends cascade-skipped
+// stages so downstream branches aren't lost, then re-arms the loop pointer. It
+// no-ops when the run has nothing to resume.
+//
+// The retry/attempt distinction (spec §9 note 10) is load-bearing:
+//   - failed stages are real retries: attempt++ and consume the retries budget.
+//   - outdated stages were running when an external event (NEW_SHA_DETECTED,
+//     CONFIG_CHANGED, a parallel-sibling failure) forced terminateRunFromState
+//     to cancel them. That is not a stage failure, so reviving them must NOT
+//     consume the retry cap. They keep their attempt counter and just get a
+//     fresh stageRunId.
+func reduceRunResumed(state EngineState, event RunResumed) (EngineState, []Effect) {
+	now := event.Now
+	run, ok := state.Runs[event.RunID]
+	if !ok {
+		return invalidTransition(state, "RUN_RESUMED for unknown runId="+string(event.RunID))
+	}
+
+	// Resume only applies to runs that have stopped advancing. The service
+	// layer rejects non-terminal runs; this guard catches direct dispatch so
+	// the reducer never re-arms a run the engine still considers active.
+	if !run.LoopState.IsTerminal() {
+		return invalidTransition(state, "RUN_RESUMED requires a terminal loop state; got "+string(run.LoopState)+" for "+string(event.RunID))
+	}
+
+	// Refuse to resume when another run already owns the loop key: resuming an
+	// old stalled run after a fresh trigger claimed the loop would silently
+	// dispossess the active run of its loop pointer.
+	key := LoopKey(run.SessionID, run.PipelineName)
+	if activeRunID, present := state.CurrentRunByLoop[key]; present && activeRunID != event.RunID {
+		return invalidTransition(state, "RUN_RESUMED for "+string(event.RunID)+" but loop \""+key+"\" is already owned by active run "+string(activeRunID)+"; cancel that run before resuming the older one")
+	}
+
+	var failedStageNames, outdatedStageNames []string
+	// Iterate pipeline stages (not the map) so the resumed stage-name lists are
+	// in declaration order, giving deterministic observation payloads.
+	for _, def := range run.PipelineConfigSnapshot.Stages {
+		s, ok := run.Stages[def.Name]
+		if !ok {
+			continue
+		}
+		switch s.Status {
+		case StageStatusFailed:
+			failedStageNames = append(failedStageNames, def.Name)
+		case StageStatusOutdated:
+			outdatedStageNames = append(outdatedStageNames, def.Name)
+		}
+	}
+	if len(failedStageNames) == 0 && len(outdatedStageNames) == 0 {
+		// Nothing to resume; keep state unchanged so the caller can no-op too.
+		return state, nil
+	}
+
+	retriesByName := make(map[string]*int, len(run.PipelineConfigSnapshot.Stages))
+	for _, def := range run.PipelineConfigSnapshot.Stages {
+		retriesByName[def.Name] = def.Retries
+	}
+
+	stageDelta := make(map[string]StageState)
+
+	// Real retries: bump attempt, enforce the retries cap.
+	for _, name := range failedStageNames {
+		fresh, ok := event.StageRunIDs[name]
+		if !ok || fresh == "" {
+			return invalidTransition(state, "RUN_RESUMED missing stageRunId for failed stage \""+name+"\"")
+		}
+		prior := run.Stages[name]
+		if cap := retriesByName[name]; cap != nil && prior.Attempt >= *cap+1 {
+			return invalidTransition(state, "RUN_RESUMED would exceed stage.retries for \""+name+"\"")
+		}
+		stageDelta[name] = StageState{
+			StageRunID: fresh,
+			Status:     StageStatusPending,
+			Attempt:    prior.Attempt + 1,
+		}
+	}
+
+	// External cancellations: fresh stageRunId, but don't bump attempt or check
+	// the cap.
+	for _, name := range outdatedStageNames {
+		fresh, ok := event.StageRunIDs[name]
+		if !ok || fresh == "" {
+			return invalidTransition(state, "RUN_RESUMED missing stageRunId for outdated stage \""+name+"\"")
+		}
+		prior := run.Stages[name]
+		stageDelta[name] = StageState{
+			StageRunID: fresh,
+			Status:     StageStatusPending,
+			Attempt:    prior.Attempt,
+		}
+	}
+
+	// Revive stages that terminateRunFromState cascade-skipped when the run
+	// failed: they never got an execution attempt, so they keep their existing
+	// stageRunId, attempt, and artifacts. scheduleAfterChange re-skips any whose
+	// routes predicate is genuinely unsatisfied, so predicate-driven skips are
+	// not accidentally revived.
+	for name, prior := range run.Stages {
+		if prior.Status != StageStatusSkipped {
+			continue
+		}
+		if _, taken := stageDelta[name]; taken {
+			continue
+		}
+		stageDelta[name] = StageState{
+			StageRunID: prior.StageRunID,
+			Status:     StageStatusPending,
+			Attempt:    prior.Attempt,
+			Artifacts:  prior.Artifacts,
+		}
+	}
+
+	updatedRun := patchRun(run, stageDelta, now)
+	updatedRun.LoopState = LoopRunning
+	updatedRun.TerminationReason = ""
+
+	// Re-run the DAG scheduler so re-pending stages start in dependsOn order.
+	// Resumes never terminate the run on their own (we just transitioned back
+	// to running), so allTerminal is ignored.
+	sched := scheduleAfterChange(updatedRun, now)
+	finalRun := sched.run
+
+	nextState := replaceRun(state, finalRun)
+	nextState = withCurrentRun(nextState, key, event.RunID)
+
+	effects := []Effect{
+		PersistRun{RunState: finalRun},
+		PersistLoopState{RunID: event.RunID, LoopState: deriveLoopStateFromRun(finalRun, now)},
+	}
+	effects = append(effects, sched.startEffects...)
+	effects = append(effects, skipObservations(event.RunID, sched.newlySkipped, finalRun)...)
+	resumedNames := append(append([]string{}, failedStageNames...), outdatedStageNames...)
+	effects = append(effects, EmitObservation{
+		Name: "pipeline.run.resumed",
+		Data: map[string]any{
+			"runId":        event.RunID,
+			"pipelineName": run.PipelineName,
+			"stageNames":   resumedNames,
+		},
+	})
+
+	return nextState, effects
+}

--- a/backend/internal/pipeline/reducer_resume.go
+++ b/backend/internal/pipeline/reducer_resume.go
@@ -70,7 +70,7 @@ func reduceRunResumed(state EngineState, event RunResumed) (EngineState, []Effec
 			return invalidTransition(state, "RUN_RESUMED missing stageRunId for failed stage \""+name+"\"")
 		}
 		prior := run.Stages[name]
-		if cap := retriesByName[name]; cap != nil && prior.Attempt >= *cap+1 {
+		if retryCap := retriesByName[name]; retryCap != nil && prior.Attempt >= *retryCap+1 {
 			return invalidTransition(state, "RUN_RESUMED would exceed stage.retries for \""+name+"\"")
 		}
 		stageDelta[name] = StageState{
@@ -128,10 +128,11 @@ func reduceRunResumed(state EngineState, event RunResumed) (EngineState, []Effec
 	nextState := replaceRun(state, finalRun)
 	nextState = withCurrentRun(nextState, key, event.RunID)
 
-	effects := []Effect{
+	effects := make([]Effect, 0, 3+len(sched.startEffects)+len(sched.newlySkipped))
+	effects = append(effects,
 		PersistRun{RunState: finalRun},
 		PersistLoopState{RunID: event.RunID, LoopState: deriveLoopStateFromRun(finalRun, now)},
-	}
+	)
 	effects = append(effects, sched.startEffects...)
 	effects = append(effects, skipObservations(event.RunID, sched.newlySkipped, finalRun)...)
 	resumedNames := append(append([]string{}, failedStageNames...), outdatedStageNames...)

--- a/backend/internal/pipeline/reducer_resume_test.go
+++ b/backend/internal/pipeline/reducer_resume_test.go
@@ -1,0 +1,131 @@
+package pipeline
+
+import (
+	"reflect"
+	"testing"
+)
+
+// stalledRun builds a terminal (stalled) run with the given per-stage statuses
+// and attempts, no longer owning its loop key (as after terminateRun).
+func stalledRun(p Pipeline, statuses map[string]StageStatus, attempts map[string]int) (EngineState, RunState) {
+	run := runState("r1", p, statuses)
+	run.LoopState = LoopStalled
+	run.TerminationReason = TerminationStageFailure
+	for name, a := range attempts {
+		s := run.Stages[name]
+		s.Attempt = a
+		run.Stages[name] = s
+	}
+	st := EmptyEngineState()
+	st.Runs[run.RunID] = run
+	// Loop key is already freed (run terminated).
+	st.HistorySummaries[LoopKey(run.SessionID, run.PipelineName)] = []RunSummary{summarizeRun(run)}
+	return st, run
+}
+
+func resumeIDs(names ...string) map[string]StageRunID {
+	out := map[string]StageRunID{}
+	for _, n := range names {
+		out[n] = StageRunID("sr2-" + n)
+	}
+	return out
+}
+
+func TestReduceRunResumed(t *testing.T) {
+	t.Run("failed stage is retried: attempt++ and fresh stageRunId", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		st, _ := stalledRun(p, map[string]StageStatus{"a": StageStatusFailed}, map[string]int{"a": 1})
+		state, effects := Reduce(st, RunResumed{Now: testNow, RunID: "r1", StageRunIDs: resumeIDs("a")})
+
+		final := state.Runs["r1"]
+		if final.LoopState != LoopRunning {
+			t.Fatalf("run should be running again, got %v", final.LoopState)
+		}
+		a := final.Stages["a"]
+		if a.Status != StageStatusPending {
+			t.Fatalf("stage a status = %v, want pending", a.Status)
+		}
+		if a.Attempt != 2 {
+			t.Fatalf("failed retry should bump attempt to 2, got %d", a.Attempt)
+		}
+		if a.StageRunID != "sr2-a" {
+			t.Fatalf("stage a should get a fresh stageRunId, got %v", a.StageRunID)
+		}
+		if state.CurrentRunByLoop[LoopKey("sess-1", "p")] != "r1" {
+			t.Fatal("loop key should be re-armed")
+		}
+		if got := startedStageNames(effects); !reflect.DeepEqual(got, []string{"a"}) {
+			t.Fatalf("started = %v, want [a]", got)
+		}
+	})
+
+	t.Run("outdated stage revival keeps attempt (not a real failure)", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		st, _ := stalledRun(p, map[string]StageStatus{"a": StageStatusOutdated}, map[string]int{"a": 3})
+		st.Runs["r1"] = func() RunState { r := st.Runs["r1"]; r.LoopState = LoopTerminated; return r }()
+		state, _ := Reduce(st, RunResumed{Now: testNow, RunID: "r1", StageRunIDs: resumeIDs("a")})
+		a := state.Runs["r1"].Stages["a"]
+		if a.Attempt != 3 {
+			t.Fatalf("outdated revival must NOT bump attempt, got %d want 3", a.Attempt)
+		}
+		if a.Status != StageStatusPending || a.StageRunID != "sr2-a" {
+			t.Fatalf("outdated stage should be pending with a fresh id, got %v/%v", a.Status, a.StageRunID)
+		}
+	})
+
+	t.Run("retries cap is enforced for failed stages", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		p.Stages[0].Retries = intPtr(1) // allows attempts up to 2
+		st, _ := stalledRun(p, map[string]StageStatus{"a": StageStatusFailed}, map[string]int{"a": 2})
+		_, effects := Reduce(st, RunResumed{Now: testNow, RunID: "r1", StageRunIDs: resumeIDs("a")})
+		assertInvalid(t, effects)
+	})
+
+	t.Run("cascade-skipped downstream is revived on resume", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"), stageDef("b", "a"))
+		// a failed, b was cascade-skipped when the run stalled.
+		st, _ := stalledRun(p, map[string]StageStatus{"a": StageStatusFailed, "b": StageStatusSkipped}, map[string]int{"a": 1})
+		state, _ := Reduce(st, RunResumed{Now: testNow, RunID: "r1", StageRunIDs: resumeIDs("a")})
+		b := state.Runs["r1"].Stages["b"]
+		if b.Status != StageStatusPending {
+			t.Fatalf("skipped downstream b should be revived to pending, got %v", b.Status)
+		}
+		if b.StageRunID != "sr-b" {
+			t.Fatalf("revived skip keeps its existing stageRunId, got %v", b.StageRunID)
+		}
+	})
+
+	t.Run("nothing to resume is a no-op", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		st, _ := stalledRun(p, map[string]StageStatus{"a": StageStatusSucceeded}, nil)
+		st.Runs["r1"] = func() RunState { r := st.Runs["r1"]; r.LoopState = LoopDone; return r }()
+		_, effects := Reduce(st, RunResumed{Now: testNow, RunID: "r1", StageRunIDs: resumeIDs("a")})
+		if len(effects) != 0 {
+			t.Fatalf("expected no effects, got %v", effects)
+		}
+	})
+
+	t.Run("resuming a non-terminal run is invalid", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusFailed})
+		run.LoopState = LoopRunning // not terminal
+		_, effects := Reduce(engineWith(run), RunResumed{Now: testNow, RunID: "r1", StageRunIDs: resumeIDs("a")})
+		assertInvalid(t, effects)
+	})
+
+	t.Run("resuming when the loop is owned by another run is invalid", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		st, _ := stalledRun(p, map[string]StageStatus{"a": StageStatusFailed}, map[string]int{"a": 1})
+		// A fresh run now owns the loop key.
+		st.CurrentRunByLoop[LoopKey("sess-1", "p")] = "r2"
+		_, effects := Reduce(st, RunResumed{Now: testNow, RunID: "r1", StageRunIDs: resumeIDs("a")})
+		assertInvalid(t, effects)
+	})
+
+	t.Run("missing stageRunId for a failed stage is invalid", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		st, _ := stalledRun(p, map[string]StageStatus{"a": StageStatusFailed}, map[string]int{"a": 1})
+		_, effects := Reduce(st, RunResumed{Now: testNow, RunID: "r1", StageRunIDs: map[string]StageRunID{}})
+		assertInvalid(t, effects)
+	})
+}

--- a/backend/internal/pipeline/reducer_test.go
+++ b/backend/internal/pipeline/reducer_test.go
@@ -1,0 +1,450 @@
+package pipeline
+
+import (
+	"reflect"
+	"testing"
+)
+
+// triggerFor builds a TRIGGER_FIRED event for pipeline p.
+func triggerFor(p Pipeline, trigger StageTriggerEvent, runID RunID) TriggerFired {
+	return TriggerFired{
+		Now:         testNow,
+		Trigger:     trigger,
+		SessionID:   "sess-1",
+		Pipeline:    p,
+		HeadSHA:     "sha-1",
+		RunID:       runID,
+		StageRunIDs: stageRunIDsFor(p),
+	}
+}
+
+// findingInput builds a finding ArtifactInput.
+func findingInput(file, title, category string, sev Severity) ArtifactInput {
+	return ArtifactInput{
+		Kind: ArtifactKindFinding, FilePath: file, Title: title,
+		Category: category, Severity: sev, StartLine: 10, EndLine: 12,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TRIGGER_FIRED
+// ---------------------------------------------------------------------------
+
+func TestReduceTriggerFired(t *testing.T) {
+	t.Run("creates a run, claims the loop key, and starts the root stage", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"), stageDef("b", "a"))
+		state, effects := Reduce(EmptyEngineState(), triggerFor(p, TriggerManual, "r1"))
+
+		run, ok := state.Runs["r1"]
+		if !ok {
+			t.Fatal("run r1 not created")
+		}
+		if run.LoopState != LoopRunning {
+			t.Fatalf("loopState = %v, want running", run.LoopState)
+		}
+		if run.LoopRounds != 1 {
+			t.Fatalf("loopRounds = %d, want 1", run.LoopRounds)
+		}
+		if state.CurrentRunByLoop[LoopKey("sess-1", "p")] != "r1" {
+			t.Fatal("loop key not pointing at r1")
+		}
+		if got := startedStageNames(effects); !reflect.DeepEqual(got, []string{"a"}) {
+			t.Fatalf("started = %v, want [a]", got)
+		}
+		byType := effectsByType(effects)
+		if len(byType[EffectPersistRun]) != 1 || len(byType[EffectPersistLoopState]) != 1 {
+			t.Fatalf("want one PersistRun + one PersistLoopState, got %v", byType)
+		}
+	})
+
+	t.Run("second trigger for a live loop is a no-op", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		state, _ := Reduce(EmptyEngineState(), triggerFor(p, TriggerManual, "r1"))
+		state2, effects := Reduce(state, triggerFor(p, TriggerManual, "r2"))
+		if _, exists := state2.Runs["r2"]; exists {
+			t.Fatal("r2 should not have been created while r1 is live")
+		}
+		if len(effects) != 0 {
+			t.Fatalf("expected no effects, got %v", effects)
+		}
+	})
+
+	t.Run("missing stageRunIds is an invalid transition", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"), stageDef("b"))
+		ev := triggerFor(p, TriggerManual, "r1")
+		delete(ev.StageRunIDs, "b")
+		state, effects := Reduce(EmptyEngineState(), ev)
+		if len(state.Runs) != 0 {
+			t.Fatal("no run should be created")
+		}
+		requireOneEffect[EmitObservation](t, effects)
+		if effects[0].(EmitObservation).Name != "pipeline.invalid_transition" {
+			t.Fatalf("want invalid_transition, got %v", effects[0])
+		}
+	})
+
+	t.Run("pr.opened after history keeps loopRounds at max(prior,1)", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		st := EmptyEngineState()
+		key := LoopKey("sess-1", "p")
+		st.HistorySummaries[key] = []RunSummary{{RunID: "old1"}, {RunID: "old2"}}
+		state, _ := Reduce(st, triggerFor(p, TriggerPROpened, "r1"))
+		if state.Runs["r1"].LoopRounds != 2 {
+			t.Fatalf("loopRounds = %d, want 2", state.Runs["r1"].LoopRounds)
+		}
+	})
+
+	t.Run("manual continuation increments loopRounds past history", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		st := EmptyEngineState()
+		key := LoopKey("sess-1", "p")
+		st.HistorySummaries[key] = []RunSummary{{RunID: "old1"}, {RunID: "old2"}}
+		state, _ := Reduce(st, triggerFor(p, TriggerManual, "r1"))
+		if state.Runs["r1"].LoopRounds != 3 {
+			t.Fatalf("loopRounds = %d, want 3", state.Runs["r1"].LoopRounds)
+		}
+	})
+
+	t.Run("degenerate all-skip at trigger terminates the run cleanly", func(t *testing.T) {
+		// b routes on an empty all_pass over a non-existent context, but the
+		// canonical degenerate case: a fails-out immediately is impossible at
+		// trigger. Instead use a routed stage whose predicate can never pass
+		// because it references only itself's peers that are absent -> we build
+		// a single stage whose routes references a stage that is already
+		// terminal-skipped. Simplest: one stage routed on any_pass of a stage
+		// that does not exist is caught by validation; so we use majority_pass
+		// over an empty stage list, which is always false and has no refs.
+		only := withRoutes(stageDef("only"), Predicate{Kind: PredicateMajorityPass, Stages: []string{}})
+		p := pipelineOf("p", 1, only)
+		state, effects := Reduce(EmptyEngineState(), triggerFor(p, TriggerManual, "r1"))
+		run := state.Runs["r1"]
+		if run.LoopState != LoopDone {
+			t.Fatalf("loopState = %v, want done (no failed stages -> v0 default done)", run.LoopState)
+		}
+		if _, live := state.CurrentRunByLoop[LoopKey("sess-1", "p")]; live {
+			t.Fatal("loop key should be freed after terminal trigger")
+		}
+		byType := effectsByType(effects)
+		if len(byType[EffectStartStage]) != 0 {
+			t.Fatal("no stage should start")
+		}
+		if len(state.HistorySummaries[LoopKey("sess-1", "p")]) != 1 {
+			t.Fatal("history summary should be appended")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// STAGE_STARTED / STAGE_COMPLETED / STAGE_FAILED
+// ---------------------------------------------------------------------------
+
+func TestReduceStageStarted(t *testing.T) {
+	p := pipelineOf("p", 1, stageDef("a"))
+	run := runState("r1", p, nil)
+
+	t.Run("pending -> running", func(t *testing.T) {
+		state, effects := Reduce(engineWith(run), StageStarted{Now: testNow, RunID: "r1", StageName: "a"})
+		if state.Runs["r1"].Stages["a"].Status != StageStatusRunning {
+			t.Fatal("stage a should be running")
+		}
+		if state.Runs["r1"].Stages["a"].StartedAt == nil {
+			t.Fatal("startedAt should be set")
+		}
+		requireOneEffect[PersistRun](t, effects)
+	})
+
+	t.Run("unknown run is invalid", func(t *testing.T) {
+		_, effects := Reduce(engineWith(run), StageStarted{Now: testNow, RunID: "ghost", StageName: "a"})
+		assertInvalid(t, effects)
+	})
+
+	t.Run("non-pending stage is invalid", func(t *testing.T) {
+		r := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		_, effects := Reduce(engineWith(r), StageStarted{Now: testNow, RunID: "r1", StageName: "a"})
+		assertInvalid(t, effects)
+	})
+}
+
+func TestReduceStageCompleted(t *testing.T) {
+	t.Run("single stage completing terminates the run as done", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		state, effects := Reduce(engineWith(run), StageCompleted{
+			Now: testNow, RunID: "r1", StageName: "a", Verdict: VerdictPass,
+			Artifacts: []ArtifactInput{findingInput("x.go", "bug", "correctness", SeverityError)},
+		})
+		final := state.Runs["r1"]
+		if final.LoopState != LoopDone || final.TerminationReason != TerminationCompleted {
+			t.Fatalf("run = %v/%v, want done/completed", final.LoopState, final.TerminationReason)
+		}
+		if final.Stages["a"].Status != StageStatusSucceeded {
+			t.Fatal("stage a should be succeeded")
+		}
+		if len(final.Findings) != 1 || final.Findings[0].Fingerprint == "" {
+			t.Fatalf("expected 1 mirrored finding with a fingerprint, got %+v", final.Findings)
+		}
+		if len(final.Fingerprints) != 1 {
+			t.Fatalf("expected 1 accumulated fingerprint, got %v", final.Fingerprints)
+		}
+		byType := effectsByType(effects)
+		if len(byType[EffectAppendArtifacts]) != 1 {
+			t.Fatal("want an AppendArtifacts effect")
+		}
+		if _, live := state.CurrentRunByLoop[LoopKey("sess-1", "p")]; live {
+			t.Fatal("loop key should be freed")
+		}
+	})
+
+	t.Run("completing an upstream starts the downstream without terminating", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"), stageDef("b", "a"))
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		state, effects := Reduce(engineWith(run), StageCompleted{Now: testNow, RunID: "r1", StageName: "a"})
+		if state.Runs["r1"].LoopState != LoopRunning {
+			t.Fatal("run should still be running")
+		}
+		if got := startedStageNames(effects); !reflect.DeepEqual(got, []string{"b"}) {
+			t.Fatalf("started = %v, want [b]", got)
+		}
+		// PersistRun must precede the START_STAGE in the non-terminal path.
+		requireOneEffect[PersistRun](t, effects)
+	})
+
+	t.Run("completing a non-running stage is invalid", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		run := runState("r1", p, nil) // a is pending
+		_, effects := Reduce(engineWith(run), StageCompleted{Now: testNow, RunID: "r1", StageName: "a"})
+		assertInvalid(t, effects)
+	})
+}
+
+func TestReduceStageFailed(t *testing.T) {
+	t.Run("failure with no recovery terminates the run as stalled", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"), stageDef("b", "a"))
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		state, _ := Reduce(engineWith(run), StageFailed{Now: testNow, RunID: "r1", StageName: "a", ErrorMessage: "boom"})
+		final := state.Runs["r1"]
+		if final.LoopState != LoopStalled || final.TerminationReason != TerminationStageFailure {
+			t.Fatalf("run = %v/%v, want stalled/stage_failure", final.LoopState, final.TerminationReason)
+		}
+		if final.Stages["b"].Status != StageStatusSkipped {
+			t.Fatal("downstream b should be cascade-skipped")
+		}
+		if final.Stages["a"].ErrorMessage != "boom" {
+			t.Fatal("error message should be recorded")
+		}
+	})
+
+	t.Run("failed pending stage is allowed", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		run := runState("r1", p, nil) // pending
+		state, _ := Reduce(engineWith(run), StageFailed{Now: testNow, RunID: "r1", StageName: "a", ErrorMessage: "x"})
+		if state.Runs["r1"].Stages["a"].Status != StageStatusFailed {
+			t.Fatal("pending stage should be allowed to fail")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// NEW_SHA_DETECTED / RUN_CANCELLED / CONFIG_CHANGED
+// ---------------------------------------------------------------------------
+
+func TestReduceNewSHADetected(t *testing.T) {
+	p := pipelineOf("p", 1, stageDef("a"))
+
+	t.Run("new sha cancels the run as outdated and frees the loop key", func(t *testing.T) {
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		state, effects := Reduce(engineWith(run), NewSHADetected{Now: testNow, SessionID: "sess-1", PipelineName: "p", SHA: "sha-2"})
+		final := state.Runs["r1"]
+		if final.LoopState != LoopTerminated || final.TerminationReason != TerminationOutdated {
+			t.Fatalf("run = %v/%v, want terminated/outdated", final.LoopState, final.TerminationReason)
+		}
+		if final.Stages["a"].Status != StageStatusOutdated {
+			t.Fatal("running stage should become outdated")
+		}
+		if _, live := state.CurrentRunByLoop[LoopKey("sess-1", "p")]; live {
+			t.Fatal("loop key should be freed for the new SHA")
+		}
+		if len(effectsByType(effects)[EffectCancelStage]) != 1 {
+			t.Fatal("running stage should emit CANCEL_STAGE")
+		}
+	})
+
+	t.Run("same sha is a no-op", func(t *testing.T) {
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		_, effects := Reduce(engineWith(run), NewSHADetected{Now: testNow, SessionID: "sess-1", PipelineName: "p", SHA: "sha-1"})
+		if len(effects) != 0 {
+			t.Fatalf("expected no effects, got %v", effects)
+		}
+	})
+
+	t.Run("no active run is a no-op", func(t *testing.T) {
+		_, effects := Reduce(EmptyEngineState(), NewSHADetected{Now: testNow, SessionID: "sess-1", PipelineName: "p", SHA: "sha-2"})
+		if len(effects) != 0 {
+			t.Fatalf("expected no effects, got %v", effects)
+		}
+	})
+}
+
+func TestReduceRunCancelled(t *testing.T) {
+	p := pipelineOf("p", 1, stageDef("a"))
+
+	t.Run("manual cancel terminates", func(t *testing.T) {
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		state, _ := Reduce(engineWith(run), RunCancelled{Now: testNow, RunID: "r1", Reason: TerminationManualCancel})
+		if state.Runs["r1"].LoopState != LoopTerminated {
+			t.Fatalf("want terminated, got %v", state.Runs["r1"].LoopState)
+		}
+	})
+
+	t.Run("stage_failure reason stalls", func(t *testing.T) {
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		state, _ := Reduce(engineWith(run), RunCancelled{Now: testNow, RunID: "r1", Reason: TerminationStageFailure})
+		if state.Runs["r1"].LoopState != LoopStalled {
+			t.Fatalf("want stalled, got %v", state.Runs["r1"].LoopState)
+		}
+	})
+
+	t.Run("cancelling an already-terminal run is invalid", func(t *testing.T) {
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusSucceeded})
+		run.LoopState = LoopDone
+		_, effects := Reduce(engineWith(run), RunCancelled{Now: testNow, RunID: "r1", Reason: TerminationManualCancel})
+		assertInvalid(t, effects)
+	})
+}
+
+func TestReduceConfigChanged(t *testing.T) {
+	p := pipelineOf("p", 1, stageDef("a"))
+	run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+	state, _ := Reduce(engineWith(run), ConfigChanged{Now: testNow, SessionID: "sess-1", PipelineName: "p"})
+	if state.Runs["r1"].TerminationReason != TerminationConfigChange {
+		t.Fatalf("want config_change, got %v", state.Runs["r1"].TerminationReason)
+	}
+	if state.Runs["r1"].LoopState != LoopTerminated {
+		t.Fatalf("want terminated, got %v", state.Runs["r1"].LoopState)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ARTIFACT_STATUS_CHANGED / TICK
+// ---------------------------------------------------------------------------
+
+func TestReduceArtifactStatusChanged(t *testing.T) {
+	p := pipelineOf("p", 1, stageDef("a"))
+	run := runState("r1", p, map[string]StageStatus{"a": StageStatusSucceeded})
+	run.Findings = []Artifact{{
+		ArtifactInput: ArtifactInput{Kind: ArtifactKindFinding},
+		ArtifactID:    "art-1", StageName: "a", Status: ArtifactStatusOpen,
+	}}
+	state, effects := Reduce(engineWith(run), ArtifactStatusChanged{
+		Now: testNow, RunID: "r1", StageRunID: "sr-a", ArtifactID: "art-1",
+		Status: ArtifactStatusDismissed, Actor: "reviewer",
+	})
+	if state.Runs["r1"].Findings[0].Status != ArtifactStatusDismissed {
+		t.Fatal("finding status should be dismissed in the mirror")
+	}
+	byType := effectsByType(effects)
+	if len(byType[EffectUpdateArtifactStatus]) != 1 || len(byType[EffectPersistRun]) != 1 {
+		t.Fatalf("want UpdateArtifactStatus + PersistRun, got %v", byType)
+	}
+}
+
+func TestReduceTick(t *testing.T) {
+	p := pipelineOf("p", 1, stageDef("a"))
+	run := runState("r1", p, nil)
+	in := engineWith(run)
+	state, effects := Reduce(in, Tick{Now: testNow})
+	if len(effects) != 0 {
+		t.Fatalf("tick should produce no effects, got %v", effects)
+	}
+	if !reflect.DeepEqual(state, in) {
+		t.Fatal("tick should not change state")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Exit predicates + convergence
+// ---------------------------------------------------------------------------
+
+func TestExitPredicates(t *testing.T) {
+	t.Run("done predicate resolves the run to done even with a failed stage", func(t *testing.T) {
+		p := pipelineOf("p", 2, stageDef("a"), stageDef("b"))
+		p.ExitPredicates = &ExitPredicates{
+			Done: &Predicate{Kind: PredicateAnyPass, Stages: []string{"a"}},
+		}
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusSucceeded, "b": StageStatusRunning})
+		state, _ := Reduce(engineWith(run), StageFailed{Now: testNow, RunID: "r1", StageName: "b", ErrorMessage: "x"})
+		final := state.Runs["r1"]
+		if final.LoopState != LoopDone || final.TerminationReason != TerminationCompleted {
+			t.Fatalf("run = %v/%v, want done/completed (done predicate wins)", final.LoopState, final.TerminationReason)
+		}
+	})
+
+	t.Run("stalled predicate resolves the run to stalled", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		p.ExitPredicates = &ExitPredicates{
+			Stalled: &Predicate{Kind: PredicateLoopRoundsAtLeast, N: intPtr(1)},
+		}
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		state, _ := Reduce(engineWith(run), StageCompleted{Now: testNow, RunID: "r1", StageName: "a"})
+		final := state.Runs["r1"]
+		if final.LoopState != LoopStalled || final.TerminationReason != TerminationStageFailure {
+			t.Fatalf("run = %v/%v, want stalled/stage_failure", final.LoopState, final.TerminationReason)
+		}
+	})
+}
+
+func TestConvergence(t *testing.T) {
+	// stallWindow=2: when the prior run's fingerprint set equals this run's,
+	// terminate as converged -> stalled.
+	sw := 2
+	p := pipelineOf("p", 1, stageDef("a"))
+	p.Stages[0].Policy = &StagePolicy{StallWindow: &sw}
+
+	run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+	// Prior history with a matching fingerprint set.
+	fp := computeFindingFingerprint(findingInput("x.go", "bug", "correctness", SeverityError), "a")
+	st := engineWith(run)
+	st.HistorySummaries[LoopKey("sess-1", "p")] = []RunSummary{{RunID: "old", Fingerprints: []string{fp}}}
+
+	state, _ := Reduce(st, StageCompleted{
+		Now: testNow, RunID: "r1", StageName: "a",
+		Artifacts: []ArtifactInput{findingInput("x.go", "bug", "correctness", SeverityError)},
+	})
+	final := state.Runs["r1"]
+	if final.TerminationReason != TerminationConverged || final.LoopState != LoopStalled {
+		t.Fatalf("run = %v/%v, want converged/stalled", final.LoopState, final.TerminationReason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Immutability
+// ---------------------------------------------------------------------------
+
+func TestReducerDoesNotMutateInput(t *testing.T) {
+	p := pipelineOf("p", 1, stageDef("a"), stageDef("b", "a"))
+	run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+	in := engineWith(run)
+
+	Reduce(in, StageCompleted{Now: testNow, RunID: "r1", StageName: "a"})
+
+	if in.Runs["r1"].Stages["a"].Status != StageStatusRunning {
+		t.Fatal("input run's stage a was mutated")
+	}
+	if in.Runs["r1"].LoopState != LoopRunning {
+		t.Fatal("input run's loopState was mutated")
+	}
+	if len(in.Runs["r1"].Findings) != 0 {
+		t.Fatal("input run's findings were mutated")
+	}
+}
+
+func assertInvalid(t *testing.T, effects []Effect) {
+	t.Helper()
+	if len(effects) != 1 {
+		t.Fatalf("expected exactly one (invalid_transition) effect, got %d: %v", len(effects), effects)
+	}
+	obs, ok := effects[0].(EmitObservation)
+	if !ok || obs.Name != "pipeline.invalid_transition" {
+		t.Fatalf("expected invalid_transition observation, got %v", effects[0])
+	}
+}

--- a/backend/internal/pipeline/scheduler.go
+++ b/backend/internal/pipeline/scheduler.go
@@ -43,9 +43,9 @@ type scheduleResult struct {
 func scheduleAfterChange(run RunState, now time.Time) scheduleResult {
 	current, newlySkipped := applyEligibleSkips(run, now)
 
-	max := 1
+	maxConcurrent := 1
 	if current.PipelineConfigSnapshot.MaxConcurrentStages != nil {
-		max = *current.PipelineConfigSnapshot.MaxConcurrentStages
+		maxConcurrent = *current.PipelineConfigSnapshot.MaxConcurrentStages
 	}
 	inflight := 0
 	for _, s := range current.Stages {
@@ -53,7 +53,7 @@ func scheduleAfterChange(run RunState, now time.Time) scheduleResult {
 			inflight++
 		}
 	}
-	slots := max - inflight
+	slots := maxConcurrent - inflight
 	if slots < 0 {
 		slots = 0
 	}

--- a/backend/internal/pipeline/scheduler.go
+++ b/backend/internal/pipeline/scheduler.go
@@ -1,0 +1,215 @@
+package pipeline
+
+import "time"
+
+// DAG-aware scheduling for the pipeline reducer.
+//
+// Pure: every function takes the driver-stamped clock as a parameter; no clock
+// reads, no I/O. Split out from the reducer so it can stay focused on
+// event-shape transitions while the dependency / routing logic lives here.
+//
+// Ordering invariants (what callers can rely on):
+//   - Skips cascade in a single pass: skipping a stage may make a downstream
+//     stage's routes evaluate to false, marking it skipped, which may cascade
+//     further. scheduleAfterChange runs the cascade to fixpoint before emitting
+//     any START_STAGE effects.
+//   - Stage declaration order is preserved as priority for slotting: when more
+//     stages are eligible than MaxConcurrentStages allows, earlier-declared
+//     stages win the available slots. This keeps linear pipelines (no
+//     dependsOn) behaviorally identical to v0.
+//
+// Ported from the old TypeScript dag.ts (scheduler part; cycle detection lives
+// in dag.go).
+
+// scheduleResult is the output of scheduleAfterChange.
+type scheduleResult struct {
+	// run is the run with any newly-skipped stages applied; may equal the input.
+	run RunState
+	// startEffects are START_STAGE effects for stages eligible to run, capped
+	// by concurrency.
+	startEffects []Effect
+	// newlySkipped lists stage names that transitioned pending -> skipped
+	// during this call.
+	newlySkipped []string
+	// allTerminal is true iff every stage is in a terminal status.
+	allTerminal bool
+}
+
+// scheduleAfterChange, after a state change (TRIGGER_FIRED, STAGE_COMPLETED,
+// RUN_RESUMED), figures out which pending stages should be skipped (routes
+// predicate failed) and which are eligible to start. Cascade skips run to
+// fixpoint before emitting any START_STAGE effects, so downstream stages whose
+// dependencies were just skipped get marked skipped in the same reducer step.
+func scheduleAfterChange(run RunState, now time.Time) scheduleResult {
+	current, newlySkipped := applyEligibleSkips(run, now)
+
+	max := 1
+	if current.PipelineConfigSnapshot.MaxConcurrentStages != nil {
+		max = *current.PipelineConfigSnapshot.MaxConcurrentStages
+	}
+	inflight := 0
+	for _, s := range current.Stages {
+		if s.Status == StageStatusRunning {
+			inflight++
+		}
+	}
+	slots := max - inflight
+	if slots < 0 {
+		slots = 0
+	}
+
+	var startEffects []Effect
+	if slots > 0 {
+		for i := range current.PipelineConfigSnapshot.Stages {
+			stageDef := current.PipelineConfigSnapshot.Stages[i]
+			if len(startEffects) >= slots {
+				break
+			}
+			state := current.Stages[stageDef.Name]
+			if state.Status != StageStatusPending {
+				continue
+			}
+			if !areDepsSatisfiedForStart(stageDef, current.Stages) {
+				continue
+			}
+			if !evaluateRoutes(stageDef, current) {
+				continue
+			}
+			startEffects = append(startEffects, StartStage{
+				RunID:      current.RunID,
+				StageRunID: state.StageRunID,
+				Stage:      stageDef,
+			})
+		}
+	}
+
+	allTerminal := true
+	for _, s := range current.Stages {
+		if !s.Status.IsTerminal() {
+			allTerminal = false
+			break
+		}
+	}
+	return scheduleResult{
+		run:          current,
+		startEffects: startEffects,
+		newlySkipped: newlySkipped,
+		allTerminal:  allTerminal,
+	}
+}
+
+// applyEligibleSkips walks the pipeline and marks as skipped every pending
+// stage whose:
+//   - preconditions (dependsOn ∪ routes refs) are all in a terminal state
+//     (only then is the activation decision deterministic), AND
+//   - routes predicate evaluates to false (or, when routes is unset, any
+//     dependsOn reached a non-succeeded terminal state).
+//
+// Iterates to fixpoint so cascade skips land in one reducer step. routes may
+// reference stages outside dependsOn (e.g. a parallel branch the user wants to
+// react to without forcing serialization); the scheduler waits for those
+// references to be terminal too before deciding.
+func applyEligibleSkips(run RunState, now time.Time) (RunState, []string) {
+	current := run
+	var newlySkipped []string
+	changed := true
+	for changed {
+		changed = false
+		for i := range current.PipelineConfigSnapshot.Stages {
+			stageDef := current.PipelineConfigSnapshot.Stages[i]
+			state := current.Stages[stageDef.Name]
+			if state.Status != StageStatusPending {
+				continue
+			}
+			if !arePreconditionsTerminal(stageDef, current.Stages) {
+				continue
+			}
+
+			var shouldSkip bool
+			if stageDef.Routes != nil {
+				shouldSkip = !evaluatePredicateForRun(stageDef.Routes.When, current)
+			} else {
+				shouldSkip = !areAllDepsSucceeded(stageDef, current.Stages)
+			}
+
+			if shouldSkip {
+				completed := now
+				skipped := state
+				skipped.Status = StageStatusSkipped
+				skipped.CompletedAt = &completed
+				current = patchRun(current, map[string]StageState{stageDef.Name: skipped}, now)
+				newlySkipped = append(newlySkipped, stageDef.Name)
+				changed = true
+			}
+		}
+	}
+	return current, newlySkipped
+}
+
+func arePreconditionsTerminal(stage Stage, stages map[string]StageState) bool {
+	if !areDepsTerminal(stage, stages) {
+		return false
+	}
+	if stage.Routes != nil {
+		for _, ref := range stage.Routes.When.ReferencedStages() {
+			refState, ok := stages[ref]
+			if !ok || !refState.Status.IsTerminal() {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func areDepsTerminal(stage Stage, stages map[string]StageState) bool {
+	for _, dep := range stage.DependsOn {
+		depState, ok := stages[dep]
+		if !ok || !depState.Status.IsTerminal() {
+			return false
+		}
+	}
+	return true
+}
+
+func areAllDepsSucceeded(stage Stage, stages map[string]StageState) bool {
+	for _, dep := range stage.DependsOn {
+		depState, ok := stages[dep]
+		if !ok || depState.Status != StageStatusSucceeded {
+			return false
+		}
+	}
+	return true
+}
+
+// areDepsSatisfiedForStart reports whether a stage is eligible to start. With
+// no routes, every dependsOn must be succeeded so the scheduler doesn't
+// optimistically start a stage whose upstream skipped or failed. When routes
+// IS set the user opts into custom activation semantics (recovery branches
+// with routes.when referencing failed upstream are the canonical case): we
+// only require deps to be terminal (already ensured by
+// arePreconditionsTerminal) and let the routes predicate make the final call.
+func areDepsSatisfiedForStart(stage Stage, stages map[string]StageState) bool {
+	if stage.Routes != nil {
+		return areDepsTerminal(stage, stages)
+	}
+	return areAllDepsSucceeded(stage, stages)
+}
+
+func evaluateRoutes(stage Stage, run RunState) bool {
+	if stage.Routes == nil {
+		return true
+	}
+	return evaluatePredicateForRun(stage.Routes.When, run)
+}
+
+// evaluatePredicateForRun runs a routes-time predicate against a minimal
+// PredicateCtx. The scheduler has no access to durable cross-run history, so
+// History is empty; findings are surfaced from run.Findings.
+func evaluatePredicateForRun(p Predicate, run RunState) bool {
+	ctx := PredicateCtx{
+		Run:      &run,
+		History:  nil,
+		Findings: run.Findings,
+	}
+	return Evaluate(p, ctx)
+}

--- a/backend/internal/pipeline/scheduler_test.go
+++ b/backend/internal/pipeline/scheduler_test.go
@@ -79,9 +79,9 @@ func TestScheduleAfterChange(t *testing.T) {
 
 	t.Run("routes.when recovery branch starts when the predicate matches a failure", func(t *testing.T) {
 		// recover activates when a failed (stage_verdict fail).
-		recover := withRoutes(stageDef("recover", "a"),
+		recoverStage := withRoutes(stageDef("recover", "a"),
 			Predicate{Kind: PredicateStageVerdict, Stage: "a", Verdict: VerdictFail})
-		p := pipelineOf("routed", 1, stageDef("a"), recover)
+		p := pipelineOf("routed", 1, stageDef("a"), recoverStage)
 		run := runState("r1", p, map[string]StageStatus{"a": StageStatusFailed})
 		sched := scheduleAfterChange(run, testNow)
 		if got := startedStageNames(sched.startEffects); !reflect.DeepEqual(got, []string{"recover"}) {

--- a/backend/internal/pipeline/scheduler_test.go
+++ b/backend/internal/pipeline/scheduler_test.go
@@ -1,0 +1,109 @@
+package pipeline
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestScheduleAfterChange(t *testing.T) {
+	t.Run("linear pipeline starts only the root at trigger time", func(t *testing.T) {
+		p := pipelineOf("lin", 1, stageDef("a"), stageDef("b", "a"), stageDef("c", "b"))
+		run := runState("r1", p, nil)
+		sched := scheduleAfterChange(run, testNow)
+		if got := startedStageNames(sched.startEffects); !reflect.DeepEqual(got, []string{"a"}) {
+			t.Fatalf("started = %v, want [a]", got)
+		}
+		if sched.allTerminal {
+			t.Fatal("allTerminal should be false")
+		}
+		if len(sched.newlySkipped) != 0 {
+			t.Fatalf("newlySkipped = %v, want none", sched.newlySkipped)
+		}
+	})
+
+	t.Run("slot-fill respects MaxConcurrentStages and declaration order", func(t *testing.T) {
+		p := pipelineOf("par", 2, stageDef("a"), stageDef("b"), stageDef("c"))
+		run := runState("r1", p, nil)
+		sched := scheduleAfterChange(run, testNow)
+		if got := startedStageNames(sched.startEffects); !reflect.DeepEqual(got, []string{"a", "b"}) {
+			t.Fatalf("started = %v, want [a b] (declaration order, capped at 2)", got)
+		}
+	})
+
+	t.Run("running stages consume concurrency slots", func(t *testing.T) {
+		p := pipelineOf("par", 2, stageDef("a"), stageDef("b"), stageDef("c"))
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		sched := scheduleAfterChange(run, testNow)
+		if got := startedStageNames(sched.startEffects); !reflect.DeepEqual(got, []string{"b"}) {
+			t.Fatalf("started = %v, want [b] (one slot left)", got)
+		}
+	})
+
+	t.Run("default concurrency is 1", func(t *testing.T) {
+		p := pipelineOf("par", 0, stageDef("a"), stageDef("b"))
+		run := runState("r1", p, nil)
+		sched := scheduleAfterChange(run, testNow)
+		if got := startedStageNames(sched.startEffects); !reflect.DeepEqual(got, []string{"a"}) {
+			t.Fatalf("started = %v, want [a]", got)
+		}
+	})
+
+	t.Run("no-routes stage skips when a dependency failed, and cascades", func(t *testing.T) {
+		p := pipelineOf("lin", 1, stageDef("a"), stageDef("b", "a"), stageDef("c", "b"))
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusFailed})
+		sched := scheduleAfterChange(run, testNow)
+		if !reflect.DeepEqual(sched.newlySkipped, []string{"b", "c"}) {
+			t.Fatalf("newlySkipped = %v, want [b c] (cascade to fixpoint)", sched.newlySkipped)
+		}
+		if !sched.allTerminal {
+			t.Fatal("allTerminal should be true (a failed, b+c skipped)")
+		}
+		if sched.run.Stages["b"].Status != StageStatusSkipped || sched.run.Stages["c"].Status != StageStatusSkipped {
+			t.Fatal("b and c should be skipped in the returned run")
+		}
+	})
+
+	t.Run("routes.when gates activation: false predicate skips the stage", func(t *testing.T) {
+		// b activates only if a passed; a failed, so b is skipped.
+		b := withRoutes(stageDef("b", "a"), Predicate{Kind: PredicateAnyPass, Stages: []string{"a"}})
+		p := pipelineOf("routed", 1, stageDef("a"), b)
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusFailed})
+		sched := scheduleAfterChange(run, testNow)
+		if !reflect.DeepEqual(sched.newlySkipped, []string{"b"}) {
+			t.Fatalf("newlySkipped = %v, want [b]", sched.newlySkipped)
+		}
+		if len(startedStageNames(sched.startEffects)) != 0 {
+			t.Fatalf("expected no starts, got %v", startedStageNames(sched.startEffects))
+		}
+	})
+
+	t.Run("routes.when recovery branch starts when the predicate matches a failure", func(t *testing.T) {
+		// recover activates when a failed (stage_verdict fail).
+		recover := withRoutes(stageDef("recover", "a"),
+			Predicate{Kind: PredicateStageVerdict, Stage: "a", Verdict: VerdictFail})
+		p := pipelineOf("routed", 1, stageDef("a"), recover)
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusFailed})
+		sched := scheduleAfterChange(run, testNow)
+		if got := startedStageNames(sched.startEffects); !reflect.DeepEqual(got, []string{"recover"}) {
+			t.Fatalf("started = %v, want [recover]", got)
+		}
+		if len(sched.newlySkipped) != 0 {
+			t.Fatalf("newlySkipped = %v, want none", sched.newlySkipped)
+		}
+	})
+
+	t.Run("stage waits until routes-referenced stage outside dependsOn is terminal", func(t *testing.T) {
+		// b routes on c (not a dependsOn edge). While c is still running, b must
+		// not be skipped or started: the decision isn't deterministic yet.
+		b := withRoutes(stageDef("b"), Predicate{Kind: PredicateAnyPass, Stages: []string{"c"}})
+		p := pipelineOf("cross", 2, b, stageDef("c"))
+		run := runState("r1", p, map[string]StageStatus{"c": StageStatusRunning})
+		sched := scheduleAfterChange(run, testNow)
+		if len(sched.newlySkipped) != 0 {
+			t.Fatalf("newlySkipped = %v, want none while c is running", sched.newlySkipped)
+		}
+		if names := startedStageNames(sched.startEffects); len(names) != 0 {
+			t.Fatalf("started = %v, want none (b blocked on c, c already running)", names)
+		}
+	})
+}


### PR DESCRIPTION
Implements **T2: pipeline engine core** for the Pipelines v1 reimplementation (spec §6, §8 T2, §9 notes 3 & 10).

Pure, no I/O, no clock reads, no goroutines, no `context.Context`. Every `Event` carries a driver-stamped `Now`; effects are intents only. Ported behavior 1:1 from `origin/legacy-pipelines` TypeScript (reducer.ts, reducer-helpers.ts, dag.ts, predicate-evaluator.ts).

## What's here

- **`evaluator.go`** — `Evaluate(p, ctx)` for the full v1 typed DSL: `all_pass` / `any_pass` / `majority_pass`, `no_open_findings` / `finding_count_below` (open-finding counting by stage/severity), `loop_rounds_at_least` / `stage_retried_at_least`, `stage_verdict` (status→verdict mapping), and `and` / `or` / `not`. Unknown stages degrade to `false` (never green-light on missing data); `not` flips it.
- **`scheduler.go`** — `scheduleAfterChange`: cascade-skip to fixpoint (skip any pending stage whose preconditions are terminal and `routes.when` is false, cascading downstream in one pass) + slot-fill up to `MaxConcurrentStages` with declaration-order tie-break; running stages consume slots.
- **`reducer.go` / `reducer_resume.go` / `reducer_helpers.go`** — `Reduce(state, event)` over all 10 T1 event types: `TRIGGER_FIRED` (create + snapshot + schedule, degenerate all-terminal short-circuit), `STAGE_STARTED/COMPLETED/FAILED` (materialize artifacts + fingerprints, mirror findings, re-schedule downstream, convergence + exit-predicate resolution when all terminal), `NEW_SHA_DETECTED` (outdated + free loop key), `RUN_CANCELLED`, `RUN_RESUMED`, `CONFIG_CHANGED`, `ARTIFACT_STATUS_CHANGED`, `TICK`. Ports `patchRun` / `replaceRun` / `materializeArtifact` (fingerprint = sha256(stageName·filePath·anchor·category·title)[:16]) / `terminateRun` / `summarizeRun`. Copy-on-write throughout: the reducer never mutates its input state.

### Port gotcha §9 note 10 (retry/attempt counting)
`failed` stages are real retries: `attempt++` and consume the `retries` cap. `outdated` stages (externally cancelled by new-SHA/config-change/sibling-failure) revive WITHOUT bumping attempt or checking the cap. Cascade-skipped downstream stages are re-pended on resume so DAG branches aren't lost. Covered directly in `reducer_resume_test.go`.

## Tests
Reducer transition table (≥1 per event type) + exit-predicate resolution (done/stalled), convergence, invalid transitions, loop-key lifecycle; DAG cascade-skip fixpoint / slot-fill / routes-gated skip; predicate DSL table across every kind incl. nested composites; fingerprint stability + anchor fallback.

`cd backend && go test ./internal/pipeline/ && go vet ./...` green (170 tests, `-race` clean). The `internal/cli` spawn tests fail identically on the clean base branch (they need a live daemon) and are unrelated to this change.

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)