### PR TITLE
feat(pipeline): T9 UI — Definitions tab (CodeMirror 6 YAML editor + CRUD)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,12 @@
 			"version": "0.10.3",
 			"license": "MIT",
 			"dependencies": {
+				"@codemirror/commands": "^6.10.4",
+				"@codemirror/lang-yaml": "^6.1.3",
+				"@codemirror/language": "^6.12.4",
+				"@codemirror/state": "^6.7.1",
+				"@codemirror/view": "^6.43.6",
+				"@lezer/highlight": "^1.2.3",
 				"@radix-ui/react-dialog": "^1.1.16",
 				"@radix-ui/react-slot": "^1.2.5",
 				"@radix-ui/react-tabs": "^1.1.14",
@@ -427,6 +433,80 @@
 			},
 			"bin": {
 				"specificity": "bin/cli.js"
+			}
+		},
+		"node_modules/@codemirror/autocomplete": {
+			"version": "6.20.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+			"integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.17.0",
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/commands": {
+			"version": "6.10.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+			"integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.7.0",
+				"@codemirror/view": "^6.27.0",
+				"@lezer/common": "^1.1.0"
+			}
+		},
+		"node_modules/@codemirror/lang-yaml": {
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+			"integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/autocomplete": "^6.0.0",
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@lezer/common": "^1.2.0",
+				"@lezer/highlight": "^1.2.0",
+				"@lezer/lr": "^1.0.0",
+				"@lezer/yaml": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/language": {
+			"version": "6.12.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+			"integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.23.0",
+				"@lezer/common": "^1.5.0",
+				"@lezer/highlight": "^1.0.0",
+				"@lezer/lr": "^1.0.0",
+				"style-mod": "^4.0.0"
+			}
+		},
+		"node_modules/@codemirror/state": {
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+			"integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+			"license": "MIT",
+			"dependencies": {
+				"@marijn/find-cluster-break": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/view": {
+			"version": "6.43.6",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+			"integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.7.0",
+				"crelt": "^1.0.6",
+				"style-mod": "^4.1.0",
+				"w3c-keyname": "^2.2.4"
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
@@ -3153,6 +3233,41 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@lezer/common": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+			"integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+			"license": "MIT"
+		},
+		"node_modules/@lezer/highlight": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+			"integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.3.0"
+			}
+		},
+		"node_modules/@lezer/lr": {
+			"version": "1.4.10",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+			"integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@lezer/yaml": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+			"integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.2.0",
+				"@lezer/highlight": "^1.0.0",
+				"@lezer/lr": "^1.4.0"
+			}
+		},
 		"node_modules/@listr2/prompt-adapter-inquirer": {
 			"version": "2.0.22",
 			"resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-2.0.22.tgz",
@@ -3259,6 +3374,12 @@
 			"engines": {
 				"node": ">= 10.0.0"
 			}
+		},
+		"node_modules/@marijn/find-cluster-break": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+			"integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+			"license": "MIT"
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "1.1.4",
@@ -8390,6 +8511,12 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/crelt": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+			"integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
 			"license": "MIT"
 		},
 		"node_modules/cross-dirname": {
@@ -14476,6 +14603,12 @@
 				"node": ">=0.8.0"
 			}
 		},
+		"node_modules/style-mod": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+			"license": "MIT"
+		},
 		"node_modules/sumchecker": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -15392,6 +15525,12 @@
 					"optional": false
 				}
 			}
