### PR TITLE
feat(pipeline): T4 executors (agent/command/builtin + dispatcher)

### DIFF
--- a/backend/internal/pipeline/executors/agent.go
+++ b/backend/internal/pipeline/executors/agent.go
@@ -1,0 +1,181 @@
+package executors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// SpawnRequest is the narrow spawn payload the agent executor hands the session
+// manager. It carries only what a pipeline stage needs; the concrete adapter
+// (wired by T5) maps it onto ports.SpawnConfig.
+type SpawnRequest struct {
+	ProjectID string
+	IssueID   string
+	// Prompt is the fully-assembled stage prompt injected at spawn time.
+	Prompt string
+	// Harness is the agent plugin the stage requested (stage.executor.plugin).
+	// Empty lets the project default pick the harness.
+	Harness string
+}
+
+// SpawnedSession is what the session manager returns for a fresh spawn.
+type SpawnedSession struct {
+	SessionID     string
+	WorkspacePath string
+}
+
+// SessionSnapshot is the subset of session state the agent executor polls: is
+// the agent idle, and has the session gone terminal (killed/exited) without
+// producing findings.
+type SessionSnapshot struct {
+	// Activity is the agent's reported activity state (domain.ActivityState
+	// value, e.g. "idle", "active", "exited").
+	Activity string
+	// Terminated reports whether the session row is terminated.
+	Terminated bool
+}
+
+// SessionSpawner is the session-manager seam the agent executor needs: spawn a
+// fresh visible session, snapshot its state, and kill it. Mirrors the DI style
+// of internal/review's Launcher so the concrete Manager never enters this
+// package's core logic.
+type SessionSpawner interface {
+	Spawn(ctx context.Context, req SpawnRequest) (SpawnedSession, error)
+	// Get returns a snapshot and whether the session still exists.
+	Get(ctx context.Context, sessionID string) (SessionSnapshot, bool, error)
+	// Kill tears the session down. Idempotent; a missing session is not an error.
+	Kill(ctx context.Context, sessionID string) error
+}
+
+// agentHandle is the running-stage token for an agent stage.
+type agentHandle struct {
+	stageIdentity
+	sessionID     string
+	workspacePath string
+}
+
+// AgentExecutor bridges a pipeline stage to a real, visible AO session: spawn a
+// fresh session with the stage prompt, wait for the agent to go idle AND drop
+// its findings file, harvest the findings, then kill the session. It touches
+// neither the reducer nor the store; the engine threads outcomes onward.
+type AgentExecutor struct {
+	sessions SessionSpawner
+}
+
+// NewAgentExecutor builds an agent executor over the given session seam.
+func NewAgentExecutor(sessions SessionSpawner) *AgentExecutor {
+	return &AgentExecutor{sessions: sessions}
+}
+
+var _ StageExecutor = (*AgentExecutor)(nil)
+
+// Start spawns the stage's session and returns a handle. It errors (mapped by
+// the engine to STAGE_FAILED) when the stage is not an agent stage, the spawn
+// fails, or the spawned session has no workspace to harvest findings from.
+func (e *AgentExecutor) Start(ctx context.Context, in StartInput) (Handle, error) {
+	if in.Stage.Executor.Kind != pipeline.ExecutorAgent {
+		return nil, fmt.Errorf("agent executor cannot start stage %q with executor.kind=%s", in.Stage.Name, in.Stage.Executor.Kind)
+	}
+
+	prompt := buildStagePrompt(in.PipelineName, in.Stage, in.LoopRound)
+	session, err := e.sessions.Spawn(ctx, SpawnRequest{
+		ProjectID: in.ProjectID,
+		IssueID:   in.IssueID,
+		Prompt:    prompt,
+		Harness:   in.Stage.Executor.Plugin,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("agent executor: spawn session for stage %q: %w", in.Stage.Name, err)
+	}
+	if session.WorkspacePath == "" {
+		// Belt-and-suspenders: without a workspace there is no known path to
+		// harvest findings from. Kill the orphan and fail the start.
+		_ = e.sessions.Kill(ctx, session.SessionID)
+		return nil, fmt.Errorf("agent executor: session %s for stage %q has no workspace; cannot harvest findings", session.SessionID, in.Stage.Name)
+	}
+
+	return &agentHandle{
+		stageIdentity: stageIdentity{runID: in.RunID, stageRunID: in.StageRunID, stageName: in.Stage.Name},
+		sessionID:     session.SessionID,
+		workspacePath: session.WorkspacePath,
+	}, nil
+}
+
+// Poll reports OutcomeRunning until the session is idle AND the findings file
+// exists, then harvests findings, kills the session, and returns
+// OutcomeCompleted. A vanished or terminal-without-findings session, or an
+// unparseable findings file, yields OutcomeFailed. On a bad findings file the
+// session is left alive for human inspection.
+func (e *AgentExecutor) Poll(ctx context.Context, h Handle) (Outcome, error) {
+	handle, ok := h.(*agentHandle)
+	if !ok {
+		return Outcome{}, fmt.Errorf("agent executor: unexpected handle type %T", h)
+	}
+
+	snap, exists, err := e.sessions.Get(ctx, handle.sessionID)
+	if err != nil {
+		return Outcome{}, fmt.Errorf("agent executor: get session %s: %w", handle.sessionID, err)
+	}
+	if !exists {
+		// The session vanished between polls: fail rather than spin forever
+		// waiting for an idle signal that will never come.
+		return Outcome{
+			Status:       OutcomeFailed,
+			ErrorMessage: fmt.Sprintf("stage %q session %s no longer exists", handle.stageName, handle.sessionID),
+		}, nil
+	}
+	if snap.Terminated || snap.Activity == "exited" {
+		return Outcome{
+			Status:       OutcomeFailed,
+			ErrorMessage: fmt.Sprintf("stage %q session %s terminated without findings (activity=%s)", handle.stageName, handle.sessionID, snap.Activity),
+		}, nil
+	}
+
+	findingsPath := filepath.Join(handle.workspacePath, stageFindingsRelativePath)
+	if snap.Activity != "idle" || !fileExists(findingsPath) {
+		return Outcome{Status: OutcomeRunning}, nil
+	}
+
+	result, err := parseFindingsFile(findingsPath)
+	if err != nil {
+		// Leave the session up so a human can inspect the bad findings file.
+		return Outcome{
+			Status:       OutcomeFailed,
+			ErrorMessage: fmt.Sprintf("stage %q produced unparseable findings at %s: %v", handle.stageName, findingsPath, err),
+		}, nil
+	}
+
+	_ = e.sessions.Kill(ctx, handle.sessionID)
+
+	outcome := Outcome{Status: OutcomeCompleted, Artifacts: result.artifacts}
+	if result.truncated {
+		outcome.Observations = []Observation{{
+			Name: "pipeline.findings.truncated",
+			Data: map[string]any{
+				"runId":        string(handle.runID),
+				"stageRunId":   string(handle.stageRunID),
+				"stageName":    handle.stageName,
+				"findingsPath": findingsPath,
+				"capBytes":     findingsFileSizeCapBytes,
+				"bytesRead":    result.bytesRead,
+			},
+		}}
+	}
+	return outcome, nil
+}
+
+// Cancel kills the underlying session early. Idempotent.
+func (e *AgentExecutor) Cancel(ctx context.Context, h Handle) error {
+	handle, ok := h.(*agentHandle)
+	if !ok {
+		return fmt.Errorf("agent executor: unexpected handle type %T", h)
+	}
+	if err := e.sessions.Kill(ctx, handle.sessionID); err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("agent executor: kill session %s: %w", handle.sessionID, err)
+	}
+	return nil
+}

