### PR TITLE
feat(pipeline): T5 engine runtime (per-project actor loop + effects + daemon wiring)

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -133,6 +133,12 @@ func Run() error {
 		return fmt.Errorf("wire session service: %w", err)
 	}
 	lcStack.trackerDone = startTrackerIntake(ctx, store, sessionSvc, log)
+
+	// Pipelines v1 (spec §4b T5): one actor-loop engine per project, driving the
+	// pure reducer + executors + store. Single wiring seam so T11 can gate the
+	// whole subsystem behind AO_PIPELINES here.
+	pipelineStk := startPipelineEngine(ctx, store, sessionSvc, log)
+
 	previewDone := preview.NewPoller(store, sessionSvc, "http://"+cfg.Addr(), preview.PollerConfig{Logger: log}).Start(ctx)
 	agentSvc := agentsvc.New()
 	go func() {
@@ -170,6 +176,7 @@ func Run() error {
 	if err != nil {
 		stop()
 		<-previewDone
+		pipelineStk.Stop(context.Background())
 		lcStack.Stop()
 		if cdcErr := cdcPipe.Stop(); cdcErr != nil {
 			log.Error("cdc pipeline shutdown", "err", cdcErr)
@@ -229,6 +236,10 @@ func Run() error {
 	// runs before the cancel: a non-signal exit path would hang otherwise.
 	stop()
 	<-previewDone
+	// Stop pipeline engines before the lifecycle stack: cancelling in-flight runs
+	// kills their stage sessions (reclaiming worktrees) through the still-live
+	// session manager.
+	pipelineStk.Stop(context.Background())
 	lcStack.Stop()
 	lanStopCtx, lanCancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
 	defer lanCancel()

--- a/backend/internal/daemon/pipeline_wiring.go
+++ b/backend/internal/daemon/pipeline_wiring.go
@@ -1,0 +1,44 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+
+	pipelineengine "github.com/aoagents/agent-orchestrator/backend/internal/pipeline/engine"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+// pipelineStack holds the pipeline engine supervisor and its teardown. It is the
+// single wiring seam for the pipelines subsystem (spec §4b T5): T11 will gate
+// this one constructor call behind the AO_PIPELINES flag with no other change.
+type pipelineStack struct {
+	supervisor *pipelineengine.Supervisor
+}
+
+// startPipelineEngine builds the executor set over the session service + store,
+// constructs the per-project engine supervisor, and starts one engine per known
+// project. A start failure is logged, never fatal: an unhealthy pipeline
+// subsystem must not block daemon boot, and idle engines (no definitions, no
+// triggers) are harmless.
+func startPipelineEngine(ctx context.Context, store *sqlite.Store, sessions pipelineengine.SessionCommander, log *slog.Logger) *pipelineStack {
+	execs := pipelineengine.BuildExecutorSet(sessions, store)
+	sup := pipelineengine.NewSupervisor(pipelineengine.SupervisorConfig{
+		Store:     store,
+		Executors: execs,
+		Projects:  store,
+		Logger:    log,
+	})
+	if err := sup.Start(ctx); err != nil {
+		log.Error("pipeline engine supervisor start failed", "err", err)
+	}
+	return &pipelineStack{supervisor: sup}
+}
+
+// Stop tears down every project engine, cancelling in-flight runs so their
+// session-owned stage worktrees are reclaimed (spec §9 note 9).
+func (p *pipelineStack) Stop(ctx context.Context) {
+	if p == nil || p.supervisor == nil {
+		return
+	}
+	_ = p.supervisor.Stop(ctx)
+}

--- a/backend/internal/pipeline/engine/adapters.go
+++ b/backend/internal/pipeline/engine/adapters.go
@@ -1,0 +1,213 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// This file wires the T4 executor DI seams (SessionSpawner, CommandSessions,
+// ArtifactStore, SessionMessenger) onto the real session service and store. The
+// executors stay unaware of concrete infra; these adapters translate their
+// narrow shapes to/from domain + ports types.
+
+// SessionCommander is the session-manager surface the agent-spawn and router
+// adapters need. Satisfied by *internal/service/session.Service (which spawns
+// visible sidebar sessions, per spec §4b).
+type SessionCommander interface {
+	Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Session, error)
+	Kill(ctx context.Context, id domain.SessionID) (bool, error)
+	Send(ctx context.Context, id domain.SessionID, message string) error
+}
+
+// SessionReader reads session snapshots, PR facts, and persisted pipeline
+// artifacts for the executor adapters. Satisfied by *storage/sqlite/store.Store.
+type SessionReader interface {
+	GetSession(ctx context.Context, id domain.SessionID) (domain.SessionRecord, bool, error)
+	GetDisplayPRFactsForSession(ctx context.Context, id domain.SessionID) (domain.PRFacts, bool, error)
+	GetPipelineRun(ctx context.Context, id pipeline.RunID) (pipeline.RunState, bool, error)
+	GetPipelineArtifact(ctx context.Context, id pipeline.ArtifactID) (pipeline.Artifact, bool, error)
+}
+
+// BuildExecutorSet assembles the three kind executors over the real session
+// service + store and returns the routing facade the engine drives. This is the
+// single place the executors are wired to infra.
+func BuildExecutorSet(cmd SessionCommander, reader SessionReader) *executors.Set {
+	agent := executors.NewAgentExecutor(&sessionSpawnerAdapter{cmd: cmd, reader: reader})
+	// nil LogSink: the subprocess output is still captured (capped) for the
+	// JSON-over-stdout contract; streaming it to an activity log is a phase-2
+	// nicety, not needed for correctness.
+	// ponytail: nil sink drops live command logs; wire a LogSink when the Runs UI
+	// wants streaming stdout.
+	command := executors.NewCommandExecutor(executors.NewOSRunner(nil), &commandSessionsAdapter{reader: reader})
+	builtin := executors.NewBuiltinExecutor(&artifactStoreAdapter{reader: reader}, &sessionMessengerAdapter{cmd: cmd, reader: reader})
+	return executors.NewSet(agent, command, builtin)
+}
+
+// ---------------------------------------------------------------------------
+// SessionSpawner (agent executor)
+// ---------------------------------------------------------------------------
+
+type sessionSpawnerAdapter struct {
+	cmd    SessionCommander
+	reader SessionReader
+}
+
+var _ executors.SessionSpawner = (*sessionSpawnerAdapter)(nil)
+
+func (a *sessionSpawnerAdapter) Spawn(ctx context.Context, req executors.SpawnRequest) (executors.SpawnedSession, error) {
+	sess, err := a.cmd.Spawn(ctx, ports.SpawnConfig{
+		ProjectID: domain.ProjectID(req.ProjectID),
+		IssueID:   domain.IssueID(req.IssueID),
+		Kind:      domain.KindWorker,
+		Harness:   domain.AgentHarness(req.Harness),
+		Prompt:    req.Prompt,
+	})
+	if err != nil {
+		return executors.SpawnedSession{}, err
+	}
+	return executors.SpawnedSession{
+		SessionID:     string(sess.ID),
+		WorkspacePath: sess.Metadata.WorkspacePath,
+	}, nil
+}
+
+func (a *sessionSpawnerAdapter) Get(ctx context.Context, sessionID string) (executors.SessionSnapshot, bool, error) {
+	rec, ok, err := a.reader.GetSession(ctx, domain.SessionID(sessionID))
+	if err != nil {
+		return executors.SessionSnapshot{}, false, err
+	}
+	if !ok {
+		return executors.SessionSnapshot{}, false, nil
+	}
+	return executors.SessionSnapshot{
+		Activity:   string(rec.Activity.State),
+		Terminated: rec.IsTerminated,
+	}, true, nil
+}
+
+func (a *sessionSpawnerAdapter) Kill(ctx context.Context, sessionID string) error {
+	// Best-effort, idempotent teardown: a missing or already-dead session is not
+	// an error (the executor contract requires this). The session manager logs
+	// its own kill failures, so swallowing here keeps stage teardown clean.
+	_, _ = a.cmd.Kill(ctx, domain.SessionID(sessionID))
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// CommandSessions (command executor)
+// ---------------------------------------------------------------------------
+
+type commandSessionsAdapter struct {
+	reader SessionReader
+}
+
+var _ executors.CommandSessions = (*commandSessionsAdapter)(nil)
+
+func (a *commandSessionsAdapter) Get(ctx context.Context, sessionID string) (executors.CommandSession, bool, error) {
+	rec, ok, err := a.reader.GetSession(ctx, domain.SessionID(sessionID))
+	if err != nil {
+		return executors.CommandSession{}, false, err
+	}
+	if !ok {
+		return executors.CommandSession{}, false, nil
+	}
+
+	// Fork provenance is not persisted anywhere in the store: only the SCM
+	// observer sees a PR's head-repo, transiently, and it never survives to the
+	// pr table (see the base-repo-only Repo column). So we cannot classify a
+	// real PR as fork/no-fork after the fact. Fail safe (spec §4b): a session
+	// with an attributed PR is treated as ForkUnknown, which the command
+	// executor gates behind allowForkPRs. A session with no PR is ForkNo and
+	// runs normally.
+	fork := executors.ForkNo
+	prNumber := 0
+	if prf, prok, perr := a.reader.GetDisplayPRFactsForSession(ctx, domain.SessionID(sessionID)); perr == nil && prok && prf.Number > 0 {
+		fork = executors.ForkUnknown
+		prNumber = prf.Number
+	}
+
+	return executors.CommandSession{
+		WorkspacePath: rec.Metadata.WorkspacePath,
+		Fork:          fork,
+		PRNumber:      prNumber,
+	}, true, nil
+}
+
+// ---------------------------------------------------------------------------
+// SessionMessenger (builtin router)
+// ---------------------------------------------------------------------------
+
+type sessionMessengerAdapter struct {
+	cmd    SessionCommander
+	reader SessionReader
+}
+
+var _ executors.SessionMessenger = (*sessionMessengerAdapter)(nil)
+
+func (a *sessionMessengerAdapter) Alive(ctx context.Context, sessionID string) (bool, error) {
+	rec, ok, err := a.reader.GetSession(ctx, domain.SessionID(sessionID))
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	return !rec.IsTerminated && rec.Activity.State != domain.ActivityExited, nil
+}
+
+func (a *sessionMessengerAdapter) Send(ctx context.Context, sessionID, message string) error {
+	return a.cmd.Send(ctx, domain.SessionID(sessionID), message)
+}
+
+// ---------------------------------------------------------------------------
+// ArtifactStore (builtin router/compose)
+// ---------------------------------------------------------------------------
+
+type artifactStoreAdapter struct {
+	reader SessionReader
+}
+
+var _ executors.ArtifactStore = (*artifactStoreAdapter)(nil)
+
+// UpstreamArtifacts returns the persisted artifacts of the named upstream stages,
+// keyed by stage name. It reads through the existing public store surface
+// (GetPipelineRun for the stage->artifact-id mapping, then GetPipelineArtifact
+// for each blob) so no new store query is introduced.
+//
+// ponytail: N+1 artifact fetch per builtin stage. Fine at v1 scale (builtins
+// consume a handful of upstream artifacts); add a batch "artifacts by run+stage"
+// store query if builtin-heavy pipelines show up hot in a profile.
+func (a *artifactStoreAdapter) UpstreamArtifacts(ctx context.Context, runID pipeline.RunID, stageNames []string) (map[string][]pipeline.Artifact, error) {
+	out := make(map[string][]pipeline.Artifact, len(stageNames))
+	run, ok, err := a.reader.GetPipelineRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return out, nil
+	}
+	for _, name := range stageNames {
+		stage, ok := run.Stages[name]
+		if !ok {
+			continue
+		}
+		var arts []pipeline.Artifact
+		for _, id := range stage.Artifacts {
+			art, ok, err := a.reader.GetPipelineArtifact(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				arts = append(arts, art)
+			}
+		}
+		if len(arts) > 0 {
+			out[name] = arts
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/pipeline/engine/adapters_test.go
+++ b/backend/internal/pipeline/engine/adapters_test.go
@@ -1,0 +1,226 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// fakeCommander records spawn/kill/send calls for the adapter tests.
+type fakeCommander struct {
+	spawned  ports.SpawnConfig
+	spawnOut domain.Session
+	spawnErr error
+	killErr  error
+	killed   []domain.SessionID
+	sent     map[domain.SessionID]string
+}
+
+func (f *fakeCommander) Spawn(_ context.Context, cfg ports.SpawnConfig) (domain.Session, error) {
+	f.spawned = cfg
+	return f.spawnOut, f.spawnErr
+}
+
+func (f *fakeCommander) Kill(_ context.Context, id domain.SessionID) (bool, error) {
+	f.killed = append(f.killed, id)
+	return f.killErr == nil, f.killErr
+}
+
+func (f *fakeCommander) Send(_ context.Context, id domain.SessionID, message string) error {
+	if f.sent == nil {
+		f.sent = map[domain.SessionID]string{}
+	}
+	f.sent[id] = message
+	return nil
+}
+
+// fakeReader serves session/PR/artifact facts from in-memory maps.
+type fakeReader struct {
+	sessions map[domain.SessionID]domain.SessionRecord
+	prs      map[domain.SessionID]domain.PRFacts
+	runs     map[pipeline.RunID]pipeline.RunState
+	arts     map[pipeline.ArtifactID]pipeline.Artifact
+}
+
+func (f *fakeReader) GetSession(_ context.Context, id domain.SessionID) (domain.SessionRecord, bool, error) {
+	rec, ok := f.sessions[id]
+	return rec, ok, nil
+}
+
+func (f *fakeReader) GetDisplayPRFactsForSession(_ context.Context, id domain.SessionID) (domain.PRFacts, bool, error) {
+	pr, ok := f.prs[id]
+	return pr, ok, nil
+}
+
+func (f *fakeReader) GetPipelineRun(_ context.Context, id pipeline.RunID) (pipeline.RunState, bool, error) {
+	run, ok := f.runs[id]
+	return run, ok, nil
+}
+
+func (f *fakeReader) GetPipelineArtifact(_ context.Context, id pipeline.ArtifactID) (pipeline.Artifact, bool, error) {
+	a, ok := f.arts[id]
+	return a, ok, nil
+}
+
+func TestSessionSpawnerAdapterSpawnMapsConfig(t *testing.T) {
+	cmd := &fakeCommander{spawnOut: domain.Session{SessionRecord: domain.SessionRecord{
+		ID: "mer-3", Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-3"},
+	}}}
+	a := &sessionSpawnerAdapter{cmd: cmd, reader: &fakeReader{}}
+
+	got, err := a.Spawn(context.Background(), executors.SpawnRequest{
+		ProjectID: "mer", IssueID: "issue-1", Prompt: "review this", Harness: "codex",
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if got.SessionID != "mer-3" || got.WorkspacePath != "/ws/mer-3" {
+		t.Fatalf("spawned session = %+v", got)
+	}
+	if cmd.spawned.ProjectID != "mer" || cmd.spawned.IssueID != "issue-1" ||
+		cmd.spawned.Prompt != "review this" || cmd.spawned.Harness != "codex" ||
+		cmd.spawned.Kind != domain.KindWorker {
+		t.Fatalf("spawn config mismapped: %+v", cmd.spawned)
+	}
+}
+
+func TestSessionSpawnerAdapterGetAndKill(t *testing.T) {
+	reader := &fakeReader{sessions: map[domain.SessionID]domain.SessionRecord{
+		"live": {Activity: domain.Activity{State: domain.ActivityIdle}},
+	}}
+	cmd := &fakeCommander{killErr: errors.New("already gone")}
+	a := &sessionSpawnerAdapter{cmd: cmd, reader: reader}
+
+	snap, ok, err := a.Get(context.Background(), "live")
+	if err != nil || !ok || snap.Activity != "idle" || snap.Terminated {
+		t.Fatalf("get live = %+v ok=%v err=%v", snap, ok, err)
+	}
+	if _, ok, _ := a.Get(context.Background(), "missing"); ok {
+		t.Fatal("missing session must report ok=false")
+	}
+	// Kill is best-effort: a kill error is swallowed so teardown stays clean.
+	if err := a.Kill(context.Background(), "live"); err != nil {
+		t.Fatalf("kill must swallow errors, got %v", err)
+	}
+	if len(cmd.killed) != 1 || cmd.killed[0] != "live" {
+		t.Fatalf("kill not delegated: %v", cmd.killed)
+	}
+}
+
+func TestCommandSessionsAdapterForkGate(t *testing.T) {
+	reader := &fakeReader{
+		sessions: map[domain.SessionID]domain.SessionRecord{
+			"nopr": {Metadata: domain.SessionMetadata{WorkspacePath: "/ws/nopr"}},
+			"pr":   {Metadata: domain.SessionMetadata{WorkspacePath: "/ws/pr"}},
+		},
+		prs: map[domain.SessionID]domain.PRFacts{
+			"pr": {Number: 42},
+		},
+	}
+	a := &commandSessionsAdapter{reader: reader}
+
+	// No PR: safe to run (ForkNo), PRNumber 0.
+	got, ok, err := a.Get(context.Background(), "nopr")
+	if err != nil || !ok {
+		t.Fatalf("get nopr: ok=%v err=%v", ok, err)
+	}
+	if got.Fork != executors.ForkNo || got.PRNumber != 0 || got.WorkspacePath != "/ws/nopr" {
+		t.Fatalf("no-PR session = %+v, want ForkNo/0", got)
+	}
+
+	// PR present but fork provenance unknowable from the store: fail safe to
+	// ForkUnknown so the command executor gates it behind allowForkPRs.
+	got, ok, err = a.Get(context.Background(), "pr")
+	if err != nil || !ok {
+		t.Fatalf("get pr: ok=%v err=%v", ok, err)
+	}
+	if got.Fork != executors.ForkUnknown || got.PRNumber != 42 {
+		t.Fatalf("PR session = %+v, want ForkUnknown/42", got)
+	}
+
+	if _, ok, _ := a.Get(context.Background(), "missing"); ok {
+		t.Fatal("missing session must report ok=false")
+	}
+}
+
+func TestSessionMessengerAdapterAlive(t *testing.T) {
+	reader := &fakeReader{sessions: map[domain.SessionID]domain.SessionRecord{
+		"live":   {Activity: domain.Activity{State: domain.ActivityActive}},
+		"exited": {Activity: domain.Activity{State: domain.ActivityExited}},
+		"dead":   {IsTerminated: true, Activity: domain.Activity{State: domain.ActivityIdle}},
+	}}
+	cmd := &fakeCommander{}
+	a := &sessionMessengerAdapter{cmd: cmd, reader: reader}
+
+	cases := map[string]bool{"live": true, "exited": false, "dead": false, "missing": false}
+	for id, want := range cases {
+		got, err := a.Alive(context.Background(), id)
+		if err != nil {
+			t.Fatalf("alive %s: %v", id, err)
+		}
+		if got != want {
+			t.Fatalf("alive %s = %v, want %v", id, got, want)
+		}
+	}
+
+	if err := a.Send(context.Background(), "live", "hello"); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if cmd.sent["live"] != "hello" {
+		t.Fatalf("send not delegated: %v", cmd.sent)
+	}
+}
+
+func TestArtifactStoreAdapterGroupsUpstreamByStage(t *testing.T) {
+	run := pipeline.RunState{
+		RunID: "run-1",
+		Stages: map[string]pipeline.StageState{
+			"lint":   {StageRunID: "sr-lint", Artifacts: []pipeline.ArtifactID{"a1", "a2"}},
+			"secrev": {StageRunID: "sr-sec", Artifacts: []pipeline.ArtifactID{"a3"}},
+		},
+	}
+	reader := &fakeReader{
+		runs: map[pipeline.RunID]pipeline.RunState{"run-1": run},
+		arts: map[pipeline.ArtifactID]pipeline.Artifact{
+			"a1": {ArtifactID: "a1", StageName: "lint", ArtifactInput: pipeline.ArtifactInput{Kind: pipeline.ArtifactKindFinding, Title: "f1"}},
+			"a2": {ArtifactID: "a2", StageName: "lint", ArtifactInput: pipeline.ArtifactInput{Kind: pipeline.ArtifactKindJSON, Data: map[string]any{"k": "v"}}},
+			"a3": {ArtifactID: "a3", StageName: "secrev", ArtifactInput: pipeline.ArtifactInput{Kind: pipeline.ArtifactKindFinding, Title: "f3"}},
+		},
+	}
+	a := &artifactStoreAdapter{reader: reader}
+
+	// Request an extra stage ("missing") that has no state; it is simply omitted.
+	got, err := a.UpstreamArtifacts(context.Background(), "run-1", []string{"lint", "secrev", "missing"})
+	if err != nil {
+		t.Fatalf("upstream artifacts: %v", err)
+	}
+	if len(got["lint"]) != 2 || len(got["secrev"]) != 1 {
+		t.Fatalf("grouping = %+v, want lint:2 secrev:1", got)
+	}
+	if _, present := got["missing"]; present {
+		t.Fatalf("stage not in run must be omitted, got %+v", got["missing"])
+	}
+	// Both finding and JSON kinds are returned (builtins consume both).
+	if got["lint"][0].Kind != pipeline.ArtifactKindFinding || got["lint"][1].Kind != pipeline.ArtifactKindJSON {
+		t.Fatalf("lint artifacts lost kind fidelity: %+v", got["lint"])
+	}
+
+	// Unknown run yields an empty (non-nil) map, not an error.
+	empty, err := a.UpstreamArtifacts(context.Background(), "nope", []string{"lint"})
+	if err != nil || len(empty) != 0 {
+		t.Fatalf("unknown run = %+v err=%v, want empty", empty, err)
+	}
+}
+
+// Compile-time proof the adapters satisfy the executor DI seams.
+var (
+	_ executors.SessionSpawner   = (*sessionSpawnerAdapter)(nil)
+	_ executors.CommandSessions  = (*commandSessionsAdapter)(nil)
+	_ executors.SessionMessenger = (*sessionMessengerAdapter)(nil)
+	_ executors.ArtifactStore    = (*artifactStoreAdapter)(nil)
+)

--- a/backend/internal/pipeline/engine/engine.go
+++ b/backend/internal/pipeline/engine/engine.go
@@ -1,0 +1,584 @@
+// Package engine is the pipeline runtime: a per-project, actor-style event loop
+// that drives the pure pipeline reducer, executes its effects against the store
+// and executors, polls inflight stages, and hydrates on boot.
+//
+// The single-writer invariant is the core correctness property (spec §9 note 4):
+// ALL EngineState mutation happens on one goroutine, serialized through the
+// engine's mailbox channel. This replaces the old TypeScript engine's `lockTail`
+// promise chain. Public entry points (TriggerRun, Cancel, Resume, ...) post a
+// closure onto the mailbox and block until the actor runs it; effect execution
+// feeds follow-up events back into the reducer synchronously on the same
+// goroutine (the Go analogue of the old `dispatchInline`), never through the
+// channel, so there is no re-entrancy deadlock and no interleaving.
+//
+// Ported behaviourally from packages/core/src/pipeline/engine.ts on the
+// origin/legacy-pipelines branch, minus the deferred follow-up delivery
+// (SEND_FOLLOWUP / FOLLOWUP_REPLY) which is phase 2.
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+)
+
+// defaultTickInterval is how often the engine polls inflight stage handles when
+// no interval is configured. Agent/command stages finish asynchronously, so the
+// loop needs a heartbeat to make progress; 2s balances latency against churn.
+const defaultTickInterval = 2 * time.Second
+
+// Store is the persistence surface the engine drives via the reducer's PERSIST_*
+// and artifact effects. It is deliberately a subset of the sqlite store so the
+// engine unit-tests against an in-memory fake; *store.Store satisfies it.
+type Store interface {
+	SavePipelineRun(ctx context.Context, projectID domain.ProjectID, run pipeline.RunState) error
+	AppendPipelineArtifacts(ctx context.Context, projectID domain.ProjectID, artifacts []pipeline.Artifact) error
+	UpdatePipelineArtifactStatus(ctx context.Context, id pipeline.ArtifactID, status pipeline.ArtifactStatus, sentToAgentAt *time.Time) (bool, error)
+	HydratePipelineEngineState(ctx context.Context, projectID domain.ProjectID) (pipeline.EngineState, error)
+}
+
+// ObservationSink receives every EMIT_OBSERVATION effect and every executor-side
+// observation. It is always wired, never nil, never silently drops (spec §9
+// note 8). The default implementation logs structured slog at the daemon logger.
+type ObservationSink interface {
+	Observe(name string, data map[string]any)
+}
+
+// Config constructs an Engine. Only ProjectID, Store, and Executors are
+// required; the rest default sensibly.
+type Config struct {
+	ProjectID domain.ProjectID
+	Store     Store
+	Executors *executors.Set
+
+	// Sink receives observations. Defaults to a slog sink over Logger.
+	Sink ObservationSink
+	// Logger backs the default observation sink and internal warnings.
+	Logger *slog.Logger
+	// Clock is the driver clock stamped onto every event. Defaults to
+	// time.Now().UTC.
+	Clock func() time.Time
+	// NewRunID / NewStageRunID allocate identity for triggered runs and resumed
+	// stages. Default to a "run-"/"sr-"-prefixed uuid, mirroring internal/review.
+	NewRunID      func() pipeline.RunID
+	NewStageRunID func() pipeline.StageRunID
+	// TickInterval overrides the inflight-poll heartbeat. <=0 uses the default.
+	TickInterval time.Duration
+}
+
+// Engine is one project's pipeline runtime. All exported methods are safe to
+// call from any goroutine; each serializes onto the actor loop.
+type Engine struct {
+	projectID     domain.ProjectID
+	store         Store
+	execs         *executors.Set
+	sink          ObservationSink
+	log           *slog.Logger
+	now           func() time.Time
+	newRunID      func() pipeline.RunID
+	newStageRunID func() pipeline.StageRunID
+	tickInterval  time.Duration
+
+	mailbox  chan func()
+	quit     chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+	baseCtx  context.Context
+	cancel   context.CancelFunc
+
+	// The fields below are owned exclusively by the actor goroutine and need no
+	// lock: only the mailbox closures (which run on that goroutine) touch them.
+	state    pipeline.EngineState
+	inflight map[pipeline.StageRunID]executors.Handle
+	// issueByRun threads the trigger's issue id to START_STAGE, out-of-band from
+	// RunState (which does not carry it). Pruned when a run goes terminal.
+	issueByRun map[pipeline.RunID]string
+}
+
+// New builds an Engine. It does not touch the store or start any goroutine;
+// call Start for that.
+func New(cfg Config) *Engine {
+	e := &Engine{
+		projectID:     cfg.ProjectID,
+		store:         cfg.Store,
+		execs:         cfg.Executors,
+		sink:          cfg.Sink,
+		log:           cfg.Logger,
+		now:           cfg.Clock,
+		newRunID:      cfg.NewRunID,
+		newStageRunID: cfg.NewStageRunID,
+		tickInterval:  cfg.TickInterval,
+		mailbox:       make(chan func()),
+		quit:          make(chan struct{}),
+		state:         pipeline.EmptyEngineState(),
+		inflight:      map[pipeline.StageRunID]executors.Handle{},
+		issueByRun:    map[pipeline.RunID]string{},
+	}
+	if e.log == nil {
+		e.log = slog.Default()
+	}
+	if e.sink == nil {
+		e.sink = slogSink{log: e.log}
+	}
+	if e.now == nil {
+		e.now = func() time.Time { return time.Now().UTC() }
+	}
+	if e.newRunID == nil {
+		e.newRunID = func() pipeline.RunID { return pipeline.RunID("run-" + uuid.NewString()) }
+	}
+	if e.newStageRunID == nil {
+		e.newStageRunID = func() pipeline.StageRunID { return pipeline.StageRunID("sr-" + uuid.NewString()) }
+	}
+	if e.tickInterval <= 0 {
+		e.tickInterval = defaultTickInterval
+	}
+	return e
+}
+
+// Start hydrates the engine's state from the store, launches the actor loop, and
+// reconciles any stages left running by a previous process. It returns an error
+// only if hydration fails; after Start the engine serves entry points until Stop.
+func (e *Engine) Start(ctx context.Context) error {
+	e.baseCtx, e.cancel = context.WithCancel(context.Background())
+
+	// Hydrate before the actor serves. Nothing else touches e.state yet, so this
+	// direct assignment is race-free.
+	state, err := e.store.HydratePipelineEngineState(ctx, e.projectID)
+	if err != nil {
+		e.cancel()
+		return fmt.Errorf("pipeline engine %s: hydrate: %w", e.projectID, err)
+	}
+	e.state = state
+
+	e.wg.Add(1)
+	go e.runLoop()
+
+	// Stages persisted as "running" have no live executor handle in this process.
+	// Fail them so their runs advance (recovery branch) or terminate as stalled,
+	// exactly as the old engine's reconcileInflightStages did on hydrate.
+	e.do(e.reconcileInflight)
+	return nil
+}
+
+// Stop cancels every non-terminal run (tearing down its inflight stages and
+// reclaiming session-owned worktrees), stops the actor loop, and waits for it to
+// drain. Idempotent. After Stop the engine must not be used.
+func (e *Engine) Stop(ctx context.Context) error {
+	e.stopOnce.Do(func() {
+		// Cancel in-flight work on the actor so teardown is serialized with any
+		// in-progress reduce, then stop the loop and cancel base I/O.
+		e.do(e.shutdown)
+		close(e.quit)
+		if e.cancel != nil {
+			e.cancel()
+		}
+	})
+	e.wg.Wait()
+	return nil
+}
+
+// runLoop is the single actor goroutine: the only place e.state, e.inflight, and
+// e.issueByRun are read or written after Start.
+func (e *Engine) runLoop() {
+	defer e.wg.Done()
+	ticker := time.NewTicker(e.tickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-e.quit:
+			return
+		case fn := <-e.mailbox:
+			fn()
+		case <-ticker.C:
+			e.tick()
+		}
+	}
+}
+
+// do runs fn on the actor goroutine and blocks until it completes. If the engine
+// has stopped, fn is dropped and do returns immediately.
+func (e *Engine) do(fn func()) {
+	done := make(chan struct{})
+	select {
+	case e.mailbox <- func() { defer close(done); fn() }:
+		<-done
+	case <-e.quit:
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points (each serialized onto the actor)
+// ---------------------------------------------------------------------------
+
+// TriggerRequest describes a run to start. IDs are allocated by TriggerRun.
+type TriggerRequest struct {
+	Pipeline  pipeline.Pipeline
+	SessionID string
+	// Trigger defaults to pipeline.TriggerManual when empty.
+	Trigger pipeline.StageTriggerEvent
+	HeadSHA string
+	// IssueID is forwarded into spawned agent-stage sessions.
+	IssueID string
+}
+
+// TriggerRun allocates a RunID plus one StageRunID per stage, then dispatches
+// TRIGGER_FIRED. The pipeline is validated for DAG cycles first (defense in
+// depth; definitions are validated at author time by the CRUD layer). Returns
+// the allocated RunID, or an error if the config is structurally invalid.
+func (e *Engine) TriggerRun(req TriggerRequest) (pipeline.RunID, error) {
+	if err := pipeline.ValidateDAG(&req.Pipeline); err != nil {
+		return "", fmt.Errorf("pipeline engine %s: reject trigger for %q: %w", e.projectID, req.Pipeline.Name, err)
+	}
+
+	trigger := req.Trigger
+	if trigger == "" {
+		trigger = pipeline.TriggerManual
+	}
+	runID := e.newRunID()
+	stageRunIDs := make(map[string]pipeline.StageRunID, len(req.Pipeline.Stages))
+	for _, s := range req.Pipeline.Stages {
+		stageRunIDs[s.Name] = e.newStageRunID()
+	}
+
+	e.do(func() {
+		if req.IssueID != "" {
+			e.issueByRun[runID] = req.IssueID
+		}
+		e.reduceAndExecute(pipeline.TriggerFired{
+			Now:         e.now(),
+			Trigger:     trigger,
+			SessionID:   req.SessionID,
+			Pipeline:    req.Pipeline,
+			HeadSHA:     req.HeadSHA,
+			RunID:       runID,
+			StageRunIDs: stageRunIDs,
+		})
+	})
+	return runID, nil
+}
+
+// Cancel terminates an in-flight run. Unknown runs are a no-op. reason defaults
+// to manual_cancel.
+func (e *Engine) Cancel(runID pipeline.RunID, reason pipeline.RunTerminationReason) {
+	if reason == "" {
+		reason = pipeline.TerminationManualCancel
+	}
+	e.do(func() {
+		run, ok := e.state.Runs[runID]
+		if !ok {
+			return
+		}
+		// The reducer's RUN_CANCELLED guard rejects already-terminal runs; skip
+		// them here so a redundant cancel stays a clean no-op rather than an
+		// invalid-transition observation.
+		if run.LoopState.IsTerminal() {
+			return
+		}
+		e.reduceAndExecute(pipeline.RunCancelled{Now: e.now(), RunID: runID, Reason: reason})
+	})
+}
+
+// Resume re-arms a terminal (stalled/failed) run: failed and externally-cancelled
+// stages get fresh StageRunIDs and the loop restarts. Unknown or non-terminal
+// runs are a no-op.
+func (e *Engine) Resume(runID pipeline.RunID) {
+	e.do(func() {
+		run, ok := e.state.Runs[runID]
+		if !ok || !run.LoopState.IsTerminal() {
+			return
+		}
+		ids := map[string]pipeline.StageRunID{}
+		for name, st := range run.Stages {
+			if st.Status == pipeline.StageStatusFailed || st.Status == pipeline.StageStatusOutdated {
+				ids[name] = e.newStageRunID()
+			}
+		}
+		e.reduceAndExecute(pipeline.RunResumed{Now: e.now(), RunID: runID, StageRunIDs: ids})
+	})
+}
+
+// ArtifactStatusRequest changes one artifact's status (e.g. dismissing a
+// finding) on a run.
+type ArtifactStatusRequest struct {
+	RunID      pipeline.RunID
+	StageRunID pipeline.StageRunID
+	ArtifactID pipeline.ArtifactID
+	Status     pipeline.ArtifactStatus
+	// Actor is an optional audit label.
+	Actor string
+}
+
+// ChangeArtifactStatus dispatches ARTIFACT_STATUS_CHANGED.
+func (e *Engine) ChangeArtifactStatus(req ArtifactStatusRequest) {
+	e.do(func() {
+		e.reduceAndExecute(pipeline.ArtifactStatusChanged{
+			Now:        e.now(),
+			RunID:      req.RunID,
+			StageRunID: req.StageRunID,
+			ArtifactID: req.ArtifactID,
+			Status:     req.Status,
+			Actor:      req.Actor,
+		})
+	})
+}
+
+// Dispatch feeds a pre-formed event through the reducer. It is the seam for T6
+// trigger bridging (NEW_SHA_DETECTED, CONFIG_CHANGED) and any caller that builds
+// its own event. Prefer TriggerRun for starting runs so IDs are allocated.
+func (e *Engine) Dispatch(event pipeline.Event) {
+	e.do(func() { e.reduceAndExecute(event) })
+}
+
+// Tick polls inflight stage handles once, synchronously. Production drives this
+// on an internal heartbeat; tests call it for determinism.
+func (e *Engine) Tick() {
+	e.do(e.tick)
+}
+
+// State returns a snapshot of the engine's current EngineState. The reducer is
+// copy-on-write, so the returned value is safe to read.
+func (e *Engine) State() pipeline.EngineState {
+	snap := pipeline.EmptyEngineState()
+	e.do(func() { snap = e.state })
+	return snap
+}
+
+// ---------------------------------------------------------------------------
+// Actor-goroutine internals (never call these off the actor)
+// ---------------------------------------------------------------------------
+
+// reduceAndExecute is the Go analogue of the old dispatchInline: reduce, then
+// execute each effect (which may recurse back through here for follow-up events),
+// then prune terminated run metadata. Runs only on the actor goroutine.
+func (e *Engine) reduceAndExecute(event pipeline.Event) {
+	var effects []pipeline.Effect
+	e.state, effects = pipeline.Reduce(e.state, event)
+	for _, eff := range effects {
+		e.executeEffect(eff)
+	}
+	e.pruneRunMeta()
+}
+
+func (e *Engine) executeEffect(eff pipeline.Effect) {
+	switch ef := eff.(type) {
+	case pipeline.PersistRun:
+		if err := e.store.SavePipelineRun(e.baseCtx, e.projectID, ef.RunState); err != nil {
+			e.observe("pipeline.persist.failed", map[string]any{"effect": "PERSIST_RUN", "runId": string(ef.RunState.RunID), "error": err.Error()})
+		}
+	case pipeline.PersistLoopState:
+		// ponytail: no-op in v1. T3 has no loop table; loop pointers and history
+		// are derived on hydrate from the runs themselves. This arm is a
+		// documented seam so a phase-2 loop table slots in without touching the
+		// reducer's effect contract.
+	case pipeline.AppendArtifacts:
+		if err := e.store.AppendPipelineArtifacts(e.baseCtx, e.projectID, ef.Artifacts); err != nil {
+			e.observe("pipeline.persist.failed", map[string]any{"effect": "APPEND_ARTIFACTS", "runId": string(ef.RunID), "error": err.Error()})
+		}
+	case pipeline.UpdateArtifactStatus:
+		var sentAt *time.Time
+		if ef.Status == pipeline.ArtifactStatusSentToAgent {
+			t := e.now()
+			sentAt = &t
+		}
+		if _, err := e.store.UpdatePipelineArtifactStatus(e.baseCtx, ef.ArtifactID, ef.Status, sentAt); err != nil {
+			e.observe("pipeline.persist.failed", map[string]any{"effect": "UPDATE_ARTIFACT_STATUS", "artifactId": string(ef.ArtifactID), "error": err.Error()})
+		}
+	case pipeline.EmitObservation:
+		e.observe(ef.Name, ef.Data)
+	case pipeline.StartStage:
+		e.startStage(ef)
+	case pipeline.CancelStage:
+		e.cancelStage(ef)
+	default:
+		e.observe("pipeline.effect.unknown", map[string]any{"type": string(eff.Type())})
+	}
+}
+
+// startStage begins a stage's executor, then feeds STAGE_STARTED (on success) or
+// STAGE_FAILED (on a start error) back through the reducer. Following the task
+// contract: Start first, then STAGE_STARTED. The reducer allows STAGE_FAILED from
+// pending, so a start error still lands cleanly.
+func (e *Engine) startStage(eff pipeline.StartStage) {
+	run, ok := e.state.Runs[eff.RunID]
+	if !ok {
+		return
+	}
+	h, err := e.execs.Start(e.baseCtx, e.startInput(run, eff))
+	if err != nil {
+		e.reduceAndExecute(pipeline.StageFailed{Now: e.now(), RunID: eff.RunID, StageName: eff.Stage.Name, ErrorMessage: err.Error()})
+		return
+	}
+	e.inflight[eff.StageRunID] = h
+	e.reduceAndExecute(pipeline.StageStarted{Now: e.now(), RunID: eff.RunID, StageName: eff.Stage.Name})
+}
+
+func (e *Engine) startInput(run pipeline.RunState, eff pipeline.StartStage) executors.StartInput {
+	loopRound := run.LoopRounds
+	allowFork := run.PipelineConfigSnapshot.AllowForkPRs != nil && *run.PipelineConfigSnapshot.AllowForkPRs
+	return executors.StartInput{
+		PipelineName:    run.PipelineName,
+		ProjectID:       string(e.projectID),
+		RunID:           eff.RunID,
+		StageRunID:      eff.StageRunID,
+		Stage:           eff.Stage,
+		IssueID:         e.issueByRun[eff.RunID],
+		LoopRound:       &loopRound,
+		LinkedSessionID: run.SessionID,
+		AllowForkPRs:    allowFork,
+	}
+}
+
+func (e *Engine) cancelStage(eff pipeline.CancelStage) {
+	h, ok := e.inflight[eff.StageRunID]
+	if !ok {
+		return
+	}
+	delete(e.inflight, eff.StageRunID)
+	if err := e.execs.Cancel(e.baseCtx, h); err != nil {
+		e.observe("pipeline.cancel.failed", map[string]any{
+			"runId": string(eff.RunID), "stageRunId": string(eff.StageRunID),
+			"stageName": eff.StageName, "error": err.Error(),
+		})
+	}
+}
+
+// tick polls every inflight handle. A terminal outcome is removed from the
+// inflight set and fed back as STAGE_COMPLETED / STAGE_FAILED. Handles are
+// snapshotted first because a completing stage can, via the reducer, cancel a
+// sibling (removing it from inflight) or start a new stage (adding one).
+func (e *Engine) tick() {
+	if len(e.inflight) == 0 {
+		return
+	}
+	keys := make([]pipeline.StageRunID, 0, len(e.inflight))
+	for k := range e.inflight {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
+	for _, k := range keys {
+		h, ok := e.inflight[k]
+		if !ok {
+			// Removed by a prior iteration's cascade (e.g. a sibling completing
+			// terminated the run and cancelled this stage). Nothing to poll.
+			continue
+		}
+		outcome, err := e.execs.Poll(e.baseCtx, h)
+		if err != nil {
+			delete(e.inflight, k)
+			e.reduceAndExecute(pipeline.StageFailed{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), ErrorMessage: fmt.Sprintf("stage poll error: %v", err)})
+			continue
+		}
+		if outcome.Status == executors.OutcomeRunning {
+			continue
+		}
+		delete(e.inflight, k)
+		if outcome.Status == executors.OutcomeCompleted {
+			e.reduceAndExecute(pipeline.StageCompleted{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), Verdict: outcome.Verdict, Artifacts: outcome.Artifacts})
+		} else {
+			e.reduceAndExecute(pipeline.StageFailed{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), ErrorMessage: outcome.ErrorMessage})
+		}
+		e.routeObservations(outcome.Observations)
+	}
+}
+
+// reconcileInflight fails every stage a previous process left running: the
+// in-memory executor handle is gone, so the stage can never complete on its own.
+func (e *Engine) reconcileInflight() {
+	type candidate struct {
+		runID pipeline.RunID
+		stage string
+	}
+	var candidates []candidate
+	for _, run := range e.state.Runs {
+		if run.LoopState.IsTerminal() {
+			continue
+		}
+		for name, st := range run.Stages {
+			if st.Status == pipeline.StageStatusRunning {
+				candidates = append(candidates, candidate{run.RunID, name})
+			}
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].runID != candidates[j].runID {
+			return candidates[i].runID < candidates[j].runID
+		}
+		return candidates[i].stage < candidates[j].stage
+	})
+	for _, c := range candidates {
+		e.reduceAndExecute(pipeline.StageFailed{
+			Now:          e.now(),
+			RunID:        c.runID,
+			StageName:    c.stage,
+			ErrorMessage: "pipeline engine restarted while stage was running; in-flight executor handle is lost",
+		})
+	}
+}
+
+// shutdown cancels every non-terminal run so in-flight stages tear down (killing
+// session-owned worktrees, spec §9 note 9) and final state is persisted.
+func (e *Engine) shutdown() {
+	var ids []pipeline.RunID
+	for id, run := range e.state.Runs {
+		if !run.LoopState.IsTerminal() {
+			ids = append(ids, id)
+		}
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		e.reduceAndExecute(pipeline.RunCancelled{Now: e.now(), RunID: id, Reason: pipeline.TerminationManualCancel})
+	}
+}
+
+func (e *Engine) routeObservations(obs []executors.Observation) {
+	for _, o := range obs {
+		e.observe(o.Name, o.Data)
+	}
+}
+
+// observe forwards an observation to the sink, enriching it with the project id
+// when the caller did not already set one.
+func (e *Engine) observe(name string, data map[string]any) {
+	if _, ok := data["projectId"]; !ok {
+		enriched := make(map[string]any, len(data)+1)
+		for k, v := range data {
+			enriched[k] = v
+		}
+		enriched["projectId"] = string(e.projectID)
+		data = enriched
+	}
+	e.sink.Observe(name, data)
+}
+
+// pruneRunMeta drops issue-id side-table entries for runs the reducer has moved
+// to a terminal loop state, so the map does not grow unbounded.
+func (e *Engine) pruneRunMeta() {
+	for id := range e.issueByRun {
+		run, ok := e.state.Runs[id]
+		if !ok || run.LoopState.IsTerminal() {
+			delete(e.issueByRun, id)
+		}
+	}
+}
+
+// slogSink is the default ObservationSink: structured logging that never drops.
+type slogSink struct{ log *slog.Logger }
+
+func (s slogSink) Observe(name string, data map[string]any) {
+	attrs := make([]any, 0, len(data)+1)
+	attrs = append(attrs, slog.String("observation", name))
+	for k, v := range data {
+		attrs = append(attrs, slog.Any(k, v))
+	}
+	s.log.Info("pipeline observation", attrs...)
+}

--- a/backend/internal/pipeline/engine/engine_test.go
+++ b/backend/internal/pipeline/engine/engine_test.go
@@ -1,0 +1,491 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+// fakeHandle is a minimal executors.Handle the fake executor hands back.
+type fakeHandle struct {
+	runID      pipeline.RunID
+	stageRunID pipeline.StageRunID
+	stageName  string
+}
+
+func (h fakeHandle) RunID() pipeline.RunID           { return h.runID }
+func (h fakeHandle) StageRunID() pipeline.StageRunID { return h.stageRunID }
+func (h fakeHandle) StageName() string               { return h.stageName }
+
+// fakeExecutor is a scripted StageExecutor keyed by stage name. Poll returns
+// OutcomeRunning until the test marks the stage's outcome ready. It stands in for
+// all three kind executors so any stage routes to it through executors.Set.
+type fakeExecutor struct {
+	mu        sync.Mutex
+	startErr  map[string]error
+	outcome   map[string]executors.Outcome
+	ready     map[string]bool
+	started   map[string]int
+	cancelled map[string]int
+}
+
+func newFakeExecutor() *fakeExecutor {
+	return &fakeExecutor{
+		startErr:  map[string]error{},
+		outcome:   map[string]executors.Outcome{},
+		ready:     map[string]bool{},
+		started:   map[string]int{},
+		cancelled: map[string]int{},
+	}
+}
+
+func (f *fakeExecutor) Start(_ context.Context, in executors.StartInput) (executors.Handle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.startErr[in.Stage.Name]; err != nil {
+		return nil, err
+	}
+	f.started[in.Stage.Name]++
+	return fakeHandle{runID: in.RunID, stageRunID: in.StageRunID, stageName: in.Stage.Name}, nil
+}
+
+func (f *fakeExecutor) Poll(_ context.Context, h executors.Handle) (executors.Outcome, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.ready[h.StageName()] {
+		return f.outcome[h.StageName()], nil
+	}
+	return executors.Outcome{Status: executors.OutcomeRunning}, nil
+}
+
+func (f *fakeExecutor) Cancel(_ context.Context, h executors.Handle) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cancelled[h.StageName()]++
+	return nil
+}
+
+func (f *fakeExecutor) complete(stage string, verdict pipeline.Verdict, arts ...pipeline.ArtifactInput) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.outcome[stage] = executors.Outcome{Status: executors.OutcomeCompleted, Verdict: verdict, Artifacts: arts}
+	f.ready[stage] = true
+}
+
+func (f *fakeExecutor) fail(stage, msg string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.outcome[stage] = executors.Outcome{Status: executors.OutcomeFailed, ErrorMessage: msg}
+	f.ready[stage] = true
+}
+
+func (f *fakeExecutor) startCount(stage string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.started[stage]
+}
+
+func (f *fakeExecutor) cancelCount(stage string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.cancelled[stage]
+}
+
+// captureSink records observation names so tests can assert lifecycle signals
+// fired. Safe for the actor + test goroutines.
+type captureSink struct {
+	mu    sync.Mutex
+	names []string
+}
+
+func (c *captureSink) Observe(name string, _ map[string]any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.names = append(c.names, name)
+}
+
+func (c *captureSink) count(name string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, got := range c.names {
+		if got == name {
+			n++
+		}
+	}
+	return n
+}
+
+// monotonicClock hands out strictly increasing timestamps so persisted runs sort
+// deterministically on hydrate. Only the actor goroutine calls now().
+type monotonicClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *monotonicClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(time.Millisecond)
+	return c.t
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+func agentStage(name string, dependsOn ...string) pipeline.Stage {
+	return pipeline.Stage{
+		Name:      name,
+		Trigger:   pipeline.StageTrigger{On: []pipeline.StageTriggerEvent{pipeline.TriggerManual}},
+		Executor:  pipeline.StageExecutor{Kind: pipeline.ExecutorAgent, Plugin: "claude-code", Mode: pipeline.ModeReview},
+		DependsOn: dependsOn,
+	}
+}
+
+func pipelineOf(name string, maxConcurrent int, stages ...pipeline.Stage) pipeline.Pipeline {
+	p := pipeline.Pipeline{ID: pipeline.ID("pl-" + name), Name: name, Scope: pipeline.ScopeWorker, Stages: stages}
+	if maxConcurrent > 0 {
+		mc := maxConcurrent
+		p.MaxConcurrentStages = &mc
+	}
+	return p
+}
+
+func finding(title string) pipeline.ArtifactInput {
+	return pipeline.ArtifactInput{
+		Kind: pipeline.ArtifactKindFinding, FilePath: "main.go", StartLine: 1, EndLine: 2,
+		Title: title, Category: "correctness", Severity: pipeline.SeverityError,
+	}
+}
+
+func newTestStore(t *testing.T, projectID string) *sqlite.Store {
+	t.Helper()
+	s, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if err := s.UpsertProject(context.Background(), domain.ProjectRecord{
+		ID: projectID, Path: "/tmp/" + projectID, RegisteredAt: time.Now().UTC().Truncate(time.Second),
+	}); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	return s
+}
+
+// newTestEngine builds a started engine over a real store + the given fake
+// executor, with the internal ticker disabled so tests drive Tick() explicitly.
+func newTestEngine(t *testing.T, projectID string, store *sqlite.Store, fake executors.StageExecutor, sink ObservationSink) *Engine {
+	t.Helper()
+	clk := &monotonicClock{t: time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)}
+	e := New(Config{
+		ProjectID:    domain.ProjectID(projectID),
+		Store:        store,
+		Executors:    executors.NewSet(fake, fake, fake),
+		Sink:         sink,
+		Clock:        clk.now,
+		TickInterval: time.Hour, // disable the internal heartbeat; tests call Tick()
+	})
+	if err := e.Start(context.Background()); err != nil {
+		t.Fatalf("engine start: %v", err)
+	}
+	t.Cleanup(func() { _ = e.Stop(context.Background()) })
+	return e
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestSingleStageRunEndToEnd drives one agent stage through the REAL engine loop:
+// trigger -> START_STAGE -> STAGE_STARTED -> poll completes -> exit predicate ->
+// done, then asserts the persisted run, its artifact, and loop-state derivation
+// on a fresh hydrate.
+func TestSingleStageRunEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t, "mer")
+	fake := newFakeExecutor()
+	e := newTestEngine(t, "mer", store, fake, nil)
+
+	p := pipelineOf("review", 1, agentStage("review"))
+	runID, err := e.TriggerRun(TriggerRequest{Pipeline: p, SessionID: "mer-1", HeadSHA: "sha1"})
+	if err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+
+	// After trigger the stage is running and persisted.
+	if got := e.State().Runs[runID].Stages["review"].Status; got != pipeline.StageStatusRunning {
+		t.Fatalf("stage status after trigger = %s, want running", got)
+	}
+	if fake.startCount("review") != 1 {
+		t.Fatalf("review started %d times, want 1", fake.startCount("review"))
+	}
+
+	// Complete the stage; one tick drives it through to a done run.
+	fake.complete("review", pipeline.VerdictPass, finding("bug"))
+	e.Tick()
+
+	run := e.State().Runs[runID]
+	if run.LoopState != pipeline.LoopDone {
+		t.Fatalf("loop state = %s, want done", run.LoopState)
+	}
+	if st := run.Stages["review"]; st.Status != pipeline.StageStatusSucceeded || st.Verdict != pipeline.VerdictPass {
+		t.Fatalf("review stage = %+v, want succeeded/pass", st)
+	}
+
+	// Persisted run + artifact.
+	persisted, ok, err := store.GetPipelineRun(ctx, runID)
+	if err != nil || !ok {
+		t.Fatalf("get persisted run: ok=%v err=%v", ok, err)
+	}
+	if persisted.LoopState != pipeline.LoopDone {
+		t.Fatalf("persisted loop state = %s, want done", persisted.LoopState)
+	}
+	if len(persisted.Findings) != 1 || persisted.Findings[0].Title != "bug" || persisted.Findings[0].Fingerprint == "" {
+		t.Fatalf("persisted findings = %+v, want one fingerprinted finding", persisted.Findings)
+	}
+
+	// Loop-state derivation: a fresh hydrate rebuilds the terminal run into
+	// history with the loop pointer freed (v1 derives loop state from runs, no
+	// loop table).
+	hydrated, err := store.HydratePipelineEngineState(ctx, "mer")
+	if err != nil {
+		t.Fatalf("hydrate: %v", err)
+	}
+	key := pipeline.LoopKey("mer-1", "review")
+	if _, live := hydrated.CurrentRunByLoop[key]; live {
+		t.Fatalf("terminal run must not hold a live loop pointer")
+	}
+	if h := hydrated.HistorySummaries[key]; len(h) != 1 || h[0].RunID != runID || h[0].LoopState != pipeline.LoopDone {
+		t.Fatalf("history summaries = %+v, want one done run", h)
+	}
+}
+
+// TestMultiStageDAGWithFailureAndResume runs a build->test->deploy DAG where test
+// fails (cascade-skipping deploy and stalling the run), then resumes: test is
+// re-armed, deploy is revived, and the run converges to done.
+func TestMultiStageDAGWithFailureAndResume(t *testing.T) {
+	store := newTestStore(t, "mer")
+	fake := newFakeExecutor()
+	e := newTestEngine(t, "mer", store, fake, nil)
+
+	p := pipelineOf("ci", 2, agentStage("build"), agentStage("test", "build"), agentStage("deploy", "test"))
+	runID, err := e.TriggerRun(TriggerRequest{Pipeline: p, SessionID: "mer-1", HeadSHA: "sha1"})
+	if err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+
+	// Only build is eligible at trigger (test/deploy depend upstream).
+	if fake.startCount("build") != 1 || fake.startCount("test") != 0 {
+		t.Fatalf("initial starts: build=%d test=%d, want 1/0", fake.startCount("build"), fake.startCount("test"))
+	}
+
+	fake.complete("build", pipeline.VerdictPass)
+	e.Tick() // build succeeds -> test starts
+	if fake.startCount("test") != 1 {
+		t.Fatalf("test started %d times after build, want 1", fake.startCount("test"))
+	}
+
+	fake.fail("test", "boom")
+	e.Tick() // test fails -> deploy cascade-skipped -> run stalls
+	run := e.State().Runs[runID]
+	if run.LoopState != pipeline.LoopStalled {
+		t.Fatalf("loop state after test failure = %s, want stalled", run.LoopState)
+	}
+	if run.Stages["test"].Status != pipeline.StageStatusFailed {
+		t.Fatalf("test status = %s, want failed", run.Stages["test"].Status)
+	}
+	if run.Stages["deploy"].Status != pipeline.StageStatusSkipped {
+		t.Fatalf("deploy status = %s, want skipped", run.Stages["deploy"].Status)
+	}
+	if fake.startCount("deploy") != 0 {
+		t.Fatalf("deploy must not have started before resume")
+	}
+
+	// Recover: test now passes on the next attempt.
+	fake.complete("test", pipeline.VerdictPass)
+	e.Resume(runID)
+	if run := e.State().Runs[runID]; run.LoopState != pipeline.LoopRunning {
+		t.Fatalf("loop state after resume = %s, want running", run.LoopState)
+	}
+	if fake.startCount("test") != 2 {
+		t.Fatalf("test restarted %d times, want 2 (attempt++ on resume)", fake.startCount("test"))
+	}
+
+	e.Tick() // test succeeds -> deploy (revived) starts
+	if fake.startCount("deploy") != 1 {
+		t.Fatalf("deploy started %d times after resume, want 1", fake.startCount("deploy"))
+	}
+
+	fake.complete("deploy", pipeline.VerdictPass)
+	e.Tick() // deploy succeeds -> all terminal -> done
+	final := e.State().Runs[runID]
+	if final.LoopState != pipeline.LoopDone {
+		t.Fatalf("final loop state = %s, want done", final.LoopState)
+	}
+	for name, st := range final.Stages {
+		if st.Status != pipeline.StageStatusSucceeded {
+			t.Fatalf("stage %s = %s, want succeeded", name, st.Status)
+		}
+	}
+	if got := final.Stages["test"].Attempt; got != 2 {
+		t.Fatalf("test attempt = %d, want 2", got)
+	}
+}
+
+// TestCancelMidFlight cancels a running stage: CANCEL_STAGE reaches the executor,
+// the stage goes outdated, and the run terminates.
+func TestCancelMidFlight(t *testing.T) {
+	store := newTestStore(t, "mer")
+	fake := newFakeExecutor()
+	sink := &captureSink{}
+	e := newTestEngine(t, "mer", store, fake, sink)
+
+	p := pipelineOf("review", 1, agentStage("review"))
+	runID, err := e.TriggerRun(TriggerRequest{Pipeline: p, SessionID: "mer-1", HeadSHA: "sha1"})
+	if err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+	if e.State().Runs[runID].Stages["review"].Status != pipeline.StageStatusRunning {
+		t.Fatal("review must be running before cancel")
+	}
+
+	e.Cancel(runID, pipeline.TerminationManualCancel)
+
+	run := e.State().Runs[runID]
+	if run.LoopState != pipeline.LoopTerminated {
+		t.Fatalf("loop state after cancel = %s, want terminated", run.LoopState)
+	}
+	if st := run.Stages["review"].Status; st != pipeline.StageStatusOutdated {
+		t.Fatalf("review status after cancel = %s, want outdated", st)
+	}
+	if fake.cancelCount("review") != 1 {
+		t.Fatalf("CANCEL_STAGE reached executor %d times, want 1", fake.cancelCount("review"))
+	}
+	if sink.count("pipeline.run.terminated") != 1 {
+		t.Fatalf("run.terminated observed %d times, want 1", sink.count("pipeline.run.terminated"))
+	}
+
+	// A second cancel is a clean no-op (already terminal).
+	e.Cancel(runID, pipeline.TerminationManualCancel)
+	if fake.cancelCount("review") != 1 {
+		t.Fatalf("redundant cancel re-cancelled the stage")
+	}
+}
+
+// TestHydrateOnBoot reconstructs engine state from a populated store: a terminal
+// run lands in history untouched, and a run left running by a prior process is
+// failed by reconcile so it stalls.
+func TestHydrateOnBoot(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t, "mer")
+	now := time.Date(2026, 7, 15, 10, 0, 0, 0, time.UTC)
+
+	done := pipelineOf("review", 1, agentStage("review"))
+	terminalRun := pipeline.RunState{
+		RunID: "run-done", PipelineID: done.ID, PipelineName: done.Name, SessionID: "mer-1",
+		PipelineConfigSnapshot: done, HeadSHA: "sha0", LoopState: pipeline.LoopDone,
+		TerminationReason: pipeline.TerminationCompleted, LoopRounds: 1,
+		Stages:    map[string]pipeline.StageState{"review": {StageRunID: "sr-done", Status: pipeline.StageStatusSucceeded, Attempt: 1, Verdict: pipeline.VerdictPass, CompletedAt: &now}},
+		CreatedAt: now, UpdatedAt: now,
+	}
+	crashed := pipelineOf("review", 1, agentStage("review"))
+	runningRun := pipeline.RunState{
+		RunID: "run-crashed", PipelineID: crashed.ID, PipelineName: crashed.Name, SessionID: "mer-2",
+		PipelineConfigSnapshot: crashed, HeadSHA: "sha1", LoopState: pipeline.LoopRunning, LoopRounds: 1,
+		Stages:    map[string]pipeline.StageState{"review": {StageRunID: "sr-run", Status: pipeline.StageStatusRunning, Attempt: 1, StartedAt: &now}},
+		CreatedAt: now.Add(time.Minute), UpdatedAt: now.Add(time.Minute),
+	}
+	if err := store.SavePipelineRun(ctx, "mer", terminalRun); err != nil {
+		t.Fatalf("seed terminal run: %v", err)
+	}
+	if err := store.SavePipelineRun(ctx, "mer", runningRun); err != nil {
+		t.Fatalf("seed running run: %v", err)
+	}
+
+	fake := newFakeExecutor()
+	e := newTestEngine(t, "mer", store, fake, nil)
+
+	// The terminal run stays in history; reconcile never touches it.
+	if h := e.State().HistorySummaries[pipeline.LoopKey("mer-1", "review")]; len(h) != 1 || h[0].RunID != "run-done" {
+		t.Fatalf("terminal run history = %+v, want one done run", h)
+	}
+	// The crash-surviving run's running stage is failed by reconcile and, being a
+	// single-stage pipeline, the run stalls.
+	crashedState := e.State().Runs["run-crashed"]
+	if crashedState.LoopState != pipeline.LoopStalled {
+		t.Fatalf("crashed run loop state = %s, want stalled", crashedState.LoopState)
+	}
+	if st := crashedState.Stages["review"].Status; st != pipeline.StageStatusFailed {
+		t.Fatalf("crashed stage status = %s, want failed", st)
+	}
+	// Reconcile fails the stage without re-invoking the (gone) executor.
+	if fake.startCount("review") != 0 {
+		t.Fatalf("reconcile must not re-start a stage")
+	}
+}
+
+// TestConcurrentDispatchesSerialize fires many triggers, ticks, and reads from
+// separate goroutines. The actor loop serializes every mutation, so -race sees no
+// data race and all runs converge to done.
+func TestConcurrentDispatchesSerialize(t *testing.T) {
+	store := newTestStore(t, "mer")
+	fake := newFakeExecutor()
+	// Every stage of every run shares the name "review", so one outcome script
+	// drives them all once ticked.
+	fake.complete("review", pipeline.VerdictPass)
+	e := newTestEngine(t, "mer", store, fake, nil)
+
+	p := pipelineOf("review", 1, agentStage("review"))
+
+	const n = 25
+	var wg sync.WaitGroup
+	runIDs := make([]pipeline.RunID, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id, err := e.TriggerRun(TriggerRequest{Pipeline: p, SessionID: fmt.Sprintf("mer-%d", i), HeadSHA: "sha1"})
+			if err != nil {
+				t.Errorf("trigger %d: %v", i, err)
+				return
+			}
+			runIDs[i] = id
+			// Concurrently read state and tick to exercise serialization.
+			_ = e.State()
+			e.Tick()
+		}(i)
+	}
+	wg.Wait()
+
+	// Drain any stages that started after their goroutine's tick.
+	for i := 0; i < 3; i++ {
+		e.Tick()
+	}
+
+	state := e.State()
+	if len(state.Runs) != n {
+		t.Fatalf("runs = %d, want %d", len(state.Runs), n)
+	}
+	for i, id := range runIDs {
+		run, ok := state.Runs[id]
+		if !ok {
+			t.Fatalf("run %d (%s) missing", i, id)
+		}
+		if run.LoopState != pipeline.LoopDone {
+			t.Fatalf("run %d loop state = %s, want done", i, run.LoopState)
+		}
+	}
+}