+		},
+		"node_modules/w3c-keyname": {
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+			"license": "MIT"
 		},
 		"node_modules/w3c-xmlserializer": {
 			"version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,12 @@
 		"vitest": "^4.1.8"
 	},
 	"dependencies": {
+		"@codemirror/commands": "^6.10.4",
+		"@codemirror/lang-yaml": "^6.1.3",
+		"@codemirror/language": "^6.12.4",
+		"@codemirror/state": "^6.7.1",
+		"@codemirror/view": "^6.43.6",
+		"@lezer/highlight": "^1.2.3",
 		"@radix-ui/react-dialog": "^1.1.16",
 		"@radix-ui/react-slot": "^1.2.5",
 		"@radix-ui/react-tabs": "^1.1.14",

--- a/frontend/src/renderer/components/PipelineDefinitionsPage.test.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.test.tsx
@@ -1,0 +1,137 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PipelineDefinitionsPage } from "./PipelineDefinitionsPage";
+
+const { getMock, postMock, putMock, deleteMock } = vi.hoisted(() => ({
+	getMock: vi.fn(),
+	postMock: vi.fn(),
+	putMock: vi.fn(),
+	deleteMock: vi.fn(),
+}));
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: {
+		GET: (...args: unknown[]) => getMock(...args),
+		POST: (...args: unknown[]) => postMock(...args),
+		PUT: (...args: unknown[]) => putMock(...args),
+		DELETE: (...args: unknown[]) => deleteMock(...args),
+	},
+	apiErrorMessage: (e: unknown) => (e instanceof Error ? e.message : "error"),
+}));
+
+// CodeMirror needs a real layout engine jsdom lacks; swap it for a textarea so
+// the CRUD/validation flow is what's under test, not the editor internals.
+vi.mock("./YamlEditor", () => ({
+	YamlEditor: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+		<textarea aria-label="Pipeline YAML" value={value} onChange={(e) => onChange(e.target.value)} />
+	),
+}));
+
+const def = (id: string, name: string, yamlSource: string) => ({
+	id,
+	projectId: "proj-1",
+	name,
+	yamlSource,
+	createdAt: "2026-07-01T00:00:00Z",
+	updatedAt: "2026-07-10T00:00:00Z",
+});
+
+const TWO_STAGE_YAML = "name: review\nstages:\n  - name: a\n  - name: b\n";
+
+function renderPage() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	render(
+		<QueryClientProvider client={client}>
+			<PipelineDefinitionsPage projectId="proj-1" />
+		</QueryClientProvider>,
+	);
+}
+
+beforeEach(() => {
+	getMock.mockReset().mockResolvedValue({
+		data: { definitions: [def("pl-1", "review", TWO_STAGE_YAML)] },
+		error: undefined,
+	});
+	postMock.mockReset().mockResolvedValue({ data: { definition: def("pl-2", "new", "name: new\n") }, error: undefined });
+	putMock
+		.mockReset()
+		.mockResolvedValue({ data: { definition: def("pl-1", "review", TWO_STAGE_YAML) }, error: undefined });
+	deleteMock.mockReset().mockResolvedValue({ data: { id: "pl-1", deleted: true }, error: undefined });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("PipelineDefinitionsPage", () => {
+	it("lists definitions with a derived stage count", async () => {
+		renderPage();
+		const row = (await screen.findByText("review")).closest("tr")!;
+		expect(within(row).getByText("2")).toBeInTheDocument();
+		expect(getMock).toHaveBeenCalledWith("/api/v1/pipelines", { params: { query: { project: "proj-1" } } });
+	});
+
+	it("creates a definition through the editor and returns to the list", async () => {
+		renderPage();
+		await screen.findByText("review");
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: /New pipeline/ }));
+		const editor = screen.getByLabelText("Pipeline YAML");
+		await user.clear(editor);
+		await user.type(editor, "name: created");
+		await user.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+		expect(postMock).toHaveBeenCalledWith("/api/v1/pipelines", {
+			params: { query: { project: "proj-1" } },
+			body: { yamlSource: "name: created" },
+		});
+		// Back to the list view.
+		await screen.findByRole("button", { name: /New pipeline/ });
+	});
+
+	it("surfaces each validation issue inline and keeps the buffer", async () => {
+		postMock.mockResolvedValue({
+			data: undefined,
+			error: {
+				code: "PIPELINE_VALIDATION_FAILED",
+				message: "pipeline definition is invalid",
+				details: {
+					issues: [
+						{ path: "stages[0].name", message: "is required" },
+						{ path: "name", message: "must not be empty" },
+					],
+				},
+			},
+		});
+		renderPage();
+		await screen.findByText("review");
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: /New pipeline/ }));
+		await user.click(screen.getByRole("button", { name: "Save" }));
+
+		expect(await screen.findByText("2 validation issues")).toBeInTheDocument();
+		expect(screen.getByText("stages[0].name")).toBeInTheDocument();
+		expect(screen.getByText("is required")).toBeInTheDocument();
+		expect(screen.getByText("must not be empty")).toBeInTheDocument();
+		// Buffer intact; the editor is still open.
+		expect(screen.getByLabelText("Pipeline YAML")).toBeInTheDocument();
+	});
+
+	it("confirms before deleting a definition", async () => {
+		renderPage();
+		await screen.findByText("review");
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: /Delete review/ }));
+		expect(deleteMock).not.toHaveBeenCalled();
+
+		await user.click(screen.getByRole("button", { name: "Delete" }));
+		await waitFor(() => expect(deleteMock).toHaveBeenCalledTimes(1));
+		expect(deleteMock).toHaveBeenCalledWith("/api/v1/pipelines/{id}", { params: { path: { id: "pl-1" } } });
+	});
+});