--- a/backend/internal/pipeline/executors/agent_test.go
+++ b/backend/internal/pipeline/executors/agent_test.go
@@ -1,0 +1,247 @@
+package executors
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// mockSpawner is a scriptable SessionSpawner for agent-executor tests. No real
+// session is ever created.
+type mockSpawner struct {
+	workspace  string
+	spawnErr   error
+	spawnCalls int
+	killCalls  int
+
+	// snapshot state, mutated by tests between polls.
+	activity   string
+	terminated bool
+	exists     bool
+}
+
+func (m *mockSpawner) Spawn(_ context.Context, _ SpawnRequest) (SpawnedSession, error) {
+	m.spawnCalls++
+	if m.spawnErr != nil {
+		return SpawnedSession{}, m.spawnErr
+	}
+	m.exists = true
+	return SpawnedSession{SessionID: "sess-1", WorkspacePath: m.workspace}, nil
+}
+
+func (m *mockSpawner) Get(_ context.Context, _ string) (SessionSnapshot, bool, error) {
+	if !m.exists {
+		return SessionSnapshot{}, false, nil
+	}
+	return SessionSnapshot{Activity: m.activity, Terminated: m.terminated}, true, nil
+}
+
+func (m *mockSpawner) Kill(_ context.Context, _ string) error {
+	m.killCalls++
+	m.exists = false
+	return nil
+}
+
+func agentStartInput(ws string) StartInput {
+	return StartInput{
+		PipelineName: "ci",
+		ProjectID:    "proj",
+		RunID:        "run-1",
+		StageRunID:   "sr-1",
+		Stage:        agentStage(pipeline.ModeReview),
+	}
+}
+
+func startAgent(t *testing.T, m *mockSpawner) (*AgentExecutor, Handle) {
+	t.Helper()
+	exec := NewAgentExecutor(m)
+	h, err := exec.Start(context.Background(), agentStartInput(m.workspace))
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	return exec, h
+}
+
+func TestAgent_RunningUntilIdleAndFile(t *testing.T) {
+	m := &mockSpawner{workspace: t.TempDir(), activity: "active"}
+	exec, h := startAgent(t, m)
+
+	// Active, no file -> running.
+	out, _ := exec.Poll(context.Background(), h)
+	if out.Status != OutcomeRunning {
+		t.Fatalf("want running while active, got %s", out.Status)
+	}
+
+	// Idle but file still missing -> running.
+	m.activity = "idle"
+	out, _ = exec.Poll(context.Background(), h)
+	if out.Status != OutcomeRunning {
+		t.Fatalf("want running with no findings file, got %s", out.Status)
+	}
+}
+
+func TestAgent_CompletesAndKills(t *testing.T) {
+	ws := t.TempDir()
+	m := &mockSpawner{workspace: ws, activity: "idle"}
+	exec, h := startAgent(t, m)
+	writeFindingsAt(t, ws, findingLine(t, 0.9, "error"))
+
+	out, err := exec.Poll(context.Background(), h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != OutcomeCompleted {
+		t.Fatalf("want completed, got %s (%s)", out.Status, out.ErrorMessage)
+	}
+	if len(out.Artifacts) != 1 {
+		t.Fatalf("want 1 artifact, got %d", len(out.Artifacts))
+	}
+	if m.killCalls != 1 {
+		t.Errorf("want session killed once on completion, got %d", m.killCalls)
+	}
+}
+
+func TestAgent_EmptyFileCompletesZeroArtifacts(t *testing.T) {
+	ws := t.TempDir()
+	m := &mockSpawner{workspace: ws, activity: "idle"}
+	exec, h := startAgent(t, m)
+	writeFindingsAt(t, ws) // empty file
+
+	out, _ := exec.Poll(context.Background(), h)
+	if out.Status != OutcomeCompleted || len(out.Artifacts) != 0 {
+		t.Fatalf("empty file should complete with zero artifacts, got %s / %d", out.Status, len(out.Artifacts))
+	}
+	if m.killCalls != 1 {
+		t.Errorf("want kill on completion, got %d", m.killCalls)
+	}
+}
+
+func TestAgent_BadFindingsFailsWithoutKill(t *testing.T) {
+	ws := t.TempDir()
+	m := &mockSpawner{workspace: ws, activity: "idle"}
+	exec, h := startAgent(t, m)
+	writeFindingsAt(t, ws, "not-json {{{")
+
+	out, _ := exec.Poll(context.Background(), h)
+	if out.Status != OutcomeFailed {
+		t.Fatalf("want failed, got %s", out.Status)
+	}
+	if m.killCalls != 0 {
+		t.Errorf("bad findings file must leave session up, got kills=%d", m.killCalls)
+	}
+}
+
+func TestAgent_VanishedSessionFails(t *testing.T) {
+	m := &mockSpawner{workspace: t.TempDir(), activity: "idle"}
+	exec, h := startAgent(t, m)
+	m.exists = false // vanished
+
+	out, _ := exec.Poll(context.Background(), h)
+	if out.Status != OutcomeFailed {
+		t.Fatalf("want failed, got %s", out.Status)
+	}
+	if !strings.Contains(out.ErrorMessage, "no longer exists") {
+		t.Errorf("unexpected message: %s", out.ErrorMessage)
+	}
+}
+
+func TestAgent_TerminatedWithoutFindingsFails(t *testing.T) {
+	m := &mockSpawner{workspace: t.TempDir(), activity: "exited"}
+	exec, h := startAgent(t, m)
+
+	out, _ := exec.Poll(context.Background(), h)
+	if out.Status != OutcomeFailed {
+		t.Fatalf("want failed, got %s", out.Status)
+	}
+	if !strings.Contains(out.ErrorMessage, "terminated without findings") {
+		t.Errorf("unexpected message: %s", out.ErrorMessage)
+	}
+}
+
+func TestAgent_TruncationEmitsObservation(t *testing.T) {
+	ws := t.TempDir()
+	m := &mockSpawner{workspace: ws, activity: "idle"}
+	exec, h := startAgent(t, m)
+
+	// Write past the cap.
+	path := filepath.Join(ws, ".ao", pipeline.FindingsFilename)
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	f, _ := os.Create(path)
+	line := findingLine(t, 0.5, "info") + "\n"
+	for w := 0; w <= findingsFileSizeCapBytes; w += len(line) {
+		f.WriteString(line)
+	}
+	f.Close()
+
+	out, _ := exec.Poll(context.Background(), h)
+	if out.Status != OutcomeCompleted {
+		t.Fatalf("want completed, got %s", out.Status)
+	}
+	if len(out.Observations) != 1 || out.Observations[0].Name != "pipeline.findings.truncated" {
+		t.Fatalf("expected a truncation observation, got %+v", out.Observations)
+	}
+}
+
+func TestAgent_StartRejectsNonAgentStage(t *testing.T) {
+	m := &mockSpawner{workspace: t.TempDir()}
+	exec := NewAgentExecutor(m)
+	in := agentStartInput(m.workspace)
+	in.Stage.Executor.Kind = pipeline.ExecutorCommand
+	if _, err := exec.Start(context.Background(), in); err == nil {
+		t.Fatal("expected error starting a command stage on the agent executor")
+	}
+	if m.spawnCalls != 0 {
+		t.Error("must not spawn for a non-agent stage")
+	}
+}
+
+func TestAgent_SpawnErrorPropagates(t *testing.T) {
+	m := &mockSpawner{workspace: t.TempDir(), spawnErr: errors.New("boom")}
+	exec := NewAgentExecutor(m)
+	if _, err := exec.Start(context.Background(), agentStartInput(m.workspace)); err == nil {
+		t.Fatal("expected spawn error to propagate")
+	}
+}
+
+func TestAgent_NoWorkspaceKillsAndFails(t *testing.T) {
+	m := &mockSpawner{workspace: ""} // spawn returns empty workspace
+	exec := NewAgentExecutor(m)
+	if _, err := exec.Start(context.Background(), agentStartInput("")); err == nil {
+		t.Fatal("expected error when spawned session has no workspace")
+	}
+	if m.killCalls != 1 {
+		t.Errorf("want the workspace-less orphan killed, got %d", m.killCalls)
+	}
+}
+
+func TestAgent_CancelKills(t *testing.T) {
+	m := &mockSpawner{workspace: t.TempDir(), activity: "active"}
+	exec, h := startAgent(t, m)
+	if err := exec.Cancel(context.Background(), h); err != nil {
+		t.Fatal(err)
+	}
+	if m.killCalls != 1 {
+		t.Errorf("cancel should kill once, got %d", m.killCalls)
+	}
+}
+
+// writeFindingsAt writes a findings file under {ws}/.ao/.
+func writeFindingsAt(t *testing.T, ws string, lines ...string) {
+	t.Helper()
+	dir := filepath.Join(ws, ".ao")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := ""
+	for _, l := range lines {
+		content += l + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, pipeline.FindingsFilename), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/pipeline/executors/builtin.go
+++ b/backend/internal/pipeline/executors/builtin.go
@@ -1,0 +1,268 @@
+package executors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// ArtifactStore fetches persisted upstream artifacts for a run. Injected so the
+// builtin executor never reads SQLite directly (that seam is the store task's
+// concern); the engine's adapter maps it onto the real store.
+type ArtifactStore interface {
+	// UpstreamArtifacts returns the artifacts each named upstream stage produced
+	// in the run, keyed by stage name. Stages with no artifacts may be omitted.
+	UpstreamArtifacts(ctx context.Context, runID pipeline.RunID, stageNames []string) (map[string][]pipeline.Artifact, error)
+}
+
+// SessionMessenger is the router's delivery seam: probe a session before
+// delivering, then send it a message. Mirrors SessionManager.Send/liveness but
+// stays a narrow, mockable interface.
+type SessionMessenger interface {
+	Alive(ctx context.Context, sessionID string) (bool, error)
+	Send(ctx context.Context, sessionID, message string) error
+}
+
+// builtinHandle is the running-stage token for a builtin stage. Builtins run
+// synchronously in-process, so the outcome is computed in Start and latched
+// here; Poll returns it immediately.
+type builtinHandle struct {
+	stageIdentity
+	final Outcome
+}
+
+// BuiltinExecutor runs the engine-internal builtins (router, compose). It
+// fetches upstream artifacts through the injected store, dispatches to the
+// named builtin, and returns the resulting artifacts. It never spawns a session
+// or shells out.
+type BuiltinExecutor struct {
+	store     ArtifactStore
+	messenger SessionMessenger
+}
+
+// NewBuiltinExecutor builds a builtin executor over the store + messenger seams.
+func NewBuiltinExecutor(store ArtifactStore, messenger SessionMessenger) *BuiltinExecutor {
+	return &BuiltinExecutor{store: store, messenger: messenger}
+}
+
+var _ StageExecutor = (*BuiltinExecutor)(nil)
+
+// Start fetches the stage's upstream artifacts and dispatches the builtin. The
+// work is synchronous; Poll returns the latched outcome.
+func (e *BuiltinExecutor) Start(ctx context.Context, in StartInput) (Handle, error) {
+	if in.Stage.Executor.Kind != pipeline.ExecutorBuiltin {
+		return nil, fmt.Errorf("builtin executor cannot start stage %q with executor.kind=%s", in.Stage.Name, in.Stage.Executor.Kind)
+	}
+	id := stageIdentity{runID: in.RunID, stageRunID: in.StageRunID, stageName: in.Stage.Name}
+
+	inputs, err := e.store.UpstreamArtifacts(ctx, in.RunID, in.Stage.DependsOn)
+	if err != nil {
+		return &builtinHandle{stageIdentity: id, final: Outcome{
+			Status:       OutcomeFailed,
+			ErrorMessage: fmt.Sprintf("builtin stage %q: fetch upstream artifacts: %v", in.Stage.Name, err),
+		}}, nil
+	}
+
+	out := e.dispatch(ctx, in, inputs)
+	return &builtinHandle{stageIdentity: id, final: out}, nil
+}
+
+// Poll returns the builtin's latched outcome.
+func (e *BuiltinExecutor) Poll(_ context.Context, h Handle) (Outcome, error) {
+	handle, ok := h.(*builtinHandle)
+	if !ok {
+		return Outcome{}, fmt.Errorf("builtin executor: unexpected handle type %T", h)
+	}
+	return handle.final, nil
+}
+
+// Cancel is a no-op: builtins finish synchronously in Start with nothing to
+// tear down.
+func (e *BuiltinExecutor) Cancel(_ context.Context, h Handle) error {
+	if _, ok := h.(*builtinHandle); !ok {
+		return fmt.Errorf("builtin executor: unexpected handle type %T", h)
+	}
+	return nil
+}
+
+// dispatch routes to the named builtin. An unknown name is a config bug that
+// validation should have caught; surface it as a failed outcome rather than a
+// panic.
+func (e *BuiltinExecutor) dispatch(ctx context.Context, in StartInput, inputs map[string][]pipeline.Artifact) Outcome {
+	switch in.Stage.Executor.Name {
+	case pipeline.BuiltinRouter:
+		return e.runRouter(ctx, in, inputs)
+	case pipeline.BuiltinCompose:
+		return runCompose(inputs)
+	default:
+		return Outcome{
+			Status:       OutcomeFailed,
+			ErrorMessage: fmt.Sprintf("unknown builtin executor name %q", in.Stage.Executor.Name),
+		}
+	}
+}
+
+// runRouter delivers each upstream stage's artifacts to the linked worker
+// session as one message per stage. A single pre-send liveness probe gates all
+// deliveries: a dead worker yields a skipped_worker_dead observation + a
+// delivery_failed json artifact per stage, leaving the findings for the next
+// tick. Per-send errors are captured the same way without aborting the rest.
+func (e *BuiltinExecutor) runRouter(ctx context.Context, in StartInput, inputs map[string][]pipeline.Artifact) Outcome {
+	target := in.RoutingTargetSessionID
+	if target == "" {
+		target = in.LinkedSessionID
+	}
+
+	var artifacts []pipeline.ArtifactInput
+	var observations []Observation
+
+	// Single liveness probe — every input stage shares the same target, so one
+	// probe avoids hammering the runtime when there are many findings.
+	alive, err := e.messenger.Alive(ctx, target)
+	if err != nil {
+		// Treat a probe error as "not alive": we cannot confirm the worker can
+		// receive, so skip delivery and leave findings open for the next tick.
+		alive = false
+	}
+
+	for _, fromStage := range sortedStageNames(inputs) {
+		stageArtifacts := inputs[fromStage]
+		if len(stageArtifacts) == 0 {
+			continue
+		}
+
+		if !alive {
+			observations = append(observations, Observation{
+				Name: "pipeline.send.skipped_worker_dead",
+				Data: routerObsData(in, fromStage, target, len(stageArtifacts)),
+			})
+			artifacts = append(artifacts, pipeline.ArtifactInput{
+				Kind: pipeline.ArtifactKindJSON,
+				Data: map[string]any{
+					"result":          "delivery_failed",
+					"reason":          "worker_dead",
+					"fromStage":       fromStage,
+					"targetSessionId": target,
+					"artifactCount":   len(stageArtifacts),
+				},
+			})
+			continue
+		}
+
+		message := composeRouterMessage(fromStage, stageArtifacts)
+		if err := e.messenger.Send(ctx, target, message); err != nil {
+			observations = append(observations, Observation{
+				Name: "pipeline.send.failed",
+				Data: mergeMap(routerObsData(in, fromStage, target, len(stageArtifacts)), map[string]any{"error": err.Error()}),
+			})
+			artifacts = append(artifacts, pipeline.ArtifactInput{
+				Kind: pipeline.ArtifactKindJSON,
+				Data: map[string]any{
+					"result":          "delivery_failed",
+					"reason":          "send_error",
+					"fromStage":       fromStage,
+					"targetSessionId": target,
+					"error":           err.Error(),
+				},
+			})
+			continue
+		}
+
+		artifacts = append(artifacts, pipeline.ArtifactInput{
+			Kind: pipeline.ArtifactKindJSON,
+			Data: map[string]any{
+				"result":          "delivered",
+				"fromStage":       fromStage,
+				"targetSessionId": target,
+				"artifactCount":   len(stageArtifacts),
+			},
+		})
+	}
+
+	return Outcome{Status: OutcomeCompleted, Verdict: pipeline.VerdictNeutral, Artifacts: artifacts, Observations: observations}
+}
+
+// runCompose merges upstream artifacts into a single JSON artifact so a
+// downstream stage can consume one structured input instead of N per-stage
+// blobs.
+func runCompose(inputs map[string][]pipeline.Artifact) Outcome {
+	stages := map[string]any{}
+	totalArtifacts := 0
+	composedFrom := sortedStageNames(inputs)
+	for _, name := range composedFrom {
+		arts := inputs[name]
+		stages[name] = arts
+		totalArtifacts += len(arts)
+	}
+
+	artifact := pipeline.ArtifactInput{
+		Kind: pipeline.ArtifactKindJSON,
+		Data: map[string]any{
+			"composedFrom":   composedFrom,
+			"totalArtifacts": totalArtifacts,
+			"stages":         stages,
+		},
+	}
+	return Outcome{Status: OutcomeCompleted, Verdict: pipeline.VerdictNeutral, Artifacts: []pipeline.ArtifactInput{artifact}}
+}
+
+// composeRouterMessage renders one upstream stage's artifacts as a human/agent
+// readable delivery message.
+func composeRouterMessage(stageName string, artifacts []pipeline.Artifact) string {
+	var lines []string
+	lines = append(lines, fmt.Sprintf("Findings from upstream pipeline stage %q:", stageName))
+	lines = append(lines, "")
+	for _, a := range artifacts {
+		if a.Kind == pipeline.ArtifactKindFinding {
+			lines = append(lines, fmt.Sprintf("- [%s] %s:%d-%d - %s", a.Severity, a.FilePath, a.StartLine, a.EndLine, a.Title))
+			lines = append(lines, "  "+a.Description)
+		} else {
+			lines = append(lines, "- "+marshalCompact(a.Data))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// sortedStageNames returns the input stage names in a stable order so router
+// deliveries and compose output are deterministic (map iteration is random).
+func sortedStageNames(inputs map[string][]pipeline.Artifact) []string {
+	names := make([]string, 0, len(inputs))
+	for name := range inputs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func routerObsData(in StartInput, fromStage, target string, count int) map[string]any {
+	return map[string]any{
+		"runId":           string(in.RunID),
+		"stageRunId":      string(in.StageRunID),
+		"stageName":       in.Stage.Name,
+		"fromStage":       fromStage,
+		"targetSessionId": target,
+		"artifactCount":   count,
+	}
+}
+
+func mergeMap(base, extra map[string]any) map[string]any {
+	for k, v := range extra {
+		base[k] = v
+	}
+	return base
+}
+
+// marshalCompact renders a JSON artifact's data on one line for the router
+// message. A marshal failure (free-form data) degrades to an empty object
+// rather than aborting delivery.
+func marshalCompact(data map[string]any) string {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}

--- a/backend/internal/pipeline/executors/builtin.go
+++ b/backend/internal/pipeline/executors/builtin.go
@@ -214,12 +214,12 @@ func runCompose(inputs map[string][]pipeline.Artifact) Outcome {
 // readable delivery message.
 func composeRouterMessage(stageName string, artifacts []pipeline.Artifact) string {
 	lines := make([]string, 0, len(artifacts)*2+2)
-	lines = append(lines, fmt.Sprintf("Findings from upstream pipeline stage %q:", stageName))
-	lines = append(lines, "")
+	lines = append(lines, fmt.Sprintf("Findings from upstream pipeline stage %q:", stageName), "")
 	for _, a := range artifacts {
 		if a.Kind == pipeline.ArtifactKindFinding {
-			lines = append(lines, fmt.Sprintf("- [%s] %s:%d-%d - %s", a.Severity, a.FilePath, a.StartLine, a.EndLine, a.Title))
-			lines = append(lines, "  "+a.Description)
+			lines = append(lines,
+				fmt.Sprintf("- [%s] %s:%d-%d - %s", a.Severity, a.FilePath, a.StartLine, a.EndLine, a.Title),
+				"  "+a.Description)
 		} else {
 			lines = append(lines, "- "+marshalCompact(a.Data))
 		}

--- a/backend/internal/pipeline/executors/builtin.go
+++ b/backend/internal/pipeline/executors/builtin.go
@@ -117,7 +117,7 @@ func (e *BuiltinExecutor) runRouter(ctx context.Context, in StartInput, inputs m
 		target = in.LinkedSessionID
 	}
 
-	var artifacts []pipeline.ArtifactInput
+	artifacts := make([]pipeline.ArtifactInput, 0, len(inputs))
 	var observations []Observation
 
 	// Single liveness probe — every input stage shares the same target, so one
@@ -213,7 +213,7 @@ func runCompose(inputs map[string][]pipeline.Artifact) Outcome {
 // composeRouterMessage renders one upstream stage's artifacts as a human/agent
 // readable delivery message.
 func composeRouterMessage(stageName string, artifacts []pipeline.Artifact) string {
-	var lines []string
+	lines := make([]string, 0, len(artifacts)*2+2)
 	lines = append(lines, fmt.Sprintf("Findings from upstream pipeline stage %q:", stageName))
 	lines = append(lines, "")
 	for _, a := range artifacts {

--- a/backend/internal/pipeline/executors/builtin_test.go
+++ b/backend/internal/pipeline/executors/builtin_test.go
@@ -1,0 +1,275 @@
+package executors
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// fakeStore returns scripted upstream artifacts.
+type fakeStore struct {
+	arts map[string][]pipeline.Artifact
+	err  error
+}
+
+func (s *fakeStore) UpstreamArtifacts(_ context.Context, _ pipeline.RunID, _ []string) (map[string][]pipeline.Artifact, error) {
+	return s.arts, s.err
+}
+
+// fakeMessenger records deliveries and scripts liveness/send behavior.
+type fakeMessenger struct {
+	alive    bool
+	aliveErr error
+	sendErr  error
+
+	aliveCalls int
+	sent       []string // messages delivered
+}
+
+func (m *fakeMessenger) Alive(_ context.Context, _ string) (bool, error) {
+	m.aliveCalls++
+	return m.alive, m.aliveErr
+}
+
+func (m *fakeMessenger) Send(_ context.Context, _, message string) error {
+	if m.sendErr != nil {
+		return m.sendErr
+	}
+	m.sent = append(m.sent, message)
+	return nil
+}
+
+func finding(stage, file, title string) pipeline.Artifact {
+	return pipeline.Artifact{
+		ArtifactInput: pipeline.ArtifactInput{
+			Kind: pipeline.ArtifactKindFinding, FilePath: file, StartLine: 1, EndLine: 2,
+			Title: title, Description: "d", Category: "general", Severity: pipeline.SeverityWarning, Confidence: 0.7,
+		},
+		StageName: stage,
+	}
+}
+
+func builtinStage(name pipeline.BuiltinName, dependsOn ...string) pipeline.Stage {
+	return pipeline.Stage{
+		Name:      "builtin-stage",
+		Executor:  pipeline.StageExecutor{Kind: pipeline.ExecutorBuiltin, Name: name},
+		DependsOn: dependsOn,
+	}
+}
+
+func runBuiltin(t *testing.T, store ArtifactStore, msg SessionMessenger, in StartInput) Outcome {
+	t.Helper()
+	exec := NewBuiltinExecutor(store, msg)
+	h, err := exec.Start(context.Background(), in)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	out, err := exec.Poll(context.Background(), h)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	return out
+}
+
+func builtinInput(stage pipeline.Stage) StartInput {
+	return StartInput{
+		PipelineName: "ci", RunID: "run-1", StageRunID: "sr-1",
+		Stage: stage, LinkedSessionID: "worker-1",
+	}
+}
+
+func TestRouter_DeliversToLinkedSession(t *testing.T) {
+	store := &fakeStore{arts: map[string][]pipeline.Artifact{
+		"review": {finding("review", "a.go", "bug A")},
+	}}
+	msg := &fakeMessenger{alive: true}
+	out := runBuiltin(t, store, msg, builtinInput(builtinStage(pipeline.BuiltinRouter, "review")))
+
+	if out.Status != OutcomeCompleted || out.Verdict != pipeline.VerdictNeutral {
+		t.Fatalf("want completed/neutral, got %s/%s", out.Status, out.Verdict)
+	}
+	if msg.aliveCalls != 1 {
+		t.Errorf("want a single liveness probe, got %d", msg.aliveCalls)
+	}
+	if len(msg.sent) != 1 {
+		t.Fatalf("want 1 delivery, got %d", len(msg.sent))
+	}
+	if len(out.Artifacts) != 1 || out.Artifacts[0].Data["result"] != "delivered" {
+		t.Fatalf("want a delivered json artifact, got %+v", out.Artifacts)
+	}
+}
+
+func TestRouter_TargetOverrideWins(t *testing.T) {
+	store := &fakeStore{arts: map[string][]pipeline.Artifact{"review": {finding("review", "a.go", "x")}}}
+	msg := &fakeMessenger{alive: true}
+	in := builtinInput(builtinStage(pipeline.BuiltinRouter, "review"))
+	in.RoutingTargetSessionID = "orchestrator-9"
+	out := runBuiltin(t, store, msg, in)
+	if out.Artifacts[0].Data["targetSessionId"] != "orchestrator-9" {
+		t.Errorf("routing target override must win, got %v", out.Artifacts[0].Data["targetSessionId"])
+	}
+}
+
+func TestRouter_DeadWorkerSkipsDelivery(t *testing.T) {
+	store := &fakeStore{arts: map[string][]pipeline.Artifact{
+		"review": {finding("review", "a.go", "x")},
+		"lint":   {finding("lint", "b.go", "y")},
+	}}
+	msg := &fakeMessenger{alive: false}
+	out := runBuiltin(t, store, msg, builtinInput(builtinStage(pipeline.BuiltinRouter, "review", "lint")))
+
+	if len(msg.sent) != 0 {
+		t.Fatalf("dead worker must not receive deliveries, got %d", len(msg.sent))
+	}
+	if len(out.Observations) != 2 {
+		t.Fatalf("want a skipped_worker_dead observation per stage, got %d", len(out.Observations))
+	}
+	for _, o := range out.Observations {
+		if o.Name != "pipeline.send.skipped_worker_dead" {
+			t.Errorf("unexpected observation %q", o.Name)
+		}
+	}
+	for _, a := range out.Artifacts {
+		if a.Data["result"] != "delivery_failed" || a.Data["reason"] != "worker_dead" {
+			t.Errorf("want delivery_failed/worker_dead, got %+v", a.Data)
+		}
+	}
+}
+
+func TestRouter_SendErrorCaptured(t *testing.T) {
+	store := &fakeStore{arts: map[string][]pipeline.Artifact{"review": {finding("review", "a.go", "x")}}}
+	msg := &fakeMessenger{alive: true, sendErr: errors.New("pipe broke")}
+	out := runBuiltin(t, store, msg, builtinInput(builtinStage(pipeline.BuiltinRouter, "review")))
+
+	if len(out.Observations) != 1 || out.Observations[0].Name != "pipeline.send.failed" {
+		t.Fatalf("want a send.failed observation, got %+v", out.Observations)
+	}
+	if out.Artifacts[0].Data["reason"] != "send_error" {
+		t.Errorf("want send_error artifact, got %+v", out.Artifacts[0].Data)
+	}
+}
+
+func TestRouter_ProbeErrorTreatedAsDead(t *testing.T) {
+	store := &fakeStore{arts: map[string][]pipeline.Artifact{"review": {finding("review", "a.go", "x")}}}
+	msg := &fakeMessenger{aliveErr: errors.New("probe failed")}
+	out := runBuiltin(t, store, msg, builtinInput(builtinStage(pipeline.BuiltinRouter, "review")))
+	if len(msg.sent) != 0 {
+		t.Fatal("a failed probe must skip delivery")
+	}
+	if out.Observations[0].Name != "pipeline.send.skipped_worker_dead" {
+		t.Errorf("want skipped_worker_dead on probe error, got %q", out.Observations[0].Name)
+	}
+}
+
+func TestRouter_EmptyStagesProduceNothing(t *testing.T) {
+	store := &fakeStore{arts: map[string][]pipeline.Artifact{"review": {}}}
+	msg := &fakeMessenger{alive: true}
+	out := runBuiltin(t, store, msg, builtinInput(builtinStage(pipeline.BuiltinRouter, "review")))
+	if len(out.Artifacts) != 0 || len(msg.sent) != 0 {
+		t.Fatalf("stages with no artifacts should produce no delivery, got %+v", out.Artifacts)
+	}
+}
+
+func TestCompose_MergesUpstream(t *testing.T) {
+	store := &fakeStore{arts: map[string][]pipeline.Artifact{
+		"a": {finding("a", "f1.go", "x")},
+		"b": {finding("b", "f2.go", "y"), finding("b", "f3.go", "z")},
+	}}
+	out := runBuiltin(t, store, &fakeMessenger{}, builtinInput(builtinStage(pipeline.BuiltinCompose, "a", "b")))
+
+	if out.Status != OutcomeCompleted || len(out.Artifacts) != 1 {
+		t.Fatalf("compose should yield one json artifact, got %s / %d", out.Status, len(out.Artifacts))
+	}
+	data := out.Artifacts[0].Data
+	if data["totalArtifacts"] != 3 {
+		t.Errorf("want totalArtifacts=3, got %v", data["totalArtifacts"])
+	}
+	from, ok := data["composedFrom"].([]string)
+	if !ok || len(from) != 2 || from[0] != "a" || from[1] != "b" {
+		t.Errorf("want composedFrom=[a b] (sorted), got %v", data["composedFrom"])
+	}
+	stages, ok := data["stages"].(map[string]any)
+	if !ok || len(stages) != 2 {
+		t.Errorf("want per-stage buckets, got %v", data["stages"])
+	}
+}
+
+func TestBuiltin_StoreErrorFails(t *testing.T) {
+	store := &fakeStore{err: errors.New("db down")}
+	out := runBuiltin(t, store, &fakeMessenger{}, builtinInput(builtinStage(pipeline.BuiltinCompose, "a")))
+	if out.Status != OutcomeFailed {
+		t.Fatalf("store error should fail the stage, got %s", out.Status)
+	}
+}
+
+func TestBuiltin_UnknownNameFails(t *testing.T) {
+	store := &fakeStore{arts: map[string][]pipeline.Artifact{}}
+	out := runBuiltin(t, store, &fakeMessenger{}, builtinInput(builtinStage(pipeline.BuiltinName("bogus"))))
+	if out.Status != OutcomeFailed {
+		t.Fatalf("unknown builtin should fail, got %s", out.Status)
+	}
+}
+
+func TestBuiltin_StartRejectsNonBuiltinStage(t *testing.T) {
+	exec := NewBuiltinExecutor(&fakeStore{}, &fakeMessenger{})
+	in := builtinInput(agentStage(pipeline.ModeReview))
+	if _, err := exec.Start(context.Background(), in); err == nil {
+		t.Fatal("expected error for a non-builtin stage")
+	}
+}
+
+// --- Set facade routing ---
+
+func TestSet_RoutesByKind(t *testing.T) {
+	agentSpawner := &mockSpawner{workspace: t.TempDir(), activity: "active"}
+	cmdRunner := &fakeRunner{res: CommandResult{ExitCode: 0, Stdout: `{"outcome":"succeeded"}`}}
+	cmdSessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "/ws", Fork: ForkNo}}
+	store := &fakeStore{arts: map[string][]pipeline.Artifact{}}
+
+	set := NewSet(
+		NewAgentExecutor(agentSpawner),
+		NewCommandExecutor(cmdRunner, cmdSessions),
+		NewBuiltinExecutor(store, &fakeMessenger{}),
+	)
+
+	// Command stage routes to the command executor.
+	h, err := set.Start(context.Background(), baseCommandInput())
+	if err != nil {
+		t.Fatalf("start command via set: %v", err)
+	}
+	out, err := set.Poll(context.Background(), h)
+	if err != nil || out.Status != OutcomeCompleted {
+		t.Fatalf("command via set should complete, got %s (%v)", out.Status, err)
+	}
+	if !cmdRunner.started {
+		t.Error("set did not route the command stage to the command runner")
+	}
+
+	// Builtin stage routes to the builtin executor.
+	bh, err := set.Start(context.Background(), builtinInput(builtinStage(pipeline.BuiltinCompose)))
+	if err != nil {
+		t.Fatalf("start builtin via set: %v", err)
+	}
+	bout, _ := set.Poll(context.Background(), bh)
+	if bout.Status != OutcomeCompleted {
+		t.Errorf("builtin via set should complete, got %s", bout.Status)
+	}
+}
+
+func TestSet_CancelRoutesToOwner(t *testing.T) {
+	agentSpawner := &mockSpawner{workspace: t.TempDir(), activity: "active"}
+	set := NewSet(NewAgentExecutor(agentSpawner), nil, nil)
+	in := agentStartInput(agentSpawner.workspace)
+	h, err := set.Start(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := set.Cancel(context.Background(), h); err != nil {
+		t.Fatal(err)
+	}
+	if agentSpawner.killCalls != 1 {
+		t.Errorf("cancel via set should kill the agent session, got %d", agentSpawner.killCalls)
+	}
+}

--- a/backend/internal/pipeline/executors/command.go
+++ b/backend/internal/pipeline/executors/command.go
@@ -1,0 +1,338 @@
+package executors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// commandOutputCapBytes bounds captured stdout/stderr (1 MiB) so a runaway shim
+// cannot OOM the engine.
+const commandOutputCapBytes = 1 << 20
+
+// ForkStatus classifies the linked session's PR provenance for the fork gate.
+// The nil-safe Unknown value is the fail-safe default: a PR whose fork status
+// the SCM plugin cannot determine is treated as untrusted.
+type ForkStatus int
+
+const (
+	// ForkUnknown means fork status could not be determined; blocked by default.
+	ForkUnknown ForkStatus = iota
+	// ForkNo means the PR is not from a fork (or there is no PR); safe to run.
+	ForkNo
+	// ForkYes means the PR is from a fork; blocked unless allowForkPRs.
+	ForkYes
+)
+
+// CommandSession is the linked-session facts the command executor needs: where
+// to run (workspace + cwd) and whether the PR is from a fork. Injected so the
+// executor stays decoupled from session storage.
+type CommandSession struct {
+	WorkspacePath string
+	Fork          ForkStatus
+	// PRNumber is surfaced in the fork-skip observation; 0 when there is no PR.
+	PRNumber int
+}
+
+// CommandSessions resolves the linked worker session for a command stage.
+type CommandSessions interface {
+	Get(ctx context.Context, sessionID string) (CommandSession, bool, error)
+}
+
+// CommandSpec is the resolved subprocess the runner should start.
+type CommandSpec struct {
+	Command string
+	Args    []string
+	Env     map[string]string
+	Dir     string
+	// OutputCap bounds captured stdout/stderr bytes.
+	OutputCap int
+}
+
+// CommandResult is a finished subprocess. ExitCode is meaningful only when
+// Signal is empty; a non-empty Signal means the process was killed.
+type CommandResult struct {
+	ExitCode     int
+	Signal       string
+	Stdout       string
+	Stderr       string
+	StdoutCapped bool
+	// Err is set when the process failed to spawn or wait errored for a reason
+	// other than a non-zero exit (which is reported via ExitCode).
+	Err error
+}
+
+// CommandProcess is a started subprocess. Done closes on exit, after which
+// Result is readable. Kill terminates the process tree (the runner owns
+// SIGTERM->SIGKILL escalation so detached shells do not outlive the stage).
+type CommandProcess interface {
+	Done() <-chan struct{}
+	Result() CommandResult
+	Kill()
+}
+
+// CommandRunner starts a subprocess for a command stage. The production impl
+// (osRunner) shells out; unit tests inject a fake so no real process is spawned.
+type CommandRunner interface {
+	Start(ctx context.Context, spec CommandSpec) (CommandProcess, error)
+}
+
+// commandHandle is the running-stage token for a command stage. child is nil
+// when the stage short-circuited before spawn (fork gate or a start error);
+// final is then pre-populated.
+type commandHandle struct {
+	stageIdentity
+	child CommandProcess
+	final *Outcome
+}
+
+// CommandExecutor shells out a stage's command in the linked session's
+// workspace and maps its JSON-over-stdout result to a verdict. Fork PRs are
+// gated before any subprocess spawns.
+type CommandExecutor struct {
+	runner   CommandRunner
+	sessions CommandSessions
+}
+
+// NewCommandExecutor builds a command executor over the given runner + session
+// seams.
+func NewCommandExecutor(runner CommandRunner, sessions CommandSessions) *CommandExecutor {
+	return &CommandExecutor{runner: runner, sessions: sessions}
+}
+
+var _ StageExecutor = (*CommandExecutor)(nil)
+
+// Start resolves the linked session, applies the fork-PR gate, then spawns the
+// command. Fork-gated stages complete as neutral with a skip observation and
+// NO subprocess is ever started. A missing session/workspace or spawn failure
+// short-circuits to a failed outcome.
+func (e *CommandExecutor) Start(ctx context.Context, in StartInput) (Handle, error) {
+	if in.Stage.Executor.Kind != pipeline.ExecutorCommand {
+		return nil, fmt.Errorf("command executor cannot start stage %q with executor.kind=%s", in.Stage.Name, in.Stage.Executor.Kind)
+	}
+	id := stageIdentity{runID: in.RunID, stageRunID: in.StageRunID, stageName: in.Stage.Name}
+	spec := in.Stage.Executor
+
+	session, exists, err := e.sessions.Get(ctx, in.LinkedSessionID)
+	if err != nil {
+		return shortCircuit(id, Outcome{Status: OutcomeFailed,
+			ErrorMessage: fmt.Sprintf("failed to resolve session %s for command stage %q: %v", in.LinkedSessionID, in.Stage.Name, err)}), nil
+	}
+	if !exists {
+		return shortCircuit(id, Outcome{Status: OutcomeFailed,
+			ErrorMessage: fmt.Sprintf("command stage %q references unknown session %s", in.Stage.Name, in.LinkedSessionID)}), nil
+	}
+
+	// Fork-PR gate, BEFORE spawn. ForkUnknown is fail-safe (blocks) so untrusted
+	// code we cannot classify never executes.
+	if session.Fork != ForkNo && !in.AllowForkPRs {
+		reason := fmt.Sprintf("PR #%d is from a fork and pipeline.allowForkPRs is not enabled", session.PRNumber)
+		if session.Fork == ForkUnknown {
+			reason = fmt.Sprintf("SCM plugin could not determine fork status for PR #%d; blocking by default", session.PRNumber)
+		}
+		return shortCircuit(id, Outcome{
+			Status:    OutcomeCompleted,
+			Verdict:   pipeline.VerdictNeutral,
+			Artifacts: nil,
+			Observations: []Observation{{
+				Name: "command_stage_skipped_fork_pr",
+				Data: map[string]any{
+					"stage":      in.Stage.Name,
+					"prNumber":   session.PRNumber,
+					"isFromFork": session.Fork == ForkYes,
+					"reason":     reason,
+				},
+			}},
+		}), nil
+	}
+
+	if session.WorkspacePath == "" {
+		return shortCircuit(id, Outcome{Status: OutcomeFailed,
+			ErrorMessage: fmt.Sprintf("command stage %q requires a workspace but session %s has none", in.Stage.Name, in.LinkedSessionID)}), nil
+	}
+
+	dir, err := resolveCwd(session.WorkspacePath, spec.Cwd)
+	if err != nil {
+		return shortCircuit(id, Outcome{Status: OutcomeFailed,
+			ErrorMessage: fmt.Sprintf("command stage %q: %v", in.Stage.Name, err)}), nil
+	}
+
+	child, err := e.runner.Start(ctx, CommandSpec{
+		Command:   spec.Command,
+		Args:      spec.Args,
+		Env:       spec.Env,
+		Dir:       dir,
+		OutputCap: commandOutputCapBytes,
+	})
+	if err != nil {
+		return shortCircuit(id, Outcome{Status: OutcomeFailed,
+			ErrorMessage: fmt.Sprintf("failed to spawn command %q: %v", spec.Command, err)}), nil
+	}
+
+	return &commandHandle{stageIdentity: id, child: child}, nil
+}
+
+// Poll returns OutcomeRunning until the child exits, then interprets its exit
+// code + stdout into a terminal outcome. A short-circuited handle returns its
+// latched outcome immediately.
+func (e *CommandExecutor) Poll(_ context.Context, h Handle) (Outcome, error) {
+	handle, ok := h.(*commandHandle)
+	if !ok {
+		return Outcome{}, fmt.Errorf("command executor: unexpected handle type %T", h)
+	}
+	if handle.final != nil {
+		return *handle.final, nil
+	}
+	select {
+	case <-handle.child.Done():
+		out := interpretExit(handle.stageName, handle.child.Result())
+		handle.final = &out
+		return out, nil
+	default:
+		return Outcome{Status: OutcomeRunning}, nil
+	}
+}
+
+// Cancel kills the subprocess tree. Idempotent and a no-op on a short-circuited
+// or already-finished handle.
+func (e *CommandExecutor) Cancel(_ context.Context, h Handle) error {
+	handle, ok := h.(*commandHandle)
+	if !ok {
+		return fmt.Errorf("command executor: unexpected handle type %T", h)
+	}
+	if handle.child == nil || handle.final != nil {
+		return nil
+	}
+	handle.child.Kill()
+	return nil
+}
+
+// shortCircuit builds a handle whose outcome is already decided (fork gate,
+// resolution failure, spawn failure). No subprocess is attached.
+func shortCircuit(id stageIdentity, out Outcome) *commandHandle {
+	return &commandHandle{stageIdentity: id, child: nil, final: &out}
+}
+
+// resolveCwd joins a config-provided relative cwd onto the workspace root,
+// rejecting absolute paths and ".." segments so a malicious config cannot
+// escape the worktree.
+func resolveCwd(base, rel string) (string, error) {
+	if rel == "" {
+		return base, nil
+	}
+	if strings.HasPrefix(rel, "/") || strings.HasPrefix(rel, "\\") || isWindowsAbs(rel) {
+		return "", fmt.Errorf("command.cwd must be a relative path inside the workspace, got %q", rel)
+	}
+	for _, seg := range strings.FieldsFunc(rel, func(r rune) bool { return r == '/' || r == '\\' }) {
+		if seg == ".." {
+			return "", fmt.Errorf("command.cwd must be a relative path inside the workspace, got %q", rel)
+		}
+	}
+	return strings.TrimRight(base, "/\\") + "/" + strings.TrimLeft(rel, "/\\"), nil
+}
+
+func isWindowsAbs(rel string) bool {
+	return len(rel) >= 2 && rel[1] == ':' &&
+		((rel[0] >= 'a' && rel[0] <= 'z') || (rel[0] >= 'A' && rel[0] <= 'Z'))
+}
+
+// commandTaskResult is the single JSON object a command shim writes to stdout.
+type commandTaskResult struct {
+	Outcome   string                   `json:"outcome"`
+	Verdict   pipeline.Verdict         `json:"verdict,omitempty"`
+	Artifacts []pipeline.ArtifactInput `json:"artifacts,omitempty"`
+	Reason    string                   `json:"reason,omitempty"`
+}
+
+// interpretExit maps a finished subprocess to a stage outcome per the
+// JSON-over-stdout contract:
+//
+//   - non-zero exit / signal / spawn error -> failed (the shim itself crashed;
+//     a partial stdout dump is worse than a clean failure label).
+//   - exit 0 with capped/empty/unparseable/invalid stdout -> failed.
+//   - exit 0 with outcome=failed -> failed (with the shim's reason).
+//   - otherwise -> completed, verdict from the result (or derived from outcome),
+//     with a self-skip observation for outcome=skipped.
+func interpretExit(stageName string, res CommandResult) Outcome {
+	if res.Err != nil {
+		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q spawn error: %v", stageName, res.Err)}
+	}
+	if res.Signal != "" || res.ExitCode != 0 {
+		label := fmt.Sprintf("code %d", res.ExitCode)
+		if res.Signal != "" {
+			label = "signal " + res.Signal
+		}
+		suffix := ""
+		if preview := strings.TrimSpace(res.Stderr); preview != "" {
+			if len(preview) > 500 {
+				preview = preview[:500]
+			}
+			suffix = "; stderr: " + preview
+		}
+		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q exited with %s%s", stageName, label, suffix)}
+	}
+	if res.StdoutCapped {
+		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q stdout exceeded %d bytes", stageName, commandOutputCapBytes)}
+	}
+
+	trimmed := strings.TrimSpace(res.Stdout)
+	if trimmed == "" {
+		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q produced no JSON on stdout", stageName)}
+	}
+
+	var result commandTaskResult
+	if err := json.Unmarshal([]byte(trimmed), &result); err != nil {
+		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q produced unparseable JSON on stdout: %v", stageName, err)}
+	}
+	if verr := validateTaskResult(result); verr != "" {
+		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q JSON failed validation: %s", stageName, verr)}
+	}
+
+	if result.Outcome == "failed" {
+		if reason := strings.TrimSpace(result.Reason); reason != "" {
+			return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q reported outcome=failed: %s", stageName, reason)}
+		}
+		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q reported outcome=failed", stageName)}
+	}
+
+	verdict := result.Verdict
+	if verdict == "" {
+		verdict = defaultVerdictFor(result.Outcome)
+	}
+	out := Outcome{Status: OutcomeCompleted, Verdict: verdict, Artifacts: result.Artifacts}
+	if result.Outcome == "skipped" {
+		data := map[string]any{"stage": stageName}
+		if result.Reason != "" {
+			data["reason"] = result.Reason
+		}
+		out.Observations = []Observation{{Name: "command_stage_self_skipped", Data: data}}
+	}
+	return out
+}
+
+func defaultVerdictFor(outcome string) pipeline.Verdict {
+	if outcome == "succeeded" {
+		return pipeline.VerdictPass
+	}
+	return pipeline.VerdictNeutral // "neutral" and "skipped" both map to neutral
+}
+
+// validateTaskResult returns "" when the decoded result is well-formed, else a
+// human-readable reason. Decoding already rejected unknown fields and bad
+// types; this enforces the outcome enum.
+func validateTaskResult(r commandTaskResult) string {
+	switch r.Outcome {
+	case "succeeded", "failed", "neutral", "skipped":
+	default:
+		return fmt.Sprintf(`field "outcome" must be one of "succeeded"|"failed"|"neutral"|"skipped", got %q`, r.Outcome)
+	}
+	switch r.Verdict {
+	case "", pipeline.VerdictPass, pipeline.VerdictFail, pipeline.VerdictNeutral:
+	default:
+		return fmt.Sprintf(`field "verdict" must be "pass"|"fail"|"neutral", got %q`, r.Verdict)
+	}
+	return ""
+}

--- a/backend/internal/pipeline/executors/command_test.go
+++ b/backend/internal/pipeline/executors/command_test.go
@@ -1,0 +1,292 @@
+package executors
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// fakeProcess is a CommandProcess whose result is pre-set; Done is already
+// closed so Poll sees it as finished immediately.
+type fakeProcess struct {
+	res    CommandResult
+	killed bool
+	done   chan struct{}
+}
+
+func newFakeProcess(res CommandResult) *fakeProcess {
+	ch := make(chan struct{})
+	close(ch)
+	return &fakeProcess{res: res, done: ch}
+}
+
+func (p *fakeProcess) Done() <-chan struct{} { return p.done }
+func (p *fakeProcess) Result() CommandResult { return p.res }
+func (p *fakeProcess) Kill()                 { p.killed = true }
+
+// fakeRunner records the spec it was asked to start and returns a scripted
+// process. startErr forces Start to fail. started reports whether a subprocess
+// was ever requested, so fork-gate tests can assert no spawn happened.
+type fakeRunner struct {
+	res      CommandResult
+	startErr error
+	started  bool
+	lastSpec CommandSpec
+	proc     *fakeProcess
+}
+
+func (r *fakeRunner) Start(_ context.Context, spec CommandSpec) (CommandProcess, error) {
+	r.started = true
+	r.lastSpec = spec
+	if r.startErr != nil {
+		return nil, r.startErr
+	}
+	r.proc = newFakeProcess(r.res)
+	return r.proc, nil
+}
+
+// fakeCommandSessions returns a scripted linked session.
+type fakeCommandSessions struct {
+	session CommandSession
+	exists  bool
+	err     error
+}
+
+func (s *fakeCommandSessions) Get(_ context.Context, _ string) (CommandSession, bool, error) {
+	return s.session, s.exists, s.err
+}
+
+func commandStage() pipeline.Stage {
+	return pipeline.Stage{
+		Name:     "typecheck",
+		Executor: pipeline.StageExecutor{Kind: pipeline.ExecutorCommand, Command: "tsc-shim"},
+	}
+}
+
+func runCommand(t *testing.T, runner CommandRunner, sessions CommandSessions, in StartInput) Outcome {
+	t.Helper()
+	exec := NewCommandExecutor(runner, sessions)
+	h, err := exec.Start(context.Background(), in)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	out, err := exec.Poll(context.Background(), h)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	return out
+}
+
+func baseCommandInput() StartInput {
+	return StartInput{
+		PipelineName:    "ci",
+		RunID:           "run-1",
+		StageRunID:      "sr-1",
+		Stage:           commandStage(),
+		LinkedSessionID: "sess-1",
+	}
+}
+
+func TestCommand_ForkGateSkipsWithoutSpawn(t *testing.T) {
+	for _, fork := range []ForkStatus{ForkYes, ForkUnknown} {
+		runner := &fakeRunner{}
+		sessions := &fakeCommandSessions{
+			exists:  true,
+			session: CommandSession{WorkspacePath: "/ws", Fork: fork, PRNumber: 7},
+		}
+		out := runCommand(t, runner, sessions, baseCommandInput())
+
+		if runner.started {
+			t.Fatalf("fork=%v: a subprocess must NEVER be spawned when the fork gate blocks", fork)
+		}
+		if out.Status != OutcomeCompleted || out.Verdict != pipeline.VerdictNeutral {
+			t.Fatalf("fork=%v: want completed/neutral skip, got %s/%s", fork, out.Status, out.Verdict)
+		}
+		if len(out.Observations) != 1 || out.Observations[0].Name != "command_stage_skipped_fork_pr" {
+			t.Fatalf("fork=%v: expected a fork-skip observation, got %+v", fork, out.Observations)
+		}
+	}
+}
+
+func TestCommand_ForkAllowedRuns(t *testing.T) {
+	runner := &fakeRunner{res: CommandResult{ExitCode: 0, Stdout: `{"outcome":"succeeded"}`}}
+	sessions := &fakeCommandSessions{
+		exists:  true,
+		session: CommandSession{WorkspacePath: "/ws", Fork: ForkYes, PRNumber: 7},
+	}
+	in := baseCommandInput()
+	in.AllowForkPRs = true
+	out := runCommand(t, runner, sessions, in)
+
+	if !runner.started {
+		t.Fatal("allowForkPRs=true must let the fork PR run")
+	}
+	if out.Status != OutcomeCompleted || out.Verdict != pipeline.VerdictPass {
+		t.Fatalf("want completed/pass, got %s/%s", out.Status, out.Verdict)
+	}
+}
+
+func TestCommand_NonForkRuns(t *testing.T) {
+	runner := &fakeRunner{res: CommandResult{ExitCode: 0, Stdout: `{"outcome":"succeeded","verdict":"pass"}`}}
+	sessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "/ws", Fork: ForkNo}}
+	out := runCommand(t, runner, sessions, baseCommandInput())
+	if !runner.started || out.Status != OutcomeCompleted {
+		t.Fatalf("non-fork PR should run: started=%v status=%s", runner.started, out.Status)
+	}
+}
+
+func TestCommand_ExitCodeSemantics(t *testing.T) {
+	sessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "/ws", Fork: ForkNo}}
+	cases := []struct {
+		name     string
+		res      CommandResult
+		want     OutcomeStatus
+		verdict  pipeline.Verdict
+		errMatch string
+	}{
+		{"nonzero exit fails", CommandResult{ExitCode: 1, Stderr: "tsc blew up"}, OutcomeFailed, "", "exited with code 1"},
+		{"signal fails", CommandResult{Signal: "killed"}, OutcomeFailed, "", "signal killed"},
+		{"empty stdout fails", CommandResult{ExitCode: 0, Stdout: "  "}, OutcomeFailed, "", "no JSON on stdout"},
+		{"bad json fails", CommandResult{ExitCode: 0, Stdout: "{not json"}, OutcomeFailed, "", "unparseable JSON"},
+		{"capped stdout fails", CommandResult{ExitCode: 0, Stdout: "{}", StdoutCapped: true}, OutcomeFailed, "", "exceeded"},
+		{"bad outcome enum fails", CommandResult{ExitCode: 0, Stdout: `{"outcome":"weird"}`}, OutcomeFailed, "", "failed validation"},
+		{"outcome=failed fails with reason", CommandResult{ExitCode: 0, Stdout: `{"outcome":"failed","reason":"3 type errors"}`}, OutcomeFailed, "", "3 type errors"},
+		{"succeeded -> pass", CommandResult{ExitCode: 0, Stdout: `{"outcome":"succeeded"}`}, OutcomeCompleted, pipeline.VerdictPass, ""},
+		{"neutral -> neutral", CommandResult{ExitCode: 0, Stdout: `{"outcome":"neutral"}`}, OutcomeCompleted, pipeline.VerdictNeutral, ""},
+		{"explicit verdict wins", CommandResult{ExitCode: 0, Stdout: `{"outcome":"succeeded","verdict":"fail"}`}, OutcomeCompleted, pipeline.VerdictFail, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &fakeRunner{res: tc.res}
+			out := runCommand(t, runner, sessions, baseCommandInput())
+			if out.Status != tc.want {
+				t.Fatalf("want %s, got %s (%s)", tc.want, out.Status, out.ErrorMessage)
+			}
+			if tc.verdict != "" && out.Verdict != tc.verdict {
+				t.Errorf("want verdict %s, got %s", tc.verdict, out.Verdict)
+			}
+			if tc.errMatch != "" && !strings.Contains(out.ErrorMessage, tc.errMatch) {
+				t.Errorf("want error containing %q, got %q", tc.errMatch, out.ErrorMessage)
+			}
+		})
+	}
+}
+
+func TestCommand_SelfSkipObservation(t *testing.T) {
+	runner := &fakeRunner{res: CommandResult{ExitCode: 0, Stdout: `{"outcome":"skipped","reason":"nothing to do"}`}}
+	sessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "/ws", Fork: ForkNo}}
+	out := runCommand(t, runner, sessions, baseCommandInput())
+	if out.Status != OutcomeCompleted || out.Verdict != pipeline.VerdictNeutral {
+		t.Fatalf("skipped should be completed/neutral, got %s/%s", out.Status, out.Verdict)
+	}
+	if len(out.Observations) != 1 || out.Observations[0].Name != "command_stage_self_skipped" {
+		t.Fatalf("expected a self-skip observation, got %+v", out.Observations)
+	}
+}
+
+func TestCommand_ArtifactsPassThrough(t *testing.T) {
+	runner := &fakeRunner{res: CommandResult{ExitCode: 0, Stdout: `{"outcome":"succeeded","artifacts":[{"kind":"finding","filePath":"a.go","startLine":1,"endLine":1,"title":"t","description":"d","category":"c","severity":"warning","confidence":0.8}]}`}}
+	sessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "/ws", Fork: ForkNo}}
+	out := runCommand(t, runner, sessions, baseCommandInput())
+	if len(out.Artifacts) != 1 || out.Artifacts[0].FilePath != "a.go" {
+		t.Fatalf("artifacts should pass through, got %+v", out.Artifacts)
+	}
+}
+
+func TestCommand_UnknownSessionFails(t *testing.T) {
+	runner := &fakeRunner{}
+	sessions := &fakeCommandSessions{exists: false}
+	out := runCommand(t, runner, sessions, baseCommandInput())
+	if out.Status != OutcomeFailed || runner.started {
+		t.Fatalf("unknown session should fail without spawn, got %s started=%v", out.Status, runner.started)
+	}
+}
+
+func TestCommand_NoWorkspaceFails(t *testing.T) {
+	runner := &fakeRunner{}
+	sessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "", Fork: ForkNo}}
+	out := runCommand(t, runner, sessions, baseCommandInput())
+	if out.Status != OutcomeFailed || runner.started {
+		t.Fatalf("no workspace should fail without spawn, got %s started=%v", out.Status, runner.started)
+	}
+	if !strings.Contains(out.ErrorMessage, "workspace") {
+		t.Errorf("unexpected message: %s", out.ErrorMessage)
+	}
+}
+
+func TestCommand_SpawnErrorFails(t *testing.T) {
+	runner := &fakeRunner{startErr: context.DeadlineExceeded}
+	sessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "/ws", Fork: ForkNo}}
+	out := runCommand(t, runner, sessions, baseCommandInput())
+	if out.Status != OutcomeFailed {
+		t.Fatalf("spawn error should fail, got %s", out.Status)
+	}
+}
+
+func TestCommand_CwdResolution(t *testing.T) {
+	runner := &fakeRunner{res: CommandResult{ExitCode: 0, Stdout: `{"outcome":"succeeded"}`}}
+	sessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "/ws", Fork: ForkNo}}
+	in := baseCommandInput()
+	in.Stage.Executor.Cwd = "sub/dir"
+	runCommand(t, runner, sessions, in)
+	if runner.lastSpec.Dir != "/ws/sub/dir" {
+		t.Errorf("want cwd /ws/sub/dir, got %q", runner.lastSpec.Dir)
+	}
+}
+
+func TestCommand_CwdEscapeRejected(t *testing.T) {
+	sessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "/ws", Fork: ForkNo}}
+	for _, bad := range []string{"../escape", "/abs", "a/../../b", "C:\\win"} {
+		runner := &fakeRunner{}
+		in := baseCommandInput()
+		in.Stage.Executor.Cwd = bad
+		out := runCommand(t, runner, sessions, in)
+		if out.Status != OutcomeFailed || runner.started {
+			t.Errorf("cwd %q should be rejected without spawn, got %s started=%v", bad, out.Status, runner.started)
+		}
+	}
+}
+
+func TestCommand_RunningThenDone(t *testing.T) {
+	// A process whose Done channel is still open reports running until closed.
+	sessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "/ws", Fork: ForkNo}}
+	proc := &fakeProcess{res: CommandResult{ExitCode: 0, Stdout: `{"outcome":"succeeded"}`}, done: make(chan struct{})}
+	runner := &openProcRunner{proc: proc}
+	exec := NewCommandExecutor(runner, sessions)
+	h, err := exec.Start(context.Background(), baseCommandInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, _ := exec.Poll(context.Background(), h)
+	if out.Status != OutcomeRunning {
+		t.Fatalf("want running while process is live, got %s", out.Status)
+	}
+	close(proc.done)
+	out, _ = exec.Poll(context.Background(), h)
+	if out.Status != OutcomeCompleted {
+		t.Fatalf("want completed after exit, got %s", out.Status)
+	}
+}
+
+func TestCommand_CancelKills(t *testing.T) {
+	sessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "/ws", Fork: ForkNo}}
+	proc := &fakeProcess{res: CommandResult{}, done: make(chan struct{})}
+	runner := &openProcRunner{proc: proc}
+	exec := NewCommandExecutor(runner, sessions)
+	h, _ := exec.Start(context.Background(), baseCommandInput())
+	if err := exec.Cancel(context.Background(), h); err != nil {
+		t.Fatal(err)
+	}
+	if !proc.killed {
+		t.Error("cancel should kill the running process")
+	}
+}
+
+// openProcRunner returns a process whose Done channel the test controls.
+type openProcRunner struct{ proc *fakeProcess }
+
+func (r *openProcRunner) Start(_ context.Context, _ CommandSpec) (CommandProcess, error) {
+	return r.proc, nil
+}

