### PR TITLE
feat(pipelines): V5 pipeline settings modal

### DIFF
--- a/frontend/src/renderer/components/PipelineDefinitionsPage.test.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.test.tsx
@@ -129,6 +129,42 @@ describe("PipelineDefinitionsPage", () => {
 		expect(screen.getByLabelText("Pipeline YAML")).toBeInTheDocument();
 	});
 
+	it("opens the settings modal from the top bar and commits edits into the draft", async () => {
+		renderPage();
+		const user = userEvent.setup();
+
+		await user.click(await screen.findByRole("button", { name: "Edit" }));
+		await user.click(screen.getByRole("button", { name: "Settings" }));
+		expect(screen.getByText("Pipeline settings")).toBeInTheDocument();
+
+		const name = screen.getByRole("textbox", { name: "Pipeline name" });
+		await user.clear(name);
+		await user.type(name, "renamed");
+		await user.click(screen.getByRole("button", { name: "Done" }));
+
+		// Modal closed; Done reserialized the draft (normalized shape) into the
+		// YAML buffer.
+		expect(screen.queryByText("Pipeline settings")).not.toBeInTheDocument();
+		expect(screen.getByLabelText("Pipeline YAML")).toHaveValue(
+			"name: renamed\nstages:\n  - name: a\n    executor:\n      kind: agent\n  - name: b\n    executor:\n      kind: agent\n",
+		);
+	});
+
+	it("closes the settings modal on Cancel without touching the buffer", async () => {
+		renderPage();
+		const user = userEvent.setup();
+
+		await user.click(await screen.findByRole("button", { name: "Edit" }));
+		await user.click(screen.getByRole("button", { name: "Settings" }));
+		const name = screen.getByRole("textbox", { name: "Pipeline name" });
+		await user.clear(name);
+		await user.type(name, "scrapped");
+		await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel" }));
+
+		expect(screen.queryByText("Pipeline settings")).not.toBeInTheDocument();
+		expect(screen.getByLabelText("Pipeline YAML")).toHaveValue(TWO_STAGE_YAML);
+	});
+
 	it("saves the edited YAML buffer when updating an existing definition", async () => {
 		renderPage();
 		const user = userEvent.setup();

--- a/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { AlertCircle, CheckCircle2, Loader2, Pencil, Plus, Trash2 } from "lucide-react";
+import { AlertCircle, CheckCircle2, Loader2, Pencil, Plus, Settings2, Trash2 } from "lucide-react";
 import { apiErrorMessage } from "../lib/api-client";
 import { formatTimeCompact } from "../lib/format-time";
 import {
@@ -17,6 +17,7 @@ import { usePipelineDraft, type PipelineDraftValidation } from "../hooks/usePipe
 import { useStageSelection } from "../hooks/useStageSelection";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { PipelineCanvas } from "./PipelineCanvas";
+import { PipelineSettingsModal } from "./PipelineSettingsModal";
 import { YamlEditor } from "./YamlEditor";
 import { Button } from "./ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./ui/table";
@@ -185,6 +186,7 @@ function DefinitionEditor({
 	// click, the stage inspector (V3) binds to the same stage name.
 	const selection = useStageSelection();
 	const [view, setView] = useState<ViewMode>("yaml");
+	const [settingsOpen, setSettingsOpen] = useState(false);
 	const [issues, setIssues] = useState<PipelineValidationIssue[] | null>(null);
 	const [genericError, setGenericError] = useState<string | null>(null);
 
@@ -218,6 +220,10 @@ function DefinitionEditor({
 				</div>
 				<div className="flex shrink-0 items-center gap-3">
 					<ViewToggle value={view} onChange={setView} />
+					<Button size="sm" variant="ghost" onClick={() => setSettingsOpen(true)}>
+						<Settings2 className="size-icon-sm" aria-hidden="true" />
+						Settings
+					</Button>
 					<ValidityIndicator validation={validation} />
 					<Button size="sm" variant="ghost" onClick={onClose} disabled={isSaving}>
 						Cancel
@@ -250,6 +256,16 @@ function DefinitionEditor({
 					<YamlEditor value={yamlSource} onChange={setYamlSource} aria-label="Pipeline YAML" className="px-1 py-2" />
 				)}
 			</div>
+
+			<PipelineSettingsModal
+				open={settingsOpen}
+				value={draft}
+				onCancel={() => setSettingsOpen(false)}
+				onDone={(next) => {
+					setDraft(next);
+					setSettingsOpen(false);
+				}}
+			/>
 
 			{genericError && (
 				<div className="flex items-start gap-2 border-t border-destructive/40 bg-destructive/10 px-4.5 py-2.5 text-caption text-destructive">

--- a/frontend/src/renderer/components/PipelineSettingsModal.test.tsx
+++ b/frontend/src/renderer/components/PipelineSettingsModal.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { PipelineSettingsModal } from "./PipelineSettingsModal";
+import type { PipelineDraft } from "../lib/pipeline-draft";
+
+function baseDraft(): PipelineDraft {
+	return {
+		name: "pr-review-loop",
+		stages: [
+			{ name: "security-review", trigger: { on: ["pr.opened"] }, executor: { kind: "agent" } },
+			{ name: "verify", trigger: { on: ["manual"] }, executor: { kind: "agent" } },
+		],
+	};
+}
+
+// The harness exposes the committed draft so tests assert exactly what Done
+// handed back through the V1 setDraft path.
+let committed: PipelineDraft;
+
+function Harness({ initial }: { initial: PipelineDraft }) {
+	const [draft, setDraft] = useState(initial);
+	const [open, setOpen] = useState(true);
+	committed = draft;
+	return (
+		<>
+			<button type="button" onClick={() => setOpen(true)}>
+				open settings
+			</button>
+			<PipelineSettingsModal
+				open={open}
+				value={draft}
+				onCancel={() => setOpen(false)}
+				onDone={(next) => {
+					setDraft(next);
+					setOpen(false);
+				}}
+			/>
+		</>
+	);
+}
+
+describe("PipelineSettingsModal", () => {
+	it("binds name, max concurrent, and allow fork PRs, committing on Done", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={baseDraft()} />);
+
+		const name = screen.getByRole("textbox", { name: "Pipeline name" });
+		await user.clear(name);
+		await user.type(name, "nightly-triage");
+
+		await user.click(screen.getByRole("button", { name: "Increase max concurrent" }));
+		await user.click(screen.getByRole("button", { name: "Increase max concurrent" }));
+		await user.click(screen.getByRole("switch", { name: "Allow fork PRs" }));
+
+		await user.click(screen.getByRole("button", { name: "Done" }));
+		expect(committed).toEqual({
+			...baseDraft(),
+			name: "nightly-triage",
+			maxConcurrentStages: 2,
+			allowForkPRs: true,
+		});
+	});
+
+	it("steps max concurrent down but never below 1", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={{ ...baseDraft(), maxConcurrentStages: 2 }} />);
+
+		const decrease = screen.getByRole("button", { name: "Decrease max concurrent" });
+		await user.click(decrease);
+		expect(screen.getByRole("spinbutton", { name: "Max concurrent" })).toHaveValue(1);
+		expect(decrease).toBeDisabled();
+
+		await user.click(screen.getByRole("button", { name: "Done" }));
+		expect(committed.maxConcurrentStages).toBe(1);
+	});
+
+	it("keeps an untouched draft unchanged, exit conditions included", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={baseDraft()} />);
+
+		await user.click(screen.getByRole("button", { name: "Done" }));
+		expect(committed).toEqual(baseDraft());
+		expect(committed.exitPredicates).toBeUndefined();
+	});
+
+	it("edits each exit condition on its own tab via the builder", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={baseDraft()} />);
+
+		// done tab is active by default and starts unset.
+		expect(screen.getByText("Run is done when…")).toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: "+ Condition" }));
+		expect(screen.getByTestId("compiled-predicate")).toHaveTextContent("no_open_findings");
+
+		// stalled gets its own predicate without touching done's.
+		await user.click(screen.getByRole("tab", { name: "stalled" }));
+		expect(screen.getByText("Run is stalled when…")).toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: "+ Condition" }));
+		const row = screen.getByRole("combobox", { name: "Condition kind" }).closest("div")!;
+		await user.click(within(row).getByRole("combobox", { name: "Condition kind" }));
+		await user.click(await screen.findByRole("option", { name: "loop rounds at least" }));
+
+		await user.click(screen.getByRole("button", { name: "Done" }));
+		expect(committed.exitPredicates).toEqual({
+			done: { kind: "no_open_findings" },
+			stalled: { kind: "loop_rounds_at_least", n: 1 },
+		});
+		// blocksMerge was never touched and stays unset.
+		expect(committed.exitPredicates?.blocksMerge).toBeUndefined();
+	});
+
+	it("removing a condition unsets it, dropping exitPredicates when all are unset", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={{ ...baseDraft(), exitPredicates: { done: { kind: "no_open_findings" } } }} />);
+
+		await user.click(screen.getByRole("button", { name: "Remove condition" }));
+		expect(screen.getByText("No condition · always matches.")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Done" }));
+		expect(committed.exitPredicates).toBeUndefined();
+	});
+
+	it("discards edits on Cancel and reseeds on reopen", async () => {
+		const user = userEvent.setup();
+		render(<Harness initial={baseDraft()} />);
+
+		const name = screen.getByRole("textbox", { name: "Pipeline name" });
+		await user.clear(name);
+		await user.type(name, "scrapped");
+		await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+		expect(committed).toEqual(baseDraft());
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "open settings" }));
+		expect(screen.getByRole("textbox", { name: "Pipeline name" })).toHaveValue("pr-review-loop");
+	});
+});