--- a/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
@@ -1,0 +1,243 @@
+import { useState } from "react";
+import { AlertCircle, Loader2, Pencil, Plus, Trash2 } from "lucide-react";
+import { apiErrorMessage } from "../lib/api-client";
+import { formatTimeCompact } from "../lib/format-time";
+import {
+	countStagesFromYaml,
+	DEFAULT_PIPELINE_YAML,
+	parsePipelineValidationIssues,
+	type PipelineValidationIssue,
+} from "../lib/pipeline-yaml";
+import {
+	type PipelineDefinitionSummary,
+	usePipelineDefinitionMutations,
+	usePipelineDefinitionsQuery,
+} from "../hooks/usePipelineDefinitions";
+import { ConfirmDialog } from "./ConfirmDialog";
+import { YamlEditor } from "./YamlEditor";
+import { Button } from "./ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./ui/table";
+
+// One of: browsing the list, editing an existing definition, or drafting a new
+// one. The editor buffer lives in EditorView while a draft is open, so switching
+// modes here is what mounts/unmounts the CodeMirror instance.
+type Mode = { kind: "list" } | { kind: "edit"; def: PipelineDefinitionSummary } | { kind: "create" };
+
+// The Definitions tab: a list of the project's stored pipelines plus a CodeMirror
+// YAML editor for create/update. Server-side validation is authoritative; on
+// save we surface the daemon's per-issue error list inline and keep the buffer.
+export function PipelineDefinitionsPage({ projectId }: { projectId?: string }) {
+	const definitionsQuery = usePipelineDefinitionsQuery(projectId);
+	const [mode, setMode] = useState<Mode>({ kind: "list" });
+
+	if (mode.kind !== "list" && projectId) {
+		return (
+			<DefinitionEditor
+				projectId={projectId}
+				def={mode.kind === "edit" ? mode.def : null}
+				onClose={() => setMode({ kind: "list" })}
+			/>
+		);
+	}
+
+	const definitions = definitionsQuery.data ?? [];
+
+	return (
+		<div className="flex h-full min-h-0 flex-col">
+			<div className="flex items-center justify-between px-4.5 pt-4">
+				<p className="text-md-sm text-passive">
+					Pipeline definitions authored as YAML. A run snapshots its definition at trigger time.
+				</p>
+				<Button size="sm" variant="primary" disabled={!projectId} onClick={() => setMode({ kind: "create" })}>
+					<Plus className="size-icon-md" aria-hidden="true" />
+					New pipeline
+				</Button>
+			</div>
+
+			<div className="min-h-0 flex-1 overflow-y-auto p-4.5">
+				{!projectId ? (
+					<p className="py-10 text-center text-xs text-passive">Select a project to view its pipelines.</p>
+				) : definitionsQuery.isLoading ? (
+					<p className="py-10 text-center text-xs text-passive">Loading pipelines…</p>
+				) : definitionsQuery.isError ? (
+					<p className="py-10 text-center text-xs text-error">
+						Could not load pipelines. {apiErrorMessage(definitionsQuery.error)}
+					</p>
+				) : definitions.length === 0 ? (
+					<p className="py-10 text-center text-xs text-passive">
+						No pipelines yet. Click <span className="text-foreground">New pipeline</span> to author one.
+					</p>
+				) : (
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Name</TableHead>
+								<TableHead className="w-24 text-right">Stages</TableHead>
+								<TableHead className="w-32">Updated</TableHead>
+								<TableHead className="w-24 text-right">Actions</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{definitions.map((def) => (
+								<DefinitionRow
+									key={def.id}
+									def={def}
+									projectId={projectId}
+									onEdit={() => setMode({ kind: "edit", def })}
+								/>
+							))}
+						</TableBody>
+					</Table>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function DefinitionRow({
+	def,
+	projectId,
+	onEdit,
+}: {
+	def: PipelineDefinitionSummary;
+	projectId: string;
+	onEdit: () => void;
+}) {
+	const { remove } = usePipelineDefinitionMutations(projectId);
+	const [confirmOpen, setConfirmOpen] = useState(false);
+	const stageCount = countStagesFromYaml(def.yamlSource);
+
+	return (
+		<TableRow className="cursor-pointer" onClick={onEdit}>
+			<TableCell className="max-w-0">
+				<div className="truncate text-control text-foreground">{def.name || "(unnamed)"}</div>
+				<div className="truncate font-mono text-micro text-passive">{def.id}</div>
+			</TableCell>
+			<TableCell className="text-right font-mono text-xs text-muted-foreground">{stageCount ?? "-"}</TableCell>
+			<TableCell className="text-caption text-passive">{formatTimeCompact(def.updatedAt)}</TableCell>
+			<TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
+				<div className="flex items-center justify-end gap-1">
+					<Button size="sm" variant="ghost" className="h-6 px-2 text-caption" onClick={onEdit}>
+						<Pencil className="size-icon-sm" aria-hidden="true" />
+						Edit
+					</Button>
+					<Button
+						size="sm"
+						variant="ghost"
+						className="h-6 px-2 text-caption text-destructive hover:text-destructive"
+						onClick={() => setConfirmOpen(true)}
+						aria-label={`Delete ${def.name || def.id}`}
+					>
+						<Trash2 className="size-icon-sm" aria-hidden="true" />
+					</Button>
+				</div>
+				<ConfirmDialog
+					open={confirmOpen}
+					onOpenChange={(open) => {
+						if (!remove.isPending) setConfirmOpen(open);
+					}}
+					title="Delete pipeline"
+					description={
+						<p className="text-sm text-muted-foreground">
+							Delete <strong className="text-foreground">{def.name || def.id}</strong>? Runs already triggered keep
+							their snapshot; this only removes the definition.
+						</p>
+					}
+					confirmLabel={remove.isPending ? "Deleting…" : "Delete"}
+					destructive
+					busy={remove.isPending}
+					error={remove.isError ? apiErrorMessage(remove.error) : null}
+					size="sm"
+					onConfirm={() =>
+						remove.mutate(def.id, {
+							onSuccess: () => setConfirmOpen(false),
+						})
+					}
+				/>
+			</TableCell>
+		</TableRow>
+	);
+}
+
+function DefinitionEditor({
+	projectId,
+	def,
+	onClose,
+}: {
+	projectId: string;
+	def: PipelineDefinitionSummary | null;
+	onClose: () => void;
+}) {
+	const { create, update } = usePipelineDefinitionMutations(projectId);
+	const [draft, setDraft] = useState(def ? def.yamlSource : DEFAULT_PIPELINE_YAML);
+	const [issues, setIssues] = useState<PipelineValidationIssue[] | null>(null);
+	const [genericError, setGenericError] = useState<string | null>(null);
+
+	const mutation = def ? update : create;
+	const isSaving = mutation.isPending;
+
+	const save = () => {
+		setIssues(null);
+		setGenericError(null);
+		const onError = (error: unknown) => {
+			const parsed = parsePipelineValidationIssues(error);
+			if (parsed) setIssues(parsed);
+			else setGenericError(apiErrorMessage(error));
+		};
+		if (def) update.mutate({ id: def.id, yamlSource: draft }, { onSuccess: onClose, onError });
+		else create.mutate(draft, { onSuccess: onClose, onError });
+	};
+
+	return (
+		<div className="flex h-full min-h-0 flex-col">
+			<div className="flex items-center justify-between gap-3 border-b border-border px-4.5 py-3">
+				<div className="min-w-0">
+					<h2 className="truncate text-control font-semibold text-foreground">
+						{def ? `Edit ${def.name || def.id}` : "New pipeline"}
+					</h2>
+					<p className="text-caption text-passive">YAML validated on save by the daemon.</p>
+				</div>
+				<div className="flex shrink-0 items-center gap-2">
+					<Button size="sm" variant="ghost" onClick={onClose} disabled={isSaving}>
+						Cancel
+					</Button>
+					<Button size="sm" variant="primary" onClick={save} disabled={isSaving}>
+						{isSaving && <Loader2 className="size-icon-sm animate-spin" aria-hidden="true" />}
+						{isSaving ? "Saving…" : "Save"}
+					</Button>
+				</div>
+			</div>
+
+			<div className="min-h-0 flex-1 overflow-hidden bg-surface/40">
+				<YamlEditor value={draft} onChange={setDraft} aria-label="Pipeline YAML" className="px-1 py-2" />
+			</div>
+
+			{genericError && (
+				<div className="flex items-start gap-2 border-t border-destructive/40 bg-destructive/10 px-4.5 py-2.5 text-caption text-destructive">
+					<AlertCircle className="mt-0.5 size-icon-sm shrink-0" aria-hidden="true" />
+					<span>{genericError}</span>
+				</div>
+			)}
+
+			{issues && (
+				<div className="max-h-48 shrink-0 overflow-y-auto border-t border-warning/40 bg-warning/10 px-4.5 py-3">
+					<p className="mb-1.5 flex items-center gap-1.5 text-caption font-semibold text-warning">
+						<AlertCircle className="size-icon-sm" aria-hidden="true" />
+						{issues.length === 0
+							? "Validation failed"
+							: `${issues.length} validation ${issues.length === 1 ? "issue" : "issues"}`}
+					</p>
+					<ul className="space-y-1">
+						{issues.map((issue, i) => (
+							<li key={`${issue.path}-${i}`} className="text-caption text-foreground">
+								{issue.path && <span className="font-mono text-warning">{issue.path}</span>}
+								{issue.path && ": "}
+								<span className="text-muted-foreground">{issue.message}</span>
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
 	Smartphone,
 	Sun,
 	Trash2,
+	Workflow,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { UpdateStatus } from "../../main/update-settings";
@@ -112,6 +113,7 @@ function useSelection() {
 		activeSessionId: params.sessionId,
 		goHome: () => void navigate({ to: "/" }),
 		goPrs: () => void navigate({ to: "/prs" }),
+		goPipelines: () => void navigate({ to: "/pipelines" }),
 		goGlobalSettings: () => void navigate({ to: "/settings" }),
 		goSettings: (projectId: string) => void navigate({ to: "/projects/$projectId/settings", params: { projectId } }),
 		goProject: (projectId: string) => void navigate({ to: "/projects/$projectId", params: { projectId } }),
@@ -377,6 +379,10 @@ export function Sidebar({
 								<GitPullRequest aria-hidden="true" />
 								Pull requests
 							</DropdownMenuItem>
+							<DropdownMenuItem onSelect={selection.goPipelines}>
+								<Workflow aria-hidden="true" />
+								Pipelines
+							</DropdownMenuItem>
 							<DropdownMenuItem disabled>
 								<Search aria-hidden="true" />
 								Search
@@ -446,6 +452,10 @@ export function Sidebar({
 							<DropdownMenuItem onSelect={selection.goPrs}>
 								<GitPullRequest aria-hidden="true" />
 								Pull requests
+							</DropdownMenuItem>
+							<DropdownMenuItem onSelect={selection.goPipelines}>
+								<Workflow aria-hidden="true" />
+								Pipelines
 							</DropdownMenuItem>
 							<DropdownMenuItem disabled>
 								<Search aria-hidden="true" />

--- a/frontend/src/renderer/components/YamlEditor.tsx
+++ b/frontend/src/renderer/components/YamlEditor.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef } from "react";
+import { EditorState } from "@codemirror/state";
+import {
+	EditorView,
+	drawSelection,
+	highlightActiveLine,
+	highlightActiveLineGutter,
+	keymap,
+	lineNumbers,
+} from "@codemirror/view";
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+import { HighlightStyle, bracketMatching, indentOnInput, syntaxHighlighting } from "@codemirror/language";
+import { tags } from "@lezer/highlight";
+import { yaml } from "@codemirror/lang-yaml";
+import { cn } from "../lib/utils";
+
+// Syntax colours keyed to the app tokens so the editor tracks light/dark with
+// the rest of the renderer (refined-blue accent for keys, muted for comments).
+const highlightStyle = HighlightStyle.define([
+	{ tag: [tags.definition(tags.propertyName), tags.propertyName, tags.keyword], color: "var(--color-primary)" },
+	{ tag: [tags.string, tags.special(tags.string)], color: "var(--color-foreground)" },
+	{ tag: [tags.number, tags.bool, tags.null], color: "var(--color-text-muted)" },
+	{ tag: [tags.comment, tags.lineComment], color: "var(--color-text-passive)", fontStyle: "italic" },
+	{ tag: [tags.punctuation, tags.separator], color: "var(--color-text-passive)" },
+]);
+
+// Chrome matched to the surrounding surface; sizing/scroll owned by the parent.
+const theme = EditorView.theme({
+	"&": {
+		height: "100%",
+		fontSize: "12.5px",
+		color: "var(--color-foreground)",
+		backgroundColor: "transparent",
+	},
+	"&.cm-focused": { outline: "none" },
+	".cm-scroller": {
+		fontFamily: "var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace)",
+		lineHeight: "1.6",
+	},
+	".cm-gutters": {
+		backgroundColor: "transparent",
+		color: "var(--color-text-passive)",
+		border: "none",
+	},
+	".cm-activeLine": { backgroundColor: "color-mix(in srgb, var(--color-foreground) 4%, transparent)" },
+	".cm-activeLineGutter": { backgroundColor: "transparent", color: "var(--color-text-muted)" },
+	".cm-cursor": { borderLeftColor: "var(--color-primary)" },
+	".cm-selectionBackground, &.cm-focused .cm-selectionBackground, ::selection": {
+		backgroundColor: "color-mix(in srgb, var(--color-primary) 25%, transparent)",
+	},
+	".cm-content": { caretColor: "var(--color-primary)" },
+});
+
+function extensions(readOnly: boolean) {
+	return [
+		lineNumbers(),
+		highlightActiveLine(),
+		highlightActiveLineGutter(),
+		drawSelection(),
+		history(),
+		indentOnInput(),
+		bracketMatching(),
+		syntaxHighlighting(highlightStyle),
+		yaml(),
+		keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
+		theme,
+		EditorView.editable.of(!readOnly),
+		EditorState.readOnly.of(readOnly),
+	];
+}
+
+export type YamlEditorProps = {
+	value: string;
+	onChange: (value: string) => void;
+	readOnly?: boolean;
+	className?: string;
+	"aria-label"?: string;
+};
+
+// Thin CodeMirror 6 wrapper: builds the view once, then pushes external `value`
+// changes in only when they diverge from the live doc (so typing never fights a
+// re-render). `onChange` is read through a ref so the update listener stays
+// stable across renders.
+export function YamlEditor({ value, onChange, readOnly = false, className, ...aria }: YamlEditorProps) {
+	const hostRef = useRef<HTMLDivElement | null>(null);
+	const viewRef = useRef<EditorView | null>(null);
+	const onChangeRef = useRef(onChange);
+	onChangeRef.current = onChange;
+
+	useEffect(() => {
+		if (!hostRef.current) return;
+		const view = new EditorView({
+			parent: hostRef.current,
+			state: EditorState.create({
+				doc: value,
+				extensions: [
+					...extensions(readOnly),
+					EditorView.updateListener.of((update) => {
+						if (update.docChanged) onChangeRef.current(update.state.doc.toString());
+					}),
+				],
+			}),
+		});
+		viewRef.current = view;
+		return () => {
+			view.destroy();
+			viewRef.current = null;
+		};
+		// Rebuild only when the read-only mode flips; value sync is handled below.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [readOnly]);
+
+	useEffect(() => {
+		const view = viewRef.current;
+		if (!view) return;
+		const current = view.state.doc.toString();
+		if (current === value) return;
+		view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
+	}, [value]);
+
+	return (
+		<div
+			ref={hostRef}
+			className={cn("h-full min-h-0 overflow-auto", className)}
+			aria-label={aria["aria-label"]}
+			data-testid="yaml-editor"
+		/>
+	);
+}

--- a/frontend/src/renderer/hooks/usePipelineDefinitions.ts
+++ b/frontend/src/renderer/hooks/usePipelineDefinitions.ts
@@ -1,0 +1,72 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { components } from "../../api/schema";
+import { apiClient } from "../lib/api-client";
+
+export type PipelineDefinitionSummary = components["schemas"]["PipelineDefinitionSummary"];
+
+export const pipelineDefinitionsQueryKey = (projectId?: string) =>
+	projectId ? (["pipeline-definitions", projectId] as const) : (["pipeline-definitions"] as const);
+
+async function fetchPipelineDefinitions(projectId: string): Promise<PipelineDefinitionSummary[]> {
+	const { data, error } = await apiClient.GET("/api/v1/pipelines", {
+		params: { query: { project: projectId } },
+	});
+	if (error) throw error;
+	return data?.definitions ?? [];
+}
+
+// Definitions for one project, keyed by project id so switching the project
+// picker swaps the cache entry instead of refetching into the same key.
+export function usePipelineDefinitionsQuery(projectId?: string) {
+	return useQuery({
+		queryKey: pipelineDefinitionsQueryKey(projectId),
+		enabled: Boolean(projectId),
+		queryFn: () => fetchPipelineDefinitions(projectId!),
+		retry: 1,
+	});
+}
+
+// Create / update / delete share one invalidation of the project's list. The
+// mutations throw the raw openapi-fetch `error` body so callers can pull the
+// validation issue list out of it (parsePipelineValidationIssues) unchanged.
+export function usePipelineDefinitionMutations(projectId?: string) {
+	const queryClient = useQueryClient();
+	const invalidate = () => queryClient.invalidateQueries({ queryKey: pipelineDefinitionsQueryKey(projectId) });
+
+	const create = useMutation({
+		mutationFn: async (yamlSource: string) => {
+			if (!projectId) throw new Error("No project selected");
+			const { data, error } = await apiClient.POST("/api/v1/pipelines", {
+				params: { query: { project: projectId } },
+				body: { yamlSource },
+			});
+			if (error) throw error;
+			return data!.definition;
+		},
+		onSuccess: invalidate,
+	});
+
+	const update = useMutation({
+		mutationFn: async ({ id, yamlSource }: { id: string; yamlSource: string }) => {
+			const { data, error } = await apiClient.PUT("/api/v1/pipelines/{id}", {
+				params: { path: { id } },
+				body: { yamlSource },
+			});
+			if (error) throw error;
+			return data!.definition;
+		},
+		onSuccess: invalidate,
+	});
+
+	const remove = useMutation({
+		mutationFn: async (id: string) => {
+			const { error } = await apiClient.DELETE("/api/v1/pipelines/{id}", {
+				params: { path: { id } },
+			});
+			if (error) throw error;
+		},
+		onSuccess: invalidate,
+	});
+
+	return { create, update, remove };
+}

--- a/frontend/src/renderer/lib/pipeline-yaml.test.ts
+++ b/frontend/src/renderer/lib/pipeline-yaml.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { countStagesFromYaml, parsePipelineValidationIssues } from "./pipeline-yaml";
+
+describe("countStagesFromYaml", () => {
+	it("counts block-style stage entries", () => {
+		const yaml = `name: review
+stages:
+  - name: review
+    trigger:
+      on: [manual]
+    executor:
+      kind: agent
+  - name: guard
+    trigger:
+      on: [manual]
+`;
+		expect(countStagesFromYaml(yaml)).toBe(2);
+	});
+
+	it("handles a single stage", () => {
+		const yaml = `name: review
+stages:
+  - name: review
+    executor:
+      kind: agent
+`;
+		expect(countStagesFromYaml(yaml)).toBe(1);
+	});
+
+	it("reads an inline empty sequence as zero", () => {
+		expect(countStagesFromYaml("name: x\nstages: []\n")).toBe(0);
+	});
+
+	it("reads an inline flow sequence", () => {
+		expect(countStagesFromYaml("stages: [a, b, c]")).toBe(3);
+	});
+
+	it("returns null when there is no stages key", () => {
+		expect(countStagesFromYaml("name: x\n")).toBeNull();
+	});
+
+	it("stops counting at a dedent to a sibling key", () => {
+		const yaml = `stages:
+  - name: one
+  - name: two
+maxConcurrentStages: 4
+`;
+		expect(countStagesFromYaml(yaml)).toBe(2);
+	});
+});
+
+describe("parsePipelineValidationIssues", () => {
+	it("extracts the issue list from a validation error body", () => {
+		const error = {
+			code: "PIPELINE_VALIDATION_FAILED",
+			message: "pipeline definition is invalid",
+			details: {
+				issues: [
+					{ path: "stages[0].name", message: "is required" },
+					{ path: "name", message: "must not be empty" },
+				],
+			},
+		};
+		expect(parsePipelineValidationIssues(error)).toEqual([
+			{ path: "stages[0].name", message: "is required" },
+			{ path: "name", message: "must not be empty" },
+		]);
+	});
+
+	it("returns an empty array when the code matches but issues are absent", () => {
+		expect(parsePipelineValidationIssues({ code: "PIPELINE_VALIDATION_FAILED", details: {} })).toEqual([]);
+	});
+
+	it("returns null for a non-validation error", () => {
+		expect(parsePipelineValidationIssues({ code: "NOT_FOUND", message: "missing" })).toBeNull();
+		expect(parsePipelineValidationIssues(new Error("boom"))).toBeNull();
+		expect(parsePipelineValidationIssues(null)).toBeNull();
+	});
+});

--- a/frontend/src/renderer/lib/pipeline-yaml.ts
+++ b/frontend/src/renderer/lib/pipeline-yaml.ts
@@ -1,0 +1,87 @@
+// Client-side helpers for the Pipelines Definitions UI. Server-side validation
+// is the source of truth (spec §4b); these only shape wire values for display.
+
+export type PipelineValidationIssue = { path: string; message: string };
+
+// Pull the full per-issue list out of the daemon's validation error. On a 422
+// the pipelines controller sets code=PIPELINE_VALIDATION_FAILED and stashes the
+// issues under details.issues (path + message per issue) so the editor can
+// surface every problem at once. Returns null for any other error shape.
+export function parsePipelineValidationIssues(error: unknown): PipelineValidationIssue[] | null {
+	if (typeof error !== "object" || error === null) return null;
+	const body = error as { code?: unknown; details?: unknown };
+	if (body.code !== "PIPELINE_VALIDATION_FAILED") return null;
+	const details = body.details;
+	if (typeof details !== "object" || details === null) return null;
+	const issues = (details as { issues?: unknown }).issues;
+	if (!Array.isArray(issues)) return [];
+	return issues.flatMap((raw) => {
+		if (typeof raw !== "object" || raw === null) return [];
+		const { path, message } = raw as { path?: unknown; message?: unknown };
+		return [
+			{
+				path: typeof path === "string" ? path : "",
+				message: typeof message === "string" ? message : String(message ?? ""),
+			},
+		];
+	});
+}
+
+// Best-effort stage count for the definitions list. The definition summary the
+// API returns carries only the raw YAML (no normalized config), so we count the
+// block-style entries under the top-level `stages:` list, plus the inline
+// `stages: []` / `stages: [a, b]` forms the schema editor can produce.
+//
+// ponytail: heuristic YAML scan, not a real parser. Handles the block + simple
+// inline shapes the editor authors; returns null when it can't tell (caller
+// renders "-"). Upgrade path: have the API expose a stageCount field on
+// PipelineDefinitionSummary (informed to orchestrator) and drop this.
+export function countStagesFromYaml(source: string): number | null {
+	const lines = source.split("\n");
+	for (let i = 0; i < lines.length; i += 1) {
+		const match = /^(\s*)stages\s*:(.*)$/.exec(lines[i]);
+		if (!match) continue;
+		const keyIndent = match[1].length;
+		const inline = match[2].trim();
+
+		// Inline flow sequence: `stages: []` or `stages: [a, b]`.
+		if (inline.startsWith("[")) {
+			const inner = inline
+				.replace(/^\[/, "")
+				.replace(/\][^\]]*$/, "")
+				.trim();
+			return inner === "" ? 0 : inner.split(",").filter((part) => part.trim() !== "").length;
+		}
+		// Anything else on the line (a scalar, an anchor) is not a block list.
+		if (inline !== "") return null;
+
+		// Block sequence: count `- ` items at the child indent until we dedent
+		// back to or past the `stages:` key.
+		let itemIndent = -1;
+		let count = 0;
+		for (let j = i + 1; j < lines.length; j += 1) {
+			const line = lines[j];
+			if (line.trim() === "") continue;
+			const indent = line.length - line.trimStart().length;
+			if (indent <= keyIndent) break;
+			const isItem = /^-(\s|$)/.test(line.trimStart());
+			if (itemIndent === -1 && isItem) itemIndent = indent;
+			if (isItem && indent === itemIndent) count += 1;
+		}
+		return count;
+	}
+	return null;
+}
+
+// Starter document offered when creating a new definition, so the editor is
+// never empty and authors get a valid-shaped skeleton to edit.
+export const DEFAULT_PIPELINE_YAML = `name: my-pipeline
+stages:
+  - name: review
+    trigger:
+      on: [manual]
+    executor:
+      kind: agent
+      plugin: claude-code
+      mode: review
+`;

--- a/frontend/src/renderer/routes/_shell.pipelines.index.tsx
+++ b/frontend/src/renderer/routes/_shell.pipelines.index.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, getRouteApi } from "@tanstack/react-router";
+import { PipelineDefinitionsPage } from "../components/PipelineDefinitionsPage";
+
+// The project lives on the parent section route's `project` search param; read it
+// there so the picker in the section shell drives this tab.
+const sectionRoute = getRouteApi("/_shell/pipelines");
+
+export const Route = createFileRoute("/_shell/pipelines/")({
+	component: PipelinesDefinitionsRoute,
+});
+
+function PipelinesDefinitionsRoute() {
+	const { project } = sectionRoute.useSearch();
+	return <PipelineDefinitionsPage projectId={project} />;
+}

--- a/frontend/src/renderer/routes/_shell.pipelines.tsx
+++ b/frontend/src/renderer/routes/_shell.pipelines.tsx
@@ -1,0 +1,105 @@
+import { createFileRoute, Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../components/ui/select";
+import { cn } from "../lib/utils";
+
+// The `project` search param is the single source of truth for which project's
+// pipelines are shown; both the Definitions (T9) and Runs (T10) tabs read it, so
+// switching the picker or deep-linking keeps them in sync via the URL.
+type PipelinesSearch = { project?: string };
+
+export const Route = createFileRoute("/_shell/pipelines")({
+	validateSearch: (search: Record<string, unknown>): PipelinesSearch => ({
+		project: typeof search.project === "string" ? search.project : undefined,
+	}),
+	component: PipelinesLayout,
+});
+
+// Runs lives on a sibling route owned by T10; until it merges this link 404s,
+// which is fine; the whole section ships behind T11's flag. Cast keeps the typed
+// Link happy while the target route is absent from the generated tree.
+const RUNS_PATH = "/pipelines/runs" as "/pipelines";
+
+function PipelinesLayout() {
+	const navigate = useNavigate();
+	const { project } = Route.useSearch();
+	const pathname = useRouterState({ select: (s) => s.location.pathname });
+	const workspaces = useWorkspaceQuery().data ?? [];
+
+	const selectedProject = project ?? workspaces[0]?.id;
+
+	// Pin the effective project into the URL so children (and reloads) resolve the
+	// same project the picker shows, instead of an implicit default.
+	useEffect(() => {
+		if (!project && selectedProject) {
+			void navigate({ to: "/pipelines", search: { project: selectedProject }, replace: true });
+		}
+	}, [project, selectedProject, navigate]);
+
+	const onRunsTab = pathname.startsWith("/pipelines/runs");
+
+	return (
+		<div className="flex h-full min-h-0 flex-col bg-background text-foreground">
+			<div className="flex items-center gap-3 px-4.5 pt-5.5">
+				<h1 className="text-heading font-bold tracking-tight-xl text-foreground">Pipelines</h1>
+				<div className="ml-auto">
+					<Select
+						value={selectedProject}
+						onValueChange={(value) => void navigate({ to: "/pipelines", search: { project: value } })}
+						disabled={workspaces.length === 0}
+					>
+						<SelectTrigger size="sm" aria-label="Project" className="min-w-40">
+							<SelectValue placeholder="Select a project" />
+						</SelectTrigger>
+						<SelectContent>
+							{workspaces.map((workspace) => (
+								<SelectItem key={workspace.id} value={workspace.id}>
+									{workspace.name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+			</div>
+
+			<div className="mt-3 flex items-center gap-1 border-b border-border px-4.5">
+				<TabLink to="/pipelines" active={!onRunsTab} search={{ project: selectedProject }}>
+					Definitions
+				</TabLink>
+				<TabLink to={RUNS_PATH} active={onRunsTab} search={{ project: selectedProject }}>
+					Runs
+				</TabLink>
+			</div>
+
+			<div className="min-h-0 flex-1">
+				<Outlet />
+			</div>
+		</div>
+	);
+}
+
+function TabLink({
+	to,
+	active,
+	search,
+	children,
+}: {
+	to: "/pipelines";
+	active: boolean;
+	search: PipelinesSearch;
+	children: React.ReactNode;
+}) {
+	return (
+		<Link
+			to={to}
+			search={search}
+			className={cn(
+				"-mb-px border-b-2 px-2.5 py-2 text-control font-medium transition-colors",
+				active ? "border-accent text-foreground" : "border-transparent text-muted-foreground hover:text-foreground",
+			)}
+		>
+			{children}
+		</Link>
+	);
+}


### PR DESCRIPTION
## T9 · Pipelines UI — Definitions

Adds the top-level **Pipelines** section and its **Definitions** tab: a
project-scoped list of stored pipeline definitions plus a CodeMirror 6 YAML
editor with full CRUD, wired to the T7 API.

Closes #241 (label `pipelines-v1`). PR base is `pipelines`.

### What's here
- **Nav**: a `Pipelines` entry beside `Pull requests` in the sidebar Settings
  menu (matches the existing global-nav pattern; both dropdown variants).
- **Routes**: `_shell.pipelines.tsx` (section shell: project picker +
  Definitions/Runs tab bar) and `_shell.pipelines.index.tsx` (Definitions tab).
  The Runs tab links to T10's route, which is absent until T10 merges (transient
  404 is expected; the section ships behind T11's flag).
- **Definitions tab**: list (name, stage count, updated) + New pipeline +
  per-row Edit/Delete (delete is confirm-gated).
- **Editor**: CodeMirror 6 with YAML highlighting, themed to the app tokens.
  Server-side validation is the source of truth: on save the daemon's full
  per-issue error list (path + message) is surfaced inline and the buffer is
  kept.
- **CRUD**: TanStack Query mutations with list invalidation, following existing
  hook patterns.

### Project selection
Pipelines are per-project but the section is top-level, so the chosen project
rides a `project` search param that both tabs read. The shell defaults it to the
first project. (No existing "current project" concept fit a top-level page.)

### New dependency
The approved lean CodeMirror set only: `@codemirror/{state,view,commands,
language}`, `@codemirror/lang-yaml`, and `@lezer/highlight` (for the themed
syntax colours). No themes or heavy schema tooling.

### Notes / coordination
- `routeTree.gen.ts` is generated at build/test time and is **not tracked**
  upstream, so it is not committed. Regenerated by the vite router plugin.
- Kept disjoint from T10 (owns `_shell.pipelines.runs*.tsx`, its components,
  `event-transport.ts`).
- **Open item (informed to orchestrator):** the list wants a per-definition
  stage count but `PipelineDefinitionSummary` doesn't expose one. Interim: a
  small, tested client-side count from the YAML (block + inline shapes, marked
  `ponytail:`, degrades to `-`). Cleaner fix would be a `stageCount` field on
  the summary DTO (tiny T7 follow-up).

### Tests
`pipeline-yaml.test.ts` (stage-count + validation-issue parsing) and
`PipelineDefinitionsPage.test.tsx` (list renders, create/save, per-issue
validation surfacing, delete confirm). Full renderer suite green (609 passed),
typecheck clean, prettier-clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)