### PR TITLE
feat(pipelines): V3 stage inspector panel

### DIFF
--- a/frontend/src/renderer/components/StageInspector.test.tsx
+++ b/frontend/src/renderer/components/StageInspector.test.tsx
@@ -1,0 +1,217 @@
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { StageDraft } from "../lib/pipeline-draft";
+import { StageInspector, type StageInspectorProps } from "./StageInspector";
+
+const STAGE_NAMES = ["fix", "triage", "tests"];
+
+function agentStage(): StageDraft {
+	return {
+		name: "fix",
+		trigger: { on: ["pr.updated"] },
+		executor: { kind: "agent", plugin: "claude-code", mode: "code" },
+	};
+}
+
+// Controlled harness: feeds edits back into the stage prop (like the editor
+// area does via usePipelineDraft) and records every change.
+function Harness({
+	initial,
+	onChange,
+	...rest
+}: { initial: StageDraft; onChange: (next: StageDraft) => void } & Partial<StageInspectorProps>) {
+	const [stage, setStage] = useState(initial);
+	return (
+		<StageInspector
+			stage={stage}
+			stageNames={STAGE_NAMES}
+			onChange={(next) => {
+				setStage(next);
+				onChange(next);
+			}}
+			{...rest}
+		/>
+	);
+}
+
+function renderInspector(initial: StageDraft, rest: Partial<StageInspectorProps> = {}) {
+	const changes: StageDraft[] = [];
+	render(<Harness initial={initial} onChange={(next) => changes.push(next)} {...rest} />);
+	return { last: () => changes[changes.length - 1] };
+}
+
+async function chooseOption(trigger: HTMLElement, optionName: string) {
+	await userEvent.click(trigger);
+	await userEvent.click(await screen.findByRole("option", { name: optionName }));
+}
+
+describe("StageInspector", () => {
+	it("binds the name field", async () => {
+		const { last } = renderInspector(agentStage());
+		await userEvent.type(screen.getByRole("textbox", { name: "Stage name" }), "!");
+		expect(last().name).toBe("fix!");
+	});
+
+	it("renders and binds agent executor fields", async () => {
+		const { last } = renderInspector(agentStage());
+		expect(screen.getByRole("combobox", { name: "Plugin" })).toHaveTextContent("claude-code");
+		expect(screen.getByRole("combobox", { name: "Mode" })).toHaveTextContent("code");
+
+		await chooseOption(screen.getByRole("combobox", { name: "Mode" }), "review");
+		expect(last().executor).toEqual({ kind: "agent", plugin: "claude-code", mode: "review" });
+
+		await chooseOption(screen.getByRole("combobox", { name: "Plugin" }), "codex");
+		expect(last().executor).toEqual({ kind: "agent", plugin: "codex", mode: "review" });
+	});
+
+	it("renders and binds command executor fields", async () => {
+		const { last } = renderInspector({
+			name: "tests",
+			trigger: { on: ["manual"] },
+			executor: { kind: "command", command: "npm", args: ["test"] },
+		});
+
+		await userEvent.type(screen.getByRole("textbox", { name: "Command" }), "x");
+		expect(last().executor.command).toBe("npmx");
+
+		await userEvent.type(screen.getByRole("textbox", { name: "Args" }), "\n--ci");
+		expect(last().executor.args).toEqual(["test", "--ci"]);
+
+		await userEvent.type(screen.getByRole("textbox", { name: "Env" }), "CI=1");
+		expect(last().executor.env).toEqual({ CI: "1" });
+
+		await userEvent.type(screen.getByRole("textbox", { name: "Working directory" }), "frontend");
+		expect(last().executor.cwd).toBe("frontend");
+		expect(last().executor.kind).toBe("command");
+	});
+
+	it("renders and binds builtin executor fields", async () => {
+		const { last } = renderInspector({
+			name: "gate",
+			trigger: { on: ["pr.merge_ready"] },
+			executor: { kind: "builtin", name: "router" },
+		});
+		expect(screen.getByRole("combobox", { name: "Builtin name" })).toHaveTextContent("router");
+
+		await chooseOption(screen.getByRole("combobox", { name: "Builtin name" }), "compose");
+		expect(last().executor).toEqual({ kind: "builtin", name: "compose" });
+	});
+
+	it("rewrites the executor sub-object when switching kind, leaking no fields", async () => {
+		const { last } = renderInspector(agentStage());
+		await userEvent.click(screen.getByRole("radio", { name: "command" }));
+		expect(last().executor).toEqual({ kind: "command" });
+
+		await userEvent.click(screen.getByRole("radio", { name: "builtin" }));
+		expect(last().executor).toEqual({ kind: "builtin" });
+
+		await userEvent.click(screen.getByRole("radio", { name: "agent" }));
+		expect(last().executor).toEqual({ kind: "agent" });
+	});
+
+	it("toggles trigger events as a multi-select", async () => {
+		const { last } = renderInspector(agentStage());
+		await userEvent.click(screen.getByRole("button", { name: "manual" }));
+		expect(last().trigger.on).toEqual(["pr.updated", "manual"]);
+
+		await userEvent.click(screen.getByRole("button", { name: "pr.updated" }));
+		expect(last().trigger.on).toEqual(["manual"]);
+	});
+
+	it("adds and removes dependsOn entries", async () => {
+		const { last } = renderInspector({ ...agentStage(), dependsOn: ["triage"] });
+		await userEvent.click(screen.getByRole("button", { name: "Add dependency tests" }));
+		expect(last().dependsOn).toEqual(["triage", "tests"]);
+
+		await userEvent.click(screen.getByRole("button", { name: "Remove dependency triage" }));
+		expect(last().dependsOn).toEqual(["tests"]);
+
+		await userEvent.click(screen.getByRole("button", { name: "Remove dependency tests" }));
+		expect(last().dependsOn).toBeUndefined();
+	});
+
+	it("never offers the stage itself as a dependency", () => {
+		renderInspector(agentStage());
+		expect(screen.queryByRole("button", { name: "Add dependency fix" })).not.toBeInTheDocument();
+	});
+
+	it("binds task prompt and JSON fields", async () => {
+		const { last } = renderInspector(agentStage());
+		await userEvent.type(screen.getByRole("textbox", { name: "Task prompt" }), "Fix it");
+		expect(last().task?.prompt).toBe("Fix it");
+
+		const inputs = screen.getByLabelText(/Inputs/);
+		await userEvent.click(inputs);
+		await userEvent.paste('{"from": "triage"}');
+		expect(last().task?.inputs).toEqual({ from: "triage" });
+
+		// Partial/invalid JSON never commits; it only flags the field.
+		await userEvent.type(inputs, "{{");
+		expect(screen.getByText("invalid JSON")).toBeInTheDocument();
+		expect(last().task?.inputs).toEqual({ from: "triage" });
+	});
+
+	it("binds the workspace segmented control", async () => {
+		const { last } = renderInspector(agentStage());
+		await userEvent.click(screen.getByRole("radio", { name: "isolated-rw" }));
+		expect(last().workspace).toBe("isolated-rw");
+
+		await userEvent.click(screen.getByRole("radio", { name: "Default" }));
+		expect(last().workspace).toBeUndefined();
+	});
+
+	it("binds the advanced knobs", async () => {
+		const { last } = renderInspector(agentStage());
+		await userEvent.type(screen.getByRole("spinbutton", { name: "Retries" }), "2");
+		expect(last().retries).toBe(2);
+
+		await userEvent.type(screen.getByRole("spinbutton", { name: "Timeout (ms)" }), "1800000");
+		expect(last().timeoutMs).toBe(1800000);
+
+		await userEvent.type(screen.getByRole("spinbutton", { name: "Max rounds" }), "5");
+		expect(last().maxLoopRounds).toBe(5);
+
+		await userEvent.type(screen.getByRole("spinbutton", { name: "Budget · max USD" }), "5");
+		await userEvent.type(screen.getByRole("spinbutton", { name: "Budget · max duration (ms)" }), "60000");
+		expect(last().budget).toEqual({ maxUsd: 5, maxDurationMs: 60000 });
+
+		await userEvent.clear(screen.getByRole("spinbutton", { name: "Retries" }));
+		expect(last().retries).toBeUndefined();
+	});
+
+	it("summarizes an unset routes.when as always", () => {
+		renderInspector(agentStage());
+		expect(screen.getByTestId("routes-when-summary")).toHaveTextContent("always");
+	});
+
+	it("summarizes a set routes.when predicate", () => {
+		renderInspector({
+			...agentStage(),
+			routes: { when: { kind: "not", predicate: { kind: "no_open_findings" } } },
+		});
+		expect(screen.getByTestId("routes-when-summary")).toHaveTextContent("not( no_open_findings )");
+	});
+
+	it("calls onEditCondition from the Edit-condition button", async () => {
+		const onEditCondition = vi.fn();
+		renderInspector(agentStage(), { onEditCondition });
+		await userEvent.click(screen.getByRole("button", { name: "Edit condition" }));
+		expect(onEditCondition).toHaveBeenCalledTimes(1);
+	});
+
+	it("disables Edit condition with a coming-soon affordance when unwired", () => {
+		renderInspector(agentStage());
+		const button = screen.getByRole("button", { name: /Edit condition · coming soon/ });
+		expect(button).toBeDisabled();
+		expect(button).toHaveAttribute("title", "Predicate builder coming soon");
+	});
+
+	it("calls onClose from the header close button", async () => {
+		const onClose = vi.fn();
+		renderInspector(agentStage(), { onClose });
+		await userEvent.click(screen.getByRole("button", { name: "Close inspector" }));
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/renderer/components/StageInspector.tsx
+++ b/frontend/src/renderer/components/StageInspector.tsx
@@ -1,0 +1,543 @@
+import { useId, useState } from "react";
+import { Pencil, X } from "lucide-react";
+import { cn } from "../lib/utils";
+import { AGENT_OPTIONS } from "../lib/agent-options";
+import {
+	ALL_EXECUTOR_KINDS,
+	ALL_TRIGGER_EVENTS,
+	type BuiltinName,
+	type ExecutorKind,
+	type StageDraft,
+	type StageTriggerEvent,
+	type TaskDraft,
+	type TaskMode,
+	type WorkspaceMode,
+} from "../lib/pipeline-draft";
+import { summarizePredicate } from "../lib/predicate-summary";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+
+// The stage inspector (mockup 1a, right panel): a form two-way bound to the
+// selected StageDraft. Every edit calls onChange with the next stage; the
+// editor area owns the draft (usePipelineDraft) and the selection
+// (useStageSelection), so this component stays a pure controlled form. The
+// routes.when block is a read-only summary; the predicate builder is V4 and is
+// wired in through onEditCondition by Batch C (undefined until then).
+
+export interface StageInspectorProps {
+	stage: StageDraft;
+	// All stage names in the draft; candidates for dependsOn.
+	stageNames: string[];
+	onChange: (next: StageDraft) => void;
+	// Opens the V4 predicate builder for routes.when. Left unwired until Batch
+	// C; while undefined the Edit-condition button is a disabled coming-soon stub.
+	onEditCondition?: () => void;
+	onClose?: () => void;
+}
+
+const TASK_MODES: TaskMode[] = ["review", "code", "answer"];
+const BUILTIN_NAMES: BuiltinName[] = ["router", "compose"];
+const WORKSPACE_OPTIONS: { value: WorkspaceMode | "default"; label: string }[] = [
+	{ value: "default", label: "Default" },
+	{ value: "shared-ro", label: "shared-ro" },
+	{ value: "isolated-rw", label: "isolated-rw" },
+];
+
+const EXECUTOR_SUBTITLE: Record<ExecutorKind, string> = {
+	agent: "Agent executor",
+	command: "Command executor",
+	builtin: "Builtin executor",
+};
+
+export function StageInspector({ stage, stageNames, onChange, onEditCondition, onClose }: StageInspectorProps) {
+	const update = (patch: Partial<StageDraft>) => onChange({ ...stage, ...patch });
+
+	// Merges a task patch and drops the task object entirely once every field is
+	// empty, so an untouched stage serializes without a dangling `task:`.
+	const updateTask = (patch: Partial<TaskDraft>) => {
+		const task: TaskDraft = { ...stage.task, ...patch };
+		const empty = !task.prompt && task.outputSchema === undefined && task.inputs === undefined;
+		update({ task: empty ? undefined : task });
+	};
+
+	const updateBudget = (patch: { maxUsd?: number; maxDurationMs?: number }) => {
+		const budget = { ...stage.budget, ...patch };
+		const empty = budget.maxUsd === undefined && budget.maxDurationMs === undefined;
+		update({ budget: empty ? undefined : budget });
+	};
+
+	// Swapping executor kind rewrites the sub-object from scratch so no other
+	// kind's fields leak into the serialized config (the daemon rejects them).
+	const setExecutorKind = (kind: ExecutorKind) => {
+		if (kind !== stage.executor.kind) update({ executor: { kind } });
+	};
+
+	const toggleTrigger = (event: StageTriggerEvent) => {
+		const on = stage.trigger.on.includes(event)
+			? stage.trigger.on.filter((e) => e !== event)
+			: [...stage.trigger.on, event];
+		update({ trigger: { on } });
+	};
+
+	const dependsOn = stage.dependsOn ?? [];
+	const dependsOnCandidates = stageNames.filter((name) => name !== stage.name && !dependsOn.includes(name));
+
+	return (
+		<div
+			data-testid="stage-inspector"
+			className="flex h-full min-h-0 w-full flex-col overflow-y-auto border-l border-border bg-background"
+		>
+			<div className="flex items-start justify-between gap-2 border-b border-border px-4 py-3">
+				<div className="min-w-0">
+					<h2 className="truncate text-control font-semibold text-foreground">Stage: {stage.name || "(unnamed)"}</h2>
+					<p className="text-caption text-passive">{EXECUTOR_SUBTITLE[stage.executor.kind]}</p>
+				</div>
+				{onClose && (
+					<Button size="icon-sm" variant="ghost" onClick={onClose} aria-label="Close inspector">
+						<X className="size-icon-sm" aria-hidden="true" />
+					</Button>
+				)}
+			</div>
+
+			<div className="flex flex-col gap-5 px-4 py-4">
+				<Section label="Name">
+					<Input
+						aria-label="Stage name"
+						value={stage.name}
+						onChange={(e) => update({ name: e.target.value })}
+						placeholder="stage-name"
+					/>
+				</Section>
+
+				<Section label="Trigger · on">
+					<div className="flex flex-wrap gap-1.5">
+						{ALL_TRIGGER_EVENTS.map((event) => {
+							const active = stage.trigger.on.includes(event);
+							return (
+								<button
+									key={event}
+									type="button"
+									aria-pressed={active}
+									onClick={() => toggleTrigger(event)}
+									className={cn(
+										"rounded-md border px-2 py-0.5 font-mono text-caption transition-colors",
+										active
+											? "border-accent-dim bg-accent-weak text-accent"
+											: "border-border bg-raised text-muted-foreground hover:text-foreground",
+									)}
+								>
+									{event}
+								</button>
+							);
+						})}
+					</div>
+				</Section>
+
+				<Section label="Executor">
+					<Segmented
+						ariaLabel="Executor kind"
+						options={ALL_EXECUTOR_KINDS.map((kind) => ({ value: kind, label: kind }))}
+						value={stage.executor.kind}
+						onChange={setExecutorKind}
+					/>
+					<div className="mt-2.5">
+						{stage.executor.kind === "agent" && <AgentFields stage={stage} update={update} />}
+						{stage.executor.kind === "command" && <CommandFields stage={stage} update={update} />}
+						{stage.executor.kind === "builtin" && <BuiltinFields stage={stage} update={update} />}
+					</div>
+				</Section>
+
+				<Section label="Task · prompt">
+					<textarea
+						aria-label="Task prompt"
+						className={textareaClass}
+						rows={4}
+						value={stage.task?.prompt ?? ""}
+						onChange={(e) => updateTask({ prompt: e.target.value || undefined })}
+						placeholder="What this stage should do."
+					/>
+					<div className="mt-2 flex flex-col gap-2">
+						<JsonField
+							key={`schema-${stage.name}`}
+							label="Output schema"
+							value={stage.task?.outputSchema}
+							onCommit={(outputSchema) => updateTask({ outputSchema })}
+						/>
+						<JsonField
+							key={`inputs-${stage.name}`}
+							label="Inputs"
+							value={stage.task?.inputs}
+							onCommit={(inputs) => updateTask({ inputs })}
+						/>
+					</div>
+				</Section>
+
+				<Section label="Depends on">
+					<div className="flex flex-wrap gap-1.5">
+						{dependsOn.map((name) => (
+							<span
+								key={name}
+								className="inline-flex items-center gap-1 rounded-md border border-border bg-raised px-2 py-0.5 font-mono text-caption text-foreground"
+							>
+								{name}
+								<button
+									type="button"
+									aria-label={`Remove dependency ${name}`}
+									onClick={() => {
+										const next = dependsOn.filter((d) => d !== name);
+										update({ dependsOn: next.length ? next : undefined });
+									}}
+									className="text-passive transition-colors hover:text-foreground"
+								>
+									<X className="size-icon-xs" aria-hidden="true" />
+								</button>
+							</span>
+						))}
+						{dependsOnCandidates.map((name) => (
+							<button
+								key={name}
+								type="button"
+								aria-label={`Add dependency ${name}`}
+								onClick={() => update({ dependsOn: [...dependsOn, name] })}
+								className="rounded-md border border-dashed border-border px-2 py-0.5 font-mono text-caption text-passive transition-colors hover:text-foreground"
+							>
+								+ {name}
+							</button>
+						))}
+						{dependsOn.length === 0 && dependsOnCandidates.length === 0 && (
+							<span className="text-caption text-passive">No other stages to depend on.</span>
+						)}
+					</div>
+				</Section>
+
+				<Section label="Routes · when">
+					<div className="rounded-md border border-border bg-surface/60 px-3 py-2.5">
+						<p className="text-caption text-muted-foreground">Run this stage only when</p>
+						<p className="mt-1 font-mono text-caption text-warning" data-testid="routes-when-summary">
+							{summarizePredicate(stage.routes?.when)}
+						</p>
+						<Button
+							size="sm"
+							variant="ghost"
+							className="mt-1.5 -ml-2 h-6 px-2 text-caption text-accent hover:text-accent"
+							disabled={!onEditCondition}
+							title={onEditCondition ? undefined : "Predicate builder coming soon"}
+							onClick={onEditCondition}
+						>
+							<Pencil className="size-icon-xs" aria-hidden="true" />
+							Edit condition{onEditCondition ? "" : " · coming soon"}
+						</Button>
+					</div>
+				</Section>
+
+				<Section label="Workspace">
+					<Segmented
+						ariaLabel="Workspace mode"
+						options={WORKSPACE_OPTIONS}
+						value={stage.workspace ?? "default"}
+						onChange={(value) => update({ workspace: value === "default" ? undefined : value })}
+					/>
+				</Section>
+
+				<Section label="Advanced knobs">
+					<div className="grid grid-cols-2 gap-x-3 gap-y-2.5">
+						<NumberField label="Retries" value={stage.retries} onCommit={(retries) => update({ retries })} />
+						<NumberField label="Timeout (ms)" value={stage.timeoutMs} onCommit={(timeoutMs) => update({ timeoutMs })} />
+						<NumberField
+							label="Max rounds"
+							value={stage.maxLoopRounds}
+							onCommit={(maxLoopRounds) => update({ maxLoopRounds })}
+						/>
+						<NumberField
+							label="Budget · max USD"
+							value={stage.budget?.maxUsd}
+							onCommit={(maxUsd) => updateBudget({ maxUsd })}
+						/>
+						<NumberField
+							label="Budget · max duration (ms)"
+							value={stage.budget?.maxDurationMs}
+							onCommit={(maxDurationMs) => updateBudget({ maxDurationMs })}
+						/>
+					</div>
+				</Section>
+			</div>
+		</div>
+	);
+}
+
+// --- executor sub-forms ------------------------------------------------------
+
+type FieldsProps = { stage: StageDraft; update: (patch: Partial<StageDraft>) => void };
+
+function AgentFields({ stage, update }: FieldsProps) {
+	const executor = stage.executor;
+	return (
+		<div className="grid grid-cols-2 gap-x-3 gap-y-2.5">
+			<LabeledControl label="Plugin">
+				<Select
+					value={executor.plugin ?? ""}
+					onValueChange={(plugin) => update({ executor: { ...executor, plugin } })}
+				>
+					<SelectTrigger size="sm" aria-label="Plugin" className="w-full">
+						<SelectValue placeholder="Select plugin" />
+					</SelectTrigger>
+					<SelectContent>
+						{AGENT_OPTIONS.map((plugin) => (
+							<SelectItem key={plugin} value={plugin}>
+								{plugin}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</LabeledControl>
+			<LabeledControl label="Mode">
+				<Select
+					value={executor.mode ?? ""}
+					onValueChange={(mode) => update({ executor: { ...executor, mode: mode as TaskMode } })}
+				>
+					<SelectTrigger size="sm" aria-label="Mode" className="w-full">
+						<SelectValue placeholder="Select mode" />
+					</SelectTrigger>
+					<SelectContent>
+						{TASK_MODES.map((mode) => (
+							<SelectItem key={mode} value={mode}>
+								{mode}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</LabeledControl>
+		</div>
+	);
+}
+
+function CommandFields({ stage, update }: FieldsProps) {
+	const executor = stage.executor;
+	return (
+		<div className="flex flex-col gap-2.5">
+			<LabeledControl label="Command">
+				<Input
+					aria-label="Command"
+					value={executor.command ?? ""}
+					onChange={(e) => update({ executor: { ...executor, command: e.target.value || undefined } })}
+					placeholder="npm"
+				/>
+			</LabeledControl>
+			<LabeledControl label="Args (one per line)">
+				<textarea
+					key={`args-${stage.name}`}
+					aria-label="Args"
+					className={textareaClass}
+					rows={2}
+					defaultValue={(executor.args ?? []).join("\n")}
+					onChange={(e) => {
+						const args = e.target.value
+							.split("\n")
+							.map((line) => line.trim())
+							.filter(Boolean);
+						update({ executor: { ...executor, args: args.length ? args : undefined } });
+					}}
+					placeholder={"test\n--ci"}
+				/>
+			</LabeledControl>
+			<LabeledControl label="Env (KEY=VALUE per line)">
+				<textarea
+					key={`env-${stage.name}`}
+					aria-label="Env"
+					className={textareaClass}
+					rows={2}
+					defaultValue={Object.entries(executor.env ?? {})
+						.map(([k, v]) => `${k}=${v}`)
+						.join("\n")}
+					onChange={(e) => update({ executor: { ...executor, env: parseEnvLines(e.target.value) } })}
+					placeholder="CI=1"
+				/>
+			</LabeledControl>
+			<LabeledControl label="Working directory">
+				<Input
+					aria-label="Working directory"
+					value={executor.cwd ?? ""}
+					onChange={(e) => update({ executor: { ...executor, cwd: e.target.value || undefined } })}
+					placeholder="(repo root)"
+				/>
+			</LabeledControl>
+		</div>
+	);
+}
+
+function BuiltinFields({ stage, update }: FieldsProps) {
+	const executor = stage.executor;
+	return (
+		<LabeledControl label="Builtin">
+			<Select
+				value={executor.name ?? ""}
+				onValueChange={(name) => update({ executor: { ...executor, name: name as BuiltinName } })}
+			>
+				<SelectTrigger size="sm" aria-label="Builtin name" className="w-full">
+					<SelectValue placeholder="Select builtin" />
+				</SelectTrigger>
+				<SelectContent>
+					{BUILTIN_NAMES.map((name) => (
+						<SelectItem key={name} value={name}>
+							{name}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+		</LabeledControl>
+	);
+}
+
+// --- small building blocks ---------------------------------------------------
+
+const textareaClass =
+	"w-full resize-y rounded-md border border-border bg-transparent px-3 py-2 font-mono text-caption leading-relaxed text-foreground outline-none transition placeholder:text-passive focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent-weak";
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+	return (
+		<section>
+			<h3 className="mb-1.5 font-mono text-micro font-medium uppercase tracking-wide text-passive">{label}</h3>
+			{children}
+		</section>
+	);
+}
+
+function LabeledControl({ label, children }: { label: string; children: React.ReactNode }) {
+	return (
+		<div className="flex min-w-0 flex-col gap-1">
+			<span className="text-caption text-muted-foreground">{label}</span>
+			{children}
+		</div>
+	);
+}
+
+function Segmented<T extends string>({
+	ariaLabel,
+	options,
+	value,
+	onChange,
+}: {
+	ariaLabel: string;
+	options: { value: T; label: string }[];
+	value: T;
+	onChange: (next: T) => void;
+}) {
+	return (
+		<div role="radiogroup" aria-label={ariaLabel} className="flex w-fit items-center rounded-md border border-border p-0.5">
+			{options.map((opt) => (
+				<button
+					key={opt.value}
+					type="button"
+					role="radio"
+					aria-checked={value === opt.value}
+					onClick={() => onChange(opt.value)}
+					className={cn(
+						"rounded px-2.5 py-1 text-caption font-medium transition-colors",
+						value === opt.value ? "bg-accent/15 text-foreground" : "text-muted-foreground hover:text-foreground",
+					)}
+				>
+					{opt.label}
+				</button>
+			))}
+		</div>
+	);
+}
+
+function NumberField({
+	label,
+	value,
+	onCommit,
+}: {
+	label: string;
+	value: number | undefined;
+	onCommit: (next: number | undefined) => void;
+}) {
+	const id = useId();
+	return (
+		<div className="flex min-w-0 flex-col gap-1">
+			<label htmlFor={id} className="text-caption text-muted-foreground">
+				{label}
+			</label>
+			<Input
+				id={id}
+				type="number"
+				value={value ?? ""}
+				onChange={(e) => {
+					if (e.target.value === "") return onCommit(undefined);
+					const n = Number(e.target.value);
+					if (Number.isFinite(n)) onCommit(n);
+				}}
+			/>
+		</div>
+	);
+}
+
+// JsonField edits an optional Record<string, unknown> as JSON text. The buffer
+// is local so partial JSON can be typed freely; only a parseable object (or an
+// emptied field) commits to the draft, anything else just shows the invalid
+// hint until it parses again.
+function JsonField({
+	label,
+	value,
+	onCommit,
+}: {
+	label: string;
+	value: Record<string, unknown> | undefined;
+	onCommit: (next: Record<string, unknown> | undefined) => void;
+}) {
+	const [text, setText] = useState(value === undefined ? "" : JSON.stringify(value, null, 2));
+	const [invalid, setInvalid] = useState(false);
+	const id = useId();
+
+	const handleChange = (next: string) => {
+		setText(next);
+		if (next.trim() === "") {
+			setInvalid(false);
+			onCommit(undefined);
+			return;
+		}
+		try {
+			const parsed: unknown = JSON.parse(next);
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+				setInvalid(false);
+				onCommit(parsed as Record<string, unknown>);
+			} else {
+				setInvalid(true);
+			}
+		} catch {
+			setInvalid(true);
+		}
+	};
+
+	return (
+		<div className="flex min-w-0 flex-col gap-1">
+			<label htmlFor={id} className="text-caption text-muted-foreground">
+				{label} <span className="text-passive">(JSON, optional)</span>
+				{invalid && <span className="ml-1 text-warning">invalid JSON</span>}
+			</label>
+			<textarea
+				id={id}
+				className={cn(textareaClass, invalid && "border-warning/60")}
+				rows={2}
+				value={text}
+				onChange={(e) => handleChange(e.target.value)}
+				placeholder="{ }"
+			/>
+		</div>
+	);
+}
+
+function parseEnvLines(text: string): Record<string, string> | undefined {
+	const out: Record<string, string> = {};
+	for (const line of text.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		const eq = trimmed.indexOf("=");
+		// ponytail: lines without KEY= are ignored while typing; /validate is the
+		// authoritative check, this field never blocks input.
+		if (eq <= 0) continue;
+		out[trimmed.slice(0, eq)] = trimmed.slice(eq + 1);
+	}
+	return Object.keys(out).length ? out : undefined;
+}

--- a/frontend/src/renderer/components/StageInspector.tsx
+++ b/frontend/src/renderer/components/StageInspector.tsx
@@ -275,10 +275,7 @@ function AgentFields({ stage, update }: FieldsProps) {
 	return (
 		<div className="grid grid-cols-2 gap-x-3 gap-y-2.5">
 			<LabeledControl label="Plugin">
-				<Select
-					value={executor.plugin ?? ""}
-					onValueChange={(plugin) => update({ executor: { ...executor, plugin } })}
-				>
+				<Select value={executor.plugin ?? ""} onValueChange={(plugin) => update({ executor: { ...executor, plugin } })}>
 					<SelectTrigger size="sm" aria-label="Plugin" className="w-full">
 						<SelectValue placeholder="Select plugin" />
 					</SelectTrigger>
@@ -424,7 +421,11 @@ function Segmented<T extends string>({
 	onChange: (next: T) => void;
 }) {
 	return (
-		<div role="radiogroup" aria-label={ariaLabel} className="flex w-fit items-center rounded-md border border-border p-0.5">
+		<div
+			role="radiogroup"
+			aria-label={ariaLabel}
+			className="flex w-fit items-center rounded-md border border-border p-0.5"
+		>
 			{options.map((opt) => (
 				<button
 					key={opt.value}

--- a/frontend/src/renderer/hooks/useStageSelection.ts
+++ b/frontend/src/renderer/hooks/useStageSelection.ts
@@ -1,0 +1,18 @@
+import { useCallback, useState } from "react";
+
+// Shared stage-selection state for the visual editor area: the canvas (V2)
+// selects a stage by name, the inspector (V3) binds to it. V3 defined this
+// minimal version first (V2 had not landed one yet); V2/Batch-C reconcile on
+// this name and shape when the canvas wires node clicks into it. The editor
+// area holds one instance and passes selectedStage/selectStage down; names are
+// the stable stage identity in the draft model (dependsOn/routes refer by name).
+export interface StageSelection {
+	selectedStage: string | null;
+	selectStage: (name: string | null) => void;
+}
+
+export function useStageSelection(): StageSelection {
+	const [selectedStage, setSelectedStage] = useState<string | null>(null);
+	const selectStage = useCallback((name: string | null) => setSelectedStage(name), []);
+	return { selectedStage, selectStage };
+}

--- a/frontend/src/renderer/lib/predicate-summary.test.ts
+++ b/frontend/src/renderer/lib/predicate-summary.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { PredicateDraft } from "./pipeline-draft";
+import { summarizePredicate } from "./predicate-summary";
+
+describe("summarizePredicate", () => {
+	it("summarizes an unset predicate as always", () => {
+		expect(summarizePredicate(undefined)).toBe("always");
+	});
+
+	it.each<[PredicateDraft, string]>([
+		[{ kind: "all_pass", stages: ["tests", "review"] }, "all_pass(tests, review)"],
+		[{ kind: "any_pass", stages: ["a"] }, "any_pass(a)"],
+		[{ kind: "majority_pass", stages: ["a", "b", "c"] }, "majority_pass(a, b, c)"],
+		[{ kind: "no_open_findings" }, "no_open_findings"],
+		[{ kind: "no_open_findings", stage: "triage" }, "no_open_findings(triage)"],
+		[{ kind: "finding_count_below", max: 3 }, "findings < 3"],
+		[{ kind: "finding_count_below", max: 1, stage: "triage", severity: "error" }, "findings(triage, error) < 1"],
+		[{ kind: "loop_rounds_at_least", n: 5 }, "rounds >= 5"],
+		[{ kind: "stage_retried_at_least", stage: "fix", n: 2 }, "retries(fix) >= 2"],
+		[{ kind: "stage_verdict", stage: "tests", verdict: "pass" }, "verdict(tests) = pass"],
+	])("summarizes each leaf kind", (predicate, expected) => {
+		expect(summarizePredicate(predicate)).toBe(expected);
+	});
+
+	it("summarizes nested combinators", () => {
+		const predicate: PredicateDraft = {
+			kind: "and",
+			predicates: [
+				{ kind: "not", predicate: { kind: "no_open_findings" } },
+				{ kind: "or", predicates: [{ kind: "loop_rounds_at_least", n: 2 }] },
+			],
+		};
+		expect(summarizePredicate(predicate)).toBe("and( not( no_open_findings ), or( rounds >= 2 ) )");
+	});
+});

--- a/frontend/src/renderer/lib/predicate-summary.ts
+++ b/frontend/src/renderer/lib/predicate-summary.ts
@@ -1,0 +1,42 @@
+import type { PredicateDraft } from "./pipeline-draft";
+
+// Read-only human summary of a routes.when predicate for the stage inspector
+// (mockup 1a: "Run this stage only when not( no_open_findings )"). This is NOT
+// the predicate editor (V4) nor its compiled-DSL readout; it only compresses a
+// PredicateDraft into one line of text. An unset predicate means the stage
+// always runs.
+
+export const ALWAYS_SUMMARY = "always";
+
+export function summarizePredicate(predicate?: PredicateDraft): string {
+	if (!predicate) return ALWAYS_SUMMARY;
+	return render(predicate);
+}
+
+function render(p: PredicateDraft): string {
+	switch (p.kind) {
+		case "all_pass":
+		case "any_pass":
+		case "majority_pass":
+			return `${p.kind}(${(p.stages ?? []).join(", ")})`;
+		case "no_open_findings":
+			return p.stage ? `no_open_findings(${p.stage})` : "no_open_findings";
+		case "finding_count_below": {
+			const scope = [p.stage, p.severity].filter(Boolean).join(", ");
+			return `findings${scope ? `(${scope})` : ""} < ${p.max ?? "?"}`;
+		}
+		case "loop_rounds_at_least":
+			return `rounds >= ${p.n ?? "?"}`;
+		case "stage_retried_at_least":
+			return `retries(${p.stage ?? "?"}) >= ${p.n ?? "?"}`;
+		case "stage_verdict":
+			return `verdict(${p.stage ?? "?"}) = ${p.verdict ?? "?"}`;
+		case "and":
+		case "or":
+			return `${p.kind}( ${(p.predicates ?? []).map(render).join(", ")} )`;
+		case "not":
+			return `not( ${p.predicate ? render(p.predicate) : "?"} )`;
+		default:
+			return p.kind;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/harshitsinghbhandari/agent-orchestrator/issues/253

## Summary

V3 of the visual pipeline editor: the right-hand stage inspector panel (mockup 1a), a controlled form two-way bound to the selected `StageDraft` over V1's draft model.

- `components/StageInspector.tsx`: Name; Trigger multi-select chips over the 5 events; Executor segmented (agent: plugin + mode selects; command: command/args/env/cwd; builtin: name select); Task prompt + optional output schema + inputs (JSON fields that only commit parseable objects); Depends-on chips (add candidates, remove); Workspace segmented (Default / shared-ro / isolated-rw); Advanced knobs (retries, timeout, max rounds, budget maxUsd/maxDurationMs). Swapping executor kind rewrites the executor sub-object to just `{ kind }` so no other kind's fields leak into the serialized config.
- `lib/predicate-summary.ts`: read-only human summary of `routes.when` ("always" when unset). The Edit-condition button calls an injected `onEditCondition` prop; it is left unwired here (Batch C wires the V4 builder) and renders disabled with a coming-soon affordance when undefined. No V4 import.
- `hooks/useStageSelection.ts`: minimal shared selection hook (selected stage name + setter). V2 had not landed one when this branched, so this defines the coordinate-on name/shape for V2/Batch-C to reconcile (canvas node click -> `selectStage`).

All edits flow through `onChange(next: StageDraft)`; the editor area owns the draft via V1's `usePipelineDraft`. No backend changes, no new deps, no V2/V4 files touched (`routeTree.gen.ts` untouched).

## Tests

- `lib/predicate-summary.test.ts`: every leaf kind, nesting, unset -> "always".
- `components/StageInspector.test.tsx`: each executor kind renders + binds; kind switch rewrites the executor with no field leaks; trigger multi-select; dependsOn add/remove (incl. self excluded); task prompt + JSON commit/invalid handling; workspace; all knobs incl. clearing back to undefined; routes summary set/unset; Edit-condition callback + disabled coming-soon state; close button.
- Full frontend suite: 67 files, 697 tests green. `tsc --noEmit` clean. Prettier check on changed files clean (CI parity).

## Risks / follow-ups

- Batch C wires `onEditCondition` to the V4 predicate builder and mounts the inspector next to the V2 canvas via `useStageSelection`.
- Renaming a stage does not cascade into other stages' `dependsOn`/predicate references; the daemon's `/validate` flags dangling refs (existing V1 behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)