--- a/backend/internal/pipeline/engine/supervisor.go
+++ b/backend/internal/pipeline/engine/supervisor.go
@@ -1,0 +1,139 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+)
+
+// Supervisor owns one Engine per project. It is the single wiring seam the
+// daemon constructs (so T11 can gate the whole subsystem behind AO_PIPELINES at
+// one call site), and the lookup other subsystems (T6 triggers, T7 API) use to
+// reach a project's engine.
+type Supervisor struct {
+	store        Store
+	execs        *executors.Set
+	projects     ProjectLister
+	sink         ObservationSink
+	log          *slog.Logger
+	clock        func() time.Time
+	tickInterval time.Duration
+
+	mu      sync.Mutex
+	engines map[domain.ProjectID]*Engine
+	started bool
+}
+
+// ProjectLister enumerates the projects to instantiate engines for. Satisfied by
+// *storage/sqlite/store.Store.
+type ProjectLister interface {
+	ListProjects(ctx context.Context) ([]domain.ProjectRecord, error)
+}
+
+// SupervisorConfig constructs a Supervisor. Store, Executors, and Projects are
+// required; the rest default.
+type SupervisorConfig struct {
+	Store        Store
+	Executors    *executors.Set
+	Projects     ProjectLister
+	Sink         ObservationSink
+	Logger       *slog.Logger
+	Clock        func() time.Time
+	TickInterval time.Duration
+}
+
+// NewSupervisor builds a Supervisor. It starts no engines; call Start.
+func NewSupervisor(cfg SupervisorConfig) *Supervisor {
+	log := cfg.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Supervisor{
+		store:        cfg.Store,
+		execs:        cfg.Executors,
+		projects:     cfg.Projects,
+		sink:         cfg.Sink,
+		log:          log,
+		clock:        cfg.Clock,
+		tickInterval: cfg.TickInterval,
+		engines:      map[domain.ProjectID]*Engine{},
+	}
+}
+
+// Start instantiates and starts one engine per known project. A single project's
+// hydrate failure is logged and skipped rather than sinking daemon boot; the
+// project can still get an engine later via For. Engines with no definitions or
+// triggers are harmless (they just idle).
+func (s *Supervisor) Start(ctx context.Context) error {
+	projects, err := s.projects.ListProjects(ctx)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.started = true
+	for _, p := range projects {
+		pid := domain.ProjectID(p.ID)
+		if _, ok := s.engines[pid]; ok {
+			continue
+		}
+		eng := s.newEngine(pid)
+		if err := eng.Start(ctx); err != nil {
+			s.log.Error("pipeline engine start failed", "project", pid, "err", err)
+			continue
+		}
+		s.engines[pid] = eng
+	}
+	return nil
+}
+
+// Stop stops every engine. Safe to call once; subsequent lookups return an error.
+func (s *Supervisor) Stop(ctx context.Context) error {
+	s.mu.Lock()
+	engines := s.engines
+	s.engines = map[domain.ProjectID]*Engine{}
+	s.started = false
+	s.mu.Unlock()
+
+	for _, eng := range engines {
+		_ = eng.Stop(ctx)
+	}
+	return nil
+}
+
+// For returns the engine for a project, lazily creating and starting one if the
+// project was registered after Start (so triggers for new projects are not
+// silently dropped). Errors if the supervisor is stopped or hydrate fails.
+func (s *Supervisor) For(ctx context.Context, projectID domain.ProjectID) (*Engine, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.started {
+		return nil, errors.New("pipeline engine supervisor not started")
+	}
+	if eng, ok := s.engines[projectID]; ok {
+		return eng, nil
+	}
+	eng := s.newEngine(projectID)
+	if err := eng.Start(ctx); err != nil {
+		return nil, err
+	}
+	s.engines[projectID] = eng
+	return eng, nil
+}
+
+func (s *Supervisor) newEngine(pid domain.ProjectID) *Engine {
+	return New(Config{
+		ProjectID:    pid,
+		Store:        s.store,
+		Executors:    s.execs,
+		Sink:         s.sink,
+		Logger:       s.log,
+		Clock:        s.clock,
+		TickInterval: s.tickInterval,
+	})
+}