--- a/backend/internal/pipeline/executors/executor.go
+++ b/backend/internal/pipeline/executors/executor.go
@@ -1,0 +1,183 @@
+// Package executors runs a pipeline stage's work: an agent session, a
+// shelled-out command, or an engine-internal builtin (router/compose). Each
+// executor is driven through the same start/poll/cancel contract so the T5
+// engine can push every stage kind through one inflight loop, and every
+// dependency the executors touch (session manager, subprocess runner, artifact
+// store, message sink) is an injected interface so the whole package is
+// mockable with no real sessions or shells in unit tests.
+//
+// The package holds NO reducer, scheduler, store, or engine wiring; those land
+// in sibling tasks. It also does not provision worktrees: a resolved workspace
+// path arrives via the linked session, and teardown-on-crash is the engine's
+// job (spec §9 note 9).
+package executors
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// OutcomeStatus is the lifecycle of a polled stage: still running, or a
+// terminal completed/failed. It is distinct from pipeline.StageStatus (the
+// reducer's richer lifecycle) because an executor only ever reports these
+// three; the reducer maps them onto its own states.
+type OutcomeStatus string
+
+// Known outcome statuses.
+const (
+	OutcomeRunning   OutcomeStatus = "running"
+	OutcomeCompleted OutcomeStatus = "completed"
+	OutcomeFailed    OutcomeStatus = "failed"
+)
+
+// Observation is a side-channel telemetry event an executor asks the engine to
+// route through an EMIT_OBSERVATION effect (e.g. a findings-truncation warning
+// or a fork-PR skip). It never affects the stage verdict.
+type Observation struct {
+	Name string
+	Data map[string]any
+}
+
+// Outcome is the result of polling a running stage. Status is the only field
+// always set; Verdict/Artifacts are meaningful on OutcomeCompleted, and
+// ErrorMessage on OutcomeFailed. Observations may accompany any terminal
+// status.
+type Outcome struct {
+	Status       OutcomeStatus
+	Verdict      pipeline.Verdict
+	Artifacts    []pipeline.ArtifactInput
+	Observations []Observation
+	ErrorMessage string
+}
+
+// Handle is an opaque running-stage token returned by Start and threaded back
+// into Poll and Cancel. Each executor kind returns its own concrete type; the
+// engine treats it as opaque and only reads the identity accessors.
+type Handle interface {
+	RunID() pipeline.RunID
+	StageRunID() pipeline.StageRunID
+	StageName() string
+}
+
+// StartInput is everything an executor needs to begin a stage. Not every field
+// is used by every kind: agent uses Prompt context + ProjectID/IssueID;
+// command uses LinkedSessionID (cwd + fork gate) + AllowForkPRs; builtin uses
+// LinkedSessionID (routing) + the injected artifact store keyed on
+// Stage.DependsOn.
+type StartInput struct {
+	PipelineName string
+	ProjectID    string
+	RunID        pipeline.RunID
+	StageRunID   pipeline.StageRunID
+	Stage        pipeline.Stage
+	// IssueID scopes the spawned agent session, if any.
+	IssueID string
+	// LoopRound is surfaced in the agent prompt when non-nil.
+	LoopRound *int
+	// LinkedSessionID is the worker session this run is scoped to. The command
+	// executor reads its workspace + PR fork status; the builtin router
+	// delivers messages to it.
+	LinkedSessionID string
+	// RoutingTargetSessionID overrides the router's delivery destination. Unset
+	// in v1 (worker-only); it falls back to LinkedSessionID. Kept as a seam for
+	// the phase-2 workstream/orchestrator scopes.
+	RoutingTargetSessionID string
+	// AllowForkPRs opts command stages into running for fork PRs. Default false
+	// skips them before any subprocess spawns.
+	AllowForkPRs bool
+}
+
+// StageExecutor is the contract the engine drives. Start begins the work and
+// returns a handle; Poll reports progress or a terminal outcome; Cancel tears
+// the stage down early. Implementations must make Poll and Cancel safe to call
+// after a terminal Poll (idempotent teardown).
+type StageExecutor interface {
+	Start(ctx context.Context, in StartInput) (Handle, error)
+	Poll(ctx context.Context, h Handle) (Outcome, error)
+	Cancel(ctx context.Context, h Handle) error
+}
+
+// stageIdentity is embedded in every concrete handle to satisfy the Handle
+// accessors without repetition.
+type stageIdentity struct {
+	runID      pipeline.RunID
+	stageRunID pipeline.StageRunID
+	stageName  string
+}
+
+func (s stageIdentity) RunID() pipeline.RunID           { return s.runID }
+func (s stageIdentity) StageRunID() pipeline.StageRunID { return s.stageRunID }
+func (s stageIdentity) StageName() string               { return s.stageName }
+
+// Set routes a stage to the right executor by its executor kind and presents
+// the three as a single StageExecutor the engine drives uniformly. Start
+// dispatches by kind and tags the returned handle with its owner so Poll and
+// Cancel route back to the same executor.
+type Set struct {
+	agent   StageExecutor
+	command StageExecutor
+	builtin StageExecutor
+}
+
+// NewSet builds the routing facade over the three kind executors.
+func NewSet(agent, command, builtin StageExecutor) *Set {
+	return &Set{agent: agent, command: command, builtin: builtin}
+}
+
+var _ StageExecutor = (*Set)(nil)
+
+// setHandle wraps a kind executor's handle with the executor that owns it.
+type setHandle struct {
+	owner StageExecutor
+	inner Handle
+}
+
+func (h setHandle) RunID() pipeline.RunID           { return h.inner.RunID() }
+func (h setHandle) StageRunID() pipeline.StageRunID { return h.inner.StageRunID() }
+func (h setHandle) StageName() string               { return h.inner.StageName() }
+
+func (s *Set) executorFor(kind pipeline.ExecutorKind) (StageExecutor, error) {
+	switch kind {
+	case pipeline.ExecutorAgent:
+		return s.agent, nil
+	case pipeline.ExecutorCommand:
+		return s.command, nil
+	case pipeline.ExecutorBuiltin:
+		return s.builtin, nil
+	default:
+		return nil, fmt.Errorf("no executor for kind %q", kind)
+	}
+}
+
+// Start dispatches to the executor for the stage's kind.
+func (s *Set) Start(ctx context.Context, in StartInput) (Handle, error) {
+	exec, err := s.executorFor(in.Stage.Executor.Kind)
+	if err != nil {
+		return nil, err
+	}
+	h, err := exec.Start(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return setHandle{owner: exec, inner: h}, nil
+}
+
+// Poll routes to the executor that started the stage.
+func (s *Set) Poll(ctx context.Context, h Handle) (Outcome, error) {
+	sh, ok := h.(setHandle)
+	if !ok {
+		return Outcome{}, fmt.Errorf("executor set: unexpected handle type %T", h)
+	}
+	return sh.owner.Poll(ctx, sh.inner)
+}
+
+// Cancel routes to the executor that started the stage.
+func (s *Set) Cancel(ctx context.Context, h Handle) error {
+	sh, ok := h.(setHandle)
+	if !ok {
+		return fmt.Errorf("executor set: unexpected handle type %T", h)
+	}
+	return sh.owner.Cancel(ctx, sh.inner)
+}

--- a/backend/internal/pipeline/executors/findings.go
+++ b/backend/internal/pipeline/executors/findings.go
@@ -59,7 +59,7 @@ func parseFindingsFile(path string) (parseResult, error) {
 	if err != nil {
 		return parseResult{}, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	reader := bufio.NewReader(f)
 	var out []pipeline.ArtifactInput
@@ -167,14 +167,14 @@ func fileExists(path string) bool {
 }
 
 func hasTrailingNewline(s string) bool {
-	return len(s) > 0 && s[len(s)-1] == '\n'
+	return s != "" && s[len(s)-1] == '\n'
 }
 
 // trimLine strips a trailing CR/LF and surrounding ASCII whitespace so blank
 // lines are skipped and CRLF files parse the same as LF.
 func trimLine(s string) string {
 	// Drop trailing newline / carriage return first, then trim spaces/tabs.
-	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+	for s != "" && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
 		s = s[:len(s)-1]
 	}
 	start, end := 0, len(s)

--- a/backend/internal/pipeline/executors/findings.go
+++ b/backend/internal/pipeline/executors/findings.go
@@ -1,0 +1,188 @@
+package executors
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// findingsFileSizeCapBytes bounds how much of a stage's findings file the
+// executor reads (spec §4b). Beyond the cap, trailing lines are dropped and a
+// pipeline.findings.truncated observation is emitted. Generous enough for
+// thousands of legitimate findings, small enough to keep a misbehaving agent
+// from OOMing the engine.
+const findingsFileSizeCapBytes = 5 * 1024 * 1024
+
+// stageFindingsRelativePath is the conventional findings drop, relative to the
+// stage workspace root.
+var stageFindingsRelativePath = filepath.Join(".ao", pipeline.FindingsFilename)
+
+// parseResult is the outcome of harvesting a findings file.
+type parseResult struct {
+	artifacts []pipeline.ArtifactInput
+	// truncated is true when the cap fired and trailing lines were dropped.
+	truncated bool
+	// bytesRead is how many bytes were consumed before stopping.
+	bytesRead int64
+}
+
+// validSeverities are the finding severities the coercion accepts.
+var validSeverities = map[string]bool{
+	string(pipeline.SeverityError):   true,
+	string(pipeline.SeverityWarning): true,
+	string(pipeline.SeverityInfo):    true,
+}
+
+// parseFindingsFile streams the findings JSONL line by line, capping at
+// findingsFileSizeCapBytes. Behavior:
+//
+//   - Complete lines (any line followed by a newline) are parsed strictly; a
+//     malformed complete line fails the whole harvest so a human can inspect a
+//     genuinely broken file.
+//   - A torn final line (the last line, with no trailing newline, that fails to
+//     JSON-parse) is tolerated: it is dropped silently. The write-then-rename
+//     contract makes torn writes rare, but a truncated tail must never fail an
+//     otherwise-good harvest.
+//   - When the byte cap fires, reading stops, the in-progress line is dropped,
+//     and truncated is set so the caller emits an observation.
+//
+// An empty or all-blank file yields zero artifacts and no error: file
+// existence, not contents, is the completion signal.
+func parseFindingsFile(path string) (parseResult, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return parseResult{}, err
+	}
+	defer f.Close()
+
+	reader := bufio.NewReader(f)
+	var out []pipeline.ArtifactInput
+	var bytesRead int64
+	lineNo := 0
+	truncated := false
+
+	for {
+		line, readErr := reader.ReadString('\n')
+		// A final chunk without a trailing newline is a potentially-torn line:
+		// ReadString returns the bytes plus io.EOF.
+		torn := errors.Is(readErr, io.EOF) && !hasTrailingNewline(line)
+
+		// Account for the bytes of this line (including its newline) against the
+		// cap before parsing so the measured size matches the file size.
+		bytesRead += int64(len(line))
+		if bytesRead > findingsFileSizeCapBytes {
+			truncated = true
+			break
+		}
+
+		trimmed := trimLine(line)
+		if trimmed != "" {
+			lineNo++
+			artifact, perr := coerceArtifactInput([]byte(trimmed))
+			if perr != nil {
+				if torn {
+					// Tolerate a torn final line: drop it rather than failing an
+					// otherwise-complete harvest.
+					break
+				}
+				return parseResult{}, fmt.Errorf("line %d: %w", lineNo, perr)
+			}
+			out = append(out, artifact)
+		}
+
+		if readErr != nil {
+			// io.EOF (or any read error) ends the stream. A non-EOF error on a
+			// local file is unexpected; surface it.
+			if !errors.Is(readErr, io.EOF) {
+				return parseResult{}, readErr
+			}
+			break
+		}
+	}
+
+	return parseResult{artifacts: out, truncated: truncated, bytesRead: bytesRead}, nil
+}
+
+// coerceArtifactInput validates one JSONL record into an ArtifactInput,
+// enforcing the per-kind required fields the old executor checked (finding
+// needs its structural fields + a valid severity + confidence in [0,1]; json
+// needs a data object).
+func coerceArtifactInput(raw []byte) (pipeline.ArtifactInput, error) {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return pipeline.ArtifactInput{}, err
+	}
+
+	var art pipeline.ArtifactInput
+	if err := json.Unmarshal(raw, &art); err != nil {
+		return pipeline.ArtifactInput{}, err
+	}
+
+	switch art.Kind {
+	case pipeline.ArtifactKindFinding:
+		if err := requireFields(probe, "filePath", "startLine", "endLine", "title", "description", "category", "severity", "confidence"); err != nil {
+			return pipeline.ArtifactInput{}, err
+		}
+		if !validSeverities[string(art.Severity)] {
+			return pipeline.ArtifactInput{}, fmt.Errorf(`field "severity" must be one of "error", "warning", "info", got %q`, art.Severity)
+		}
+		if art.Confidence < 0 || art.Confidence > 1 {
+			return pipeline.ArtifactInput{}, fmt.Errorf(`field "confidence" must be a number in [0, 1], got %v`, art.Confidence)
+		}
+		return art, nil
+	case pipeline.ArtifactKindJSON:
+		if len(art.Data) == 0 {
+			return pipeline.ArtifactInput{}, errors.New(`"json" artifact requires object "data"`)
+		}
+		return art, nil
+	default:
+		return pipeline.ArtifactInput{}, fmt.Errorf("unknown artifact kind %q", art.Kind)
+	}
+}
+
+// requireFields checks each named field is present (non-null) in the raw
+// object. Type correctness is enforced by the strict json.Unmarshal into the
+// typed struct; presence is what the JSON tags cannot assert.
+func requireFields(obj map[string]json.RawMessage, keys ...string) error {
+	for _, k := range keys {
+		v, ok := obj[k]
+		if !ok || string(v) == "null" {
+			return fmt.Errorf("missing field %q", k)
+		}
+	}
+	return nil
+}
+
+// fileExists reports whether path names an existing file. The findings drop's
+// existence (not contents) is the stage completion signal.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func hasTrailingNewline(s string) bool {
+	return len(s) > 0 && s[len(s)-1] == '\n'
+}
+
+// trimLine strips a trailing CR/LF and surrounding ASCII whitespace so blank
+// lines are skipped and CRLF files parse the same as LF.
+func trimLine(s string) string {
+	// Drop trailing newline / carriage return first, then trim spaces/tabs.
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	start, end := 0, len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\t') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t') {
+		end--
+	}
+	return s[start:end]
+}