--- a/frontend/src/renderer/components/PipelineSettingsModal.tsx
+++ b/frontend/src/renderer/components/PipelineSettingsModal.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState } from "react";
+import { Minus, Plus } from "lucide-react";
+import type { ExitPredicatesDraft, PipelineDraft, PredicateDraft } from "../lib/pipeline-draft";
+import { cn } from "../lib/utils";
+import { CompiledPredicateReadout, PredicateBuilder } from "./PredicateBuilder";
+import { Button } from "./ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
+import { Input } from "./ui/input";
+import { Switch } from "./ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
+
+// PipelineSettingsModal edits the pipeline-level draft fields (mockup 1b top):
+// Name, Max concurrent (stepper, min 1), Allow fork PRs, plus the three exit
+// conditions (done / stalled / blocksMerge), each authored with V4's
+// PredicateBuilder over its optional slot in draft.exitPredicates. An unset
+// condition is valid ("no condition"). Edits stay local until Done, which hands
+// the caller the updated draft to commit through usePipelineDraft's setDraft;
+// Cancel (or dismissing) discards them.
+
+export interface PipelineSettingsModalProps {
+	open: boolean;
+	value: PipelineDraft;
+	onCancel: () => void;
+	onDone: (value: PipelineDraft) => void;
+}
+
+type ExitKey = keyof ExitPredicatesDraft;
+
+const EXIT_TABS: { key: ExitKey; dotClass: string; caption: string }[] = [
+	{ key: "done", dotClass: "bg-success", caption: "Run is done when…" },
+	{ key: "stalled", dotClass: "bg-error", caption: "Run is stalled when…" },
+	{ key: "blocksMerge", dotClass: "bg-warning", caption: "Run blocks merge when…" },
+];
+
+export function PipelineSettingsModal({ open, value, onCancel, onDone }: PipelineSettingsModalProps) {
+	const [draft, setDraft] = useState<PipelineDraft>(value);
+	const [tab, setTab] = useState<ExitKey>("done");
+
+	// Reseed the local draft each time the modal opens; edits while open stay
+	// local until Done (same convention as PredicateBuilderModal).
+	useEffect(() => {
+		if (open) {
+			setDraft(value);
+			setTab("done");
+		}
+	}, [open, value]);
+
+	const stageNames = draft.stages.map((s) => s.name).filter(Boolean);
+
+	const setMaxConcurrent = (n: number | undefined) => {
+		const next = { ...draft };
+		if (n === undefined || !Number.isFinite(n)) delete next.maxConcurrentStages;
+		else next.maxConcurrentStages = Math.max(1, Math.trunc(n));
+		setDraft(next);
+	};
+
+	const setExit = (key: ExitKey, predicate: PredicateDraft | undefined) => {
+		const exitPredicates: ExitPredicatesDraft = { ...draft.exitPredicates };
+		if (predicate) exitPredicates[key] = predicate;
+		else delete exitPredicates[key];
+		const next = { ...draft };
+		// All three unset means no exitPredicates at all, so the field round-trips
+		// as absent instead of an empty mapping.
+		if (Object.keys(exitPredicates).length > 0) next.exitPredicates = exitPredicates;
+		else delete next.exitPredicates;
+		setDraft(next);
+	};
+
+	const maxConcurrent = draft.maxConcurrentStages;
+
+	return (
+		<Dialog open={open} onOpenChange={(next) => !next && onCancel()}>
+			<DialogContent showCloseButton={false} aria-describedby={undefined} className="max-w-3xl">
+				<DialogHeader className="flex-row items-center justify-between">
+					<div className="min-w-0">
+						<DialogTitle>Pipeline settings</DialogTitle>
+						<p className="mt-0.5 truncate text-caption text-passive">
+							{draft.name || "untitled"} · exit conditions decide when the loop ends
+						</p>
+					</div>
+					<div className="flex shrink-0 items-center gap-2">
+						<Button variant="outline" size="sm" onClick={onCancel}>
+							Cancel
+						</Button>
+						<Button size="sm" onClick={() => onDone(draft)}>
+							Done
+						</Button>
+					</div>
+				</DialogHeader>
+
+				<div className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto">
+					<div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+						<label className="flex flex-col gap-1.5">
+							<FieldLabel>Name</FieldLabel>
+							<Input
+								aria-label="Pipeline name"
+								value={draft.name}
+								onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+							/>
+						</label>
+
+						<div className="flex flex-col gap-1.5">
+							<FieldLabel>Max concurrent</FieldLabel>
+							<div className="flex h-control-form items-center gap-1 rounded-md border border-border bg-surface px-1">
+								<Input
+									type="number"
+									min={1}
+									aria-label="Max concurrent"
+									className="h-full flex-1 border-0 bg-transparent px-2 shadow-none focus-visible:ring-0"
+									value={maxConcurrent ?? ""}
+									onChange={(e) =>
+										setMaxConcurrent(e.target.value === "" ? undefined : Number(e.target.value))
+									}
+								/>
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									aria-label="Decrease max concurrent"
+									disabled={(maxConcurrent ?? 1) <= 1}
+									onClick={() => setMaxConcurrent((maxConcurrent ?? 2) - 1)}
+								>
+									<Minus className="size-icon-sm" aria-hidden="true" />
+								</Button>
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									aria-label="Increase max concurrent"
+									onClick={() => setMaxConcurrent((maxConcurrent ?? 0) + 1)}
+								>
+									<Plus className="size-icon-sm" aria-hidden="true" />
+								</Button>
+							</div>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<FieldLabel>Allow fork PRs</FieldLabel>
+							<div className="flex h-control-form items-center gap-2 rounded-md border border-border bg-surface px-2.5">
+								<Switch
+									aria-label="Allow fork PRs"
+									checked={draft.allowForkPRs ?? false}
+									onCheckedChange={(checked) => setDraft({ ...draft, allowForkPRs: checked })}
+								/>
+								<span className="text-xs text-muted-foreground">{draft.allowForkPRs ? "On" : "Off"}</span>
+							</div>
+						</div>
+					</div>
+
+					<div className="flex flex-col gap-2">
+						<FieldLabel>Exit conditions</FieldLabel>
+						<Tabs value={tab} onValueChange={(next) => setTab(next as ExitKey)}>
+							<div className="flex items-center justify-between gap-2">
+								<TabsList>
+									{EXIT_TABS.map(({ key, dotClass }) => (
+										<TabsTrigger key={key} value={key} className="gap-1.5 font-mono">
+											<span className={cn("size-1.5 rounded-full", dotClass)} aria-hidden="true" />
+											{key}
+										</TabsTrigger>
+									))}
+								</TabsList>
+								<span className="text-caption text-passive">
+									{EXIT_TABS.find((t) => t.key === tab)?.caption}
+								</span>
+							</div>
+							{EXIT_TABS.map(({ key }) => (
+								<TabsContent key={key} value={key} className="mt-2 flex flex-col gap-3">
+									<PredicateBuilder
+										value={draft.exitPredicates?.[key]}
+										onChange={(predicate) => setExit(key, predicate)}
+										stageNames={stageNames}
+									/>
+									<CompiledPredicateReadout value={draft.exitPredicates?.[key]} />
+								</TabsContent>
+							))}
+						</Tabs>
+					</div>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+	return (
+		<span className="font-mono text-micro font-medium uppercase tracking-wide text-passive">{children}</span>
+	);
+}

--- a/frontend/src/renderer/components/PipelineSettingsModal.tsx
+++ b/frontend/src/renderer/components/PipelineSettingsModal.tsx
@@ -108,9 +108,7 @@ export function PipelineSettingsModal({ open, value, onCancel, onDone }: Pipelin
 									aria-label="Max concurrent"
 									className="h-full flex-1 border-0 bg-transparent px-2 shadow-none focus-visible:ring-0"
 									value={maxConcurrent ?? ""}
-									onChange={(e) =>
-										setMaxConcurrent(e.target.value === "" ? undefined : Number(e.target.value))
-									}
+									onChange={(e) => setMaxConcurrent(e.target.value === "" ? undefined : Number(e.target.value))}
 								/>
 								<Button
 									variant="ghost"
@@ -157,9 +155,7 @@ export function PipelineSettingsModal({ open, value, onCancel, onDone }: Pipelin
 										</TabsTrigger>
 									))}
 								</TabsList>
