### PR TITLE
feat(pipelines): V4 recursive predicate builder + compiled-DSL readout

### DIFF
--- a/frontend/src/renderer/components/PredicateBuilder.test.tsx
+++ b/frontend/src/renderer/components/PredicateBuilder.test.tsx
@@ -1,0 +1,259 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { UserEvent } from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { CompiledPredicateReadout, PredicateBuilder } from "./PredicateBuilder";
+import { PredicateBuilderModal } from "./PredicateBuilderModal";
+import type { PipelineDraft, PredicateDraft } from "../lib/pipeline-draft";
+import { parseYamlToDraft, serializeToYaml } from "../lib/pipeline-draft";
+
+const STAGES = ["security-review", "style-review", "verify", "fix"];
+
+// The harness exposes the live draft so tests can assert the exact
+// PredicateDraft the builder produced (e.g. for the codec round-trip).
+let latest: PredicateDraft | undefined;
+
+function Harness({ initial }: { initial?: PredicateDraft }) {
+	const [value, setValue] = useState<PredicateDraft | undefined>(initial);
+	latest = value;
+	return (
+		<>
+			<PredicateBuilder value={value} onChange={setValue} stageNames={STAGES} />
+			<CompiledPredicateReadout value={value} />
+		</>
+	);
+}
+
+function compiled(): string {
+	return screen.getByTestId("compiled-predicate").textContent ?? "";
+}
+
+async function pick(user: UserEvent, combobox: HTMLElement, option: string) {
+	await user.click(combobox);
+	await user.click(await screen.findByRole("option", { name: option }));
+}
+
+async function pickKind(user: UserEvent, kindLabel: string, index = 0) {
+	await pick(user, screen.getAllByRole("combobox", { name: "Condition kind" })[index], kindLabel);
+}
+
+describe("PredicateBuilder", () => {
+	it("starts empty (always) and adds a default condition", async () => {
+		const user = userEvent.setup();
+		render(<Harness />);
+
+		expect(screen.getByText("No condition · always matches.")).toBeInTheDocument();
+		expect(compiled()).toBe("always");
+
+		await user.click(screen.getByRole("button", { name: "+ Condition" }));
+		expect(compiled()).toBe("no_open_findings");
+	});
+
+	it("builds stage_verdict with stage and verdict selects", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={{ kind: "no_open_findings" }} />);
+
+		await pickKind(user, "stage verdict");
+		// Defaults: first stage + pass.
+		expect(compiled()).toBe("stage_verdict(security-review, pass)");
+
+		await pick(user, screen.getByRole("combobox", { name: "Stage" }), "verify");
+		await pick(user, screen.getByRole("combobox", { name: "Verdict" }), "fail");
+		expect(compiled()).toBe("stage_verdict(verify, fail)");
+		expect(latest).toEqual({ kind: "stage_verdict", stage: "verify", verdict: "fail" });
+	});
+
+	it("builds the stages[] kinds with the multiselect", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={{ kind: "no_open_findings" }} />);
+
+		await pickKind(user, "all pass");
+		expect(compiled()).toBe("all_pass[]");
+
+		await pick(user, screen.getByRole("combobox", { name: "Add stage" }), "security-review");
+		await pick(user, screen.getByRole("combobox", { name: "Add stage" }), "style-review");
+		expect(compiled()).toBe("all_pass[security-review, style-review]");
+
+		await user.click(screen.getByRole("button", { name: "Remove stage security-review" }));
+		expect(compiled()).toBe("all_pass[style-review]");
+
+		await pickKind(user, "any pass");
+		expect(compiled()).toBe("any_pass[]");
+		await pickKind(user, "majority pass");
+		expect(compiled()).toBe("majority_pass[]");
+	});
+
+	it("builds finding_count_below with max, severity, and optional scope", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={{ kind: "no_open_findings" }} />);
+
+		await pickKind(user, "finding count below");
+		expect(compiled()).toBe("finding_count_below(1)");
+
+		const max = screen.getByRole("spinbutton", { name: "Max findings" });
+		await user.clear(max);
+		await user.type(max, "2");
+		await pick(user, screen.getByRole("combobox", { name: "Severity" }), "error");
+		expect(compiled()).toBe("finding_count_below(2, *, error)");
+
+		await pick(user, screen.getByRole("combobox", { name: "Stage scope" }), "verify");
+		expect(compiled()).toBe("finding_count_below(2, verify, error)");
+		expect(latest).toEqual({ kind: "finding_count_below", max: 2, stage: "verify", severity: "error" });
+	});
+
+	it("builds the numeric kinds", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={{ kind: "no_open_findings" }} />);
+
+		await pickKind(user, "loop rounds at least");
+		expect(compiled()).toBe("loop_rounds_at_least(1)");
+		const rounds = screen.getByRole("spinbutton", { name: "Rounds" });
+		await user.clear(rounds);
+		await user.type(rounds, "3");
+		expect(compiled()).toBe("loop_rounds_at_least(3)");
+
+		await pickKind(user, "stage retried at least");
+		expect(compiled()).toBe("stage_retried_at_least(security-review, 1)");
+		await pick(user, screen.getByRole("combobox", { name: "Stage" }), "fix");
+		const retries = screen.getByRole("spinbutton", { name: "Retries" });
+		await user.clear(retries);
+		await user.type(retries, "3");
+		expect(compiled()).toBe("stage_retried_at_least(fix, 3)");
+	});
+
+	it("scopes no_open_findings to a stage", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={{ kind: "no_open_findings" }} />);
+
+		await pick(user, screen.getByRole("combobox", { name: "Stage scope" }), "verify");
+		expect(compiled()).toBe("no_open_findings(verify)");
+		await pick(user, screen.getByRole("combobox", { name: "Stage scope" }), "any stage");
+		expect(compiled()).toBe("no_open_findings");
+		expect(latest).toEqual({ kind: "no_open_findings" });
+	});
+
+	it("nests a group inside a group and toggles ALL/ANY", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={{ kind: "and", predicates: [{ kind: "no_open_findings" }] }} />);
+
+		await user.click(screen.getByRole("button", { name: "+ Group" }));
+		expect(compiled()).toBe(["and(", "  no_open_findings,", "  and( no_open_findings )", ")"].join("\n"));
+
+		// First "Group type" select is the root group, second the nested one.
+		await pick(user, screen.getAllByRole("combobox", { name: "Group type" })[0], "ANY");
+		expect(compiled()).toBe(["or(", "  no_open_findings,", "  and( no_open_findings )", ")"].join("\n"));
+		expect(latest).toEqual({
+			kind: "or",
+			predicates: [{ kind: "no_open_findings" }, { kind: "and", predicates: [{ kind: "no_open_findings" }] }],
+		});
+	});
+
+	it("wraps a condition in not and unwraps it", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={{ kind: "no_open_findings" }} />);
+
+		await user.click(screen.getByRole("button", { name: "Wrap condition in not" }));
+		expect(compiled()).toBe("not( no_open_findings )");
+		expect(latest).toEqual({ kind: "not", predicate: { kind: "no_open_findings" } });
+
+		await user.click(screen.getByRole("button", { name: "Unwrap not" }));
+		expect(compiled()).toBe("no_open_findings");
+	});
+
+	it("wraps a group in not", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={{ kind: "and", predicates: [{ kind: "no_open_findings" }] }} />);
+
+		await user.click(screen.getByRole("button", { name: "Wrap group in not" }));
+		expect(compiled()).toBe("not( and( no_open_findings ) )");
+	});
+
+	it("removes rows, and removing the root returns to the empty state", async () => {
+		const user = userEvent.setup();
+		render(
+			<Harness
+				initial={{ kind: "and", predicates: [{ kind: "no_open_findings" }, { kind: "loop_rounds_at_least", n: 2 }] }}
+			/>,
+		);
+
+		await user.click(screen.getAllByRole("button", { name: "Remove condition" })[0]);
+		expect(compiled()).toBe(["and(", "  loop_rounds_at_least(2)", ")"].join("\n"));
+
+		await user.click(screen.getByRole("button", { name: "Remove group" }));
+		expect(compiled()).toBe("always");
+		expect(screen.getByText("No condition · always matches.")).toBeInTheDocument();
+	});
+
+	it("round-trips a built predicate through the V1 codec", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={{ kind: "and", predicates: [{ kind: "no_open_findings" }] }} />);
+
+		// Build not( and( no_open_findings, stage_verdict(security-review, pass) ) )
+		// entirely through the UI, then round-trip the resulting draft.
+		await user.click(screen.getByRole("button", { name: "+ Condition" }));
+		await pickKind(user, "stage verdict", 1);
+		await user.click(screen.getByRole("button", { name: "Wrap group in not" }));
+		expect(compiled()).toBe("not( and( no_open_findings, stage_verdict(security-review, pass) ) )");
+
+		const pipeline: PipelineDraft = {
+			name: "p",
+			stages: [
+				{
+					name: "review",
+					trigger: { on: ["manual"] },
+					executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+					routes: { when: latest! },
+				},
+			],
+		};
+		const { draft, error } = parseYamlToDraft(serializeToYaml(pipeline));
+		expect(error).toBeUndefined();
+		expect(draft.stages[0].routes?.when).toEqual(latest);
+	});
+});
+
+describe("PredicateBuilderModal", () => {
+	it("commits edits on Done and renders the readout", async () => {
+		const user = userEvent.setup();
+		const onDone = vi.fn();
+		render(
+			<PredicateBuilderModal
+				open
+				title="Edit condition"
+				value={undefined}
+				stageNames={STAGES}
+				onCancel={() => {}}
+				onDone={onDone}
+			/>,
+		);
+
+		expect(screen.getByText("Edit condition")).toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: "+ Condition" }));
+		expect(compiled()).toBe("no_open_findings");
+
+		await user.click(screen.getByRole("button", { name: "Done" }));
+		expect(onDone).toHaveBeenCalledWith({ kind: "no_open_findings" });
+	});
+
+	it("discards edits on Cancel", async () => {
+		const user = userEvent.setup();
+		const onCancel = vi.fn();
+		const onDone = vi.fn();
+		render(
+			<PredicateBuilderModal
+				open
+				title="Edit condition"
+				value={{ kind: "no_open_findings" }}
+				stageNames={STAGES}
+				onCancel={onCancel}
+				onDone={onDone}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Wrap condition in not" }));
+		await user.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(onCancel).toHaveBeenCalled();
+		expect(onDone).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/renderer/components/PredicateBuilder.tsx
+++ b/frontend/src/renderer/components/PredicateBuilder.tsx
@@ -1,0 +1,485 @@
+import { XIcon } from "lucide-react";
+import type { PredicateDraft, PredicateKind, Severity, Verdict } from "../lib/pipeline-draft";
+import { compilePredicateToText } from "../lib/predicate-text";
+import { cn } from "../lib/utils";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+
+// PredicateBuilder is the recursive rule-builder over the predicate DSL
+// (mockup 1b): and/or groups render as "Match ALL/ANY of the following" boxes
+// with +Condition / +Group / not(…) wrap / remove, leaves render one row per
+// predicate kind with that kind's inputs (predicate.go is the authoritative
+// field set). It is a pure controlled component; V3 (routes.when) and V5 (exit
+// predicates) reuse it through PredicateBuilderModal. An undefined value is the
+// valid "always" start state.
+
+export interface PredicateBuilderProps {
+	value: PredicateDraft | undefined;
+	onChange: (value: PredicateDraft | undefined) => void;
+	stageNames: string[];
+}
+
+type LeafKind = Exclude<PredicateKind, "and" | "or" | "not">;
+
+const LEAF_KINDS: { kind: LeafKind; label: string }[] = [
+	{ kind: "no_open_findings", label: "no open findings" },
+	{ kind: "stage_verdict", label: "stage verdict" },
+	{ kind: "all_pass", label: "all pass" },
+	{ kind: "any_pass", label: "any pass" },
+	{ kind: "majority_pass", label: "majority pass" },
+	{ kind: "finding_count_below", label: "finding count below" },
+	{ kind: "loop_rounds_at_least", label: "loop rounds at least" },
+	{ kind: "stage_retried_at_least", label: "stage retried at least" },
+];
+
+const SEVERITIES: Severity[] = ["error", "warning", "info"];
+const VERDICTS: Verdict[] = ["pass", "fail", "neutral"];
+
+// Sentinel for "field unset" in single-selects; radix Select forbids the empty
+// string as an item value.
+const ANY = "__any__";
+
+// defaultLeaf seeds a freshly added or kind-switched row with that kind's
+// required fields so the row is valid (or one pick away from valid) at birth.
+function defaultLeaf(kind: LeafKind, stageNames: string[]): PredicateDraft {
+	switch (kind) {
+		case "all_pass":
+		case "any_pass":
+		case "majority_pass":
+			return { kind, stages: [] };
+		case "no_open_findings":
+			return { kind };
+		case "finding_count_below":
+			return { kind, max: 1 };
+		case "loop_rounds_at_least":
+			return { kind, n: 1 };
+		case "stage_retried_at_least":
+			return stageNames[0] ? { kind, stage: stageNames[0], n: 1 } : { kind, n: 1 };
+		case "stage_verdict":
+			return stageNames[0] ? { kind, stage: stageNames[0], verdict: "pass" } : { kind, verdict: "pass" };
+	}
+}
+
+function newCondition(stageNames: string[]): PredicateDraft {
+	return defaultLeaf("no_open_findings", stageNames);
+}
+
+// New groups start with one condition: an and/or with zero predicates is
+// invalid config, so never create one.
+function newGroup(stageNames: string[]): PredicateDraft {
+	return { kind: "and", predicates: [newCondition(stageNames)] };
+}
+
+export function PredicateBuilder({ value, onChange, stageNames }: PredicateBuilderProps) {
+	if (!value) {
+		return (
+			<div className="flex flex-col items-start gap-2 rounded-md border border-dashed border-border p-3">
+				<p className="text-xs text-muted-foreground">No condition · always matches.</p>
+				<div className="flex items-center gap-1">
+					<Button variant="ghost" size="sm" className="text-accent" onClick={() => onChange(newCondition(stageNames))}>
+						+ Condition
+					</Button>
+					<Button variant="ghost" size="sm" onClick={() => onChange(newGroup(stageNames))}>
+						+ Group
+					</Button>
+				</div>
+			</div>
+		);
+	}
+	return (
+		<PredicateNode value={value} onChange={onChange} onRemove={() => onChange(undefined)} stageNames={stageNames} />
+	);
+}
+
+interface NodeProps {
+	value: PredicateDraft;
+	onChange: (value: PredicateDraft) => void;
+	onRemove: () => void;
+	stageNames: string[];
+}
+
+function PredicateNode(props: NodeProps) {
+	if (props.value.kind === "and" || props.value.kind === "or") return <GroupNode {...props} />;
+	if (props.value.kind === "not") return <NotNode {...props} />;
+	return <LeafRow {...props} />;
+}
+
+function GroupNode({ value, onChange, onRemove, stageNames }: NodeProps) {
+	const children = value.predicates ?? [];
+	const setChildren = (predicates: PredicateDraft[]) => onChange({ ...value, predicates });
+
+	return (
+		<div
+			className={cn(
+				"flex flex-col gap-2 rounded-md border border-border border-l-2 bg-surface/50 p-3",
+				value.kind === "and" ? "border-l-accent" : "border-l-warning",
+			)}
+		>
+			<div className="flex items-center gap-2">
+				<span className="text-xs text-muted-foreground">Match</span>
+				<Select value={value.kind} onValueChange={(kind) => onChange({ ...value, kind: kind as "and" | "or" })}>
+					<SelectTrigger
+						size="sm"
+						aria-label="Group type"
+						className={cn("font-mono text-xs font-medium", value.kind === "and" ? "text-accent" : "text-warning")}
+					>
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="and">ALL</SelectItem>
+						<SelectItem value="or">ANY</SelectItem>
+					</SelectContent>
+				</Select>
+				<span className="text-xs text-muted-foreground">of the following</span>
+				<Button variant="ghost" size="icon-sm" className="ml-auto" aria-label="Remove group" onClick={onRemove}>
+					<XIcon className="size-icon-base" />
+				</Button>
+			</div>
+
+			{children.map((child, i) => (
+				<PredicateNode
+					// ponytail: index keys; rows are only appended/removed, never reordered.
+					key={i}
+					value={child}
+					stageNames={stageNames}
+					onChange={(next) => setChildren(children.map((c, j) => (j === i ? next : c)))}
+					onRemove={() => setChildren(children.filter((_, j) => j !== i))}
+				/>
+			))}
+
+			<div className="flex items-center gap-1">
+				<Button
+					variant="ghost"
+					size="sm"
+					className="text-accent"
+					onClick={() => setChildren([...children, newCondition(stageNames)])}
+				>
+					+ Condition
+				</Button>
+				<Button variant="ghost" size="sm" onClick={() => setChildren([...children, newGroup(stageNames)])}>
+					+ Group
+				</Button>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="ml-auto font-mono text-xs"
+					aria-label="Wrap group in not"
+					onClick={() => onChange({ kind: "not", predicate: value })}
+				>
+					not(…) wrap
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+function NotNode({ value, onChange, onRemove, stageNames }: NodeProps) {
+	return (
+		<div className="flex flex-col gap-2 rounded-md border border-border border-l-2 border-l-error bg-surface/50 p-3">
+			<div className="flex items-center gap-2">
+				<span className="font-mono text-xs font-medium text-error">not(…)</span>
+				{value.predicate && (
+					<Button variant="ghost" size="sm" aria-label="Unwrap not" onClick={() => onChange(value.predicate!)}>
+						Unwrap
+					</Button>
+				)}
+				<Button variant="ghost" size="icon-sm" className="ml-auto" aria-label="Remove not" onClick={onRemove}>
+					<XIcon className="size-icon-base" />
+				</Button>
+			</div>
+			{value.predicate ? (
+				<PredicateNode
+					value={value.predicate}
+					stageNames={stageNames}
+					onChange={(next) => onChange({ kind: "not", predicate: next })}
+					// A not without its inner predicate is invalid, so removing the child
+					// removes the whole wrapper.
+					onRemove={onRemove}
+				/>
+			) : (
+				<Button
+					variant="ghost"
+					size="sm"
+					className="self-start text-accent"
+					onClick={() => onChange({ kind: "not", predicate: newCondition(stageNames) })}
+				>
+					+ Condition
+				</Button>
+			)}
+		</div>
+	);
+}
+
+function LeafRow({ value, onChange, onRemove, stageNames }: NodeProps) {
+	return (
+		<div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-surface p-2">
+			<Select value={value.kind} onValueChange={(kind) => onChange(defaultLeaf(kind as LeafKind, stageNames))}>
+				<SelectTrigger size="sm" aria-label="Condition kind" className="font-mono text-xs">
+					<SelectValue />
+				</SelectTrigger>
+				<SelectContent>
+					{LEAF_KINDS.map(({ kind, label }) => (
+						<SelectItem key={kind} value={kind}>
+							{label}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+
+			<LeafFields value={value} onChange={onChange} stageNames={stageNames} />
+
+			<span className="ml-auto flex items-center">
+				<Button
+					variant="ghost"
+					size="sm"
+					className="font-mono text-xs"
+					aria-label="Wrap condition in not"
+					onClick={() => onChange({ kind: "not", predicate: value })}
+				>
+					not(…)
+				</Button>
+				<Button variant="ghost" size="icon-sm" aria-label="Remove condition" onClick={onRemove}>
+					<XIcon className="size-icon-base" />
+				</Button>
+			</span>
+		</div>
+	);
+}
+
+function LeafFields({ value, onChange, stageNames }: Omit<NodeProps, "onRemove">) {
+	switch (value.kind) {
+		case "all_pass":
+		case "any_pass":
+		case "majority_pass":
+			return (
+				<StageMultiSelect
+					stages={value.stages ?? []}
+					stageNames={stageNames}
+					onChange={(stages) => onChange({ ...value, stages })}
+				/>
+			);
+		case "no_open_findings":
+			return (
+				<>
+					<span className="text-xs text-passive">scope</span>
+					<OptionalStageSelect value={value} onChange={onChange} stageNames={stageNames} />
+				</>
+			);
+		case "finding_count_below":
+			return (
+				<>
+					<span className="text-xs text-passive">fewer than</span>
+					<NumberField field="max" min={0} label="Max findings" value={value} onChange={onChange} />
+					<SeveritySelect value={value} onChange={onChange} />
+					<span className="text-xs text-passive">in</span>
+					<OptionalStageSelect value={value} onChange={onChange} stageNames={stageNames} />
+				</>
+			);
+		case "loop_rounds_at_least":
+			return <NumberField field="n" min={1} label="Rounds" value={value} onChange={onChange} />;
+		case "stage_retried_at_least":
+			return (
+				<>
+					<RequiredStageSelect value={value} onChange={onChange} stageNames={stageNames} />
+					<span className="text-xs text-passive">at least</span>
+					<NumberField field="n" min={1} label="Retries" value={value} onChange={onChange} />
+				</>
+			);
+		case "stage_verdict":
+			return (
+				<>
+					<RequiredStageSelect value={value} onChange={onChange} stageNames={stageNames} />
+					<span className="text-xs text-passive">is</span>
+					<VerdictSelect value={value} onChange={onChange} />
+				</>
+			);
+		default:
+			return null;
+	}
+}
+
+function StageMultiSelect({
+	stages,
+	stageNames,
+	onChange,
+}: {
+	stages: string[];
+	stageNames: string[];
+	onChange: (stages: string[]) => void;
+}) {
+	const remaining = stageNames.filter((s) => !stages.includes(s));
+	return (
+		<>
+			{stages.map((stage) => (
+				<span
+					key={stage}
+					className="inline-flex items-center gap-1 rounded-md border border-border bg-raised px-2 py-0.5 font-mono text-xs text-foreground"
+				>
+					{stage}
+					<button
+						type="button"
+						aria-label={`Remove stage ${stage}`}
+						className="text-muted-foreground hover:text-foreground"
+						onClick={() => onChange(stages.filter((s) => s !== stage))}
+					>
+						<XIcon className="size-3" />
+					</button>
+				</span>
+			))}
+			{/* Controlled to "" so the trigger snaps back to the placeholder after each add. */}
+			<Select value="" onValueChange={(stage) => onChange([...stages, stage])}>
+				<SelectTrigger size="sm" aria-label="Add stage" className="text-xs" disabled={remaining.length === 0}>
+					<SelectValue placeholder="add stage…" />
+				</SelectTrigger>
+				<SelectContent>
+					{remaining.map((stage) => (
+						<SelectItem key={stage} value={stage}>
+							{stage}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+		</>
+	);
+}
+
+function OptionalStageSelect({ value, onChange, stageNames }: Omit<NodeProps, "onRemove">) {
+	return (
+		<Select
+			value={value.stage ?? ANY}
+			onValueChange={(v) => {
+				const next = { ...value };
+				if (v === ANY) delete next.stage;
+				else next.stage = v;
+				onChange(next);
+			}}
+		>
+			<SelectTrigger size="sm" aria-label="Stage scope" className="text-xs">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectItem value={ANY}>any stage</SelectItem>
+				{stageNames.map((stage) => (
+					<SelectItem key={stage} value={stage}>
+						{stage}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+function RequiredStageSelect({ value, onChange, stageNames }: Omit<NodeProps, "onRemove">) {
+	return (
+		<Select value={value.stage ?? ""} onValueChange={(stage) => onChange({ ...value, stage })}>
+			<SelectTrigger size="sm" aria-label="Stage" className="text-xs">
+				<SelectValue placeholder="stage…" />
+			</SelectTrigger>
+			<SelectContent>
+				{stageNames.map((stage) => (
+					<SelectItem key={stage} value={stage}>
+						{stage}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+function SeveritySelect({ value, onChange }: { value: PredicateDraft; onChange: (v: PredicateDraft) => void }) {
+	return (
+		<Select
+			value={value.severity ?? ANY}
+			onValueChange={(v) => {
+				const next = { ...value };
+				if (v === ANY) delete next.severity;
+				else next.severity = v as Severity;
+				onChange(next);
+			}}
+		>
+			<SelectTrigger size="sm" aria-label="Severity" className="text-xs">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectItem value={ANY}>any severity</SelectItem>
+				{SEVERITIES.map((severity) => (
+					<SelectItem key={severity} value={severity}>
+						{severity}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+function VerdictSelect({ value, onChange }: { value: PredicateDraft; onChange: (v: PredicateDraft) => void }) {
+	return (
+		<Select
+			value={value.verdict ?? ""}
+			onValueChange={(verdict) => onChange({ ...value, verdict: verdict as Verdict })}
+		>
+			<SelectTrigger size="sm" aria-label="Verdict" className="text-xs">
+				<SelectValue placeholder="verdict…" />
+			</SelectTrigger>
+			<SelectContent>
+				{VERDICTS.map((verdict) => (
+					<SelectItem key={verdict} value={verdict}>
+						{verdict}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+function NumberField({
+	field,
+	min,
+	label,
+	value,
+	onChange,
+}: {
+	field: "max" | "n";
+	min: number;
+	label: string;
+	value: PredicateDraft;
+	onChange: (v: PredicateDraft) => void;
+}) {
+	return (
+		<Input
+			type="number"
+			min={min}
+			aria-label={label}
+			className="h-control-md w-16 px-2 text-xs"
+			value={value[field] ?? ""}
+			onChange={(e) => {
+				const parsed = e.target.value === "" ? NaN : Number(e.target.value);
+				const next = { ...value };
+				// An emptied required number stays unset; the readout shows "?" and
+				// the daemon's /validate flags it.
+				if (Number.isFinite(parsed)) next[field] = Math.max(min, Math.trunc(parsed));
+				else delete next[field];
+				onChange(next);
+			}}
+		/>
+	);
+}
+
+// CompiledPredicateReadout is the live "Compiled predicate · matches the DSL"
+// panel under the builder (mockup 1b). Display only.
+export function CompiledPredicateReadout({ value }: { value: PredicateDraft | undefined }) {
+	return (
+		<div className="rounded-md border border-border bg-surface p-3">
+			<p className="font-mono text-micro font-medium uppercase tracking-wide text-passive">
+				Compiled predicate · matches the DSL
+			</p>
+			<pre
+				data-testid="compiled-predicate"
+				className="mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-xs text-foreground"
+			>
+				{compilePredicateToText(value, { pretty: true })}
+			</pre>
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/PredicateBuilderModal.tsx
+++ b/frontend/src/renderer/components/PredicateBuilderModal.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import type { PredicateDraft } from "../lib/pipeline-draft";
+import { PredicateBuilder, CompiledPredicateReadout } from "./PredicateBuilder";
+import { Button } from "./ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
+
+// PredicateBuilderModal hosts the builder + compiled readout behind a
+// Cancel/Done header (mockup 1b), so V3 (routes.when) and V5 (exit predicates)
+// can edit a predicate sub-tree in place. Edits stay local until Done; Cancel
+// (or dismissing the dialog) discards them. onDone(undefined) means the caller
+// should clear the predicate ("always").
+
+export interface PredicateBuilderModalProps {
+	open: boolean;
+	title: string;
+	value: PredicateDraft | undefined;
+	stageNames: string[];
+	onCancel: () => void;
+	onDone: (value: PredicateDraft | undefined) => void;
+}
+
+export function PredicateBuilderModal({
+	open,
+	title,
+	value,
+	stageNames,
+	onCancel,
+	onDone,
+}: PredicateBuilderModalProps) {
+	const [draft, setDraft] = useState<PredicateDraft | undefined>(value);
+
+	// Reseed the local draft each time the modal opens for a (possibly new)
+	// predicate; edits while open stay local until Done.
+	useEffect(() => {
+		if (open) setDraft(value);
+	}, [open, value]);
+
+	return (
+		<Dialog open={open} onOpenChange={(next) => !next && onCancel()}>
+			<DialogContent showCloseButton={false} aria-describedby={undefined} className="max-w-2xl">
+				<DialogHeader className="flex-row items-center justify-between">
+					<DialogTitle>{title}</DialogTitle>
+					<div className="flex items-center gap-2">
+						<Button variant="outline" size="sm" onClick={onCancel}>
+							Cancel
+						</Button>
+						<Button size="sm" onClick={() => onDone(draft)}>
+							Done
+						</Button>
+					</div>
+				</DialogHeader>
+				<div className="flex max-h-[65vh] flex-col gap-3 overflow-y-auto">
+					<PredicateBuilder value={draft} onChange={setDraft} stageNames={stageNames} />
+					<CompiledPredicateReadout value={draft} />
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/frontend/src/renderer/lib/predicate-text.test.ts
+++ b/frontend/src/renderer/lib/predicate-text.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { compilePredicateToText } from "./predicate-text";
+import type { PredicateDraft } from "./pipeline-draft";
+
+describe("compilePredicateToText", () => {
+	it("compiles no condition to always", () => {
+		expect(compilePredicateToText(undefined)).toBe("always");
+	});
+
+	it.each<[PredicateDraft, string]>([
+		[{ kind: "all_pass", stages: ["security-review", "style-review"] }, "all_pass[security-review, style-review]"],
+		[{ kind: "any_pass", stages: ["lint"] }, "any_pass[lint]"],
+		[{ kind: "majority_pass", stages: [] }, "majority_pass[]"],
+		[{ kind: "no_open_findings" }, "no_open_findings"],
+		[{ kind: "no_open_findings", stage: "verify" }, "no_open_findings(verify)"],
+		[{ kind: "finding_count_below", max: 2 }, "finding_count_below(2)"],
+		[{ kind: "finding_count_below", max: 2, stage: "verify" }, "finding_count_below(2, verify)"],
+		[
+			{ kind: "finding_count_below", max: 2, stage: "verify", severity: "error" },
+			"finding_count_below(2, verify, error)",
+		],
+		[{ kind: "finding_count_below", max: 2, severity: "warning" }, "finding_count_below(2, *, warning)"],
+		[{ kind: "finding_count_below" }, "finding_count_below(?)"],
+		[{ kind: "loop_rounds_at_least", n: 2 }, "loop_rounds_at_least(2)"],
+		[{ kind: "loop_rounds_at_least" }, "loop_rounds_at_least(?)"],
+		[{ kind: "stage_retried_at_least", stage: "fix", n: 3 }, "stage_retried_at_least(fix, 3)"],
+		[{ kind: "stage_retried_at_least" }, "stage_retried_at_least(?, ?)"],
+		[{ kind: "stage_verdict", stage: "verify", verdict: "pass" }, "stage_verdict(verify, pass)"],
+		[{ kind: "stage_verdict" }, "stage_verdict(?, ?)"],
+	])("compiles leaf %j", (draft, expected) => {
+		expect(compilePredicateToText(draft)).toBe(expected);
+	});
+
+	it("compiles composites inline", () => {
+		const draft: PredicateDraft = {
+			kind: "and",
+			predicates: [
+				{ kind: "no_open_findings" },
+				{ kind: "stage_verdict", stage: "verify", verdict: "pass" },
+				{
+					kind: "or",
+					predicates: [
+						{ kind: "loop_rounds_at_least", n: 2 },
+						{ kind: "all_pass", stages: ["security-review", "style-review"] },
+					],
+				},
+			],
+		};
+		expect(compilePredicateToText(draft)).toBe(
+			"and( no_open_findings, stage_verdict(verify, pass), or( loop_rounds_at_least(2), all_pass[security-review, style-review] ) )",
+		);
+	});
+
+	it("compiles not and empty groups", () => {
+		expect(compilePredicateToText({ kind: "not", predicate: { kind: "no_open_findings" } })).toBe(
+			"not( no_open_findings )",
+		);
+		expect(compilePredicateToText({ kind: "not" })).toBe("not( ? )");
+		expect(compilePredicateToText({ kind: "or", predicates: [] })).toBe("or( )");
+	});
+
+	it("pretty-prints a root and/or one child per line, nested composites inline", () => {
+		const draft: PredicateDraft = {
+			kind: "and",
+			predicates: [
+				{ kind: "no_open_findings" },
+				{ kind: "stage_verdict", stage: "verify", verdict: "pass" },
+				{
+					kind: "or",
+					predicates: [
+						{ kind: "loop_rounds_at_least", n: 2 },
+						{ kind: "all_pass", stages: ["security-review", "style-review"] },
+					],
+				},
+			],
+		};
+		expect(compilePredicateToText(draft, { pretty: true })).toBe(
+			[
+				"and(",
+				"  no_open_findings,",
+				"  stage_verdict(verify, pass),",
+				"  or( loop_rounds_at_least(2), all_pass[security-review, style-review] )",
+				")",
+			].join("\n"),
+		);
+	});
+
+	it("pretty falls back to inline for leaves, not-roots, and empty groups", () => {
+		expect(compilePredicateToText({ kind: "no_open_findings" }, { pretty: true })).toBe("no_open_findings");
+		expect(compilePredicateToText({ kind: "not", predicate: { kind: "no_open_findings" } }, { pretty: true })).toBe(
+			"not( no_open_findings )",
+		);
+		expect(compilePredicateToText({ kind: "and", predicates: [] }, { pretty: true })).toBe("and( )");
+	});
+});

--- a/frontend/src/renderer/lib/predicate-text.ts
+++ b/frontend/src/renderer/lib/predicate-text.ts
@@ -23,7 +23,10 @@ export function compilePredicateToText(value: PredicateDraft | undefined, opts: 
 	if (!value) return "always";
 	const children = value.predicates ?? [];
 	if (opts.pretty && (value.kind === "and" || value.kind === "or") && children.length > 0) {
-		return `${value.kind}(\n${children.map((c) => `  ${compile(c)},`).join("\n").replace(/,$/, "")}\n)`;
+		return `${value.kind}(\n${children
+			.map((c) => `  ${compile(c)},`)
+			.join("\n")
+			.replace(/,$/, "")}\n)`;
 	}
 	return compile(value);
 }

--- a/frontend/src/renderer/lib/predicate-text.ts
+++ b/frontend/src/renderer/lib/predicate-text.ts
@@ -1,0 +1,60 @@
+// Compiles a PredicateDraft tree into the textual predicate DSL shown in the
+// builder's "Compiled predicate · matches the DSL" readout (mockup 1b). Display
+// only: the YAML codec in pipeline-draft.ts remains the persisted form.
+//
+// Grammar (matches backend/internal/pipeline/predicate.go kinds exactly):
+//   all_pass[a, b]  any_pass[...]  majority_pass[...]
+//   no_open_findings              no_open_findings(stage)
+//   finding_count_below(max)      finding_count_below(max, stage)
+//   finding_count_below(max, stage, severity)
+//   finding_count_below(max, *, severity)   ("*" = any stage)
+//   loop_rounds_at_least(n)
+//   stage_retried_at_least(stage, n)
+//   stage_verdict(stage, verdict)
+//   and( p, q )   or( p, q )   not( p )
+// A missing required scalar renders as "?" so incomplete rows stay legible.
+// With { pretty: true } an and/or ROOT breaks its children one per line
+// (nested composites stay inline), matching the mockup readout. An undefined
+// predicate compiles to "always" (no condition).
+
+import type { PredicateDraft } from "./pipeline-draft";
+
+export function compilePredicateToText(value: PredicateDraft | undefined, opts: { pretty?: boolean } = {}): string {
+	if (!value) return "always";
+	const children = value.predicates ?? [];
+	if (opts.pretty && (value.kind === "and" || value.kind === "or") && children.length > 0) {
+		return `${value.kind}(\n${children.map((c) => `  ${compile(c)},`).join("\n").replace(/,$/, "")}\n)`;
+	}
+	return compile(value);
+}
+
+function compile(p: PredicateDraft): string {
+	switch (p.kind) {
+		case "all_pass":
+		case "any_pass":
+		case "majority_pass":
+			return `${p.kind}[${(p.stages ?? []).join(", ")}]`;
+		case "no_open_findings":
+			return p.stage ? `no_open_findings(${p.stage})` : "no_open_findings";
+		case "finding_count_below": {
+			const args = [p.max ?? "?"];
+			if (p.stage) args.push(p.stage);
+			else if (p.severity) args.push("*");
+			if (p.severity) args.push(p.severity);
+			return `finding_count_below(${args.join(", ")})`;
+		}
+		case "loop_rounds_at_least":
+			return `loop_rounds_at_least(${p.n ?? "?"})`;
+		case "stage_retried_at_least":
+			return `stage_retried_at_least(${p.stage || "?"}, ${p.n ?? "?"})`;
+		case "stage_verdict":
+			return `stage_verdict(${p.stage || "?"}, ${p.verdict || "?"})`;
+		case "and":
+		case "or": {
+			const children = p.predicates ?? [];
+			return children.length > 0 ? `${p.kind}( ${children.map(compile).join(", ")} )` : `${p.kind}( )`;
+		}
+		case "not":
+			return `not( ${p.predicate ? compile(p.predicate) : "?"} )`;
+	}
+}


### PR DESCRIPTION
Closes #254

## Summary

V4 of the visual pipeline editor (VISUAL_EDITOR_SPEC.md §4, mockup 1b): the standalone recursive predicate builder over the `PredicateDraft` sub-model, plus a live compiled-DSL readout and a modal wrapper for V3 (routes.when) and V5 (exit conditions) to open.

- `lib/predicate-text.ts`: `compilePredicateToText(draft, { pretty? })` renders the exact textual DSL from mockup 1b (`and( no_open_findings, stage_verdict(verify, pass), or( loop_rounds_at_least(2), all_pass[security-review, style-review] ) )`). Pretty mode breaks a root and/or one child per line like the mockup readout; `undefined` compiles to `always`.
- `components/PredicateBuilder.tsx`: pure controlled component `{ value, onChange, stageNames }`. and/or render as "Match ALL/ANY of the following" groups with `+ Condition`, `+ Group`, `not(…) wrap`, and per-row remove; `not` renders as a wrapper box with Unwrap; leaves render one row per kind with exactly the fields `backend/internal/pipeline/predicate.go` allows (stage multiselect chips for `all_pass`/`any_pass`/`majority_pass`, optional scope for `no_open_findings`/`finding_count_below`, severity/verdict dropdowns, number inputs for `max`/`n`). Undefined value is the valid "always" start state. Also exports `CompiledPredicateReadout`.
- `components/PredicateBuilderModal.tsx`: title + Cancel/Done dialog hosting builder + readout; edits stay local until Done.

Boundaries: no canvas (V2), no inspector (V3), no backend changes; files disjoint from the other Batch B workers.

## Tests

- `predicate-text.test.ts`: table tests for every leaf kind, composites, not, empty groups, pretty mode (21 tests).
- `PredicateBuilder.test.tsx`: build each leaf kind with its inputs binding, nest group in group + ALL/ANY toggle, not-wrap/unwrap on conditions and groups, remove rows/root, compiled readout strings, UI-built predicate round-trips through the V1 codec (`serializeToYaml` -> `parseYamlToDraft`), modal Done/Cancel semantics (13 tests).
- Full frontend suite green: 67 files, 703 tests. `tsc --noEmit` clean.

## Notes / risks

- `finding_count_below` display grammar (not shown in the mockup): `finding_count_below(max[, stage][, severity])`, with `*` for "any stage" when a severity is set without a stage. Display only; the YAML codec is unchanged.
- New rows seed required fields with defaults (first stage, n=1, max=1) so rows are valid at birth; incomplete fields render as `?` in the readout and remain the daemon /validate endpoint's job to flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)