--- a/backend/internal/pipeline/executors/findings_test.go
+++ b/backend/internal/pipeline/executors/findings_test.go
@@ -1,0 +1,182 @@
+package executors
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+func writeFindings(t *testing.T, lines ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, pipeline.FindingsFilename)
+	// Join with newlines and add a trailing newline: every line is a "complete"
+	// line, matching how the agent's write-then-rename drop looks.
+	content := ""
+	if len(lines) > 0 {
+		content = strings.Join(lines, "\n") + "\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write findings: %v", err)
+	}
+	return path
+}
+
+func findingLine(t *testing.T, confidence float64, severity string) string {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"kind":        "finding",
+		"filePath":    "src/foo.go",
+		"startLine":   1,
+		"endLine":     2,
+		"title":       "x",
+		"description": "y",
+		"category":    "general",
+		"severity":    severity,
+		"confidence":  confidence,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func TestParseFindings_ValidJSONL(t *testing.T) {
+	path := writeFindings(t,
+		findingLine(t, 0.9, "error"),
+		`{"kind":"json","data":{"answer":42}}`,
+	)
+	res, err := parseFindingsFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.artifacts) != 2 {
+		t.Fatalf("want 2 artifacts, got %d", len(res.artifacts))
+	}
+	if res.artifacts[0].Kind != pipeline.ArtifactKindFinding || res.artifacts[0].FilePath != "src/foo.go" {
+		t.Errorf("finding not parsed: %+v", res.artifacts[0])
+	}
+	if res.artifacts[1].Kind != pipeline.ArtifactKindJSON || res.artifacts[1].Data["answer"].(float64) != 42 {
+		t.Errorf("json artifact not parsed: %+v", res.artifacts[1])
+	}
+	if res.truncated {
+		t.Error("did not expect truncation")
+	}
+}
+
+func TestParseFindings_BlankLinesSkipped(t *testing.T) {
+	path := writeFindings(t, findingLine(t, 0.5, "info"), "", "   ")
+	res, err := parseFindingsFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.artifacts) != 1 {
+		t.Fatalf("want 1 artifact, got %d", len(res.artifacts))
+	}
+}
+
+func TestParseFindings_EmptyFile(t *testing.T) {
+	path := writeFindings(t)
+	res, err := parseFindingsFile(path)
+	if err != nil {
+		t.Fatalf("empty file must not error: %v", err)
+	}
+	if len(res.artifacts) != 0 {
+		t.Fatalf("want 0 artifacts, got %d", len(res.artifacts))
+	}
+}
+
+func TestParseFindings_TornFinalLineTolerated(t *testing.T) {
+	// A valid line followed by a torn (no trailing newline, incomplete JSON)
+	// final line: the torn tail is dropped, the good line survives.
+	dir := t.TempDir()
+	path := filepath.Join(dir, pipeline.FindingsFilename)
+	content := findingLine(t, 0.7, "warning") + "\n" + `{"kind":"finding","filePath":"src/b`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := parseFindingsFile(path)
+	if err != nil {
+		t.Fatalf("torn final line must be tolerated, got error: %v", err)
+	}
+	if len(res.artifacts) != 1 {
+		t.Fatalf("want 1 surviving artifact, got %d", len(res.artifacts))
+	}
+}
+
+func TestParseFindings_CompleteMalformedLineFails(t *testing.T) {
+	// A malformed line that IS terminated by a newline (a complete line) is a
+	// hard error, not tolerated.
+	path := writeFindings(t, "not-json {{{")
+	_, err := parseFindingsFile(path)
+	if err == nil {
+		t.Fatal("expected error on complete malformed line")
+	}
+}
+
+func TestParseFindings_RejectsBadShape(t *testing.T) {
+	cases := map[string]string{
+		"confidence out of range": findingLine(t, 7, "info"),
+		"bad severity":            findingLine(t, 0.5, "critical"),
+		"unknown kind":            `{"kind":"weird"}`,
+		"json without data":       `{"kind":"json"}`,
+		"finding missing title":   `{"kind":"finding","filePath":"a","startLine":1,"endLine":1,"description":"d","category":"c","severity":"info","confidence":0.5}`,
+	}
+	for name, line := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writeFindings(t, line)
+			if _, err := parseFindingsFile(path); err == nil {
+				t.Fatalf("%s: expected error", name)
+			}
+		})
+	}
+}
+
+func TestParseFindings_CapTriggersTruncation(t *testing.T) {
+	// Build a file larger than the cap out of valid finding lines. Each line is
+	// well under the cap; their sum crosses it.
+	dir := t.TempDir()
+	path := filepath.Join(dir, pipeline.FindingsFilename)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := findingLine(t, 0.5, "info") + "\n"
+	written := 0
+	// Write ~6MB worth to exceed the 5MB cap.
+	for written <= findingsFileSizeCapBytes+len(line) {
+		if _, err := f.WriteString(line); err != nil {
+			t.Fatal(err)
+		}
+		written += len(line)
+	}
+	f.Close()
+
+	res, err := parseFindingsFile(path)
+	if err != nil {
+		t.Fatalf("truncation must not error: %v", err)
+	}
+	if !res.truncated {
+		t.Fatal("expected truncated=true when the cap fires")
+	}
+	if res.bytesRead > findingsFileSizeCapBytes+int64(len(line)) {
+		t.Errorf("bytesRead %d ran well past the cap", res.bytesRead)
+	}
+	if len(res.artifacts) == 0 {
+		t.Error("expected the pre-cap lines to still be returned")
+	}
+}
+
+func TestParseFindings_MissingFile(t *testing.T) {
+	_, err := parseFindingsFile(filepath.Join(t.TempDir(), "nope.jsonl"))
+	if err == nil {
+		t.Fatal("expected error for a missing file")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("want not-exist error, got %v", err)
+	}
+}