### PR DESCRIPTION
Closes #234

## T5 · Pipeline engine runtime

Per-project, actor-style engine that drives the pure T2 reducer, executes its effects against the T3 store and T4 executors, polls inflight stages, hydrates on boot, and is instantiated per-project in daemon wiring.

### What landed
- **`internal/pipeline/engine/engine.go`** — one goroutine per project engine; ALL `EngineState` mutation serialized through a mailbox channel (the Go replacement for the old `lockTail` promise chain; single-writer invariant is the core correctness property, §9 note 4). Public API: `TriggerRun` (allocates RunID + per-stage StageRunIDs, uuid style like `internal/review`), `Cancel`, `Resume`, `ChangeArtifactStatus`, `Dispatch` (generic seam for T6), `Tick`, `State`, plus `Start`/`Stop`.
- **Effect execution**: START_STAGE → `executors.Set.Start` then dispatch `StageStarted` (start error → `StageFailed`); CANCEL_STAGE → `Cancel`; PERSIST_RUN / APPEND_ARTIFACTS / UPDATE_ARTIFACT_STATUS → store; EMIT_OBSERVATION → sink. **PERSIST_LOOP_STATE is a documented no-op** (v1 has no loop table; loop pointers derived on hydrate).
- **Tick loop**: polls inflight handles on an interval, maps `OutcomeCompleted`→`StageCompleted`, `OutcomeFailed`→`StageFailed`, routes executor observations to the sink. Handles snapshotted before iteration so a completing stage cancelling/scheduling a sibling can't corrupt the loop.
- **Observation sink** (§9 note 8): always wired, never nil, never drops — default is structured `slog`.
- **Executor adapters** (`adapters.go`): `SessionSpawner`/`SessionMessenger` over the session service (visible sessions, §4b) + store snapshots; `CommandSessions` over store session/PR facts; `ArtifactStore` over existing public store methods (no new store query). **Fork status fail-safe**: provenance isn't persisted anywhere, so a session with an attributed PR → `ForkUnknown` (gated behind `allowForkPRs`); no-PR session → `ForkNo`.
- **Hydrate on boot**: `HydratePipelineEngineState` per project, then `reconcileInflight` fails any stage a prior process left `running` (handle is gone) — exactly the old `engine.ts` reconcile behavior, so single-stage crashed runs stall and can be resumed.
- **Daemon wiring** (`pipeline_wiring.go` + one call in `daemon.go`): per-project engine `Supervisor` behind ONE constructor call site so T11 can gate it with `AO_PIPELINES` trivially. Idle engines (no definitions/triggers) are harmless. Clean teardown on shutdown and error paths.

