### PR TITLE
feat(pipeline): T10 Runs UI - Kanban workbench, live CDC updates, run detail

### DIFF
--- a/frontend/src/renderer/components/PipelineFilterBar.tsx
+++ b/frontend/src/renderer/components/PipelineFilterBar.tsx
@@ -1,0 +1,58 @@
+import { cn } from "../lib/utils";
+
+// Board filter bar: a pipeline-name multi-select (chip toggles). Empty selection
+// means "show all". The old design also carried a "show dismissed" toggle here,
+// but that only governs findings, which live in the run detail — so it moved
+// there rather than sitting inert on the board.
+export function PipelineFilterBar({
+	availablePipelines,
+	selected,
+	onChange,
+}: {
+	availablePipelines: string[];
+	selected: string[];
+	onChange: (next: string[]) => void;
+}) {
+	const toggle = (name: string) => {
+		const set = new Set(selected);
+		if (set.has(name)) set.delete(name);
+		else set.add(name);
+		onChange([...set]);
+	};
+	const showingAll = selected.length === 0;
+
+	return (
+		<div className="flex flex-wrap items-center gap-2 border-b border-border px-4.5 py-2.5">
+			<span className="text-micro uppercase tracking-wide text-passive">Pipelines</span>
+			{availablePipelines.length === 0 && <span className="text-caption text-passive">(none yet)</span>}
+			{availablePipelines.map((name) => {
+				const active = selected.includes(name);
+				return (
+					<button
+						key={name}
+						type="button"
+						onClick={() => toggle(name)}
+						aria-pressed={active}
+						className={cn(
+							"rounded-full border px-2.5 py-0.5 font-mono text-caption transition-colors",
+							active
+								? "border-accent-dim bg-accent-weak text-accent"
+								: "border-border bg-raised text-muted-foreground hover:text-foreground",
+						)}
+					>
+						{name}
+					</button>
+				);
+			})}
+			{!showingAll && (
+				<button
+					type="button"
+					onClick={() => onChange([])}
+					className="ml-1 text-micro text-passive underline-offset-2 hover:underline"
+				>
+					clear
+				</button>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/PipelineRunCard.tsx
+++ b/frontend/src/renderer/components/PipelineRunCard.tsx
@@ -1,0 +1,56 @@
+import { cn } from "../lib/utils";
+import { formatTimeCompact } from "../lib/format-time";
+import { loopStateTone, shortSha, stageStatusDotTone } from "../lib/pipeline-display";
+import type { PipelineRunSummary } from "../hooks/usePipelineRuns";
+
+// Card view of a single pipeline run in a Kanban column: pipeline name, run id,
+// session, loop rounds, per-stage status dots, artifact/findings hint, and a
+// relative timestamp. The whole card opens the read-only run detail.
+export function PipelineRunCard({ run, onOpen }: { run: PipelineRunSummary; onOpen: () => void }) {
+	const stageNames = Object.keys(run.stageStatuses ?? {}).sort();
+	return (
+		<button
+			type="button"
+			onClick={onOpen}
+			data-run-id={run.runId}
+			className={cn(
+				"flex w-full flex-col gap-1.5 rounded-md border bg-card p-2.5 text-left shadow-sm transition-colors hover:border-border-strong",
+				run.hasOpenFindings ? "border-warning/40" : "border-border",
+			)}
+		>
+			<div className="flex items-baseline gap-2">
+				<span className="truncate font-mono text-caption font-semibold text-foreground">{run.pipelineName}</span>
+				<span className={cn("ml-auto text-micro font-medium", loopStateTone(run.loopState))}>
+					rounds {run.loopRounds}
+				</span>
+			</div>
+			<div className="flex items-center gap-2 font-mono text-micro text-passive">
+				<span className="truncate">{run.sessionId || run.runId}</span>
+				{run.headSha && <span className="shrink-0">· {shortSha(run.headSha)}</span>}
+			</div>
+			{stageNames.length > 0 && (
+				<ul className="flex flex-wrap items-center gap-1.5" aria-label="stage statuses">
+					{stageNames.map((name) => (
+						<li
+							key={name}
+							className="inline-flex items-center gap-1 font-mono text-micro text-muted-foreground"
+							title={`${name}: ${run.stageStatuses?.[name] ?? "pending"}`}
+						>
+							<span
+								className={cn("h-1.5 w-1.5 rounded-full", stageStatusDotTone(run.stageStatuses?.[name] ?? "pending"))}
+							/>
+							<span className="truncate">{name}</span>
+						</li>
+					))}
+				</ul>
+			)}
+			<div className="flex items-center gap-2 text-micro text-passive">
+				<span>
+					{run.stageCount} stage{run.stageCount === 1 ? "" : "s"}
+				</span>
+				{run.hasOpenFindings && <span className="text-warning">· open findings</span>}
+				<span className="ml-auto">{formatTimeCompact(run.updatedAt)}</span>
+			</div>
+		</button>
+	);
+}

--- a/frontend/src/renderer/components/PipelineRunDetail.test.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.test.tsx
@@ -1,0 +1,146 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PipelineRunDetail } from "./PipelineRunDetail";
+import type { PipelineArtifact, PipelineRunDetail as RunDetail } from "../hooks/usePipelineRuns";
+
+const { usePipelineRunMock, postMock } = vi.hoisted(() => ({
+	usePipelineRunMock: vi.fn(),
+	postMock: vi.fn(),
+}));
+
+vi.mock("../hooks/usePipelineRuns", () => ({
+	usePipelineRun: () => usePipelineRunMock(),
+	pipelineRunQueryKey: (runId: string) => ["pipeline-run", runId],
+}));
+vi.mock("../lib/api-client", () => ({
+	apiClient: { POST: (...args: unknown[]) => postMock(...args) },
+	apiErrorMessage: (e: unknown) => (e instanceof Error ? e.message : "error"),
+}));
+
+type StageView = RunDetail["stages"][number];
+
+function stage(overrides: Partial<StageView> & { stageName: string }): StageView {
+	return {
+		stageRunId: `sr-${overrides.stageName}`,
+		status: "succeeded",
+		attempt: 1,
+		artifactIds: [],
+		...overrides,
+	};
+}
+
+function finding(overrides: Partial<PipelineArtifact> & { artifactId: string }): PipelineArtifact {
+	return {
+		kind: "finding",
+		pipelineRunId: "run-1",
+		stageRunId: "sr-1",
+		stageName: "review",
+		status: "open",
+		createdAt: "2026-07-15T00:00:00Z",
+		...overrides,
+	};
+}
+
+function detail(overrides: Partial<RunDetail>): RunDetail {
+	return {
+		runId: "run-1",
+		pipelineId: "def-1",
+		pipelineName: "review",
+		sessionId: "sess-1",
+		loopState: "running",
+		loopRounds: 2,
+		headSha: "abcdef1234567890",
+		stageCount: 1,
+		stageStatuses: { review: "running" },
+		hasOpenFindings: false,
+		findings: [],
+		stages: [],
+		createdAt: "2026-07-15T00:00:00Z",
+		updatedAt: "2026-07-15T00:00:00Z",
+		...overrides,
+	};
+}
+
+function setRun(run: RunDetail) {
+	usePipelineRunMock.mockReturnValue({ data: run, isLoading: false, isError: false, error: null });
+}
+
+function renderDetail(project?: string) {
+	render(
+		<QueryClientProvider client={new QueryClient()}>
+			<PipelineRunDetail runId="run-1" project={project} />
+		</QueryClientProvider>,
+	);
+}
+
+beforeEach(() => {
+	usePipelineRunMock.mockReset();
+	postMock.mockReset().mockResolvedValue({ error: undefined });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("PipelineRunDetail", () => {
+	it("renders each stage with status, attempt, verdict, and error message", () => {
+		setRun(
+			detail({
+				stages: [stage({ stageName: "lint", status: "failed", attempt: 2, verdict: "fail", errorMessage: "exit 1" })],
+			}),
+		);
+		renderDetail("proj-1");
+
+		const row = screen.getByText("lint").closest("[data-stage]") as HTMLElement;
+		expect(within(row).getByText("failed")).toBeInTheDocument();
+		expect(within(row).getByText("attempt 2")).toBeInTheDocument();
+		expect(within(row).getByText("fail")).toBeInTheDocument();
+		expect(within(row).getByText("exit 1")).toBeInTheDocument();
+	});
+
+	it("hides dismissed findings until the show-dismissed toggle is on", async () => {
+		setRun(
+			detail({
+				findings: [
+					finding({ artifactId: "f1", title: "Open bug", filePath: "a.ts", startLine: 10, severity: "high" }),
+					finding({ artifactId: "f2", title: "Dismissed nit", status: "dismissed" }),
+				],
+			}),
+		);
+		renderDetail("proj-1");
+
+		expect(screen.getByText("Open bug")).toBeInTheDocument();
+		expect(screen.getByText("a.ts:10")).toBeInTheDocument();
+		expect(screen.queryByText("Dismissed nit")).not.toBeInTheDocument();
+
+		await userEvent.setup().click(screen.getByRole("switch"));
+		expect(screen.getByText("Dismissed nit")).toBeInTheDocument();
+	});
+
+	it("cancels a running run with the run's project scope", async () => {
+		setRun(detail({ loopState: "running" }));
+		renderDetail("proj-7");
+
+		await userEvent.setup().click(screen.getByRole("button", { name: "Cancel" }));
+
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+		expect(postMock).toHaveBeenCalledWith("/api/v1/pipelines/runs/{runId}/cancel", {
+			params: { path: { runId: "run-1" }, query: { project: "proj-7" } },
+		});
+	});
+
+	it("offers Resume for a stalled run and not Cancel", () => {
+		setRun(detail({ loopState: "stalled" }));
+		renderDetail("proj-1");
+
+		expect(screen.getByRole("button", { name: "Resume" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+	});
+
+	it("disables the action when the run's project is unknown", () => {
+		setRun(detail({ loopState: "running" }));
+		renderDetail(undefined);
+
+		expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+	});
+});

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -1,0 +1,181 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { cn } from "../lib/utils";
+import { formatTimeCompact } from "../lib/format-time";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { loopStateTone, severityBadgeVariant, shortSha, stageStatusDotTone } from "../lib/pipeline-display";
+import { pipelineRunQueryKey, usePipelineRun, type PipelineArtifact } from "../hooks/usePipelineRuns";
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import { Switch } from "./ui/switch";
+
+// Read-only detail for one pipeline run: per-stage state, materialized findings,
+// and cancel/resume actions. No followup thread, no artifact editing — v1 detail
+// is observe-only beyond the two lifecycle buttons.
+export function PipelineRunDetail({ runId, project }: { runId: string; project?: string }) {
+	const queryClient = useQueryClient();
+	const { data: run, isLoading, isError, error } = usePipelineRun(runId);
+	const [showDismissed, setShowDismissed] = useState(false);
+	const [actionError, setActionError] = useState<string | null>(null);
+
+	const refresh = () => {
+		void queryClient.invalidateQueries({ queryKey: pipelineRunQueryKey(runId) });
+		void queryClient.invalidateQueries({ queryKey: ["pipeline-runs"] });
+	};
+
+	const lifecycleMutation = (
+		path: "/api/v1/pipelines/runs/{runId}/cancel" | "/api/v1/pipelines/runs/{runId}/resume",
+	) => ({
+		mutationFn: async () => {
+			if (!project) throw new Error("Project is unknown for this run");
+			const { error: apiError } = await apiClient.POST(path, {
+				params: { path: { runId }, query: { project } },
+			});
+			if (apiError) throw new Error(apiErrorMessage(apiError));
+		},
+		onSuccess: () => {
+			setActionError(null);
+			refresh();
+		},
+		onError: (e: unknown) => setActionError(e instanceof Error ? e.message : "Action failed"),
+	});
+
+	const cancel = useMutation(lifecycleMutation("/api/v1/pipelines/runs/{runId}/cancel"));
+	const resume = useMutation(lifecycleMutation("/api/v1/pipelines/runs/{runId}/resume"));
+
+	const stages = useMemo(() => [...(run?.stages ?? [])].sort((a, b) => a.stageName.localeCompare(b.stageName)), [run]);
+	const findings = useMemo(() => {
+		const list = run?.findings ?? [];
+		return showDismissed ? list : list.filter((f) => f.status !== "dismissed");
+	}, [run, showDismissed]);
+	const dismissedCount = (run?.findings ?? []).filter((f) => f.status === "dismissed").length;
+
+	if (isLoading) {
+		return <p className="p-6 text-caption text-passive">Loading run…</p>;
+	}
+	if (isError || !run) {
+		return (
+			<p className="p-6 text-caption text-error">
+				Could not load run{error instanceof Error ? `: ${error.message}` : ""}.
+			</p>
+		);
+	}
+
+	const canCancel = run.loopState === "running" || run.loopState === "awaiting_context";
+	const canResume = run.loopState === "stalled";
+
+	return (
+		<div className="flex h-full min-h-0 flex-col overflow-y-auto bg-background text-foreground">
+			<header className="flex flex-wrap items-center gap-3 border-b border-border px-6 py-5">
+				<div className="min-w-0">
+					<div className="flex items-center gap-2">
+						<h1 className="truncate text-subtitle font-bold tracking-tight text-foreground">{run.pipelineName}</h1>
+						<span className={cn("text-caption font-semibold", loopStateTone(run.loopState))}>{run.loopState}</span>
+						{run.terminationReason && <span className="text-caption text-passive">· {run.terminationReason}</span>}
+					</div>
+					<p className="mt-0.5 truncate font-mono text-micro text-passive">
+						{run.runId} · session {run.sessionId || "—"} · {shortSha(run.headSha)} · {run.loopRounds} round
+						{run.loopRounds === 1 ? "" : "s"} · updated {formatTimeCompact(run.updatedAt)}
+					</p>
+				</div>
+				<div className="ml-auto flex items-center gap-2">
+					{actionError && <span className="text-caption text-error">{actionError}</span>}
+					{canCancel && (
+						<Button
+							size="sm"
+							variant="outline"
+							disabled={cancel.isPending || !project}
+							title={project ? undefined : "Open this run from the board to cancel it"}
+							onClick={() => cancel.mutate()}
+						>
+							{cancel.isPending ? "Cancelling…" : "Cancel"}
+						</Button>
+					)}
+					{canResume && (
+						<Button
+							size="sm"
+							variant="primary"
+							disabled={resume.isPending || !project}
+							title={project ? undefined : "Open this run from the board to resume it"}
+							onClick={() => resume.mutate()}
+						>
+							{resume.isPending ? "Resuming…" : "Resume"}
+						</Button>
+					)}
+				</div>
+			</header>
+
+			<section aria-label="Stages" className="border-b border-border px-6 py-4">
+				<h2 className="mb-2 text-micro font-semibold uppercase tracking-wide text-passive">Stages</h2>
+				<div className="flex flex-col gap-2">
+					{stages.map((stage) => (
+						<div
+							key={stage.stageRunId || stage.stageName}
+							data-stage={stage.stageName}
+							className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-card px-3 py-2"
+						>
+							<span className={cn("h-2 w-2 shrink-0 rounded-full", stageStatusDotTone(stage.status))} />
+							<span className="font-mono text-caption font-medium text-foreground">{stage.stageName}</span>
+							<span className="font-mono text-micro text-passive">{stage.status}</span>
+							{stage.verdict && <Badge variant="outline">{stage.verdict}</Badge>}
+							<span className="ml-auto font-mono text-micro text-passive">
+								attempt {stage.attempt}
+								{stage.artifactIds.length > 0 &&
+									` · ${stage.artifactIds.length} artifact${stage.artifactIds.length === 1 ? "" : "s"}`}
+							</span>
+							{stage.errorMessage && <p className="w-full font-mono text-micro text-error">{stage.errorMessage}</p>}
+						</div>
+					))}
+					{stages.length === 0 && <p className="text-caption text-passive">No stages yet.</p>}
+				</div>
+			</section>
+
+			<section aria-label="Findings" className="px-6 py-4">
+				<div className="mb-2 flex items-center gap-3">
+					<h2 className="text-micro font-semibold uppercase tracking-wide text-passive">
+						Findings <span className="font-mono text-passive">{findings.length}</span>
+					</h2>
+					{dismissedCount > 0 && (
+						<label className="ml-auto flex items-center gap-2 text-caption text-muted-foreground">
+							<Switch checked={showDismissed} onCheckedChange={setShowDismissed} />
+							Show dismissed ({dismissedCount})
+						</label>
+					)}
+				</div>
+				<div className="flex flex-col gap-2">
+					{findings.map((finding) => (
+						<FindingRow key={finding.artifactId} finding={finding} />
+					))}
+					{findings.length === 0 && <p className="text-caption text-passive">No findings.</p>}
+				</div>
+			</section>
+		</div>
+	);
+}
+
+function FindingRow({ finding }: { finding: PipelineArtifact }) {
+	const location = finding.filePath
+		? `${finding.filePath}${finding.startLine ? `:${finding.startLine}` : ""}`
+		: undefined;
+	return (
+		<div
+			data-finding={finding.artifactId}
+			className={cn(
+				"rounded-md border border-border bg-card px-3 py-2",
+				finding.status === "dismissed" && "opacity-60",
+			)}
+		>
+			<div className="flex flex-wrap items-center gap-2">
+				<span className="truncate text-caption font-medium text-foreground">{finding.title || "(untitled)"}</span>
+				{finding.severity && <Badge variant={severityBadgeVariant(finding.severity)}>{finding.severity}</Badge>}
+				<span className="font-mono text-micro text-passive">{finding.status}</span>
+				{typeof finding.confidence === "number" && (
+					<span className="font-mono text-micro text-passive">· {Math.round(finding.confidence * 100)}%</span>
+				)}
+				<span className="ml-auto font-mono text-micro text-passive">{finding.stageName}</span>
+			</div>
+			{location && <p className="mt-0.5 font-mono text-micro text-passive">{location}</p>}
+			{finding.description && <p className="mt-1 text-micro text-muted-foreground">{finding.description}</p>}
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/PipelineWorkbench.test.tsx
+++ b/frontend/src/renderer/components/PipelineWorkbench.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PipelineWorkbench } from "./PipelineWorkbench";
+import type { PipelineRunSummary } from "../hooks/usePipelineRuns";
+
+const { navigateMock, usePipelineRunsMock } = vi.hoisted(() => ({
+	navigateMock: vi.fn(),
+	usePipelineRunsMock: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => navigateMock }));
+vi.mock("../hooks/usePipelineRuns", () => ({ usePipelineRuns: () => usePipelineRunsMock() }));
+
+function run(overrides: Partial<PipelineRunSummary> & { runId: string }): PipelineRunSummary {
+	return {
+		pipelineId: "def-1",
+		pipelineName: "review",
+		sessionId: "sess-1",
+		loopState: "running",
+		loopRounds: 1,
+		headSha: "abcdef1234567890",
+		stageCount: 2,
+		stageStatuses: { lint: "succeeded", test: "running" },
+		hasOpenFindings: false,
+		createdAt: "2026-07-15T00:00:00Z",
+		updatedAt: "2026-07-15T00:00:00Z",
+		projectId: "proj-1",
+		...overrides,
+	};
+}
+
+function setRuns(runs: PipelineRunSummary[]) {
+	usePipelineRunsMock.mockReturnValue({ runs, isError: false, error: null, isLoading: false });
+}
+
+beforeEach(() => {
+	navigateMock.mockReset();
+	usePipelineRunsMock.mockReset();
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("PipelineWorkbench", () => {
+	it("groups runs into the five loopState columns", () => {
+		setRuns([
+			run({ runId: "r1", pipelineName: "review", loopState: "running" }),
+			run({ runId: "r2", pipelineName: "audit", loopState: "done" }),
+			run({ runId: "r3", pipelineName: "audit", loopState: "stalled" }),
+		]);
+		render(<PipelineWorkbench />);
+
+		expect(within(screen.getByLabelText("Running column")).getByText("review")).toBeInTheDocument();
+		expect(within(screen.getByLabelText("Done column")).getByText("audit")).toBeInTheDocument();
+		expect(within(screen.getByLabelText("Stalled column")).getByText("audit")).toBeInTheDocument();
+		// Empty columns render the placeholder.
+		expect(within(screen.getByLabelText("Terminated column")).getByText("Empty")).toBeInTheDocument();
+	});
+
+	it("renders card fields: pipeline name, rounds, and stage count", () => {
+		setRuns([run({ runId: "r1", pipelineName: "review", loopRounds: 3, stageCount: 2 })]);
+		const { container } = render(<PipelineWorkbench />);
+
+		const card = container.querySelector('[data-run-id="r1"]') as HTMLElement;
+		expect(within(card).getByText("review")).toBeInTheDocument();
+		expect(within(card).getByText("rounds 3")).toBeInTheDocument();
+		expect(within(card).getByText("2 stages")).toBeInTheDocument();
+	});
+
+	it("filters the board to the selected pipeline names", async () => {
+		setRuns([
+			run({ runId: "r1", pipelineName: "review", loopState: "running" }),
+			run({ runId: "r2", pipelineName: "audit", loopState: "running" }),
+		]);
+		render(<PipelineWorkbench />);
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: "review", pressed: false }));
+
+		const running = screen.getByLabelText("Running column");
+		expect(within(running).getByText("review")).toBeInTheDocument();
+		expect(within(running).queryByText("audit")).not.toBeInTheDocument();
+	});
+
+	it("navigates to the run detail with the run's project on card click", async () => {
+		setRuns([run({ runId: "r1", pipelineName: "review", projectId: "proj-9" })]);
+		const { container } = render(<PipelineWorkbench />);
+		const user = userEvent.setup();
+
+		await user.click(container.querySelector('[data-run-id="r1"]') as HTMLElement);
+
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/pipelines/runs/$runId",
+			params: { runId: "r1" },
+			search: { project: "proj-9" },
+		});
+	});
+
+	it("shows an error state when runs fail to load", () => {
+		usePipelineRunsMock.mockReturnValue({
+			runs: [],
+			isError: true,
+			error: new Error("boom"),
+			isLoading: false,
+		});
+		render(<PipelineWorkbench />);
+		expect(screen.getByText(/Could not load pipeline runs: boom/)).toBeInTheDocument();
+	});
+});

--- a/frontend/src/renderer/components/PipelineWorkbench.tsx
+++ b/frontend/src/renderer/components/PipelineWorkbench.tsx
@@ -1,0 +1,103 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { cn } from "../lib/utils";
+import { KANBAN_COLUMNS, type LoopStateName } from "../lib/pipeline-display";
+import { usePipelineRuns, type PipelineRunSummary } from "../hooks/usePipelineRuns";
+import { DashboardSubhead } from "./DashboardSubhead";
+import { PipelineFilterBar } from "./PipelineFilterBar";
+import { PipelineRunCard } from "./PipelineRunCard";
+
+// Runs workbench: a 5-column Kanban grouped by loopState across all projects.
+// Runs stay live through the CDC event transport (pipeline_* → query
+// invalidation); the filter bar narrows to a subset of pipeline names.
+export function PipelineWorkbench() {
+	const navigate = useNavigate();
+	const { runs, isError, error } = usePipelineRuns();
+	const [selectedPipelines, setSelectedPipelines] = useState<string[]>([]);
+
+	const pipelineNames = useMemo(() => {
+		const set = new Set<string>();
+		for (const run of runs) set.add(run.pipelineName);
+		return [...set].sort();
+	}, [runs]);
+
+	const filteredRuns = useMemo(() => {
+		if (selectedPipelines.length === 0) return runs;
+		const allowed = new Set(selectedPipelines);
+		return runs.filter((run) => allowed.has(run.pipelineName));
+	}, [runs, selectedPipelines]);
+
+	const columns = useMemo(() => {
+		const grouped = new Map<LoopStateName, PipelineRunSummary[]>();
+		for (const col of KANBAN_COLUMNS) grouped.set(col.state, []);
+		for (const run of filteredRuns) grouped.get(run.loopState as LoopStateName)?.push(run);
+		// Newest first within a column.
+		for (const list of grouped.values()) {
+			list.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : a.updatedAt > b.updatedAt ? -1 : 0));
+		}
+		return KANBAN_COLUMNS.map((col) => ({ ...col, runs: grouped.get(col.state) ?? [] }));
+	}, [filteredRuns]);
+
+	return (
+		<div className="flex h-full min-h-0 flex-col bg-background text-foreground">
+			<DashboardSubhead
+				title="Pipeline runs"
+				subtitle="Live pipeline runs grouped by loop state across every project."
+				count={filteredRuns.length}
+			/>
+
+			<PipelineFilterBar
+				availablePipelines={pipelineNames}
+				selected={selectedPipelines}
+				onChange={setSelectedPipelines}
+			/>
+
+			{isError ? (
+				<p className="py-10 text-center text-caption text-error">
+					Could not load pipeline runs{error instanceof Error ? `: ${error.message}` : ""}.
+				</p>
+			) : (
+				<div className="grid min-h-0 flex-1 grid-cols-1 gap-3 overflow-auto p-4.5 md:grid-cols-5">
+					{columns.map((col) => (
+						<section
+							key={col.state}
+							aria-label={`${col.title} column`}
+							data-loop-state={col.state}
+							className={cn("flex min-h-40 flex-col rounded-md border-l-2 bg-surface p-2", col.borderClass)}
+						>
+							<header className="px-1 pb-2">
+								<h2 className="flex items-center gap-1.5 text-micro font-semibold uppercase tracking-wide text-muted-foreground">
+									{col.title}
+									<span className="rounded-full bg-raised px-1.5 font-mono text-2xs text-passive">
+										{col.runs.length}
+									</span>
+								</h2>
+								<p className="mt-0.5 text-2xs text-passive">{col.description}</p>
+							</header>
+							<div className="flex flex-1 flex-col gap-2">
+								{col.runs.map((run) => (
+									<PipelineRunCard
+										key={run.runId}
+										run={run}
+										onOpen={() =>
+											void navigate({
+												to: "/pipelines/runs/$runId",
+												params: { runId: run.runId },
+												search: { project: run.projectId },
+											})
+										}
+									/>
+								))}
+								{col.runs.length === 0 && (
+									<div className="rounded border border-dashed border-border p-3 text-center text-2xs text-passive">
+										Empty
+									</div>
+								)}
+							</div>
+						</section>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/renderer/hooks/usePipelineRuns.ts
+++ b/frontend/src/renderer/hooks/usePipelineRuns.ts
@@ -1,0 +1,70 @@
+import { useQueries, useQuery } from "@tanstack/react-query";
+import type { components } from "../../api/schema";
+import { apiClient, hasTrustedApiBaseUrl } from "../lib/api-client";
+import { useWorkspaceQuery } from "./useWorkspaceQuery";
+
+// A run summary tagged with the project it belongs to. The pipelines runs API is
+// project-scoped (`?project=ID`), but the Runs section aggregates across every
+// project (like the PR board), so each row carries its projectId for the
+// cancel/resume calls, which are also project-scoped.
+export type PipelineRunSummary = components["schemas"]["PipelineRunSummary"] & { projectId: string };
+export type PipelineRunDetail = components["schemas"]["PipelineRunDetail"];
+export type PipelineArtifact = components["schemas"]["PipelineArtifact"];
+
+// Query keys. Every pipeline key is prefixed "pipeline-" so the event transport
+// can invalidate the whole family with one predicate on a pipeline_* CDC event.
+export function pipelineRunsQueryKey(projectId: string) {
+	return ["pipeline-runs", projectId] as const;
+}
+export function pipelineRunQueryKey(runId: string) {
+	return ["pipeline-run", runId] as const;
+}
+
+function runsQueryOptions(projectId: string) {
+	return {
+		queryKey: pipelineRunsQueryKey(projectId),
+		queryFn: async (): Promise<PipelineRunSummary[]> => {
+			if (!hasTrustedApiBaseUrl()) return [];
+			const { data, error } = await apiClient.GET("/api/v1/pipelines/runs", {
+				params: { query: { project: projectId } },
+			});
+			if (error) throw error;
+			return (data?.runs ?? []).map((run) => ({ ...run, projectId }));
+		},
+		retry: 1,
+		refetchInterval: 15_000,
+	};
+}
+
+// Aggregated runs across all projects. Fans one runs query out per project and
+// flattens; live invalidation comes from the CDC event transport, the interval
+// is only a backstop.
+export function usePipelineRuns() {
+	const workspaceQuery = useWorkspaceQuery();
+	const projects = workspaceQuery.data ?? [];
+	const runQueries = useQueries({ queries: projects.map((project) => runsQueryOptions(project.id)) });
+	const runs = runQueries.flatMap((query) => query.data ?? []);
+	return {
+		runs,
+		isLoading: workspaceQuery.isLoading || runQueries.some((query) => query.isLoading),
+		isError: workspaceQuery.isError || runQueries.some((query) => query.isError),
+		error: workspaceQuery.error ?? runQueries.find((query) => query.error)?.error ?? null,
+	};
+}
+
+// One run's full detail (stages + findings). GET run detail is not project-scoped.
+export function usePipelineRun(runId: string) {
+	return useQuery({
+		queryKey: pipelineRunQueryKey(runId),
+		queryFn: async (): Promise<PipelineRunDetail> => {
+			const { data, error } = await apiClient.GET("/api/v1/pipelines/runs/{runId}", {
+				params: { path: { runId } },
+			});
+			if (error) throw error;
+			if (!data?.run) throw new Error("Run not found");
+			return data.run;
+		},
+		retry: 1,
+		refetchInterval: 10_000,
+	});
+}

--- a/frontend/src/renderer/lib/event-transport.test.ts
+++ b/frontend/src/renderer/lib/event-transport.test.ts
@@ -40,12 +40,17 @@ class EventSourceStub {
 	onerror: (() => void) | null = null;
 	onmessage: (() => void) | null = null;
 	listeners: string[] = [];
+	handlers: Record<string, () => void> = {};
 	constructor(url: string) {
 		this.url = url;
 		EventSourceStub.instances.push(this);
 	}
-	addEventListener(type: string) {
+	addEventListener(type: string, handler: () => void) {
 		this.listeners.push(type);
+		this.handlers[type] = handler;
+	}
+	emit(type: string) {
+		this.handlers[type]?.();
 	}
 	close() {
 		this.closed = true;
@@ -131,6 +136,35 @@ describe("createEventTransport", () => {
 			vi.advanceTimersByTime(200);
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["workspaces"] });
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-scm-summary"] });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("invalidates the pipeline query family on a pipeline_* event, debounced", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			createEventTransport(queryClient).connect();
+			const source = EventSourceStub.instances[0];
+			// All four pipeline event types are subscribed alongside the CDC ones.
+			expect(source.listeners).toContain("pipeline_run_updated");
+			expect(source.listeners).toContain("pipeline_stage_run_updated");
+			expect(source.listeners).toContain("pipeline_artifact_updated");
+			expect(source.listeners).toContain("pipeline_definition_changed");
+
+			source.emit("pipeline_run_updated");
+			expect(queryClient.invalidateQueries).not.toHaveBeenCalled();
+			vi.advanceTimersByTime(200);
+
+			const call = (queryClient.invalidateQueries as ReturnType<typeof vi.fn>).mock.calls.find(
+				(args) => typeof (args[0] as { predicate?: unknown })?.predicate === "function",
+			);
+			expect(call).toBeTruthy();
+			const predicate = (call![0] as { predicate: (q: { queryKey: readonly unknown[] }) => boolean }).predicate;
+			expect(predicate({ queryKey: ["pipeline-runs", "proj-1"] })).toBe(true);
+			expect(predicate({ queryKey: ["pipeline-run", "run-1"] })).toBe(true);
+			expect(predicate({ queryKey: ["workspaces"] })).toBe(false);
 		} finally {
 			vi.useRealTimers();
 		}

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -33,6 +33,22 @@ const CDC_EVENT_TYPES = [
 	"pr_review_thread_resolved",
 ] as const;
 
+// Pipeline CDC events (backend/internal/cdc/event.go) ride the same SSE stream
+// but change only pipeline state, so they invalidate the pipeline query family
+// rather than the workspace/session lists. Every pipeline query key is prefixed
+// "pipeline-" (see hooks/usePipelineRuns, T9 definitions), so one predicate
+// covers runs, run detail, and definitions.
+const PIPELINE_EVENT_TYPES = [
+	"pipeline_definition_changed",
+	"pipeline_run_updated",
+	"pipeline_stage_run_updated",
+	"pipeline_artifact_updated",
+] as const;
+
+function isPipelineQueryKey(queryKey: readonly unknown[]): boolean {
+	return typeof queryKey[0] === "string" && queryKey[0].startsWith("pipeline");
+}
+
 /**
  * Wires live server state into the TanStack Query cache. Two sources feed it:
  *   - daemon lifecycle over Electron IPC (coming up/down changes session availability)
@@ -44,6 +60,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 	return {
 		connect() {
 			let debounce: ReturnType<typeof setTimeout> | undefined;
+			let pipelineDebounce: ReturnType<typeof setTimeout> | undefined;
 			let retryTimer: ReturnType<typeof setTimeout> | undefined;
 			let source: EventSource | undefined;
 			let sourceBaseUrl: string | undefined;
@@ -52,6 +69,12 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 				debounce = setTimeout(() => {
 					void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
 					void queryClient.invalidateQueries({ queryKey: sessionScmSummaryQueryKey() });
+				}, INVALIDATE_DEBOUNCE_MS);
+			};
+			const refreshPipelines = () => {
+				if (pipelineDebounce) clearTimeout(pipelineDebounce);
+				pipelineDebounce = setTimeout(() => {
+					void queryClient.invalidateQueries({ predicate: (query) => isPipelineQueryKey(query.queryKey) });
 				}, INVALIDATE_DEBOUNCE_MS);
 			};
 
@@ -98,6 +121,9 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 					for (const type of CDC_EVENT_TYPES) {
 						source.addEventListener(type, refreshWorkspaces);
 					}
+					for (const type of PIPELINE_EVENT_TYPES) {
+						source.addEventListener(type, refreshPipelines);
+					}
 					// EventSource auto-reconnects and resumes via Last-Event-ID while
 					// CONNECTING; scheduleRetry only covers the terminal CLOSED state.
 				} catch {
@@ -116,6 +142,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 
 			return () => {
 				if (debounce) clearTimeout(debounce);
+				if (pipelineDebounce) clearTimeout(pipelineDebounce);
 				if (retryTimer) clearTimeout(retryTimer);
 				removeDaemonListener();
 				removeBaseUrlListener();

--- a/frontend/src/renderer/lib/pipeline-display.ts
+++ b/frontend/src/renderer/lib/pipeline-display.ts
@@ -1,0 +1,83 @@
+// Shared presentation helpers for the pipeline Runs UI: the fixed 5-column
+// Kanban layout (grouped by loopState), plus status/severity → tone maps used by
+// the workbench cards and the read-only run detail. Ported from the old
+// PipelineWorkbench/PipelineRunCard information design, restyled to AO tokens.
+
+export type LoopStateName = "running" | "awaiting_context" | "done" | "stalled" | "terminated";
+
+export type KanbanColumn = {
+	state: LoopStateName;
+	title: string;
+	description: string;
+	// Tailwind class for the column's 2px left accent border.
+	borderClass: string;
+};
+
+// Column order and copy are fixed; the board renders exactly these five in this
+// order regardless of which states currently have runs.
+export const KANBAN_COLUMNS: readonly KanbanColumn[] = [
+	{ state: "running", title: "Running", description: "Stage executing", borderClass: "border-l-working" },
+	{
+		state: "awaiting_context",
+		title: "Awaiting context",
+		description: "Stage paused for input",
+		borderClass: "border-l-warning",
+	},
+	{ state: "done", title: "Done", description: "All stages succeeded", borderClass: "border-l-success" },
+	{ state: "stalled", title: "Stalled", description: "Failed stages — resume to retry", borderClass: "border-l-error" },
+	{ state: "terminated", title: "Terminated", description: "Cancelled or superseded", borderClass: "border-l-border" },
+] as const;
+
+// A run's loopState → the dot/text tone used on its card header.
+export function loopStateTone(state: string): string {
+	switch (state) {
+		case "running":
+			return "text-working";
+		case "awaiting_context":
+			return "text-warning";
+		case "done":
+			return "text-success";
+		case "stalled":
+			return "text-error";
+		case "terminated":
+		default:
+			return "text-passive";
+	}
+}
+
+// Per-stage status → the small status dot's background tone.
+export function stageStatusDotTone(status: string): string {
+	switch (status) {
+		case "succeeded":
+			return "bg-success";
+		case "running":
+			return "bg-working";
+		case "failed":
+			return "bg-error";
+		case "skipped":
+			return "bg-passive";
+		case "outdated":
+			return "bg-muted-foreground";
+		case "pending":
+		default:
+			return "bg-muted-foreground";
+	}
+}
+
+// Finding severity → a Badge variant. Unknown/empty severities read as neutral.
+export function severityBadgeVariant(severity: string | undefined): "error" | "warning" | "neutral" {
+	switch ((severity ?? "").toLowerCase()) {
+		case "critical":
+		case "high":
+			return "error";
+		case "medium":
+			return "warning";
+		default:
+			return "neutral";
+	}
+}
+
+// A short commit reference for a run header.
+export function shortSha(sha: string): string {
+	return sha.length > 12 ? sha.slice(0, 12) : sha;
+}

--- a/frontend/src/renderer/routes/_shell.pipelines.runs.tsx
+++ b/frontend/src/renderer/routes/_shell.pipelines.runs.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { PipelineWorkbench } from "../components/PipelineWorkbench";
+
+export const Route = createFileRoute("/_shell/pipelines/runs")({
+	component: PipelineWorkbench,
+});

--- a/frontend/src/renderer/routes/_shell.pipelines.runs_.$runId.tsx
+++ b/frontend/src/renderer/routes/_shell.pipelines.runs_.$runId.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { PipelineRunDetail } from "../components/PipelineRunDetail";
+
+// Trailing underscore on `runs_` opts the detail out of the runs workbench
+// layout, so it renders as its own full-screen view rather than inside the
+// Kanban. `project` scopes the cancel/resume calls (they are project-scoped);
+// it is threaded in when navigating from a board card.
+export const Route = createFileRoute("/_shell/pipelines/runs_/$runId")({
+	validateSearch: (search: Record<string, unknown>): { project?: string } => ({
+		project: typeof search.project === "string" ? search.project : undefined,
+	}),
+	component: RunDetailRoute,
+});
+
+function RunDetailRoute() {
+	const { runId } = Route.useParams();
+	const { project } = Route.useSearch();
+	return <PipelineRunDetail runId={runId} project={project} />;
+}


### PR DESCRIPTION
Implements **T10** of the Pipelines v1 reimplementation (spec §7/§8): the Runs workbench, live updates over the existing CDC transport, and a read-only run detail view. Base branch is `pipelines`.

## What's here
- **Workbench Kanban** (`PipelineWorkbench`): 5 columns grouped by `loopState` (running / awaiting_context / done / stalled / terminated), aggregated across every project (like the PR board), with a pipeline-name multiselect filter bar. Cards show pipeline name, run id/session, loop rounds, per-stage status dots, stage/findings counts, and a relative timestamp. Restyled to the AO design system from shadcn primitives + tokens (old CSS not copied).
- **Read-only run detail** (`PipelineRunDetail`, route `/pipelines/runs/$runId`): per-stage state (status, attempt, verdict, error message), materialized findings (title, `file:line`, severity, status, confidence) with a **show-dismissed** toggle, and **Cancel/Resume** buttons wired to the T7 endpoints (project-scoped, plain invalidation, no optimistic updates). No followup thread, no artifact editing (deferred to phase 2).
- **Live updates**: `lib/event-transport.ts` now invalidates the pipeline query family on the four `pipeline_*` CDC events, debounced, via one predicate on the `pipeline-` key prefix. No new EventSource, no polling.

## Notes / decisions
- **Cross-project aggregation**: the runs API is project-scoped, but the Runs section is top-level, so runs are fanned out per project and merged; each row carries its `projectId` for the project-scoped cancel/resume calls. The detail route reads `project` from a search param; when absent, the lifecycle buttons are disabled.
- **`show-dismissed` placement**: moved from the board to the run detail, where findings actually live.
- `routeTree.gen.ts` is generated (in `.prettierignore`, absent from the branch) and intentionally **not** committed, keeping non-generated files disjoint from T9.
- Did not touch `Sidebar.tsx`, `_shell.pipelines.tsx`, or `_shell.pipelines.index.tsx` (T9's scope); routes stand alone under `/pipelines` so the trees compose.

## Tests
Component tests: Kanban grouping by loopState, card fields, filter behavior, card to detail navigation, run detail (stages + findings + show-dismissed), cancel/resume calls, and `pipeline_*` event invalidation. Full frontend suite green (607 tests); typecheck clean; prettier-clean on touched files.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