--- a/backend/internal/pipeline/executors/runner.go
+++ b/backend/internal/pipeline/executors/runner.go
@@ -2,6 +2,7 @@ package executors
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"sync"
@@ -85,10 +86,9 @@ func (r *osRunner) Start(ctx context.Context, spec CommandSpec) (CommandProcess,
 		}
 		// A non-zero exit surfaces via ExitCode, not Err. Only a genuine
 		// spawn/wait failure (not *exec.ExitError) is reported as Err.
-		if waitErr != nil {
-			if _, ok := waitErr.(*exec.ExitError); !ok {
-				res.Err = waitErr
-			}
+		var exitErr *exec.ExitError
+		if waitErr != nil && !errors.As(waitErr, &exitErr) {
+			res.Err = waitErr
 		}
 		p.mu.Lock()
 		p.result = res

--- a/backend/internal/pipeline/executors/runner.go
+++ b/backend/internal/pipeline/executors/runner.go
@@ -1,0 +1,112 @@
+package executors
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+// LogSink receives streamed subprocess output for logging. stream is "stdout"
+// or "stderr". Implementations must be safe for concurrent calls (stdout and
+// stderr pump on separate goroutines). Injected so the engine can route command
+// output to the activity log; may be nil.
+type LogSink interface {
+	Write(stream string, chunk []byte)
+}
+
+// osRunner is the production CommandRunner: it shells out with os/exec, streams
+// stdout/stderr to an optional sink while capturing both (capped) for the
+// JSON-over-stdout contract, and kills the whole process tree on Cancel so
+// detached shells do not outlive the stage.
+type osRunner struct {
+	sink LogSink
+}
+
+// NewOSRunner builds the production command runner. sink may be nil.
+func NewOSRunner(sink LogSink) CommandRunner {
+	return &osRunner{sink: sink}
+}
+
+// osProcess is a live os/exec subprocess.
+type osProcess struct {
+	cmd  *exec.Cmd
+	done chan struct{}
+
+	mu     sync.Mutex
+	result CommandResult
+}
+
+func (p *osProcess) Done() <-chan struct{} { return p.done }
+
+func (p *osProcess) Result() CommandResult {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.result
+}
+
+func (p *osProcess) Kill() {
+	// Terminate the process group (SIGTERM then SIGKILL) so a shell's children
+	// die with it. Best-effort: a race with natural exit is benign.
+	killProcessTree(p.cmd)
+}
+
+func (r *osRunner) Start(ctx context.Context, spec CommandSpec) (CommandProcess, error) {
+	cmd := exec.CommandContext(ctx, spec.Command, spec.Args...)
+	cmd.Dir = spec.Dir
+	cmd.Env = mergeEnv(spec.Env)
+	configureProcAttr(cmd)
+
+	capBytes := spec.OutputCap
+	if capBytes <= 0 {
+		capBytes = commandOutputCapBytes
+	}
+	stdout := &capBuffer{limit: capBytes}
+	stderr := &capBuffer{limit: capBytes}
+	cmd.Stdout = teeSink(stdout, r.sink, "stdout")
+	cmd.Stderr = teeSink(stderr, r.sink, "stderr")
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	p := &osProcess{cmd: cmd, done: make(chan struct{})}
+	go func() {
+		defer close(p.done)
+		waitErr := cmd.Wait()
+		res := CommandResult{
+			Stdout:       stdout.String(),
+			Stderr:       stderr.String(),
+			StdoutCapped: stdout.capped,
+		}
+		if cmd.ProcessState != nil {
+			res.ExitCode = cmd.ProcessState.ExitCode()
+			res.Signal = stateSignal(cmd.ProcessState)
+		}
+		// A non-zero exit surfaces via ExitCode, not Err. Only a genuine
+		// spawn/wait failure (not *exec.ExitError) is reported as Err.
+		if waitErr != nil {
+			if _, ok := waitErr.(*exec.ExitError); !ok {
+				res.Err = waitErr
+			}
+		}
+		p.mu.Lock()
+		p.result = res
+		p.mu.Unlock()
+	}()
+	return p, nil
+}
+
+// mergeEnv overlays the stage's env onto the daemon's environment.
+func mergeEnv(extra map[string]string) []string {
+	if len(extra) == 0 {
+		return os.Environ()
+	}
+	base := os.Environ()
+	env := make([]string, 0, len(base)+len(extra))
+	env = append(env, base...)
+	for k, v := range extra {
+		env = append(env, k+"="+v)
+	}
+	return env
+}

--- a/backend/internal/pipeline/executors/runner_io.go
+++ b/backend/internal/pipeline/executors/runner_io.go
@@ -1,0 +1,63 @@
+package executors
+
+import (
+	"io"
+	"sync"
+)
+
+// capBuffer is an io.Writer that captures up to limit bytes and drops the rest,
+// recording whether the cap fired. Safe for concurrent writes (one pump
+// goroutine per stream, but a shared lock keeps it robust).
+type capBuffer struct {
+	mu     sync.Mutex
+	limit  int
+	buf    []byte
+	capped bool
+}
+
+func (b *capBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	remaining := b.limit - len(b.buf)
+	if remaining <= 0 {
+		b.capped = true
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		b.buf = append(b.buf, p[:remaining]...)
+		b.capped = true
+		return len(p), nil
+	}
+	b.buf = append(b.buf, p...)
+	return len(p), nil
+}
+
+func (b *capBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(b.buf)
+}
+
+// teeSink returns a writer that fans output into the capturing buffer and, when
+// a sink is present, forwards each chunk to it tagged with the stream name.
+func teeSink(buf *capBuffer, sink LogSink, stream string) io.Writer {
+	if sink == nil {
+		return buf
+	}
+	return io.MultiWriter(buf, sinkWriter{sink: sink, stream: stream})
+}
+
+// sinkWriter adapts a LogSink to io.Writer for one named stream.
+type sinkWriter struct {
+	sink   LogSink
+	stream string
+}
+
+func (w sinkWriter) Write(p []byte) (int, error) {
+	// Copy: the caller may reuse the buffer after Write returns, and the sink
+	// might retain the slice.
+	chunk := make([]byte, len(p))
+	copy(chunk, p)
+	w.sink.Write(w.stream, chunk)
+	return len(p), nil
+}

--- a/backend/internal/pipeline/executors/runner_unix.go
+++ b/backend/internal/pipeline/executors/runner_unix.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package executors
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// configureProcAttr puts the child in its own process group so killProcessTree
+// can signal the whole tree (the shim plus any shells it spawns) via -pgid.
+func configureProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcessTree sends SIGTERM to the child's process group, then escalates to
+// SIGKILL after a short grace. Best-effort: a process that already exited makes
+// the signals no-op.
+//
+// ponytail: fixed 2s grace; make it configurable only if a slow-draining shim
+// ever needs a longer window.
+func killProcessTree(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	pgid := cmd.Process.Pid
+	_ = syscall.Kill(-pgid, syscall.SIGTERM)
+	go func(pid int) {
+		time.Sleep(2 * time.Second)
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	}(pgid)
+}
+
+// stateSignal returns the terminating signal's name, or "" for a normal exit.
+func stateSignal(state *os.ProcessState) string {
+	ws, ok := state.Sys().(syscall.WaitStatus)
+	if !ok || !ws.Signaled() {
+		return ""
+	}
+	return ws.Signal().String()
+}

--- a/backend/internal/pipeline/executors/runner_windows.go
+++ b/backend/internal/pipeline/executors/runner_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package executors
+
+import (
+	"os"
+	"os/exec"
+)
+
+// configureProcAttr is a no-op on Windows; process-group semantics differ and
+// exec.CommandContext already terminates the child on ctx cancel.
+func configureProcAttr(cmd *exec.Cmd) {}
+
+// killProcessTree kills the child process. Best-effort.
+//
+// ponytail: single-process kill; a Job Object would be needed to reap a full
+// tree on Windows if detached grandchildren ever become a problem.
+func killProcessTree(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+}
+
+// stateSignal returns "" on Windows: exits are reported via ExitCode, not
+// signals.
+func stateSignal(state *os.ProcessState) string { return "" }

--- a/backend/internal/pipeline/executors/stageprompt.go
+++ b/backend/internal/pipeline/executors/stageprompt.go
@@ -22,9 +22,7 @@ func buildStagePrompt(pipelineName string, stage pipeline.Stage, loopRound *int)
 	}
 
 	var lines []string