### Design note for review
On graceful shutdown the engine cancels non-terminal runs, which kills agent-stage sessions and reclaims their session-owned worktrees (§9 note 9; matches the old engine's shutdown). This is the sanctioned worktree-reclamation path in v1. Flagging since the daemon otherwise preserves human sessions across restart — pipeline stage sessions are ephemeral and intentionally torn down. Easy to flip to preserve-on-shutdown if preferred.

### Tests (`go test ./... && go vet ./...` green; race-clean)
- E2E single-stage run through the real loop: trigger → START_STAGE → StageStarted → poll completes → exit predicate → done; asserts persisted run + artifact + loop-state derivation on fresh hydrate.
- Multi-stage build→test→deploy DAG with a failure path (cascade-skip + stall) and recovery via `Resume` (failed stage re-armed attempt++, cascade-skipped stage revived).
- Cancel mid-flight (CANCEL_STAGE reaches executor, stage outdated, run terminated, redundant cancel is a no-op).
- Hydrate-on-boot: terminal run → history untouched; crash-surviving running stage → reconcile-failed → stalled.
- Serialization: 25 concurrent triggers/ticks/reads, `-race` clean, all runs converge.
- Executor-adapter units: spawn config mapping, fork gate classification, upstream-artifact grouping (finding + JSON kinds), messenger liveness.

Note: 4 pre-existing `internal/cli` spawn-test failures on the `pipelines` base are unrelated to this change (they fail identically at the base commit; none touch pipelines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
