### PR TITLE
feat(pipelines): T11 AO_PIPELINES flag + e2e integration test + docs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,6 @@ frontend/package-lock.json
 
 # Go uses gofmt, not Prettier
 backend/
+
+# Fork-only artifact, removed before the final upstream PR (never hand-formatted).
+PIPELINES_REIMPL_SPEC.md

--- a/PIPELINES_REIMPL_SPEC.md
+++ b/PIPELINES_REIMPL_SPEC.md
@@ -1,6 +1,6 @@
 # Pipelines v1 — Reimplementation Spec
 
-> **Status:** Resolved spec + build-time resolutions (§4b). Execution in progress via AO workers, orchestrated from session `agent-orchestrator-29`.
+> **Status:** Execution complete. All 11 tasks (T1-T11) built and merged onto `pipelines` via AO workers, orchestrated from session `agent-orchestrator-29`; shipped behind the `AO_PIPELINES` flag (default off).
 > **Target:** fork (`origin` = `harshitsinghbhandari/agent-orchestrator`) only. Integration branch: `pipelines` (kept rebased onto `upstream/main`). Task branches off `pipelines`, PRs into `pipelines`. Upstream (`AgentWrapper`) is untouched and must never learn about this work.
 > **Behavioral source of truth:** git branch `origin/legacy-pipelines` (old pre-rewrite TypeScript monorepo; renamed from `pipelines` on 2026-07-03, which auto-closed old PR #211). It is a *reference spec*, **not** portable code.
 > **Fork-only artifacts:** this spec file lives only on the `pipelines` branch and is removed before the final upstream PR.

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -94,6 +94,10 @@ type Config struct {
 	AllowedOrigins []string
 	// Telemetry controls local/remote telemetry sinks.
 	Telemetry TelemetryConfig
+	// Pipelines gates the pipelines v1 subsystem (spec §4b T11). Off by default:
+	// when off the daemon starts no engines or CDC trigger bridge and the API
+	// returns 501 on every pipelines route. Toggled by AO_PIPELINES.
+	Pipelines bool
 }
 
 // Addr returns the host:port the HTTP server binds. It uses net.JoinHostPort so
@@ -120,6 +124,7 @@ func (c Config) Addr() string {
 //	AO_TELEMETRY_REMOTE  remote exporter off|posthog (default off)
 //	AO_TELEMETRY_POSTHOG_KEY   PostHog project key
 //	AO_TELEMETRY_POSTHOG_HOST  PostHog host (default DefaultTelemetryPostHogHost)
+//	AO_PIPELINES         pipelines subsystem off|on (default off)
 //
 // The bind host is not configurable: the daemon is loopback-only by design.
 func Load() (Config, error) {
@@ -212,6 +217,14 @@ func Load() (Config, error) {
 	}
 	if raw := os.Getenv("AO_TELEMETRY_POSTHOG_HOST"); raw != "" {
 		cfg.Telemetry.PostHogHost = raw
+	}
+
+	if raw := os.Getenv("AO_PIPELINES"); raw != "" {
+		v, err := parseToggleEnv("AO_PIPELINES", raw)
+		if err != nil {
+			return Config{}, err
+		}
+		cfg.Pipelines = v
 	}
 
 	runFile, err := resolveRunFilePath()

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -10,7 +10,7 @@ import (
 func TestLoadDefaults(t *testing.T) {
 	// Clear every recognised var so we observe pure defaults regardless of the
 	// surrounding environment.
-	for _, k := range []string{"AO_PORT", "AO_REQUEST_TIMEOUT", "AO_SHUTDOWN_TIMEOUT", "AO_RUN_FILE", "AO_DATA_DIR", "AO_AGENT", "AO_ALLOWED_ORIGINS", "AO_TELEMETRY_EVENTS", "AO_TELEMETRY_METRICS", "AO_TELEMETRY_REMOTE", "AO_TELEMETRY_POSTHOG_KEY", "AO_TELEMETRY_POSTHOG_HOST"} {
+	for _, k := range []string{"AO_PORT", "AO_REQUEST_TIMEOUT", "AO_SHUTDOWN_TIMEOUT", "AO_RUN_FILE", "AO_DATA_DIR", "AO_AGENT", "AO_ALLOWED_ORIGINS", "AO_TELEMETRY_EVENTS", "AO_TELEMETRY_METRICS", "AO_TELEMETRY_REMOTE", "AO_TELEMETRY_POSTHOG_KEY", "AO_TELEMETRY_POSTHOG_HOST", "AO_PIPELINES"} {
 		t.Setenv(k, "")
 	}
 
@@ -51,6 +51,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.Telemetry.Remote != TelemetryRemoteOff || cfg.Telemetry.PostHogHost != DefaultTelemetryPostHogHost {
 		t.Fatalf("Telemetry defaults = %+v", cfg.Telemetry)
 	}
+	if cfg.Pipelines {
+		t.Error("Pipelines = true, want false by default")
+	}
 }
 
 func TestLoadOverrides(t *testing.T) {
@@ -64,10 +67,14 @@ func TestLoadOverrides(t *testing.T) {
 	t.Setenv("AO_TELEMETRY_REMOTE", "posthog")
 	t.Setenv("AO_TELEMETRY_POSTHOG_KEY", "phc_test")
 	t.Setenv("AO_TELEMETRY_POSTHOG_HOST", "https://eu.i.posthog.com")
+	t.Setenv("AO_PIPELINES", "on")
 
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Pipelines {
+		t.Error("Pipelines = false, want true when AO_PIPELINES=on")
 	}
 	if cfg.Addr() != "127.0.0.1:4002" {
 		t.Errorf("Addr() = %q, want 127.0.0.1:4002", cfg.Addr())
@@ -110,6 +117,7 @@ func TestLoadInvalid(t *testing.T) {
 		{"bad telemetry events", map[string]string{"AO_TELEMETRY_EVENTS": "maybe"}},
 		{"bad telemetry metrics", map[string]string{"AO_TELEMETRY_METRICS": "maybe"}},
 		{"bad telemetry remote", map[string]string{"AO_TELEMETRY_REMOTE": "otlp"}},
+		{"bad pipelines toggle", map[string]string{"AO_PIPELINES": "maybe"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -135,10 +135,17 @@ func Run() error {
 	}
 	lcStack.trackerDone = startTrackerIntake(ctx, store, sessionSvc, log)
 
-	// Pipelines v1 (spec §4b T5): one actor-loop engine per project, driving the
-	// pure reducer + executors + store. Single wiring seam so T11 can gate the
-	// whole subsystem behind AO_PIPELINES here.
-	pipelineStk := startPipelineEngine(ctx, store, sessionSvc, cdcPipe.Broadcaster, log)
+	// Pipelines v1 (spec §4b T5/T11): one actor-loop engine per project, driving
+	// the pure reducer + executors + store. Gated behind AO_PIPELINES (default
+	// off): when off, no engines and no CDC trigger bridge start, and Pipelines
+	// stays nil below so every API route returns 501. pipelineStk.Stop is
+	// nil-safe, so teardown needs no extra guard.
+	var pipelineStk *pipelineStack
+	var pipelinesSvc pipelinesvc.Manager
+	if cfg.Pipelines {
+		pipelineStk = startPipelineEngine(ctx, store, sessionSvc, cdcPipe.Broadcaster, log)
+		pipelinesSvc = pipelinesvc.New(store, pipelinesvc.SupervisorEngines(pipelineStk.supervisor))
+	}
 
 	previewDone := preview.NewPoller(store, sessionSvc, "http://"+cfg.Addr(), preview.PollerConfig{Logger: log}).Start(ctx)
 	agentSvc := agentsvc.New()
@@ -168,7 +175,7 @@ func Run() error {
 		Notifications:      notifier,
 		NotificationStream: notificationHub,
 		Import:             importsvc.New(importsvc.Deps{Store: store}),
-		Pipelines:          pipelinesvc.New(store, pipelinesvc.SupervisorEngines(pipelineStk.supervisor)),
+		Pipelines:          pipelinesSvc,
 		CDC:                store,
 		Events:             cdcPipe.Broadcaster,
 		Activity:           lcStack.LCM,

--- a/backend/internal/httpd/controllers/pipelines_test.go
+++ b/backend/internal/httpd/controllers/pipelines_test.go
@@ -315,6 +315,34 @@ func TestPipelinesGetArtifact_HappyAndNotFound(t *testing.T) {
 	assertErrorCode(t, body, status, http.StatusNotFound, "PIPELINE_ARTIFACT_NOT_FOUND")
 }
 
+// TestPipelinesFlagOffReturns501 is the AO_PIPELINES=off contract (T11): the
+// daemon passes a nil Pipelines Manager when the flag is off, and every route
+// stays registered but returns 501 Not Implemented, across all method kinds.
+func TestPipelinesFlagOffReturns501(t *testing.T) {
+	srv := newPipelineTestServer(t, nil)
+
+	cases := []struct {
+		method, path, body string
+	}{
+		{"GET", "/api/v1/pipelines?project=mer", ""},
+		{"POST", "/api/v1/pipelines?project=mer", `{"yamlSource":"name: review"}`},
+		{"PUT", "/api/v1/pipelines/pl-1", `{"yamlSource":"name: review"}`},
+		{"DELETE", "/api/v1/pipelines/pl-1", ""},
+		{"GET", "/api/v1/pipelines/schema", ""},
+		{"GET", "/api/v1/pipelines/runs?project=mer", ""},
+		{"GET", "/api/v1/pipelines/runs/run-1", ""},
+		{"POST", "/api/v1/pipelines/runs/run-1/cancel", ""},
+		{"POST", "/api/v1/pipelines/runs/run-1/resume", ""},
+		{"GET", "/api/v1/pipelines/runs/run-1/artifacts/a-1", ""},
+	}
+	for _, tc := range cases {
+		_, status, _ := doRequest(t, srv, tc.method, tc.path, tc.body)
+		if status != http.StatusNotImplemented {
+			t.Errorf("%s %s with flag off = %d, want 501", tc.method, tc.path, status)
+		}
+	}
+}
+
 func contains(body []byte, sub string) bool {
 	return strings.Contains(string(body), sub)
 }

--- a/backend/internal/integration/pipeline_e2e_test.go
+++ b/backend/internal/integration/pipeline_e2e_test.go
@@ -1,0 +1,316 @@
+// This file is the end-to-end integration guard for the pipelines v1 subsystem
+// (spec §8 T11). It wires the REAL components the daemon wires when AO_PIPELINES
+// is on: a real sqlite.Store (temp dir), the real CDC pipeline (SQLite triggers
+// -> change_log -> poller -> broadcaster), the real per-project engine
+// Supervisor, and the real CDC trigger Bridge, with the only stub at the
+// executor Set seam (a real agent session is impractical in CI; the executor
+// interface is designed for exactly this substitution).
+//
+// It drives the full loop: a definition is saved; a PR row is written through
+// the store, firing the real pr_created trigger; the poller fans the event out;
+// the bridge derives pr.opened and triggers a run; the engine runs the stage;
+// the stub executor completes with a finding; the default exit predicate
+// resolves the run to done. It then asserts the run persisted with its
+// fingerprinted finding, the loop history rebuilt on a fresh hydrate, and -- the
+// UI's liveness contract -- that the pipeline_* CDC events landed in change_log.
+//
+// The flag-off case is covered too: without the bridge/engine wired (what the
+// daemon does when the flag is off), the same PR row change produces no
+// pipeline runs and no pipeline_* CDC events.
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/engine"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/triggers"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+const (
+	plProject = "mer"
+	plPRURL   = "https://github.com/o/r/pull/7"
+)
+
+// stubExecutor stands in for all three kind executors at the executors.Set seam.
+// Every polled stage completes immediately with a pass verdict and one finding,
+// so a triggered run self-drives to done under the engine's heartbeat.
+type stubExecutor struct{}
+
+func (stubExecutor) Start(_ context.Context, in executors.StartInput) (executors.Handle, error) {
+	return stubHandle{runID: in.RunID, stageRunID: in.StageRunID, stageName: in.Stage.Name}, nil
+}
+
+func (stubExecutor) Poll(_ context.Context, h executors.Handle) (executors.Outcome, error) {
+	return executors.Outcome{
+		Status:  executors.OutcomeCompleted,
+		Verdict: pipeline.VerdictPass,
+		Artifacts: []pipeline.ArtifactInput{{
+			Kind: pipeline.ArtifactKindFinding, FilePath: "main.go", StartLine: 1, EndLine: 2,
+			Title: "bug", Category: "correctness", Severity: pipeline.SeverityError,
+		}},
+	}, nil
+}
+
+func (stubExecutor) Cancel(context.Context, executors.Handle) error { return nil }
+
+type stubHandle struct {
+	runID      pipeline.RunID
+	stageRunID pipeline.StageRunID
+	stageName  string
+}
+
+func (h stubHandle) RunID() pipeline.RunID           { return h.runID }
+func (h stubHandle) StageRunID() pipeline.StageRunID { return h.stageRunID }
+func (h stubHandle) StageName() string               { return h.stageName }
+
+// bridgeEngines adapts the concrete engine Supervisor to the bridge's
+// EngineProvider, exactly as the daemon's supervisorEngines does.
+type bridgeEngines struct{ sup *engine.Supervisor }
+
+func (b bridgeEngines) For(ctx context.Context, projectID domain.ProjectID) (triggers.Engine, error) {
+	return b.sup.For(ctx, projectID)
+}
+
+// prOpenedDefinition is a stored definition whose single agent stage fires on
+// pr.opened, matching the pr_created event the bridge derives.
+func prOpenedDefinition() pipeline.Definition {
+	stage := pipeline.Stage{
+		Name:     "review",
+		Trigger:  pipeline.StageTrigger{On: []pipeline.StageTriggerEvent{pipeline.TriggerPROpened}},
+		Executor: pipeline.StageExecutor{Kind: pipeline.ExecutorAgent, Plugin: "claude-code", Mode: pipeline.ModeReview},
+	}
+	now := time.Now().UTC()
+	return pipeline.Definition{
+		ID:        pipeline.ID("def-review"),
+		ProjectID: plProject,
+		Name:      "review",
+		Config:    pipeline.Pipeline{Name: "review", Scope: pipeline.ScopeWorker, Stages: []pipeline.Stage{stage}},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+// seedPipelineFixture opens a store, seeds the project + a session (the pr CDC
+// trigger derives project_id from the PR's session), and returns the store and
+// the assigned session id.
+func seedPipelineFixture(t *testing.T) (*sqlite.Store, domain.SessionID) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{
+		ID: plProject, Path: "/tmp/" + plProject, RegisteredAt: time.Now().UTC().Truncate(time.Second),
+	}); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	now := time.Now().UTC()
+	sess, err := store.CreateSession(ctx, domain.SessionRecord{
+		ProjectID: plProject, Kind: domain.KindWorker, Harness: domain.HarnessClaudeCode,
+		Metadata:  domain.SessionMetadata{Branch: "ao/mer-1/root", WorkspacePath: "/ws/mer-1"},
+		Activity:  domain.Activity{State: domain.ActivityIdle, LastActivityAt: now},
+		CreatedAt: now, UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	return store, sess.ID
+}
+
+// writeOpenPR upserts an open PR row for the session via the SCM-observation
+// write path (which persists head_sha, unlike the legacy WritePR), firing the
+// pr_created (or pr_updated on a subsequent write) CDC trigger.
+func writeOpenPR(t *testing.T, store *sqlite.Store, sessionID domain.SessionID, sha string) {
+	t.Helper()
+	if err := store.WriteSCMObservation(context.Background(), domain.PullRequest{
+		URL: plPRURL, SessionID: sessionID, Number: 7,
+		CI: domain.CIPassing, Review: domain.ReviewApproved, Mergeability: domain.MergeMergeable,
+		Provider: "github", Host: "github.com", Repo: "o/r",
+		SourceBranch: "ao/mer-1/root", TargetBranch: "main", HeadSHA: sha,
+		UpdatedAt: time.Now().UTC(),
+	}, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+		t.Fatalf("write pr: %v", err)
+	}
+}
+
+// countPipelineEvents scans the whole change_log and tallies the pipeline_*
+// event types by kind.
+func countPipelineEvents(t *testing.T, store *sqlite.Store) map[cdc.EventType]int {
+	t.Helper()
+	events, err := store.EventsAfter(context.Background(), 0, 10000)
+	if err != nil {
+		t.Fatalf("read change_log: %v", err)
+	}
+	counts := map[cdc.EventType]int{}
+	for _, e := range events {
+		switch e.Type {
+		case cdc.EventPipelineRunUpdated, cdc.EventPipelineStageRunUpdated,
+			cdc.EventPipelineArtifactUpdated, cdc.EventPipelineDefinitionChanged:
+			counts[e.Type]++
+		}
+	}
+	return counts
+}
+
+// TestPipelineEndToEndFlagOn drives a PR row through the real CDC pipeline, the
+// bridge, the engine, and a stub executor, all the way to a persisted done run,
+// then asserts the pipeline_* CDC liveness events landed.
+func TestPipelineEndToEndFlagOn(t *testing.T) {
+	// A cancelable context tears the poller/bridge goroutines down before the
+	// store closes (t.Cleanup is LIFO; store Close is registered first).
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	store, sessionID := seedPipelineFixture(t)
+
+	if err := store.CreatePipelineDefinition(ctx, prOpenedDefinition()); err != nil {
+		t.Fatalf("create definition: %v", err)
+	}
+
+	// Real CDC pipeline: the poller tails change_log and fans events out through
+	// the broadcaster, exactly as the daemon wires it.
+	bcast := cdc.NewBroadcaster()
+	poller := cdc.NewPoller(store, bcast, cdc.PollerConfig{})
+	poller.Start(ctx)
+
+	// Real per-project engine Supervisor over the store, with the only stub at
+	// the executor seam. A short tick lets a started run self-drive to done.
+	sup := engine.NewSupervisor(engine.SupervisorConfig{
+		Store:        store,
+		Executors:    executors.NewSet(stubExecutor{}, stubExecutor{}, stubExecutor{}),
+		Projects:     store,
+		TickInterval: 10 * time.Millisecond,
+	})
+	if err := sup.Start(ctx); err != nil {
+		t.Fatalf("supervisor start: %v", err)
+	}
+	t.Cleanup(func() { _ = sup.Stop(ctx) })
+
+	// Real trigger bridge over the shared broadcaster + store, exactly as the
+	// daemon wires it.
+	bridge := triggers.New(triggers.Config{
+		Broadcaster: bcast,
+		Defs:        store,
+		PRs:         store,
+		Engines:     bridgeEngines{sup: sup},
+	})
+	bridge.Start(ctx)
+	t.Cleanup(bridge.Stop)
+
+	// Fire the whole loop: an open PR row -> pr_created -> pr.opened -> run.
+	writeOpenPR(t, store, sessionID, "sha1")
+
+	// The run is created and driven asynchronously; wait for it to converge.
+	run := waitForDoneRun(t, sup, plProject)
+
+	if got := run.Stages["review"]; got.Status != pipeline.StageStatusSucceeded || got.Verdict != pipeline.VerdictPass {
+		t.Fatalf("review stage = %+v, want succeeded/pass", got)
+	}
+	if run.SessionID != string(sessionID) || run.HeadSHA != "sha1" {
+		t.Fatalf("run = session %q sha %q, want %q sha1", run.SessionID, run.HeadSHA, sessionID)
+	}
+
+	// Persisted run + fingerprinted finding.
+	persisted, ok, err := store.GetPipelineRun(ctx, run.RunID)
+	if err != nil || !ok {
+		t.Fatalf("get persisted run: ok=%v err=%v", ok, err)
+	}
+	if persisted.LoopState != pipeline.LoopDone {
+		t.Fatalf("persisted loop state = %s, want done", persisted.LoopState)
+	}
+	if len(persisted.Findings) != 1 || persisted.Findings[0].Title != "bug" || persisted.Findings[0].Fingerprint == "" {
+		t.Fatalf("persisted findings = %+v, want one fingerprinted finding", persisted.Findings)
+	}
+
+	// Loop history is rebuilt on a fresh hydrate with the loop pointer freed.
+	hydrated, err := store.HydratePipelineEngineState(ctx, plProject)
+	if err != nil {
+		t.Fatalf("hydrate: %v", err)
+	}
+	key := pipeline.LoopKey(string(sessionID), "review")
+	if _, live := hydrated.CurrentRunByLoop[key]; live {
+		t.Fatalf("terminal run must not hold a live loop pointer")
+	}
+	if h := hydrated.HistorySummaries[key]; len(h) != 1 || h[0].RunID != run.RunID || h[0].LoopState != pipeline.LoopDone {
+		t.Fatalf("history summaries = %+v, want one done run", h)
+	}
+
+	// UI liveness contract: the pipeline_* CDC events rode the change_log stream.
+	counts := countPipelineEvents(t, store)
+	if counts[cdc.EventPipelineRunUpdated] == 0 {
+		t.Fatalf("no pipeline_run_updated CDC events; change_log liveness broken")
+	}
+	if counts[cdc.EventPipelineArtifactUpdated] == 0 {
+		t.Fatalf("no pipeline_artifact_updated CDC events; findings never surfaced to the UI")
+	}
+	if counts[cdc.EventPipelineDefinitionChanged] == 0 {
+		t.Fatalf("no pipeline_definition_changed CDC events; definition CRUD not observable")
+	}
+}
+
+// TestPipelineFlagOffNoRuns is the flag-off contract: with no bridge and no
+// engine wired (what the daemon does when AO_PIPELINES is off), the same PR row
+// change produces no pipeline runs and no pipeline_* run/artifact CDC events.
+func TestPipelineFlagOffNoRuns(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	store, sessionID := seedPipelineFixture(t)
+
+	if err := store.CreatePipelineDefinition(ctx, prOpenedDefinition()); err != nil {
+		t.Fatalf("create definition: %v", err)
+	}
+
+	// Flag off: the daemon starts neither the CDC trigger bridge nor any engine.
+	// The CDC substrate itself still runs (it is not pipeline-specific), so a PR
+	// write still fires pr_created -- but with nothing subscribed, no run starts.
+	bcast := cdc.NewBroadcaster()
+	_ = cdc.NewPoller(store, bcast, cdc.PollerConfig{}).Start(ctx)
+
+	writeOpenPR(t, store, sessionID, "sha1")
+
+	// Give any (absent) async trigger path time to misfire.
+	time.Sleep(200 * time.Millisecond)
+
+	hydrated, err := store.HydratePipelineEngineState(ctx, plProject)
+	if err != nil {
+		t.Fatalf("hydrate: %v", err)
+	}
+	if len(hydrated.Runs) != 0 {
+		t.Fatalf("runs with flag off = %d, want 0", len(hydrated.Runs))
+	}
+	counts := countPipelineEvents(t, store)
+	if counts[cdc.EventPipelineRunUpdated] != 0 || counts[cdc.EventPipelineArtifactUpdated] != 0 {
+		t.Fatalf("pipeline run/artifact CDC events with flag off = %+v, want none", counts)
+	}
+}
+
+// waitForDoneRun polls the project engine until exactly one run has converged to
+// done, or fails on deadline.
+func waitForDoneRun(t *testing.T, sup *engine.Supervisor, projectID string) pipeline.RunState {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		eng, err := sup.For(ctx, domain.ProjectID(projectID))
+		if err != nil {
+			t.Fatalf("engine for project: %v", err)
+		}
+		for _, r := range eng.State().Runs {
+			if r.LoopState == pipeline.LoopDone {
+				return r
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("no done run within deadline; end-to-end loop did not converge")
+	return pipeline.RunState{}
+}

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1,0 +1,203 @@
+# Pipelines
+
+Pipelines let a project define a repeatable multi-stage review/build workflow
+that runs against a session's workspace. A pipeline definition is a DAG of
+stages (an agent review, a shell command, or a builtin router/compose step)
+triggered by git events or run manually. A run drives the DAG to completion,
+looping through multiple rounds of feedback until a typed exit predicate
+resolves the run to `done` or `stalled`. Definitions are first-class,
+CRUD-authored YAML, validated server-side and stored in SQLite; each run
+snapshots the definition it was triggered from.
+
+## Enabling the feature
+
+Pipelines are off by default. Set `AO_PIPELINES=on` in the daemon's
+environment before `ao start` (or before the daemon boots), following the
+same on/off convention as AO's other `AO_*` toggles: `on`/`true`/`1`/`yes`
+enable it, `off`/`false`/`0`/`no` (or unset) disable it.
+
+When the flag is off:
+
+- The Pipelines entry is hidden from the sidebar nav.
+- Every `/api/v1/pipelines/*` route returns 501.
+- No per-project pipeline engines start, and the CDC trigger bridge does not
+  subscribe to PR events.
+
+```bash
+AO_PIPELINES=on ao start
+```
+
+## Authoring a definition
+
+A definition is a single YAML document: one pipeline per document (there is
+no map-of-pipelines file format). `id` is never part of the authored YAML;
+the store assigns it on save. `scope` defaults to `worker` and is the only
+scope v1 accepts (`orchestrator` and `workstream` are reserved for a later
+phase).
+
+```yaml
+name: pr-review
+stages:
+  - name: review
+    trigger:
+      on: [pr.opened, pr.updated]
+    executor:
+      kind: agent
+      plugin: claude-code
+      mode: review
+    task:
+      prompt: Review the diff for correctness and style issues.
+    policy:
+      stallWindow: 2
+
+  - name: gate
+    trigger:
+      on: [manual]
+    dependsOn: [review]
+    routes:
+      when:
+        kind: no_open_findings
+        stage: review
+    executor:
+      kind: builtin
+      name: compose
+
+exitPredicates:
+  done:
+    kind: and
+    predicates:
+      - kind: all_pass
+        stages: [review, gate]
+      - kind: finding_count_below
+        stage: review
+        severity: error
+        max: 1
+  stalled:
+    kind: or
+    predicates:
+      - kind: loop_rounds_at_least
+        n: 5
+      - kind: not
+        predicate:
+          kind: stage_verdict
+          stage: gate
+          verdict: pass
+```
+
+Key fields, by section:
+
+- **Stage**: `name`, `trigger.on`, `executor`, `task` (`prompt` /
+  `outputSchema` / `inputs`), `policy` (`blocksMerge`, `stallWindow`),
+  `budget` (`maxUsd`, `maxDurationMs`), `timeoutMs`, `retries`,
+  `maxLoopRounds`, `dependsOn`, `routes.when`, `workspace`
+  (`shared-ro` or `isolated-rw`).
+- **Executor kinds**: `agent` (requires `plugin` and `mode`, `mode` is one of
+  `review`/`code`/`answer`), `command` (requires `command`, plus optional
+  `args`/`env`/`cwd`), `builtin` (requires `name`, one of `router`/
+  `compose`). Fields from another kind are rejected, not silently dropped.
+- **Pipeline-level**: `maxConcurrentStages` (defaults to 1, i.e. serial),
+  `allowForkPRs` (defaults to false; gates `command` stages on fork PRs),
+  `exitPredicates.{done,stalled,blocksMerge}`.
+
+### Predicates
+
+`routes.when` and `exitPredicates.*` share one typed predicate DSL:
+`all_pass` / `any_pass` / `majority_pass` (each takes `stages: [...]`),
+`no_open_findings` (optional `stage`), `finding_count_below` (`max`,
+optional `stage`/`severity`), `loop_rounds_at_least` (`n`), the
+`stage_retried_at_least` (`stage`, `n`), `stage_verdict` (`stage`,
+`verdict`), and the composites `and` / `or` (`predicates: [...]`) and `not`
+(`predicate: ...`). Every referenced stage name must exist in the same
+definition; unknown kinds and cross-kind fields fail validation with a
+path-scoped issue (e.g. `stages[1].routes.when: field "max" is not valid
+for predicate kind "all_pass"`).
+
+## Triggers
+
+A stage fires on `manual` or on PR lifecycle events delivered through the
+CDC event bus: `pr.opened`, `pr.updated`, `pr.merge_ready`, `pr.merged`.
+
+- `pr.opened` fires on PR creation, `pr.updated` on every subsequent PR
+  update.
+- `pr.merge_ready` is derived, not a raw webhook event: it fires on the
+  transition into "merge ready" (PR open, CI not failing, review
+  approved-or-none, and mergeable). A PR first observed already in that
+  state counts as a transition and fires once; it does not re-fire on
+  later updates while it stays merge-ready.
+- `pr.merged` fires the same way: once, on the transition into merged
+  (including a PR first observed already merged).
+- A new head SHA on an already-triggered PR cancels the stale in-flight run
+  (marked `outdated`) and rearms the loop for the new SHA, riding the same
+  `pr.updated` event.
+
+## CLI commands
+
+```
+ao pipeline list [--project ID] [--json]
+ao pipeline runs [--project ID] [--pipeline NAME] [--status STATE] [--limit N] [--json]
+ao pipeline show <runId> [--project ID] [--json]
+ao pipeline run <pipeline-ref> [--project ID] [--session ID] [--head-sha SHA] [--json]
+ao pipeline cancel <runId> [--project ID]
+ao pipeline resume <runId> [--project ID]
+```
+
+`--project` falls back to `AO_PROJECT_ID`, then the CLI's usual
+cwd/session-based project resolution. `--status` filters `runs` by loop
+state (`running`, `awaiting_context`, `done`, `stalled`, `terminated`).
+`pipeline run` accepts either a pipeline id or its name.
+
+```bash
+ao pipeline runs --pipeline pr-review --status stalled
+ao pipeline run pr-review --head-sha abc1234
+ao pipeline resume run_01hz...
+```
+
+## Where findings land
+
+An agent stage's session is expected to write findings to
+`.ao/pipeline-findings.jsonl` inside the stage's workspace, one JSON object
+per line. The executor harvests this file after the session goes idle,
+streaming it up to a 5MB cap (a torn, unterminated final line is tolerated
+and dropped; a malformed complete line fails the harvest). Each line is
+either a `finding` or a free-form `json` artifact:
+
+```json
+{
+	"kind": "finding",
+	"filePath": "backend/internal/foo.go",
+	"startLine": 12,
+	"endLine": 18,
+	"title": "Unchecked error",
+	"description": "err is discarded",
+	"category": "correctness",
+	"severity": "warning",
+	"confidence": 0.8
+}
+```
+
+Finding fields: `filePath`, `startLine`, `endLine`, `title`, `description`,
+`category` (free-form, e.g. `security`/`correctness`/`style`/`general`),
+`severity` (`error`/`warning`/`info`), `confidence` (a float in `[0, 1]`),
+and an optional `anchorSignature` used to keep the finding's fingerprint
+stable across rounds. A `json`-kind artifact instead carries a `data`
+object. All finding fields except `anchorSignature` are required on a
+`finding`-kind line; a missing field or an out-of-range confidence fails
+that record.
+
+## UI overview
+
+The Pipelines section (hidden entirely when `AO_PIPELINES` is off) has two
+tabs:
+
+- **Definitions**: a table of the project's stored pipelines plus a
+  CodeMirror YAML editor for create/update. Validation happens
+  server-side; the editor surfaces every returned issue inline rather than
+  stopping at the first one.
+- **Runs**: a 5-column Kanban workbench (Running, Awaiting context, Done,
+  Stalled, Terminated) grouped by loop state, filterable by pipeline name,
+  spanning every project. Runs update live over the existing CDC-backed
+  event stream, the same transport the rest of the app uses for
+  query invalidation, no separate SSE endpoint.
+
+A run detail view is read-only: pipeline, session, loop state, rounds, head
+SHA, per-stage status/verdict/attempt/artifacts, and the run's findings.

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -49,6 +49,19 @@ vi.mock("../lib/api-client", () => ({
 	},
 }));
 
+// Routes getMock's apiClient.GET calls by URL: the agents catalog fetch gets
+// `agentsResponse` (or, for the deferred-catalog test, a pending promise the
+// test resolves manually), while the pipelines-flag probe always gets an
+// immediate 501 (flag off), matching this suite's daemon which never wires
+// up pipelines.
+function mockGetByUrl(agentsResponse: unknown) {
+	getMock.mockImplementation(async (url: string) => {
+		if (url === "/api/v1/agents") return agentsResponse;
+		if (url === "/api/v1/pipelines/schema") return { response: { status: 501 }, error: {} };
+		throw new Error(`unexpected GET ${url}`);
+	});
+}
+
 const workspace: WorkspaceSummary = {
 	id: "proj-1",
 	name: "Project One",
@@ -175,7 +188,11 @@ beforeEach(() => {
 	window.localStorage.clear();
 	document.documentElement.style.removeProperty("--ao-sidebar-w");
 	getMock.mockReset();
-	getMock.mockResolvedValue({
+	// The Sidebar tree makes two independent apiClient.GET calls: the agents
+	// catalog (CreateProjectFlow, on dialog open) and the AO_PIPELINES flag
+	// probe (usePipelinesEnabled, on mount). Route by URL so the probe firing
+	// first doesn't consume a response meant for the agents call.
+	mockGetByUrl({
 		data: {
 			supported: [
 				{ id: "claude-code", label: "Claude Code" },
@@ -496,7 +513,7 @@ describe("Sidebar", () => {
 		const user = userEvent.setup();
 		const onCreateProject = vi.fn().mockResolvedValue(undefined) as CreateProjectHandler;
 		window.ao!.app.chooseDirectory = vi.fn().mockResolvedValue("/repo/new-project");
-		getMock.mockResolvedValueOnce({
+		mockGetByUrl({
 			data: {
 				supported: [
 					{ id: "claude-code", label: "Claude Code" },
@@ -549,11 +566,14 @@ describe("Sidebar", () => {
 			};
 			error: undefined;
 		}) => void;
-		getMock.mockReturnValueOnce(
-			new Promise((resolve) => {
-				resolveAgents = resolve;
-			}),
-		);
+		getMock.mockImplementation(async (url: string) => {
+			if (url === "/api/v1/agents") {
+				return new Promise((resolve) => {
+					resolveAgents = resolve;
+				});
+			}
+			return { response: { status: 501 }, error: {} };
+		});
 		renderSidebar({ onCreateProject, seedAgents: false });
 
 		await user.click(screen.getByLabelText("New project"));

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -32,6 +32,7 @@ import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { renameSession } from "../lib/rename-session";
 import { useEventsConnection } from "../hooks/useEventsConnection";
+import { usePipelinesEnabled } from "../hooks/usePipelinesEnabled";
 import { useResizable } from "../hooks/useResizable";
 import { useUpdateStatus } from "../hooks/useUpdateStatus";
 import { ConnectMobileModal } from "./ConnectMobileModal";
@@ -157,6 +158,7 @@ export function Sidebar({
 }: SidebarProps) {
 	const selection = useSelection();
 	const eventsConnection = useEventsConnection();
+	const { enabled: pipelinesEnabled } = usePipelinesEnabled();
 	const { state, setOpen } = useSidebar();
 	const isCollapsed = state === "collapsed";
 	const [expandedChromeVisible, setExpandedChromeVisible] = useState(!isCollapsed);
@@ -379,10 +381,12 @@ export function Sidebar({
 								<GitPullRequest aria-hidden="true" />
 								Pull requests
 							</DropdownMenuItem>
-							<DropdownMenuItem onSelect={selection.goPipelines}>
-								<Workflow aria-hidden="true" />
-								Pipelines
-							</DropdownMenuItem>
+							{pipelinesEnabled === true && (
+								<DropdownMenuItem onSelect={selection.goPipelines}>
+									<Workflow aria-hidden="true" />
+									Pipelines
+								</DropdownMenuItem>
+							)}
 							<DropdownMenuItem disabled>
 								<Search aria-hidden="true" />
 								Search
@@ -453,10 +457,12 @@ export function Sidebar({
 								<GitPullRequest aria-hidden="true" />
 								Pull requests
 							</DropdownMenuItem>
-							<DropdownMenuItem onSelect={selection.goPipelines}>
-								<Workflow aria-hidden="true" />
-								Pipelines
-							</DropdownMenuItem>
+							{pipelinesEnabled === true && (
+								<DropdownMenuItem onSelect={selection.goPipelines}>
+									<Workflow aria-hidden="true" />
+									Pipelines
+								</DropdownMenuItem>
+							)}
 							<DropdownMenuItem disabled>
 								<Search aria-hidden="true" />
 								Search

--- a/frontend/src/renderer/hooks/usePipelinesEnabled.test.tsx
+++ b/frontend/src/renderer/hooks/usePipelinesEnabled.test.tsx
@@ -1,0 +1,51 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const { getMock } = vi.hoisted(() => ({ getMock: vi.fn() }));
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: { GET: getMock },
+}));
+
+import { usePipelinesEnabled } from "./usePipelinesEnabled";
+
+function wrapper({ children }: { children: ReactNode }) {
+	const queryClient = new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } });
+	return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+	getMock.mockReset();
+});
+
+describe("usePipelinesEnabled", () => {
+	it("reports enabled when the schema route returns 200", async () => {
+		getMock.mockResolvedValue({ data: { schema: {} }, response: { status: 200 } });
+
+		const { result } = renderHook(() => usePipelinesEnabled(), { wrapper });
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.enabled).toBe(true);
+		expect(getMock).toHaveBeenCalledWith("/api/v1/pipelines/schema", {});
+	});
+
+	it("reports disabled when the schema route returns 501 (flag off)", async () => {
+		getMock.mockResolvedValue({ error: { message: "not enabled" }, response: { status: 501 } });
+
+		const { result } = renderHook(() => usePipelinesEnabled(), { wrapper });
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.enabled).toBe(false);
+	});
+
+	it("reports disabled on a network failure instead of leaving enabled undefined", async () => {
+		getMock.mockRejectedValue(new TypeError("Failed to fetch"));
+
+		const { result } = renderHook(() => usePipelinesEnabled(), { wrapper });
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.enabled).toBe(false);
+	});
+});

--- a/frontend/src/renderer/hooks/usePipelinesEnabled.ts
+++ b/frontend/src/renderer/hooks/usePipelinesEnabled.ts
@@ -1,0 +1,37 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "../lib/api-client";
+
+export const pipelinesEnabledQueryKey = ["pipelines-enabled"] as const;
+
+// Capability probe for the backend AO_PIPELINES feature flag. There is no
+// dedicated capabilities endpoint: when the flag is off, the pipelines
+// Manager is nil and every /api/v1/pipelines/* route (including this static
+// schema route) returns 501. When the flag is on, this route returns 200
+// with a JSON body. We read the raw response status rather than the parsed
+// body, since we only care whether the route exists, not its contents.
+async function fetchPipelinesEnabled(): Promise<boolean> {
+	try {
+		const { response } = await apiClient.GET("/api/v1/pipelines/schema", {});
+		return response.status === 200;
+	} catch {
+		// Network failure or similar: fall through to the safe (hidden) default
+		// below instead of leaving the query in a permanent error state.
+		return false;
+	}
+}
+
+// The flag is fixed for a daemon's lifetime, so one probe per app session is
+// enough: cache forever and never retry. Any failure (network error, non-200
+// and non-501 status) resolves to `false`, the safe default that hides the
+// feature rather than risk showing a broken section.
+export function usePipelinesEnabled() {
+	const query = useQuery({
+		queryKey: pipelinesEnabledQueryKey,
+		queryFn: fetchPipelinesEnabled,
+		staleTime: Infinity,
+		gcTime: Infinity,
+		retry: false,
+	});
+
+	return { enabled: query.data, isLoading: query.isLoading };
+}

--- a/frontend/src/renderer/routes/_shell.pipelines.tsx
+++ b/frontend/src/renderer/routes/_shell.pipelines.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import { useEffect } from "react";
+import { usePipelinesEnabled } from "../hooks/usePipelinesEnabled";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../components/ui/select";
 import { cn } from "../lib/utils";
@@ -22,6 +23,7 @@ export const Route = createFileRoute("/_shell/pipelines")({
 const RUNS_PATH = "/pipelines/runs" as "/pipelines";
 
 function PipelinesLayout() {
+	const { enabled } = usePipelinesEnabled();
 	const navigate = useNavigate();
 	const { project } = Route.useSearch();
 	const pathname = useRouterState({ select: (s) => s.location.pathname });
@@ -39,42 +41,64 @@ function PipelinesLayout() {
 
 	const onRunsTab = pathname.startsWith("/pipelines/runs");
 
+	// The AO_PIPELINES probe (usePipelinesEnabled) is still in flight: render
+	// nothing rather than flash the tabs/outlet or the disabled panel while we
+	// wait for the answer.
+	if (enabled === undefined) {
+		return null;
+	}
+
 	return (
 		<div className="flex h-full min-h-0 flex-col bg-background text-foreground">
 			<div className="flex items-center gap-3 px-4.5 pt-5.5">
 				<h1 className="text-heading font-bold tracking-tight-xl text-foreground">Pipelines</h1>
-				<div className="ml-auto">
-					<Select
-						value={selectedProject}
-						onValueChange={(value) => void navigate({ to: "/pipelines", search: { project: value } })}
-						disabled={workspaces.length === 0}
-					>
-						<SelectTrigger size="sm" aria-label="Project" className="min-w-40">
-							<SelectValue placeholder="Select a project" />
-						</SelectTrigger>
-						<SelectContent>
-							{workspaces.map((workspace) => (
-								<SelectItem key={workspace.id} value={workspace.id}>
-									{workspace.name}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
+				{enabled && (
+					<div className="ml-auto">
+						<Select
+							value={selectedProject}
+							onValueChange={(value) => void navigate({ to: "/pipelines", search: { project: value } })}
+							disabled={workspaces.length === 0}
+						>
+							<SelectTrigger size="sm" aria-label="Project" className="min-w-40">
+								<SelectValue placeholder="Select a project" />
+							</SelectTrigger>
+							<SelectContent>
+								{workspaces.map((workspace) => (
+									<SelectItem key={workspace.id} value={workspace.id}>
+										{workspace.name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				)}
+			</div>
+
+			{enabled ? (
+				<>
+					<div className="mt-3 flex items-center gap-1 border-b border-border px-4.5">
+						<TabLink to="/pipelines" active={!onRunsTab} search={{ project: selectedProject }}>
+							Definitions
+						</TabLink>
+						<TabLink to={RUNS_PATH} active={onRunsTab} search={{ project: selectedProject }}>
+							Runs
+						</TabLink>
+					</div>
+
+					<div className="min-h-0 flex-1">
+						<Outlet />
+					</div>
+				</>
+			) : (
+				<div className="flex min-h-0 flex-1 items-center justify-center">
+					<div className="flex w-full max-w-preview-content flex-col items-center text-center">
+						<h2 className="text-subtitle font-semibold tracking-tight text-foreground">Pipelines are off</h2>
+						<p className="mt-2 text-md-sm leading-relaxed text-muted-foreground">
+							Set AO_PIPELINES=on and restart the daemon to enable pipelines.
+						</p>
+					</div>
 				</div>
-			</div>
-
-			<div className="mt-3 flex items-center gap-1 border-b border-border px-4.5">
-				<TabLink to="/pipelines" active={!onRunsTab} search={{ project: selectedProject }}>
-					Definitions
-				</TabLink>
-				<TabLink to={RUNS_PATH} active={onRunsTab} search={{ project: selectedProject }}>
-					Runs
-				</TabLink>
-			</div>
-
-			<div className="min-h-0 flex-1">
-				<Outlet />
-			</div>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## T11: Feature flag + end-to-end integration + docs (final Pipelines v1 task)

Closes #246.

Gates the whole pipelines v1 subsystem behind the `AO_PIPELINES` env flag (off by default), adds the full end-to-end integration test through real components, and documents the feature.

### Backend flag
- `AO_PIPELINES` in `config.Config` (off default, same on/off conventions as the telemetry vars).
- Daemon wiring: when off, `startPipelineEngine` is not called (no engines, no CDC trigger bridge, no CDC subscription) and `APIDeps.Pipelines` stays nil, so every pipelines route returns 501. Single gate at the designed seam; `pipelineStack.Stop` is already nil-safe.

### End-to-end integration test (flag on)
`backend/internal/integration/pipeline_e2e_test.go` drives the full loop through REAL components (store on a temp dir + CDC poller/broadcaster + engine supervisor + trigger bridge), with the only stub at the executor `Set` seam:

definition saved -> PR row write fires the real `pr_created` SQLite trigger -> poller fans it out -> bridge derives `pr.opened` -> engine runs the stage -> stub executor completes with a finding -> default exit predicate resolves the run to `done`.

Asserts: persisted run + fingerprinted finding, loop history rebuilt on a fresh hydrate, and the `pipeline_*` events on `change_log` (the UI's liveness contract). A flag-off test proves an unwired bridge/engine yields no runs and no pipeline CDC events.

### Frontend flag
Hides the Pipelines nav entry and degrades the routes gracefully when the backend has the flag off (cheap `GET /api/v1/pipelines/schema` capability probe, 501 = off).

### Docs
`docs/pipelines.md`: enabling the flag, authoring a definition, triggers, CLI, findings contract, UI overview.

Spec status header updated: execution complete, all 11 tasks merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)