-	lines = append(lines, "## Pipeline Stage")
-	lines = append(lines, "Pipeline: "+pipelineName)
-	lines = append(lines, "Stage: "+stage.Name)
+	lines = append(lines, "## Pipeline Stage", "Pipeline: "+pipelineName, "Stage: "+stage.Name)
 	if mode != "" {
 		lines = append(lines, "Mode: "+string(mode))
 	}
@@ -40,13 +38,10 @@ func buildStagePrompt(pipelineName string, stage pipeline.Stage, loopRound *int)
 	}
 
 	if len(stage.Task.Inputs) > 0 {
-		lines = append(lines, "", "## Inputs", "```json")
-		lines = append(lines, marshalInputs(stage.Task.Inputs))
-		lines = append(lines, "```")
+		lines = append(lines, "", "## Inputs", "```json", marshalInputs(stage.Task.Inputs), "```")
 	}
 
-	lines = append(lines, "", "## Reporting Findings")
-	lines = append(lines, formatFindingsInstructions(mode))
+	lines = append(lines, "", "## Reporting Findings", formatFindingsInstructions(mode))
 
 	return strings.Join(lines, "\n")
 }

--- a/backend/internal/pipeline/executors/stageprompt.go
+++ b/backend/internal/pipeline/executors/stageprompt.go
@@ -1,0 +1,91 @@
+package executors
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// buildStagePrompt composes the pipeline-specific prompt layer injected into a
+// spawned agent session: which stage it is running, in what mode, and where to
+// drop structured findings so the executor can harvest them. Ported from the
+// old stage-prompt.ts; kept terse because agents read it once.
+//
+// The findings path is documented relative to the workspace root so the agent
+// does not need the absolute path.
+func buildStagePrompt(pipelineName string, stage pipeline.Stage, loopRound *int) string {
+	var mode pipeline.TaskMode
+	if stage.Executor.Kind == pipeline.ExecutorAgent {
+		mode = stage.Executor.Mode
+	}
+
+	var lines []string
+	lines = append(lines, "## Pipeline Stage")
+	lines = append(lines, "Pipeline: "+pipelineName)
+	lines = append(lines, "Stage: "+stage.Name)
+	if mode != "" {
+		lines = append(lines, "Mode: "+string(mode))
+	}
+	if loopRound != nil {
+		lines = append(lines, "Loop round: "+strconv.Itoa(*loopRound))
+	}
+	if stage.Policy != nil && stage.Policy.BlocksMerge != nil && *stage.Policy.BlocksMerge {
+		lines = append(lines, "This stage's findings will block merge until they are resolved.")
+	}
+
+	if stage.Task.Prompt != "" {
+		lines = append(lines, "", "## Task", stage.Task.Prompt)
+	}
+
+	if len(stage.Task.Inputs) > 0 {
+		lines = append(lines, "", "## Inputs", "```json")
+		lines = append(lines, marshalInputs(stage.Task.Inputs))
+		lines = append(lines, "```")
+	}
+
+	lines = append(lines, "", "## Reporting Findings")
+	lines = append(lines, formatFindingsInstructions(mode))
+
+	return strings.Join(lines, "\n")
+}
+
+// formatFindingsInstructions mirrors the old JSONL write-then-rename contract:
+// the executor polls for the final file and parses it on first sight, so the
+// agent must write a temp file and rename it into place to avoid the executor
+// ever seeing a torn write.
+func formatFindingsInstructions(mode pipeline.TaskMode) string {
+	path := ".ao/" + pipeline.FindingsFilename
+	tmpPath := path + ".tmp"
+
+	blocks := []string{
+		"When this stage is complete, write your findings to `" + path + "` (one JSON object per line, JSONL).",
+		"Write the JSONL to `" + tmpPath + "` first, then rename it to `" + path + "` so the orchestrator never observes a partial file (e.g. `mv " + tmpPath + " " + path + "`).",
+		"The orchestrator harvests this file once you go idle — without it the stage cannot complete.",
+	}
+
+	switch mode {
+	case pipeline.ModeReview:
+		blocks = append(blocks, `Each line must be a "finding" record with: { kind: "finding", filePath, startLine, endLine, title, description, category, severity ("error" | "warning" | "info"), confidence (0-1) }.`)
+	case pipeline.ModeAnswer:
+		blocks = append(blocks, `Each line must be a "json" record: { kind: "json", data: { ... } } where `+"`data`"+` matches the task's outputSchema (if any).`)
+	default:
+		blocks = append(blocks, `Each line must be either a "finding" or a "json" record (see ArtifactInput in the orchestrator types).`)
+	}
+
+	blocks = append(blocks, "If there are no findings, rename an empty file. The file's existence, not its contents, is the completion signal.")
+
+	return strings.Join(blocks, " ")
+}
+
+func marshalInputs(inputs map[string]any) string {
+	b, err := json.MarshalIndent(inputs, "", "  ")
+	if err != nil {
+		// Inputs are free-form config; an unmarshalable value is a config bug,
+		// but the prompt should still spawn. Fall back to a compact best-effort
+		// rendering rather than aborting the stage.
+		return "{}"
+	}
+	return string(b)
+}