-								<span className="text-caption text-passive">
-									{EXIT_TABS.find((t) => t.key === tab)?.caption}
-								</span>
+								<span className="text-caption text-passive">{EXIT_TABS.find((t) => t.key === tab)?.caption}</span>
 							</div>
 							{EXIT_TABS.map(({ key }) => (
 								<TabsContent key={key} value={key} className="mt-2 flex flex-col gap-3">
@@ -180,7 +176,5 @@ export function PipelineSettingsModal({ open, value, onCancel, onDone }: Pipelin
 }
 
 function FieldLabel({ children }: { children: React.ReactNode }) {
-	return (
-		<span className="font-mono text-micro font-medium uppercase tracking-wide text-passive">{children}</span>
-	);
+	return <span className="font-mono text-micro font-medium uppercase tracking-wide text-passive">{children}</span>;
 }


### PR DESCRIPTION
Closes harshitsinghbhandari/agent-orchestrator#258

## Summary

V5 of the visual pipeline editor: the pipeline settings modal (mockup 1b top section).

- New `PipelineSettingsModal`: Name (text), Max concurrent (stepper, min 1, optional so an untouched draft omits the field), Allow fork PRs (switch).
- Exit conditions as three tabs (done / stalled / blocksMerge), each editing its optional slot in `draft.exitPredicates` with V4's `PredicateBuilder` inline plus the compiled-DSL readout. An unset condition stays unset; clearing the last one drops `exitPredicates` entirely.
- Edits stay local until Done (same convention as `PredicateBuilderModal`); Done commits through `usePipelineDraft.setDraft`, Cancel/dismiss discards.
- Wired into the definition editor top bar as a Settings entry in `PipelineDefinitionsPage`.

## Tests

- `PipelineSettingsModal.test.tsx`: field bindings commit on Done, stepper clamps at 1, untouched draft round-trips unchanged, each exit tab edits its own predicate, removing the only condition unsets it, Cancel discards and reopen reseeds.
- `PipelineDefinitionsPage.test.tsx`: Settings opens the modal, Done reserializes the draft into the YAML buffer, Cancel leaves the buffer untouched.
- Full renderer suite: 72 files / 767 tests green locally. Prettier-clean; no new tsc errors in touched files.

## Risks / notes

- Done reserializes the draft, so raw YAML formatting/comments are rewritten on commit; this is the established V1 canvas-edit path (`setDraft`).
- No route changes, so `routeTree.gen.ts` is untouched. No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)