### PR TITLE
feat(pipeline): T6 trigger bridge (CDC → runs, merge_ready, new-SHA rearm, fork provenance)

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -137,7 +137,7 @@ func Run() error {
 	// Pipelines v1 (spec §4b T5): one actor-loop engine per project, driving the
 	// pure reducer + executors + store. Single wiring seam so T11 can gate the
 	// whole subsystem behind AO_PIPELINES here.
-	pipelineStk := startPipelineEngine(ctx, store, sessionSvc, log)
+	pipelineStk := startPipelineEngine(ctx, store, sessionSvc, cdcPipe.Broadcaster, log)
 
 	previewDone := preview.NewPoller(store, sessionSvc, "http://"+cfg.Addr(), preview.PollerConfig{Logger: log}).Start(ctx)
 	agentSvc := agentsvc.New()

--- a/backend/internal/daemon/pipeline_wiring.go
+++ b/backend/internal/daemon/pipeline_wiring.go
@@ -4,23 +4,28 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	pipelineengine "github.com/aoagents/agent-orchestrator/backend/internal/pipeline/engine"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/triggers"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
 
-// pipelineStack holds the pipeline engine supervisor and its teardown. It is the
-// single wiring seam for the pipelines subsystem (spec §4b T5): T11 will gate
-// this one constructor call behind the AO_PIPELINES flag with no other change.
+// pipelineStack holds the pipeline engine supervisor, the CDC trigger bridge,
+// and their teardown. It is the single wiring seam for the pipelines subsystem
+// (spec §4b T5/T6): T11 will gate this one constructor call behind the
+// AO_PIPELINES flag with no other change.
 type pipelineStack struct {
 	supervisor *pipelineengine.Supervisor
+	bridge     *triggers.Bridge
 }
 
 // startPipelineEngine builds the executor set over the session service + store,
-// constructs the per-project engine supervisor, and starts one engine per known
-// project. A start failure is logged, never fatal: an unhealthy pipeline
-// subsystem must not block daemon boot, and idle engines (no definitions, no
-// triggers) are harmless.
-func startPipelineEngine(ctx context.Context, store *sqlite.Store, sessions pipelineengine.SessionCommander, log *slog.Logger) *pipelineStack {
+// constructs the per-project engine supervisor, starts one engine per known
+// project, and starts the CDC trigger bridge over the shared broadcaster. A
+// start failure is logged, never fatal: an unhealthy pipeline subsystem must not
+// block daemon boot, and idle engines (no definitions, no triggers) are harmless.
+func startPipelineEngine(ctx context.Context, store *sqlite.Store, sessions pipelineengine.SessionCommander, bcast *cdc.Broadcaster, log *slog.Logger) *pipelineStack {
 	execs := pipelineengine.BuildExecutorSet(sessions, store)
 	sup := pipelineengine.NewSupervisor(pipelineengine.SupervisorConfig{
 		Store:     store,
@@ -31,14 +36,43 @@ func startPipelineEngine(ctx context.Context, store *sqlite.Store, sessions pipe
 	if err := sup.Start(ctx); err != nil {
 		log.Error("pipeline engine supervisor start failed", "err", err)
 	}
-	return &pipelineStack{supervisor: sup}
+
+	bridge := triggers.New(triggers.Config{
+		Broadcaster: bcast,
+		Defs:        store,
+		PRs:         store,
+		Engines:     supervisorEngines{sup: sup},
+		Logger:      log,
+	})
+	bridge.Start(ctx)
+
+	return &pipelineStack{supervisor: sup, bridge: bridge}
 }
 
-// Stop tears down every project engine, cancelling in-flight runs so their
-// session-owned stage worktrees are reclaimed (spec §9 note 9).
+// supervisorEngines adapts *pipelineengine.Supervisor to triggers.EngineProvider
+// by narrowing the concrete *engine.Engine it returns to the bridge's Engine
+// interface.
+type supervisorEngines struct {
+	sup *pipelineengine.Supervisor
+}
+
+func (s supervisorEngines) For(ctx context.Context, projectID domain.ProjectID) (triggers.Engine, error) {
+	eng, err := s.sup.For(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	return eng, nil
+}
+
+// Stop stops the trigger bridge first (no new runs), then tears down every
+// project engine, cancelling in-flight runs so their session-owned stage
+// worktrees are reclaimed (spec §9 note 9).
 func (p *pipelineStack) Stop(ctx context.Context) {
-	if p == nil || p.supervisor == nil {
+	if p == nil {
 		return
 	}
-	_ = p.supervisor.Stop(ctx)
+	p.bridge.Stop()
+	if p.supervisor != nil {
+		_ = p.supervisor.Stop(ctx)
+	}
 }

--- a/backend/internal/domain/pr.go
+++ b/backend/internal/domain/pr.go
@@ -45,13 +45,13 @@ type PullRequest struct {
 	Host     string
 	Repo     string
 
-	SourceBranch   string
-	TargetBranch   string
-	HeadSHA        string
+	SourceBranch string
+	TargetBranch string
+	HeadSHA      string
 	// IsFromFork is fork provenance derived from the head repo vs base repo: nil
 	// = unknown, false = same-repo, true = fork. Persisted to pr.is_from_fork.
-	IsFromFork *bool
-	Title      string
+	IsFromFork     *bool
+	Title          string
 	Additions      int
 	Deletions      int
 	ChangedFiles   int

--- a/backend/internal/domain/pr.go
+++ b/backend/internal/domain/pr.go
@@ -18,7 +18,12 @@ type PRFacts struct {
 	ReviewComments bool // has unresolved review comments (any author) to address
 	SourceBranch   string
 	TargetBranch   string
-	UpdatedAt      time.Time
+	HeadSHA        string
+	// IsFromFork is fork provenance: nil = unknown, false = same-repo PR (or no
+	// PR), true = the PR head lives in a fork. Populated only by the queries that
+	// select it (display facts + by-url); other PRFacts producers leave it nil.
+	IsFromFork *bool
+	UpdatedAt  time.Time
 }
 
 // PullRequest is the app-level representation of one tracked pull request as
@@ -43,7 +48,10 @@ type PullRequest struct {
 	SourceBranch   string
 	TargetBranch   string
 	HeadSHA        string
-	Title          string
+	// IsFromFork is fork provenance derived from the head repo vs base repo: nil
+	// = unknown, false = same-repo, true = fork. Persisted to pr.is_from_fork.
+	IsFromFork *bool
+	Title      string
 	Additions      int
 	Deletions      int
 	ChangedFiles   int

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -1098,6 +1098,7 @@ func domainFromObservation(sessionID domain.SessionID, obs ports.SCMObservation,
 		ObservedAt:               observedAt,
 		CIObservedAt:             ciObservedAt,
 		ReviewObservedAt:         reviewObservedAt,
+		IsFromFork:               forkFromRepos(obs.Repo, obs.PR.HeadRepo),
 	}
 	checks := make([]domain.PullRequestCheck, 0, len(obs.CI.Checks))
 	for _, ch := range obs.CI.Checks {
@@ -1127,6 +1128,18 @@ func domainFromObservation(sessionID domain.SessionID, obs ports.SCMObservation,
 		}
 	}
 	return pr, checks, reviews, threads, comments
+}
+
+// forkFromRepos derives fork provenance for the pr.is_from_fork column: the PR
+// is from a fork when its head repo differs from the base repo. When either
+// repo is unknown the result is nil (fail-safe unknown) so the command-executor
+// gate keeps blocking rather than assuming same-repo.
+func forkFromRepos(baseRepo, headRepo string) *bool {
+	if baseRepo == "" || headRepo == "" {
+		return nil
+	}
+	v := !strings.EqualFold(baseRepo, headRepo)
+	return &v
 }
 
 func observationFromLocal(repo ports.SCMRepo, pr domain.PullRequest, checks []domain.PullRequestCheck) ports.SCMObservation {

--- a/backend/internal/observe/scm/observer_fork_test.go
+++ b/backend/internal/observe/scm/observer_fork_test.go
@@ -1,0 +1,36 @@
+package scm
+
+import "testing"
+
+// forkFromRepos derives the pr.is_from_fork tri-state the SCM observer persists:
+// a PR whose head repo differs from the base repo is from a fork; an unknown
+// repo on either side is fail-safe unknown (nil).
+func TestForkFromRepos(t *testing.T) {
+	cases := []struct {
+		name       string
+		base, head string
+		want       *bool
+	}{
+		{"same repo is not a fork", "owner/repo", "owner/repo", boolp(false)},
+		{"different head repo is a fork", "owner/repo", "contributor/repo", boolp(true)},
+		{"case-insensitive same repo", "Owner/Repo", "owner/repo", boolp(false)},
+		{"unknown base repo is unknown", "", "contributor/repo", nil},
+		{"unknown head repo is unknown", "owner/repo", "", nil},
+		{"both unknown is unknown", "", "", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := forkFromRepos(tc.base, tc.head)
+			switch {
+			case tc.want == nil && got != nil:
+				t.Fatalf("forkFromRepos(%q,%q) = %v, want nil (unknown)", tc.base, tc.head, *got)
+			case tc.want != nil && got == nil:
+				t.Fatalf("forkFromRepos(%q,%q) = nil, want %v", tc.base, tc.head, *tc.want)
+			case tc.want != nil && got != nil && *got != *tc.want:
+				t.Fatalf("forkFromRepos(%q,%q) = %v, want %v", tc.base, tc.head, *got, *tc.want)
+			}
+		})
+	}
+}
+
+func boolp(v bool) *bool { return &v }

--- a/backend/internal/pipeline/engine/adapters.go
+++ b/backend/internal/pipeline/engine/adapters.go
@@ -116,17 +116,16 @@ func (a *commandSessionsAdapter) Get(ctx context.Context, sessionID string) (exe
 		return executors.CommandSession{}, false, nil
 	}
 
-	// Fork provenance is not persisted anywhere in the store: only the SCM
-	// observer sees a PR's head-repo, transiently, and it never survives to the
-	// pr table (see the base-repo-only Repo column). So we cannot classify a
-	// real PR as fork/no-fork after the fact. Fail safe (spec §4b): a session
-	// with an attributed PR is treated as ForkUnknown, which the command
-	// executor gates behind allowForkPRs. A session with no PR is ForkNo and
-	// runs normally.
+	// Fork provenance rides the pr.is_from_fork tri-state (migration 0025),
+	// populated from the SCM observer's head-repo vs base-repo comparison. A
+	// session with no PR is ForkNo and runs normally. An attributed PR maps its
+	// stored tri-state: known-fork -> ForkYes, known-same-repo -> ForkNo, and
+	// unknown (nil, e.g. a legacy row observed before this column) stays
+	// ForkUnknown, which the command executor gates behind allowForkPRs.
 	fork := executors.ForkNo
 	prNumber := 0
 	if prf, prok, perr := a.reader.GetDisplayPRFactsForSession(ctx, domain.SessionID(sessionID)); perr == nil && prok && prf.Number > 0 {
-		fork = executors.ForkUnknown
+		fork = forkStatusFromFlag(prf.IsFromFork)
 		prNumber = prf.Number
 	}
 
@@ -135,6 +134,19 @@ func (a *commandSessionsAdapter) Get(ctx context.Context, sessionID string) (exe
 		Fork:          fork,
 		PRNumber:      prNumber,
 	}, true, nil
+}
+
+// forkStatusFromFlag maps the stored is_from_fork tri-state onto the command
+// executor's ForkStatus. nil (unknown) stays fail-safe ForkUnknown.
+func forkStatusFromFlag(isFromFork *bool) executors.ForkStatus {
+	switch {
+	case isFromFork == nil:
+		return executors.ForkUnknown
+	case *isFromFork:
+		return executors.ForkYes
+	default:
+		return executors.ForkNo
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/pipeline/engine/adapters_test.go
+++ b/backend/internal/pipeline/engine/adapters_test.go
@@ -113,13 +113,18 @@ func TestSessionSpawnerAdapterGetAndKill(t *testing.T) {
 }
 
 func TestCommandSessionsAdapterForkGate(t *testing.T) {
+	forkYes, forkNo := true, false
 	reader := &fakeReader{
 		sessions: map[domain.SessionID]domain.SessionRecord{
-			"nopr": {Metadata: domain.SessionMetadata{WorkspacePath: "/ws/nopr"}},
-			"pr":   {Metadata: domain.SessionMetadata{WorkspacePath: "/ws/pr"}},
+			"nopr":     {Metadata: domain.SessionMetadata{WorkspacePath: "/ws/nopr"}},
+			"unknown":  {Metadata: domain.SessionMetadata{WorkspacePath: "/ws/unknown"}},
+			"fork":     {Metadata: domain.SessionMetadata{WorkspacePath: "/ws/fork"}},
+			"samerepo": {Metadata: domain.SessionMetadata{WorkspacePath: "/ws/samerepo"}},
 		},
 		prs: map[domain.SessionID]domain.PRFacts{
-			"pr": {Number: 42},
+			"unknown":  {Number: 42},                       // is_from_fork unpopulated (legacy row)
+			"fork":     {Number: 43, IsFromFork: &forkYes}, // observed fork
+			"samerepo": {Number: 44, IsFromFork: &forkNo},  // observed same-repo
 		},
 	}
 	a := &commandSessionsAdapter{reader: reader}
@@ -133,14 +138,32 @@ func TestCommandSessionsAdapterForkGate(t *testing.T) {
 		t.Fatalf("no-PR session = %+v, want ForkNo/0", got)
 	}
 
-	// PR present but fork provenance unknowable from the store: fail safe to
-	// ForkUnknown so the command executor gates it behind allowForkPRs.
-	got, ok, err = a.Get(context.Background(), "pr")
+	// PR with unpopulated provenance (nil): fail safe to ForkUnknown so the
+	// command executor gates it behind allowForkPRs.
+	got, ok, err = a.Get(context.Background(), "unknown")
 	if err != nil || !ok {
-		t.Fatalf("get pr: ok=%v err=%v", ok, err)
+		t.Fatalf("get unknown: ok=%v err=%v", ok, err)
 	}
 	if got.Fork != executors.ForkUnknown || got.PRNumber != 42 {
-		t.Fatalf("PR session = %+v, want ForkUnknown/42", got)
+		t.Fatalf("unknown-provenance session = %+v, want ForkUnknown/42", got)
+	}
+
+	// PR observed to be from a fork: ForkYes.
+	got, ok, err = a.Get(context.Background(), "fork")
+	if err != nil || !ok {
+		t.Fatalf("get fork: ok=%v err=%v", ok, err)
+	}
+	if got.Fork != executors.ForkYes || got.PRNumber != 43 {
+		t.Fatalf("fork session = %+v, want ForkYes/43", got)
+	}
+
+	// PR observed to be same-repo: ForkNo, runs normally.
+	got, ok, err = a.Get(context.Background(), "samerepo")
+	if err != nil || !ok {
+		t.Fatalf("get samerepo: ok=%v err=%v", ok, err)
+	}
+	if got.Fork != executors.ForkNo || got.PRNumber != 44 {
+		t.Fatalf("same-repo session = %+v, want ForkNo/44", got)
 	}
 
 	if _, ok, _ := a.Get(context.Background(), "missing"); ok {

--- a/backend/internal/pipeline/triggers/bridge.go
+++ b/backend/internal/pipeline/triggers/bridge.go
@@ -1,0 +1,290 @@
+// Package triggers is the T6 pipeline trigger bridge: it subscribes to the CDC
+// event bus, turns PR change events into stage trigger events, and drives the
+// per-project pipeline engines to start (or cancel-and-rearm) runs.
+//
+// The CDC broadcaster delivers events synchronously on its poller goroutine and
+// must not be blocked (spec §4b, cdc.Broadcaster.Subscribe contract), so the
+// subscribe callback only enqueues; a single owned worker goroutine drains the
+// queue and does all store reads and (blocking) engine calls. Engine methods are
+// called only from that worker goroutine, never from an ObservationSink or an
+// executor, so the engine actor mailbox never deadlocks.
+//
+// Merge-ready and merged are derived on the TRANSITION into their state, using a
+// per-PR previous-state map, matching the old TypeScript lifecycle-status
+// decision (a PR first seen already in the state counts as a transition). The
+// engine reducer's loop-key guard makes duplicate TRIGGER_FIRED safe, so the
+// bridge fires freely and lets the reducer dedup.
+package triggers
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/engine"
+)
+
+// queueCap bounds the hand-off buffer between the poller goroutine and the
+// bridge worker. PR events arrive at SCM-poll cadence (seconds apart), so this
+// is never pressured in practice; an overflow is logged and dropped rather than
+// blocking the poller.
+//
+// ponytail: fixed drop-on-full buffer. Swap for an unbounded queue only if a
+// real workload ever overflows it (it won't at PR-event rates).
+const queueCap = 256
+
+// Definitions lists a project's pipeline definitions. Satisfied by
+// *storage/sqlite/store.Store.
+type Definitions interface {
+	ListPipelineDefinitions(ctx context.Context, projectID domain.ProjectID) ([]pipeline.Definition, error)
+}
+
+// PRFactsReader reads the facts of one exact PR by url (the PR named in a CDC
+// payload). Satisfied by *storage/sqlite/store.Store.
+type PRFactsReader interface {
+	GetPRFactsByURL(ctx context.Context, url string) (domain.PRFacts, bool, error)
+}
+
+// Engine is the subset of *engine.Engine the bridge drives.
+type Engine interface {
+	TriggerRun(req engine.TriggerRequest) (pipeline.RunID, error)
+	Dispatch(event pipeline.Event)
+}
+
+// EngineProvider resolves (and lazily starts) the engine for a project.
+// Satisfied by an adapter over *engine.Supervisor.
+type EngineProvider interface {
+	For(ctx context.Context, projectID domain.ProjectID) (Engine, error)
+}
+
+// Config constructs a Bridge. Broadcaster, Defs, PRs, and Engines are required;
+// Logger and Clock default.
+type Config struct {
+	Broadcaster *cdc.Broadcaster
+	Defs        Definitions
+	PRs         PRFactsReader
+	Engines     EngineProvider
+	Logger      *slog.Logger
+	// Clock stamps the events the bridge dispatches. Defaults to time.Now().UTC.
+	Clock func() time.Time
+}
+
+// prSnapshot is the bridge's memory of a PR's last-seen derivation inputs, used
+// to detect transitions (merge-ready / merged) and head-SHA changes.
+type prSnapshot struct {
+	mergeReady bool
+	merged     bool
+	headSHA    string
+}
+
+// Bridge subscribes to CDC PR events and triggers pipeline runs.
+type Bridge struct {
+	broadcaster *cdc.Broadcaster
+	defs        Definitions
+	prs         PRFactsReader
+	engines     EngineProvider
+	log         *slog.Logger
+	now         func() time.Time
+
+	queue  chan cdc.Event
+	unsub  func()
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	// prev is owned exclusively by the worker goroutine; no lock needed. Keyed
+	// by PR url so a stacked-PR session tracks each PR independently.
+	prev map[string]prSnapshot
+}
+
+// New builds a Bridge. It does not subscribe or start any goroutine; call Start.
+func New(cfg Config) *Bridge {
+	log := cfg.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+	clock := cfg.Clock
+	if clock == nil {
+		clock = func() time.Time { return time.Now().UTC() }
+	}
+	return &Bridge{
+		broadcaster: cfg.Broadcaster,
+		defs:        cfg.Defs,
+		prs:         cfg.PRs,
+		engines:     cfg.Engines,
+		log:         log,
+		now:         clock,
+		queue:       make(chan cdc.Event, queueCap),
+		prev:        map[string]prSnapshot{},
+	}
+}
+
+// Start subscribes to the broadcaster and launches the worker goroutine. The
+// worker runs until Stop (or ctx cancellation).
+func (b *Bridge) Start(ctx context.Context) {
+	wctx, cancel := context.WithCancel(ctx)
+	b.cancel = cancel
+	b.unsub = b.broadcaster.Subscribe(b.enqueue)
+	b.wg.Add(1)
+	go b.run(wctx)
+}
+
+// Stop unsubscribes from the broadcaster (no new events), stops the worker, and
+// waits for it to drain. Idempotent-safe when Start was called; a nil/unstarted
+// Bridge Stop is a no-op.
+func (b *Bridge) Stop() {
+	if b == nil || b.cancel == nil {
+		return
+	}
+	b.unsub()
+	b.cancel()
+	b.wg.Wait()
+}
+
+// enqueue runs on the poller goroutine: it must not block. It keeps only PR
+// events and hands them to the worker via the buffered queue, dropping (with a
+// log) if the buffer is somehow full.
+func (b *Bridge) enqueue(e cdc.Event) {
+	if e.Type != cdc.EventPRCreated && e.Type != cdc.EventPRUpdated {
+		return
+	}
+	select {
+	case b.queue <- e:
+	default:
+		b.log.Warn("pipeline trigger bridge: event queue full, dropping", "seq", e.Seq, "type", e.Type)
+	}
+}
+
+func (b *Bridge) run(ctx context.Context) {
+	defer b.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case e := <-b.queue:
+			b.process(ctx, e)
+		}
+	}
+}
+
+// prPayload is the subset of the CDC pr_created/pr_updated payload the bridge
+// needs; the rest of the facts are read authoritatively from the store by url.
+type prPayload struct {
+	URL     string `json:"url"`
+	Session string `json:"session"`
+}
+
+func (b *Bridge) process(ctx context.Context, e cdc.Event) {
+	var p prPayload
+	if err := json.Unmarshal(e.Payload, &p); err != nil {
+		b.log.Warn("pipeline trigger bridge: bad pr payload", "seq", e.Seq, "err", err)
+		return
+	}
+	session := e.SessionID
+	if session == "" {
+		session = p.Session
+	}
+	if p.URL == "" || session == "" || e.ProjectID == "" {
+		return
+	}
+
+	facts, ok, err := b.prs.GetPRFactsByURL(ctx, p.URL)
+	if err != nil {
+		b.log.Warn("pipeline trigger bridge: read pr facts", "url", p.URL, "err", err)
+		return
+	}
+	if !ok {
+		return
+	}
+
+	projectID := domain.ProjectID(e.ProjectID)
+	defs, err := b.defs.ListPipelineDefinitions(ctx, projectID)
+	if err != nil {
+		b.log.Warn("pipeline trigger bridge: list definitions", "project", projectID, "err", err)
+		return
+	}
+	if len(defs) == 0 {
+		return
+	}
+
+	eng, err := b.engines.For(ctx, projectID)
+	if err != nil {
+		b.log.Warn("pipeline trigger bridge: resolve engine", "project", projectID, "err", err)
+		return
+	}
+
+	prev, seen := b.prev[p.URL]
+	cur := prSnapshot{mergeReady: isMergeReady(facts), merged: facts.Merged, headSHA: facts.HeadSHA}
+
+	opened := e.Type == cdc.EventPRCreated
+	fireOpened := opened
+	fireUpdated := !opened
+	fireMergeReady := cur.mergeReady && (!seen || !prev.mergeReady)
+	fireMerged := cur.merged && (!seen || !prev.merged)
+	// A head-SHA change only matters for cancel-and-rearm, which rides the
+	// pr.updated trigger. Requires a prior observation with a known SHA.
+	shaChanged := seen && prev.headSHA != "" && cur.headSHA != "" && prev.headSHA != cur.headSHA
+
+	for _, def := range defs {
+		cfg := def.Config
+		cfg.ID = def.ID // the run records the definition it came from
+
+		subsUpdated := defSubscribes(cfg, pipeline.TriggerPRUpdated)
+		// New-SHA cancel-and-rearm: terminate the stale in-flight run as outdated
+		// and free the loop BEFORE the pr.updated trigger arms a fresh run at the
+		// new SHA. Scoped to pr.updated subscribers because the rearm is the
+		// pr.updated trigger; the reducer no-ops when no run is in flight.
+		if fireUpdated && shaChanged && subsUpdated {
+			eng.Dispatch(pipeline.NewSHADetected{Now: b.now(), SessionID: session, PipelineName: cfg.Name, SHA: cur.headSHA})
+		}
+
+		b.fireIf(eng, fireOpened && defSubscribes(cfg, pipeline.TriggerPROpened), cfg, session, pipeline.TriggerPROpened, cur.headSHA)
+		b.fireIf(eng, fireUpdated && subsUpdated, cfg, session, pipeline.TriggerPRUpdated, cur.headSHA)
+		b.fireIf(eng, fireMergeReady && defSubscribes(cfg, pipeline.TriggerPRMergeReady), cfg, session, pipeline.TriggerPRMergeReady, cur.headSHA)
+		b.fireIf(eng, fireMerged && defSubscribes(cfg, pipeline.TriggerPRMerged), cfg, session, pipeline.TriggerPRMerged, cur.headSHA)
+	}
+
+	b.prev[p.URL] = cur
+}
+
+func (b *Bridge) fireIf(eng Engine, cond bool, cfg pipeline.Pipeline, session string, ev pipeline.StageTriggerEvent, sha string) {
+	if !cond {
+		return
+	}
+	if _, err := eng.TriggerRun(engine.TriggerRequest{
+		Pipeline:  cfg,
+		SessionID: session,
+		Trigger:   ev,
+		HeadSHA:   sha,
+	}); err != nil {
+		b.log.Warn("pipeline trigger bridge: trigger run", "pipeline", cfg.Name, "trigger", ev, "session", session, "err", err)
+	}
+}
+
+// isMergeReady ports the old lifecycle-status-decisions.ts merge_ready shape
+// (spec §4b): the PR is open, CI is not failing, review is approved-or-none, and
+// the PR is mergeable.
+func isMergeReady(f domain.PRFacts) bool {
+	open := !f.Draft && !f.Merged && !f.Closed
+	ciNotFailing := f.CI != domain.CIFailing
+	reviewOK := f.Review == domain.ReviewApproved || f.Review == domain.ReviewNone || f.Review == ""
+	mergeable := f.Mergeability == domain.MergeMergeable
+	return open && ciNotFailing && reviewOK && mergeable
+}
+
+// defSubscribes reports whether any stage of the pipeline lists ev in its
+// trigger.on set.
+func defSubscribes(p pipeline.Pipeline, ev pipeline.StageTriggerEvent) bool {
+	for _, s := range p.Stages {
+		for _, on := range s.Trigger.On {
+			if on == ev {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/backend/internal/pipeline/triggers/bridge_test.go
+++ b/backend/internal/pipeline/triggers/bridge_test.go
@@ -1,0 +1,399 @@
+package triggers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/engine"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+type fakePRs struct {
+	facts map[string]domain.PRFacts
+}
+
+func (f *fakePRs) GetPRFactsByURL(_ context.Context, url string) (domain.PRFacts, bool, error) {
+	fct, ok := f.facts[url]
+	return fct, ok, nil
+}
+
+type fakeDefs struct {
+	byProject map[domain.ProjectID][]pipeline.Definition
+}
+
+func (f *fakeDefs) ListPipelineDefinitions(_ context.Context, projectID domain.ProjectID) ([]pipeline.Definition, error) {
+	return f.byProject[projectID], nil
+}
+
+// fakeEngine records the trigger/dispatch calls in order so tests can assert
+// both the set and the sequencing (NEW_SHA_DETECTED before the rearm trigger).
+type fakeEngine struct {
+	mu       sync.Mutex
+	triggers []engine.TriggerRequest
+	dispatch []pipeline.Event
+	ops      []string
+	nextID   int
+}
+
+func (f *fakeEngine) TriggerRun(req engine.TriggerRequest) (pipeline.RunID, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.triggers = append(f.triggers, req)
+	f.ops = append(f.ops, fmt.Sprintf("trigger:%s:%s", req.Trigger, req.HeadSHA))
+	f.nextID++
+	return pipeline.RunID(fmt.Sprintf("run-%d", f.nextID)), nil
+}
+
+func (f *fakeEngine) Dispatch(e pipeline.Event) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.dispatch = append(f.dispatch, e)
+	sha := ""
+	if n, ok := e.(pipeline.NewSHADetected); ok {
+		sha = n.SHA
+	}
+	f.ops = append(f.ops, fmt.Sprintf("dispatch:%s:%s", e.Type(), sha))
+}
+
+func (f *fakeEngine) triggerCount(ev pipeline.StageTriggerEvent) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, t := range f.triggers {
+		if t.Trigger == ev {
+			n++
+		}
+	}
+	return n
+}
+
+type fakeProvider struct{ eng Engine }
+
+func (p fakeProvider) For(_ context.Context, _ domain.ProjectID) (Engine, error) {
+	return p.eng, nil
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const (
+	testProject = "proj-1"
+	testSession = "sess-1"
+	testURL     = "https://github.com/o/r/pull/1"
+)
+
+// defOn builds a definition whose single stage subscribes to exactly the given
+// trigger events.
+func defOn(name string, events ...pipeline.StageTriggerEvent) pipeline.Definition {
+	stage := pipeline.Stage{
+		Name:     "review",
+		Trigger:  pipeline.StageTrigger{On: events},
+		Executor: pipeline.StageExecutor{Kind: pipeline.ExecutorAgent, Plugin: "claude-code", Mode: pipeline.ModeReview},
+	}
+	return pipeline.Definition{
+		ID:        pipeline.ID("def-" + name),
+		ProjectID: testProject,
+		Name:      name,
+		Config:    pipeline.Pipeline{Name: name, Scope: pipeline.ScopeWorker, Stages: []pipeline.Stage{stage}},
+	}
+}
+
+func readyFacts(sha string) domain.PRFacts {
+	return domain.PRFacts{URL: testURL, Number: 1, CI: domain.CIPassing, Review: domain.ReviewApproved, Mergeability: domain.MergeMergeable, HeadSHA: sha}
+}
+
+func notReadyFacts(sha string) domain.PRFacts {
+	// CI failing blocks merge-readiness.
+	return domain.PRFacts{URL: testURL, Number: 1, CI: domain.CIFailing, Review: domain.ReviewApproved, Mergeability: domain.MergeMergeable, HeadSHA: sha}
+}
+
+func mergedFacts(sha string) domain.PRFacts {
+	return domain.PRFacts{URL: testURL, Number: 1, Merged: true, CI: domain.CIPassing, Review: domain.ReviewApproved, HeadSHA: sha}
+}
+
+func prEvent(t cdc.EventType) cdc.Event {
+	payload, _ := json.Marshal(prPayload{URL: testURL, Session: testSession})
+	return cdc.Event{ProjectID: testProject, SessionID: testSession, Type: t, Payload: payload}
+}
+
+// newBridge wires a Bridge over fakes with a fixed clock. The facts pointer lets
+// a test mutate the PR snapshot between events.
+func newBridge(defs []pipeline.Definition, facts map[string]domain.PRFacts) (*Bridge, *fakeEngine) {
+	eng := &fakeEngine{}
+	b := New(Config{
+		Broadcaster: cdc.NewBroadcaster(),
+		Defs:        &fakeDefs{byProject: map[domain.ProjectID][]pipeline.Definition{testProject: defs}},
+		PRs:         &fakePRs{facts: facts},
+		Engines:     fakeProvider{eng: eng},
+		Clock:       func() time.Time { return time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC) },
+	})
+	return b, eng
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestPROpenedTriggersMatchingDefinition(t *testing.T) {
+	ctx := context.Background()
+	facts := map[string]domain.PRFacts{testURL: readyFacts("sha1")}
+	b, eng := newBridge([]pipeline.Definition{defOn("opener", pipeline.TriggerPROpened)}, facts)
+
+	b.process(ctx, prEvent(cdc.EventPRCreated))
+
+	if got := eng.triggerCount(pipeline.TriggerPROpened); got != 1 {
+		t.Fatalf("pr.opened triggers = %d, want 1", got)
+	}
+	if req := eng.triggers[0]; req.SessionID != testSession || req.HeadSHA != "sha1" {
+		t.Fatalf("trigger req = %+v, want session=%s sha=sha1", req, testSession)
+	}
+}
+
+func TestNonMatchingDefinitionDoesNotTrigger(t *testing.T) {
+	ctx := context.Background()
+	facts := map[string]domain.PRFacts{testURL: readyFacts("sha1")}
+	// Subscribes to manual only: a pr.opened event must not start it.
+	b, eng := newBridge([]pipeline.Definition{defOn("manualOnly", pipeline.TriggerManual)}, facts)
+
+	b.process(ctx, prEvent(cdc.EventPRCreated))
+
+	if got := len(eng.triggers); got != 0 {
+		t.Fatalf("triggers = %d, want 0 for a non-subscribing definition", got)
+	}
+}
+
+func TestMergeReadyFiresOnceOnTransition(t *testing.T) {
+	ctx := context.Background()
+	facts := map[string]domain.PRFacts{testURL: notReadyFacts("sha1")}
+	b, eng := newBridge([]pipeline.Definition{defOn("gate", pipeline.TriggerPRMergeReady)}, facts)
+
+	// Not ready yet -> no merge_ready trigger.
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+	if got := eng.triggerCount(pipeline.TriggerPRMergeReady); got != 0 {
+		t.Fatalf("merge_ready before transition = %d, want 0", got)
+	}
+
+	// Transition into ready -> fires once.
+	facts[testURL] = readyFacts("sha1")
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+	// Still ready on the next event -> must NOT fire again.
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+
+	if got := eng.triggerCount(pipeline.TriggerPRMergeReady); got != 1 {
+		t.Fatalf("merge_ready across hold = %d, want exactly 1 (fire on transition only)", got)
+	}
+}
+
+func TestMergeReadyFirstSeenAlreadyReadyFires(t *testing.T) {
+	ctx := context.Background()
+	facts := map[string]domain.PRFacts{testURL: readyFacts("sha1")}
+	b, eng := newBridge([]pipeline.Definition{defOn("gate", pipeline.TriggerPRMergeReady)}, facts)
+
+	// First event we ever see for this PR is already merge-ready: counts as a
+	// transition and fires.
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+
+	if got := eng.triggerCount(pipeline.TriggerPRMergeReady); got != 1 {
+		t.Fatalf("first-seen-ready merge_ready = %d, want 1", got)
+	}
+}
+
+func TestMergedTransitionFires(t *testing.T) {
+	ctx := context.Background()
+	facts := map[string]domain.PRFacts{testURL: readyFacts("sha1")}
+	b, eng := newBridge([]pipeline.Definition{defOn("onMerge", pipeline.TriggerPRMerged)}, facts)
+
+	// Open PR: no merged trigger.
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+	if got := eng.triggerCount(pipeline.TriggerPRMerged); got != 0 {
+		t.Fatalf("merged before merge = %d, want 0", got)
+	}
+
+	// Now merged.
+	facts[testURL] = mergedFacts("sha1")
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+	if got := eng.triggerCount(pipeline.TriggerPRMerged); got != 1 {
+		t.Fatalf("merged after transition = %d, want 1", got)
+	}
+}
+
+func TestNewSHACancelsAndRearms(t *testing.T) {
+	ctx := context.Background()
+	facts := map[string]domain.PRFacts{testURL: readyFacts("shaA")}
+	b, eng := newBridge([]pipeline.Definition{defOn("loop", pipeline.TriggerPRUpdated)}, facts)
+
+	// First update at shaA: arms a run, no NEW_SHA (nothing prior).
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+	if len(eng.dispatch) != 0 {
+		t.Fatalf("dispatch after first update = %d, want 0", len(eng.dispatch))
+	}
+
+	// New head SHA: cancel-and-rearm.
+	facts[testURL] = readyFacts("shaB")
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+
+	if len(eng.dispatch) != 1 {
+		t.Fatalf("dispatch after new sha = %d, want 1", len(eng.dispatch))
+	}
+	ns, ok := eng.dispatch[0].(pipeline.NewSHADetected)
+	if !ok || ns.SHA != "shaB" || ns.SessionID != testSession || ns.PipelineName != "loop" {
+		t.Fatalf("dispatched event = %+v, want NewSHADetected sha=shaB session=%s pipeline=loop", eng.dispatch[0], testSession)
+	}
+	if got := eng.triggerCount(pipeline.TriggerPRUpdated); got != 2 {
+		t.Fatalf("pr.updated triggers = %d, want 2", got)
+	}
+	// The rearm trigger must carry the new SHA...
+	if last := eng.triggers[len(eng.triggers)-1]; last.HeadSHA != "shaB" {
+		t.Fatalf("rearm trigger sha = %s, want shaB", last.HeadSHA)
+	}
+	// ...and NEW_SHA_DETECTED must be dispatched BEFORE the rearm trigger.
+	wantOrder := []string{"trigger:pr.updated:shaA", "dispatch:NEW_SHA_DETECTED:shaB", "trigger:pr.updated:shaB"}
+	if fmt.Sprint(eng.ops) != fmt.Sprint(wantOrder) {
+		t.Fatalf("op order = %v, want %v", eng.ops, wantOrder)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: real engine (Supervisor) + real store + mocked executor
+// ---------------------------------------------------------------------------
+
+// recExec is a mock StageExecutor that records Start calls and never completes,
+// so the integration test can assert a run started without racing the tick.
+type recExec struct {
+	mu      sync.Mutex
+	started int
+}
+
+func (e *recExec) Start(_ context.Context, in executors.StartInput) (executors.Handle, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.started++
+	return recHandle{runID: in.RunID, stageRunID: in.StageRunID, stageName: in.Stage.Name}, nil
+}
+
+func (e *recExec) Poll(context.Context, executors.Handle) (executors.Outcome, error) {
+	return executors.Outcome{Status: executors.OutcomeRunning}, nil
+}
+func (e *recExec) Cancel(context.Context, executors.Handle) error { return nil }
+
+func (e *recExec) startCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.started
+}
+
+type recHandle struct {
+	runID      pipeline.RunID
+	stageRunID pipeline.StageRunID
+	stageName  string
+}
+
+func (h recHandle) RunID() pipeline.RunID           { return h.runID }
+func (h recHandle) StageRunID() pipeline.StageRunID { return h.stageRunID }
+func (h recHandle) StageName() string               { return h.stageName }
+
+type supEngines struct{ sup *engine.Supervisor }
+
+func (s supEngines) For(ctx context.Context, projectID domain.ProjectID) (Engine, error) {
+	return s.sup.For(ctx, projectID)
+}
+
+func TestPRCreatedStartsRunThroughRealEngine(t *testing.T) {
+	ctx := context.Background()
+
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: testProject, Path: "/tmp/" + testProject, RegisteredAt: time.Now().UTC().Truncate(time.Second)}); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+
+	// A real definition in the store, subscribing to pr.opened.
+	def := defOn("review", pipeline.TriggerPROpened)
+	def.CreatedAt = time.Now().UTC()
+	def.UpdatedAt = def.CreatedAt
+	if err := store.CreatePipelineDefinition(ctx, def); err != nil {
+		t.Fatalf("create definition: %v", err)
+	}
+
+	exec := &recExec{}
+	sup := engine.NewSupervisor(engine.SupervisorConfig{
+		Store:        store,
+		Executors:    executors.NewSet(exec, exec, exec),
+		Projects:     store,
+		TickInterval: time.Hour, // no heartbeat; the run just needs to start
+	})
+	if err := sup.Start(ctx); err != nil {
+		t.Fatalf("supervisor start: %v", err)
+	}
+	t.Cleanup(func() { _ = sup.Stop(ctx) })
+
+	b := New(Config{
+		Broadcaster: cdc.NewBroadcaster(),
+		Defs:        store,
+		PRs:         &fakePRs{facts: map[string]domain.PRFacts{testURL: readyFacts("sha1")}},
+		Engines:     supEngines{sup: sup},
+	})
+
+	b.process(ctx, prEvent(cdc.EventPRCreated))
+
+	if exec.startCount() != 1 {
+		t.Fatalf("executor Start count = %d, want 1 (run should have started)", exec.startCount())
+	}
+	eng, err := sup.For(ctx, testProject)
+	if err != nil {
+		t.Fatalf("engine for project: %v", err)
+	}
+	runs := eng.State().Runs
+	if len(runs) != 1 {
+		t.Fatalf("engine runs = %d, want 1", len(runs))
+	}
+	for _, r := range runs {
+		if r.SessionID != testSession || r.PipelineName != "review" || r.HeadSHA != "sha1" {
+			t.Fatalf("run = %+v, want session=%s pipeline=review sha=sha1", r, testSession)
+		}
+	}
+}
+
+// TestBridgeAsyncDeliveryThroughBroadcaster covers the Subscribe -> enqueue ->
+// worker path: a published CDC event eventually drives a trigger without
+// blocking the publisher.
+func TestBridgeAsyncDeliveryThroughBroadcaster(t *testing.T) {
+	ctx := context.Background()
+	bcast := cdc.NewBroadcaster()
+	eng := &fakeEngine{}
+	b := New(Config{
+		Broadcaster: bcast,
+		Defs:        &fakeDefs{byProject: map[domain.ProjectID][]pipeline.Definition{testProject: {defOn("opener", pipeline.TriggerPROpened)}}},
+		PRs:         &fakePRs{facts: map[string]domain.PRFacts{testURL: readyFacts("sha1")}},
+		Engines:     fakeProvider{eng: eng},
+	})
+	b.Start(ctx)
+	t.Cleanup(b.Stop)
+
+	bcast.Publish(prEvent(cdc.EventPRCreated))
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if eng.triggerCount(pipeline.TriggerPROpened) == 1 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("pr.opened trigger not observed within deadline (async delivery failed)")
+}

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -73,6 +73,7 @@ type PR struct {
 	CIObservedAt             sql.NullTime
 	ReviewObservedAt         sql.NullTime
 	LastNudgeSignature       string
+	IsFromFork               sql.NullInt64
 }
 
 type PRCheck struct {

--- a/backend/internal/storage/sqlite/gen/pr.sql.go
+++ b/backend/internal/storage/sqlite/gen/pr.sql.go
@@ -55,6 +55,8 @@ SELECT
     pr.review_decision,
     pr.ci_state,
     pr.mergeability,
+    pr.head_sha,
+    pr.is_from_fork,
     pr.updated_at,
     EXISTS (
         SELECT 1
@@ -78,6 +80,8 @@ type GetDisplayPRFactsBySessionRow struct {
 	ReviewDecision domain.ReviewDecision
 	CIState        domain.CIState
 	Mergeability   domain.Mergeability
+	HeadSha        string
+	IsFromFork     sql.NullInt64
 	UpdatedAt      time.Time
 	ReviewComments bool
 }
@@ -92,6 +96,8 @@ func (q *Queries) GetDisplayPRFactsBySession(ctx context.Context, sessionID doma
 		&i.ReviewDecision,
 		&i.CIState,
 		&i.Mergeability,
+		&i.HeadSha,
+		&i.IsFromFork,
 		&i.UpdatedAt,
 		&i.ReviewComments,
 	)
@@ -99,7 +105,7 @@ func (q *Queries) GetDisplayPRFactsBySession(ctx context.Context, sessionID doma
 }
 
 const getPR = `-- name: GetPR :one
-SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature FROM pr WHERE url = ?
+SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature, is_from_fork FROM pr WHERE url = ?
 `
 
 func (q *Queries) GetPR(ctx context.Context, url string) (PR, error) {
@@ -145,6 +151,7 @@ func (q *Queries) GetPR(ctx context.Context, url string) (PR, error) {
 		&i.CIObservedAt,
 		&i.ReviewObservedAt,
 		&i.LastNudgeSignature,
+		&i.IsFromFork,
 	)
 	return i, err
 }
@@ -167,6 +174,54 @@ func (q *Queries) GetPRClaimAndOwner(ctx context.Context, url string) (GetPRClai
 	row := q.db.QueryRowContext(ctx, getPRClaimAndOwner, url)
 	var i GetPRClaimAndOwnerRow
 	err := row.Scan(&i.SessionID, &i.IsTerminated)
+	return i, err
+}
+
+const getPRFactsByURL = `-- name: GetPRFactsByURL :one
+SELECT
+    pr.url,
+    pr.number,
+    pr.pr_state,
+    pr.review_decision,
+    pr.ci_state,
+    pr.mergeability,
+    pr.head_sha,
+    pr.is_from_fork,
+    pr.updated_at
+FROM pr
+WHERE pr.url = ?
+`
+
+type GetPRFactsByURLRow struct {
+	URL            string
+	Number         int64
+	PRState        domain.PRState
+	ReviewDecision domain.ReviewDecision
+	CIState        domain.CIState
+	Mergeability   domain.Mergeability
+	HeadSha        string
+	IsFromFork     sql.NullInt64
+	UpdatedAt      time.Time
+}
+
+// Exact-PR facts for the pipeline trigger bridge (T6): the changed PR named in
+// a CDC pr_created/pr_updated payload, including head_sha for new-SHA detection.
+// Keyed by url (not session) so a stacked-PR session attributes each event to
+// the right PR.
+func (q *Queries) GetPRFactsByURL(ctx context.Context, url string) (GetPRFactsByURLRow, error) {
+	row := q.db.QueryRowContext(ctx, getPRFactsByURL, url)
+	var i GetPRFactsByURLRow
+	err := row.Scan(
+		&i.URL,
+		&i.Number,
+		&i.PRState,
+		&i.ReviewDecision,
+		&i.CIState,
+		&i.Mergeability,
+		&i.HeadSha,
+		&i.IsFromFork,
+		&i.UpdatedAt,
+	)
 	return i, err
 }
 
@@ -255,7 +310,7 @@ func (q *Queries) ListPRFactsBySession(ctx context.Context, sessionID domain.Ses
 }
 
 const listPRsBySession = `-- name: ListPRsBySession :many
-SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature FROM pr
+SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature, is_from_fork FROM pr
 WHERE session_id = ?
 ORDER BY updated_at DESC
 `
@@ -309,6 +364,7 @@ func (q *Queries) ListPRsBySession(ctx context.Context, sessionID domain.Session
 			&i.CIObservedAt,
 			&i.ReviewObservedAt,
 			&i.LastNudgeSignature,
+			&i.IsFromFork,
 		); err != nil {
 			return nil, err
 		}
@@ -394,9 +450,10 @@ INSERT INTO pr (
     is_draft, is_merged, is_closed,
     provider_state, provider_mergeable, provider_merge_state_status, html_url,
     created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider,
-    metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at
+    metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at,
+    is_from_fork
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (url) DO UPDATE SET
     number = excluded.number,
     pr_state = excluded.pr_state,
@@ -433,7 +490,8 @@ ON CONFLICT (url) DO UPDATE SET
     review_hash = excluded.review_hash,
     observed_at = excluded.observed_at,
     ci_observed_at = excluded.ci_observed_at,
-    review_observed_at = excluded.review_observed_at
+    review_observed_at = excluded.review_observed_at,
+    is_from_fork = excluded.is_from_fork
 `
 
 type UpsertPRParams struct {
@@ -475,6 +533,7 @@ type UpsertPRParams struct {
 	ObservedAt               sql.NullTime
 	CIObservedAt             sql.NullTime
 	ReviewObservedAt         sql.NullTime
+	IsFromFork               sql.NullInt64
 }
 
 func (q *Queries) UpsertPR(ctx context.Context, arg UpsertPRParams) error {
@@ -517,6 +576,7 @@ func (q *Queries) UpsertPR(ctx context.Context, arg UpsertPRParams) error {
 		arg.ObservedAt,
 		arg.CIObservedAt,
 		arg.ReviewObservedAt,
+		arg.IsFromFork,
 	)
 	return err
 }

--- a/backend/internal/storage/sqlite/migrations/0025_pr_is_from_fork.sql
+++ b/backend/internal/storage/sqlite/migrations/0025_pr_is_from_fork.sql
@@ -1,0 +1,17 @@
+-- Fork provenance for the pipeline command-executor gate (spec §4b T6, gap
+-- flagged in the T5 review PR #235). The SCM observer sees a PR's head repo,
+-- but that never survived to the pr table, so a real PR could only ever be
+-- classified ForkUnknown after the fact. This nullable tri-state column
+-- persists it: NULL = unknown (fail-safe default for legacy rows), 0 = not a
+-- fork, 1 = from a fork. The command executor blocks fork + unknown PRs unless
+-- allowForkPRs is set.
+
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE pr ADD COLUMN is_from_fork INTEGER;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE pr DROP COLUMN is_from_fork;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/migrations/0026_pr_cdc_update_head_sha.sql
+++ b/backend/internal/storage/sqlite/migrations/0026_pr_cdc_update_head_sha.sql
@@ -1,0 +1,51 @@
+-- New-SHA cancel-and-rearm (spec decision 9) rides the CDC pr_updated event, but
+-- the pr_cdc_update trigger (migration 0024) fired only when pr_state, ci_state,
+-- review_decision, or mergeability changed. A push that changes ONLY pr.head_sha
+-- (no CI reporting yet, or a repo without CI) emitted no event, so the pipeline
+-- trigger bridge never saw the new SHA: the stale run kept running and no fresh
+-- run armed. Add OLD.head_sha <> NEW.head_sha to the WHEN clause so a head-SHA
+-- change alone emits pr_updated. The payload is unchanged (the bridge reads
+-- head_sha from the store by url, not from the payload).
+
+-- +goose Up
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS pr_cdc_update;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.pr_state <> NEW.pr_state
+    OR OLD.ci_state <> NEW.ci_state
+    OR OLD.review_decision <> NEW.review_decision
+    OR OLD.mergeability <> NEW.mergeability
+    OR OLD.head_sha <> NEW.head_sha
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_updated',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS pr_cdc_update;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.pr_state <> NEW.pr_state
+    OR OLD.ci_state <> NEW.ci_state
+    OR OLD.review_decision <> NEW.review_decision
+    OR OLD.mergeability <> NEW.mergeability
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_updated',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/pr.sql
+++ b/backend/internal/storage/sqlite/queries/pr.sql
@@ -6,9 +6,10 @@ INSERT INTO pr (
     is_draft, is_merged, is_closed,
     provider_state, provider_mergeable, provider_merge_state_status, html_url,
     created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider,
-    metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at
+    metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at,
+    is_from_fork
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (url) DO UPDATE SET
     number = excluded.number,
     pr_state = excluded.pr_state,
@@ -45,7 +46,8 @@ ON CONFLICT (url) DO UPDATE SET
     review_hash = excluded.review_hash,
     observed_at = excluded.observed_at,
     ci_observed_at = excluded.ci_observed_at,
-    review_observed_at = excluded.review_observed_at;
+    review_observed_at = excluded.review_observed_at,
+    is_from_fork = excluded.is_from_fork;
 
 -- name: UpsertLegacyPR :exec
 INSERT INTO pr (
@@ -86,6 +88,8 @@ SELECT
     pr.review_decision,
     pr.ci_state,
     pr.mergeability,
+    pr.head_sha,
+    pr.is_from_fork,
     pr.updated_at,
     EXISTS (
         SELECT 1
@@ -100,6 +104,24 @@ ORDER BY
     CASE WHEN pr.pr_state NOT IN ('merged', 'closed') THEN 0 ELSE 1 END,
     pr.updated_at DESC
 LIMIT 1;
+
+-- name: GetPRFactsByURL :one
+-- Exact-PR facts for the pipeline trigger bridge (T6): the changed PR named in
+-- a CDC pr_created/pr_updated payload, including head_sha for new-SHA detection.
+-- Keyed by url (not session) so a stacked-PR session attributes each event to
+-- the right PR.
+SELECT
+    pr.url,
+    pr.number,
+    pr.pr_state,
+    pr.review_decision,
+    pr.ci_state,
+    pr.mergeability,
+    pr.head_sha,
+    pr.is_from_fork,
+    pr.updated_at
+FROM pr
+WHERE pr.url = ?;
 
 -- name: ListPRFactsBySession :many
 -- All PR snapshots for a session (every state), with source/target branch for

--- a/backend/internal/storage/sqlite/store/pr_cdc_head_sha_test.go
+++ b/backend/internal/storage/sqlite/store/pr_cdc_head_sha_test.go
@@ -1,0 +1,65 @@
+package store_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// New-SHA cancel-and-rearm (spec decision 9) rides pr_updated. Migration 0026
+// added OLD.head_sha <> NEW.head_sha to the pr_cdc_update WHEN clause so a push
+// that changes ONLY the head SHA (no CI/review/state/mergeability change, e.g. a
+// repo without CI) still emits pr_updated for the trigger bridge. Without it the
+// stale run would keep running and no fresh run would arm.
+func TestPRCDC_EmitsOnHeadSHAOnlyChange(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	rec, err := s.CreateSession(ctx, sampleRecord("mer"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	url := "https://example/pr/head"
+
+	// Every write keeps CI/review/state/mergeability identical so the ONLY thing
+	// that can drive a pr_updated event is the head_sha change.
+	write := func(headSHA string, at time.Time) {
+		t.Helper()
+		if err := s.WriteSCMObservation(ctx, domain.PullRequest{
+			URL: url, SessionID: rec.ID, Number: 1,
+			CI: domain.CIPassing, Review: domain.ReviewApproved, Mergeability: domain.MergeMergeable,
+			HeadSHA: headSHA, UpdatedAt: at, ObservedAt: at,
+		}, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+			t.Fatalf("write %s: %v", headSHA, err)
+		}
+	}
+
+	write("sha1", now)                    // INSERT -> pr_created
+	write("sha2", now.Add(time.Second))   // head_sha-only change -> pr_updated
+	write("sha2", now.Add(2*time.Second)) // nothing changed -> NO event
+
+	rows, err := s.EventsAfter(ctx, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var updated []cdc.Event
+	for _, r := range rows {
+		if r.Type == cdc.EventPRUpdated {
+			updated = append(updated, r)
+		}
+	}
+	if len(updated) != 1 {
+		t.Fatalf("want exactly 1 pr_updated CDC event from the head_sha-only change (no-op suppressed), got %d", len(updated))
+	}
+	// The bridge reads head_sha from the store, so the payload need not carry it;
+	// assert the event is well-formed and tied to the right PR.
+	if !strings.Contains(string(updated[0].Payload), `"url":"`+url+`"`) {
+		t.Fatalf("pr_updated payload missing url: %q", updated[0].Payload)
+	}
+}

--- a/backend/internal/storage/sqlite/store/pr_facts.go
+++ b/backend/internal/storage/sqlite/store/pr_facts.go
@@ -64,6 +64,36 @@ func prFactsFromGen(r gen.GetDisplayPRFactsBySessionRow) domain.PRFacts {
 		Review:         r.ReviewDecision,
 		Mergeability:   r.Mergeability,
 		ReviewComments: r.ReviewComments,
+		HeadSHA:        r.HeadSha,
+		IsFromFork:     boolPtrFromNullInt(r.IsFromFork),
 		UpdatedAt:      r.UpdatedAt,
 	}
+}
+
+// GetPRFactsByURL returns the facts for one exact PR url, including head_sha and
+// fork provenance. It backs the pipeline trigger bridge (T6), which needs the
+// changed PR named in a CDC payload, not the session's display PR. ok=false when
+// no PR with that url exists.
+func (s *Store) GetPRFactsByURL(ctx context.Context, url string) (domain.PRFacts, bool, error) {
+	r, err := s.qr.GetPRFactsByURL(ctx, url)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.PRFacts{}, false, nil
+	}
+	if err != nil {
+		return domain.PRFacts{}, false, fmt.Errorf("pr facts for %s: %w", url, err)
+	}
+	state := r.PRState
+	return domain.PRFacts{
+		URL:          r.URL,
+		Number:       int(r.Number),
+		Draft:        state == domain.PRStateDraft,
+		Merged:       state == domain.PRStateMerged,
+		Closed:       state == domain.PRStateClosed,
+		CI:           r.CIState,
+		Review:       r.ReviewDecision,
+		Mergeability: r.Mergeability,
+		HeadSHA:      r.HeadSha,
+		IsFromFork:   boolPtrFromNullInt(r.IsFromFork),
+		UpdatedAt:    r.UpdatedAt,
+	}, true, nil
 }

--- a/backend/internal/storage/sqlite/store/pr_fork_test.go
+++ b/backend/internal/storage/sqlite/store/pr_fork_test.go
@@ -1,0 +1,81 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// The is_from_fork tri-state (migration 0025) round-trips through the observer
+// write path (WriteSCMObservation -> UpsertPR) and is projected onto PRFacts by
+// both the by-url and display reads the trigger bridge + command-executor gate
+// use. NULL (unpopulated) reads back as nil = unknown.
+func TestPRIsFromForkRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	now := time.Now().UTC().Truncate(time.Second)
+	yes, no := true, false
+
+	cases := []struct {
+		url  string
+		fork *bool
+	}{
+		{"pr-fork", &yes},
+		{"pr-samerepo", &no},
+		{"pr-unknown", nil},
+	}
+	for _, tc := range cases {
+		r, _ := s.CreateSession(ctx, sampleRecord("mer"))
+		pr := domain.PullRequest{
+			URL:        tc.url,
+			SessionID:  r.ID,
+			Number:     1,
+			CI:         domain.CIPassing,
+			HeadSHA:    "deadbeef",
+			IsFromFork: tc.fork,
+			UpdatedAt:  now,
+			ObservedAt: now,
+		}
+		if err := s.WriteSCMObservation(ctx, pr, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+			t.Fatalf("write %s: %v", tc.url, err)
+		}
+
+		// By-url read (trigger bridge path): head_sha + fork provenance.
+		byURL, ok, err := s.GetPRFactsByURL(ctx, tc.url)
+		if err != nil || !ok {
+			t.Fatalf("GetPRFactsByURL %s: ok=%v err=%v", tc.url, ok, err)
+		}
+		if byURL.HeadSHA != "deadbeef" {
+			t.Fatalf("%s head_sha = %q, want deadbeef", tc.url, byURL.HeadSHA)
+		}
+		assertForkPtr(t, tc.url+" by-url", byURL.IsFromFork, tc.fork)
+
+		// Display read (command-executor fork gate path).
+		disp, ok, err := s.GetDisplayPRFactsForSession(ctx, r.ID)
+		if err != nil || !ok {
+			t.Fatalf("GetDisplayPRFactsForSession %s: ok=%v err=%v", tc.url, ok, err)
+		}
+		assertForkPtr(t, tc.url+" display", disp.IsFromFork, tc.fork)
+	}
+
+	// A url with no row reads back ok=false, not an error.
+	if _, ok, err := s.GetPRFactsByURL(ctx, "missing"); ok || err != nil {
+		t.Fatalf("GetPRFactsByURL missing: ok=%v err=%v, want false/nil", ok, err)
+	}
+}
+
+func assertForkPtr(t *testing.T, label string, got, want *bool) {
+	t.Helper()
+	switch {
+	case want == nil && got != nil:
+		t.Fatalf("%s IsFromFork = %v, want nil (unknown)", label, *got)
+	case want != nil && got == nil:
+		t.Fatalf("%s IsFromFork = nil, want %v", label, *want)
+	case want != nil && got != nil && *got != *want:
+		t.Fatalf("%s IsFromFork = %v, want %v", label, *got, *want)
+	}
+}

--- a/backend/internal/storage/sqlite/store/pr_store.go
+++ b/backend/internal/storage/sqlite/store/pr_store.go
@@ -361,7 +361,27 @@ func genPRParams(r domain.PullRequest) gen.UpsertPRParams {
 		ObservedAt:               nullTime(r.ObservedAt),
 		CIObservedAt:             nullTime(r.CIObservedAt),
 		ReviewObservedAt:         nullTime(r.ReviewObservedAt),
+		IsFromFork:               nullBoolInt(r.IsFromFork),
 	}
+}
+
+// nullBoolInt encodes a tri-state fork flag for the nullable is_from_fork
+// column: nil -> NULL (unknown), false -> 0, true -> 1.
+func nullBoolInt(v *bool) sql.NullInt64 {
+	if v == nil {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: boolInt(*v), Valid: true}
+}
+
+// boolPtrFromNullInt decodes the tri-state is_from_fork column back to a
+// *bool: NULL -> nil (unknown), 0 -> false, non-zero -> true.
+func boolPtrFromNullInt(v sql.NullInt64) *bool {
+	if !v.Valid {
+		return nil
+	}
+	b := v.Int64 != 0
+	return &b
 }
 
 func genLegacyPRParams(r domain.PullRequest) gen.UpsertLegacyPRParams {


### PR DESCRIPTION
## T6 · Pipeline trigger bridge

Closes #236 · Batch 4 of Pipelines v1 · base: `pipelines`

Turns CDC PR change events into pipeline runs, plus the fork-provenance gap flagged in the T5 review (#235).

### Trigger bridge (`backend/internal/pipeline/triggers`)
- Subscribes to the CDC broadcaster (`cdc.Broadcaster`) and hands events off the poller goroutine to an owned worker, so the poller never blocks (per the `Subscribe` contract). Engine methods are only ever called from the worker, never an ObservationSink/executor.
- Derives stage trigger events:
  - `pr.opened` from `pr_created`.
  - `pr.updated` from `pr_updated`.
  - `pr.merge_ready` on the **transition** into `open + CI-not-failing + review approved-or-none + mergeable` (ports the old `lifecycle-status-decisions.ts` shape). Fires once on transition via a per-PR previous-state map keyed by PR url; a PR first seen already-ready counts as a transition.
  - `pr.merged` on the transition into merged.
- Run triggering loads the project's definitions, selects those with at least one stage subscribing to the derived event, and `TriggerRun`s on the project engine (`Supervisor.For`). The reducer's loop-key guard makes duplicate triggers safe.
- **New-SHA cancel-and-rearm:** PR facts (incl. `head_sha`) are read from the store by url on each event; when the head SHA changed for a `pr.updated` subscriber, `Dispatch(NewSHADetected{…})` terminates the stale run as outdated and frees the loop before the `pr.updated` trigger arms a fresh run at the new SHA.
- Wired into `daemon/pipeline_wiring.go` (single seam for T11's flag); starts with the engines, stops before them on shutdown.

### Fork provenance (migration `0025`)
- Nullable tri-state `pr.is_from_fork` (NULL = unknown, 0 = same-repo, 1 = fork), derived in the SCM observation write path from head-repo vs base-repo, surfaced on `PRFacts`, and mapped onto `ForkYes`/`ForkNo`/`ForkUnknown` in the command-executor adapter instead of a blanket `ForkUnknown`. Unknown stays fail-safe (blocked unless `allowForkPRs`).

### Tests
`pr.opened` triggers a matching definition through a **real engine with a mocked executor** (non-matching does not); merge_ready fires once on transition and on first-seen-ready; merged transition; new-SHA cancel+rearm ordering; async delivery through the broadcaster; fork derivation, is_from_fork/head_sha SQLite round-trip, and the three-state adapter gate.

`cd backend && go test ./... && go vet ./...` green (the 4 pre-existing `internal/cli` spawn-daemon 404 failures reproduce on clean `origin/pipelines` and are unrelated); `-race` clean on all touched packages.

### Scope
No changes to `httpd/**` (T7), CLI, UI, reducer/executor/store contracts. Additive store query only. Upstream untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