--- a/backend/internal/pipeline/executors/stageprompt_test.go
+++ b/backend/internal/pipeline/executors/stageprompt_test.go
@@ -1,0 +1,85 @@
+package executors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+func agentStage(mode pipeline.TaskMode) pipeline.Stage {
+	return pipeline.Stage{
+		Name:     "review",
+		Executor: pipeline.StageExecutor{Kind: pipeline.ExecutorAgent, Plugin: "claude", Mode: mode},
+		Task:     pipeline.TaskSpec{Prompt: "Look for bugs."},
+	}
+}
+
+func TestBuildStagePrompt_CoreShape(t *testing.T) {
+	round := 3
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), &round)
+
+	for _, want := range []string{
+		"## Pipeline Stage",
+		"Pipeline: ci",
+		"Stage: review",
+		"Mode: review",
+		"Loop round: 3",
+		"## Task",
+		"Look for bugs.",
+		"## Reporting Findings",
+		".ao/" + pipeline.FindingsFilename,
+		".ao/" + pipeline.FindingsFilename + ".tmp",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prompt missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
+func TestBuildStagePrompt_ReviewModeFindingSchema(t *testing.T) {
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil)
+	if !strings.Contains(got, `"finding"`) || !strings.Contains(got, "severity") {
+		t.Errorf("review mode must document the finding record schema\n%s", got)
+	}
+	if strings.Contains(got, "Loop round:") {
+		t.Error("nil loopRound must not render a Loop round line")
+	}
+}
+
+func TestBuildStagePrompt_AnswerModeJSONSchema(t *testing.T) {
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeAnswer), nil)
+	if !strings.Contains(got, `"json"`) || !strings.Contains(got, "outputSchema") {
+		t.Errorf("answer mode must document the json record schema\n%s", got)
+	}
+}
+
+func TestBuildStagePrompt_BlocksMergeNotice(t *testing.T) {
+	stage := agentStage(pipeline.ModeReview)
+	blocks := true
+	stage.Policy = &pipeline.StagePolicy{BlocksMerge: &blocks}
+	got := buildStagePrompt("ci", stage, nil)
+	if !strings.Contains(got, "block merge") {
+		t.Errorf("blocksMerge stage must warn about blocking merge\n%s", got)
+	}
+}
+
+func TestBuildStagePrompt_InputsRendered(t *testing.T) {
+	stage := agentStage(pipeline.ModeReview)
+	stage.Task.Inputs = map[string]any{"threshold": 5}
+	got := buildStagePrompt("ci", stage, nil)
+	if !strings.Contains(got, "## Inputs") || !strings.Contains(got, "threshold") {
+		t.Errorf("inputs must be rendered as a JSON block\n%s", got)
+	}
+}
+
+func TestBuildStagePrompt_NonAgentStageOmitsMode(t *testing.T) {
+	stage := pipeline.Stage{
+		Name:     "typecheck",
+		Executor: pipeline.StageExecutor{Kind: pipeline.ExecutorCommand, Command: "tsc"},
+	}
+	got := buildStagePrompt("ci", stage, nil)
+	if strings.Contains(got, "Mode:") {
+		t.Errorf("command stage has no agent mode line\n%s", got)
+	}
+}


### PR DESCRIPTION
## T4 · Pipeline executors (agent / command / builtin + dispatcher)

Closes #230. Base: `pipelines`.

Implements the pipeline stage executors behind a mockable start/poll/cancel contract wired entirely to injected seams, so the T5 engine drives every stage kind through one inflight loop and unit tests use no real sessions or shells.

### What's here (all under `backend/internal/pipeline/executors/`)

- **Executor contract** (`executor.go`): `StageExecutor{Start,Poll,Cancel}`, an opaque `Handle`, an `Outcome` (status + verdict + `[]ArtifactInput` + observations), and a `Set` facade that routes a stage to the right executor by `executor.kind` and threads Poll/Cancel back to the owning executor.
- **Agent executor** (`agent.go`, `findings.go`, `stageprompt.go`): spawns a fresh, visible session via the `SessionSpawner` seam, injects the ported `stage-prompt.ts` layer, waits for idle **and** the findings file, harvests `{ws}/.ao/pipeline-findings.jsonl` (5MB cap → `pipeline.findings.truncated` observation, torn-final-line tolerance, strict per-record shape), then kills the session. A bad findings file fails the stage but leaves the session up for inspection.
- **Command executor** (`command.go`, `runner.go`, `runner_io.go`, `runner_{unix,windows}.go`): fork-PR gate runs **before any subprocess spawns** (`ForkUnknown` is fail-safe/blocked); shells out via the `CommandRunner` seam with `args`/`env`/`cwd` (cwd escapes rejected), streams stdout/stderr to an optional `LogSink`, and maps the JSON-over-stdout result + exit code to a verdict. Production `osRunner` does process-group kill so detached shells don't outlive the stage.
- **Builtin executor** (`builtin.go`): `router` (one delivery per upstream stage to the linked/routing-target session, single pre-send liveness probe, dead-worker + send-error captured as observations + `delivery_failed` artifacts) and `compose` (merge upstream artifacts into one JSON artifact). Upstream artifacts are fetched through the injected `ArtifactStore` seam keyed on `stage.dependsOn`.

### Scope notes

- v1 is worker-scope only; the `RoutingTargetSessionID` seam is kept for the phase-2 workstream/orchestrator scopes but defaults to the linked worker.
- No worktree provisioning here (spec §9 note 9): a resolved workspace path arrives via the linked session; teardown-on-crash is T5.
- No new dependencies. Only new files under `backend/internal/pipeline/executors/`.

### Tests (mocks only, no real sessions/shells)

`cd backend && go test ./internal/pipeline/executors/... && go vet ./...` green (65 tests, `-race` clean). Covers: findings valid/torn/cap/missing/bad-shape, agent lifecycle transitions, command fork-gate (asserts **no** spawn) + full exit-code semantics, router routing-target/dead-worker/send-error, compose merge shape, and Set kind-routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
