### PR TITLE
feat(pipelines): V6 Canvas/Split/YAML sync + validation surfacing + routes.when wiring

### DIFF
--- a/frontend/src/renderer/components/PipelineCanvas.test.tsx
+++ b/frontend/src/renderer/components/PipelineCanvas.test.tsx
@@ -139,6 +139,21 @@ describe("PipelineCanvas", () => {
 		expect(document.querySelector('[data-stage-name="intake"]')).not.toHaveAttribute("data-in-cycle");
 	});
 
+	it("renders validation badges on affected nodes (mockup 1d)", () => {
+		render(
+			<PipelineCanvas
+				draft={draftOf(stage("review"), stage("fix"))}
+				stageIssues={{ review: ["task.prompt is required", "unknown plugin"] }}
+			/>,
+		);
+
+		expect(screen.getByLabelText("2 validation problems")).toBeInTheDocument();
+		// The first message renders inline on the card.
+		expect(screen.getByText("task.prompt is required")).toBeInTheDocument();
+		expect(document.querySelector('[data-stage-name="review"]')).toHaveAttribute("data-issue-count", "2");
+		expect(document.querySelector('[data-stage-name="fix"]')).not.toHaveAttribute("data-issue-count");
+	});
+
 	it("shows the zoom indicator and view controls", () => {
 		render(<PipelineCanvas draft={draftOf(stage("review"))} />);
 

--- a/frontend/src/renderer/components/PipelineCanvas.tsx
+++ b/frontend/src/renderer/components/PipelineCanvas.tsx
@@ -17,7 +17,7 @@ import {
 	type NodeProps,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { Maximize, Minus, Plus, Sparkles } from "lucide-react";
+import { AlertCircle, Maximize, Minus, Plus, Sparkles } from "lucide-react";
 import type { ExecutorKind, PipelineDraft, StageDraft } from "../lib/pipeline-draft";
 import {
 	addStage,
@@ -54,21 +54,24 @@ export interface PipelineCanvasProps {
 	onDraftChange?: (next: PipelineDraft) => void;
 	// The editor area's useStageSelection instance, shared with the inspector.
 	selection?: StageSelection;
+	// Validation issue messages keyed by stage name (V6, mockup 1d): affected
+	// nodes render an inline error badge plus the first message.
+	stageIssues?: Record<string, string[]>;
 }
 
 const CYCLE_FLASH_MS = 1800;
 
-type StageNodeType = Node<{ stage: StageDraft; inCycle: boolean }, "stage">;
+type StageNodeType = Node<{ stage: StageDraft; inCycle: boolean; issues: string[] }, "stage">;
 
-export function PipelineCanvas({ draft, onDraftChange, selection }: PipelineCanvasProps) {
+export function PipelineCanvas({ draft, onDraftChange, selection, stageIssues }: PipelineCanvasProps) {
 	return (
 		<ReactFlowProvider>
-			<CanvasInner draft={draft} onDraftChange={onDraftChange} selection={selection} />
+			<CanvasInner draft={draft} onDraftChange={onDraftChange} selection={selection} stageIssues={stageIssues} />
 		</ReactFlowProvider>
 	);
 }
 
-function CanvasInner({ draft, onDraftChange, selection }: PipelineCanvasProps) {
+function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineCanvasProps) {
 	const { fitView } = useReactFlow();
 	const selected = selection?.selectedStage ?? null;
 	const selectStage = selection?.selectStage;
@@ -118,12 +121,16 @@ function CanvasInner({ draft, onDraftChange, selection }: PipelineCanvasProps) {
 				type: "stage",
 				position: positions[id] ?? { x: 32, y: i * (STAGE_NODE_HEIGHT + 32) },
 				width: STAGE_NODE_WIDTH,
-				data: { stage, inCycle: persistent.has(id) || (flash?.path.includes(id) ?? false) },
+				data: {
+					stage,
+					inCycle: persistent.has(id) || (flash?.path.includes(id) ?? false),
+					issues: stageIssues?.[id] ?? [],
+				},
 				selected: selected === id,
 			});
 		});
 		return out;
-	}, [draft, positions, selected, flash]);
+	}, [draft, positions, selected, flash, stageIssues]);
 
 	const edges = useMemo<Edge[]>(() => {
 		const out: Edge[] = draftEdges(draft).map((edge) => {
@@ -317,7 +324,7 @@ function executorSubtitle(stage: StageDraft): string {
 }
 
 function StageNode({ data, selected }: NodeProps<StageNodeType>) {
-	const { stage, inCycle } = data;
+	const { stage, inCycle, issues } = data;
 	const badge = KIND_BADGE[stage.executor.kind] ?? KIND_BADGE.agent;
 	const footer = [stage.workspace, stage.maxLoopRounds != null ? `${stage.maxLoopRounds} rounds` : null]
 		.filter(Boolean)
@@ -335,6 +342,7 @@ function StageNode({ data, selected }: NodeProps<StageNodeType>) {
 			)}
 			data-stage-name={stage.name}
 			data-in-cycle={inCycle || undefined}
+			data-issue-count={issues.length || undefined}
 		>
 			<Handle type="target" position={Position.Left} className="!size-2 !border-border-strong !bg-raised" />
 			<div className="flex items-center gap-2">
@@ -347,9 +355,21 @@ function StageNode({ data, selected }: NodeProps<StageNodeType>) {
 				>
 					{badge.letter}
 				</span>
-				<span className="truncate text-control font-semibold text-foreground">{stage.name || "(unnamed)"}</span>
+				<span className="min-w-0 flex-1 truncate text-control font-semibold text-foreground">
+					{stage.name || "(unnamed)"}
+				</span>
+				{issues.length > 0 && (
+					<span
+						className="flex shrink-0 items-center gap-0.5 text-error"
+						aria-label={`${issues.length} validation ${issues.length === 1 ? "problem" : "problems"}`}
+					>
+						<AlertCircle className="size-icon-xs" aria-hidden="true" />
+						{issues.length > 1 && <span className="font-mono text-micro">{issues.length}</span>}
+					</span>
+				)}
 			</div>
 			<p className="mt-1 truncate font-mono text-micro text-muted-foreground">{executorSubtitle(stage)}</p>
+			{issues.length > 0 && <p className="mt-1.5 truncate text-micro text-error">{issues[0]}</p>}
 			{stage.routes?.when && (
 				<p className="mt-1.5">
 					<span className="inline-block max-w-full truncate rounded border border-warning/40 bg-warning/10 px-1.5 py-0.5 font-mono text-micro text-warning">

--- a/frontend/src/renderer/components/PipelineDefinitionsPage.test.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PipelineDefinitionsPage } from "./PipelineDefinitionsPage";
@@ -22,17 +22,70 @@ vi.mock("../lib/api-client", () => ({
 }));
 
 // CodeMirror needs a real layout engine jsdom lacks; swap it for a textarea so
-// the CRUD/validation flow is what's under test, not the editor internals.
+// the CRUD/validation/sync flow is what's under test, not the editor internals.
+// revealLine is exposed as a data attribute so the scroll wiring is assertable.
 vi.mock("./YamlEditor", () => ({
-	YamlEditor: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
-		<textarea aria-label="Pipeline YAML" value={value} onChange={(e) => onChange(e.target.value)} />
+	YamlEditor: ({
+		value,
+		onChange,
+		revealLine,
+	}: {
+		value: string;
+		onChange: (v: string) => void;
+		revealLine?: number | null;
+	}) => (
+		<textarea
+			aria-label="Pipeline YAML"
+			data-reveal-line={revealLine ?? ""}
+			value={value}
+			onChange={(e) => onChange(e.target.value)}
+		/>
 	),
 }));
 
-// React Flow needs ResizeObserver + real layout jsdom lacks; the canvas is a
-// V2 placeholder here, so stub it and keep the shell/CRUD flow under test.
+// React Flow needs ResizeObserver + real layout jsdom lacks; stub the canvas
+// with hooks that expose what the shell passes in (draft, selection, issue
+// badges) and drive draft edits / node selection like real canvas gestures.
 vi.mock("./PipelineCanvas", () => ({
-	PipelineCanvas: () => <div data-testid="pipeline-canvas" />,
+	PipelineCanvas: ({
+		draft,
+		onDraftChange,
+		selection,
+		stageIssues,
+	}: {
+		draft: { stages: { name: string }[] };
+		onDraftChange?: (next: unknown) => void;
+		selection?: { selectedStage: string | null; selectStage: (name: string | null) => void };
+		stageIssues?: Record<string, string[]>;
+	}) => (
+		<div data-testid="pipeline-canvas">
+			<span data-testid="canvas-stages">{draft.stages.map((s) => s.name).join(",")}</span>
+			<span data-testid="canvas-selected">{selection?.selectedStage ?? ""}</span>
+			<span data-testid="canvas-issues">{JSON.stringify(stageIssues ?? {})}</span>
+			<button onClick={() => selection?.selectStage(draft.stages[0]?.name ?? null)}>mock-select-first</button>
+			<button
+				onClick={() =>
+					onDraftChange?.({
+						...draft,
+						stages: [...draft.stages, { name: "added", trigger: { on: ["manual"] }, executor: { kind: "agent" } }],
+					})
+				}
+			>
+				mock-add-stage
+			</button>
+		</div>
+	),
+}));
+
+// V4's builder internals are covered by PredicateBuilder.test.tsx; here only
+// the open/write-back wiring matters, so Done reports a fixed predicate.
+vi.mock("./PredicateBuilderModal", () => ({
+	PredicateBuilderModal: ({ open, onDone }: { open: boolean; onDone: (value: unknown) => void }) =>
+		open ? (
+			<div data-testid="predicate-builder-modal">
+				<button onClick={() => onDone({ kind: "no_open_findings" })}>mock-builder-done</button>
+			</div>
+		) : null,
 }));
 
 // The editor debounce-calls POST /pipelines/validate; branch that off the create
@@ -183,7 +236,7 @@ describe("PipelineDefinitionsPage", () => {
 		);
 	});
 
-	it("surfaces each validation issue inline and keeps the buffer", async () => {
+	it("surfaces save-rejection issues in the Problems panel and keeps the buffer", async () => {
 		createResponse = {
 			data: undefined,
 			error: {
@@ -204,12 +257,122 @@ describe("PipelineDefinitionsPage", () => {
 		await user.click(screen.getByRole("button", { name: /New pipeline/ }));
 		await user.click(screen.getByRole("button", { name: "Save" }));
 
-		expect(await screen.findByText("2 validation issues")).toBeInTheDocument();
-		expect(screen.getByText("stages[0].name")).toBeInTheDocument();
-		expect(screen.getByText("is required")).toBeInTheDocument();
-		expect(screen.getByText("must not be empty")).toBeInTheDocument();
+		const panel = await screen.findByTestId("problems-panel");
+		expect(within(panel).getByText("Must resolve before saving")).toBeInTheDocument();
+		expect(within(panel).getByText("stages[0].name")).toBeInTheDocument();
+		expect(within(panel).getByText("is required")).toBeInTheDocument();
+		expect(within(panel).getByText("must not be empty")).toBeInTheDocument();
+		// Top-bar indicator counts the same problems; Save is now gated.
+		expect(screen.getByText("2 problems")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
 		// Buffer intact; the editor is still open.
 		expect(screen.getByLabelText("Pipeline YAML")).toBeInTheDocument();
+	});
+
+	it("syncs a canvas edit into the YAML pane in split view", async () => {
+		renderPage();
+		const user = userEvent.setup();
+
+		await user.click(await screen.findByRole("button", { name: "Edit" }));
+		await user.click(screen.getByRole("radio", { name: "Split" }));
+
+		await user.click(screen.getByRole("button", { name: "mock-add-stage" }));
+
+		// The draft edit reserializes into the buffer immediately (no debounce on
+		// the canvas -> YAML direction) and the canvas shows the new stage.
+		expect((screen.getByLabelText("Pipeline YAML") as HTMLTextAreaElement).value).toContain("added");
+		expect(screen.getByTestId("canvas-stages")).toHaveTextContent("a,b,added");
+	});
+
+	it("parses YAML edits back into the canvas after the debounce", async () => {
+		renderPage();
+		const user = userEvent.setup();
+
+		await user.click(await screen.findByRole("button", { name: "Edit" }));
+		await user.click(screen.getByRole("radio", { name: "Split" }));
+		expect(screen.getByTestId("canvas-stages")).toHaveTextContent("a,b");
+
+		fireEvent.change(screen.getByLabelText("Pipeline YAML"), {
+			target: { value: "name: review\nstages:\n  - name: zeta\n" },
+		});
+
+		await waitFor(() => expect(screen.getByTestId("canvas-stages")).toHaveTextContent(/^zeta$/), { timeout: 2000 });
+	});
+
+	it("keeps the last good graph on a YAML parse error and gates Save", async () => {
+		renderPage();
+		const user = userEvent.setup();
+
+		await user.click(await screen.findByRole("button", { name: "Edit" }));
+		await user.click(screen.getByRole("radio", { name: "Split" }));
+		expect(screen.getByTestId("yaml-parse-status")).toHaveTextContent("parsed");
+
+		fireEvent.change(screen.getByLabelText("Pipeline YAML"), { target: { value: "name: [broken" } });
+
+		await waitFor(() => expect(screen.getByTestId("yaml-parse-status")).toHaveTextContent("YAML error"), {
+			timeout: 2000,
+		});
+		// The canvas still renders the pre-error graph (mockup 1c: the editor
+		// never throws the drawing away mid-edit).
+		expect(screen.getByTestId("canvas-stages")).toHaveTextContent("a,b");
+		// The parse error is a blocking problem: panel row + disabled Save.
+		expect(within(screen.getByTestId("problems-panel")).getByText(/YAML syntax error/)).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+	});
+
+	it("renders live validate problems with Reveal selecting the stage", async () => {
+		postMock.mockImplementation((url: string) => {
+			if (url.endsWith("/validate")) {
+				return Promise.resolve({
+					data: { valid: false, issues: [{ path: "stages[0].executor.kind", message: "unknown executor kind" }] },
+					error: undefined,
+				});
+			}
+			return Promise.resolve(createResponse);
+		});
+		renderPage();
+		const user = userEvent.setup();
+
+		await user.click(await screen.findByRole("button", { name: "Edit" }));
+		await user.click(screen.getByRole("radio", { name: "Split" }));
+
+		const panel = await screen.findByTestId("problems-panel");
+		expect(within(panel).getByText("stages[0].executor.kind")).toBeInTheDocument();
+		expect(within(panel).getByText("unknown executor kind")).toBeInTheDocument();
+		expect(screen.getByText("1 problem")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+		// The affected node gets its badge messages.
+		expect(screen.getByTestId("canvas-issues")).toHaveTextContent('{"a":["unknown executor kind"]}');
+
+		// Reveal selects the offending stage; the split view scrolls the YAML
+		// pane to its block (stage `a` starts on line 3 of TWO_STAGE_YAML).
+		await user.click(within(panel).getByRole("button", { name: "Reveal" }));
+		expect(screen.getByTestId("canvas-selected")).toHaveTextContent("a");
+		expect(screen.getByLabelText("Pipeline YAML")).toHaveAttribute("data-reveal-line", "3");
+	});
+
+	it("opens the predicate builder from the inspector and writes routes.when back", async () => {
+		renderPage();
+		const user = userEvent.setup();
+
+		await user.click(await screen.findByRole("button", { name: "Edit" }));
+		await user.click(screen.getByRole("radio", { name: "Canvas" }));
+
+		// Selecting a node mounts the inspector for that stage.
+		await user.click(screen.getByRole("button", { name: "mock-select-first" }));
+		const inspector = await screen.findByTestId("stage-inspector");
+		expect(within(inspector).getByText("Stage: a")).toBeInTheDocument();
+
+		// Edit condition opens V4's builder; Done writes the predicate into the
+		// selected stage's routes.when on the draft.
+		await user.click(within(inspector).getByRole("button", { name: /Edit condition/ }));
+		await user.click(screen.getByRole("button", { name: "mock-builder-done" }));
+
+		expect(within(inspector).getByTestId("routes-when-summary")).toHaveTextContent("no_open_findings");
+
+		// The draft edit reserialized into the YAML buffer.
+		await user.click(screen.getByRole("radio", { name: "YAML" }));
+		expect((screen.getByLabelText("Pipeline YAML") as HTMLTextAreaElement).value).toContain("no_open_findings");
 	});
 
 	it("confirms before deleting a definition", async () => {

--- a/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
@@ -28,9 +28,9 @@ import { Button } from "./ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./ui/table";
 import { cn } from "../lib/utils";
 
-// The definition editor's view modes (mockups 1a/1c): the node-graph canvas, a
-// side-by-side canvas+YAML split, and the raw YAML editor. V1 fills in YAML mode
-// end to end; Canvas/Split mount placeholders that V2/V6 flesh out.
+// The definition editor's view modes (mockups 1a/1c): the node-graph canvas
+// (with the stage inspector on selection), a side-by-side canvas+YAML split
+// with two-way sync, and the raw YAML editor.
 type ViewMode = "canvas" | "split" | "yaml";
 
 // One of: browsing the list, editing an existing definition, or drafting a new

--- a/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { AlertCircle, CheckCircle2, Loader2, Pencil, Plus, Settings2, Trash2 } from "lucide-react";
 import { apiErrorMessage } from "../lib/api-client";
 import { formatTimeCompact } from "../lib/format-time";
+import type { StageDraft } from "../lib/pipeline-draft";
+import { issueStageName, stageIssueMessages, stageYamlLine } from "../lib/pipeline-problems";
 import {
 	countStagesFromYaml,
 	DEFAULT_PIPELINE_YAML,
@@ -17,7 +19,10 @@ import { usePipelineDraft, type PipelineDraftValidation } from "../hooks/usePipe
 import { useStageSelection } from "../hooks/useStageSelection";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { PipelineCanvas } from "./PipelineCanvas";
+import { PipelineProblemsPanel, type PipelineProblem } from "./PipelineProblemsPanel";
 import { PipelineSettingsModal } from "./PipelineSettingsModal";
+import { PredicateBuilderModal } from "./PredicateBuilderModal";
+import { StageInspector } from "./StageInspector";
 import { YamlEditor } from "./YamlEditor";
 import { Button } from "./ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./ui/table";
@@ -179,7 +184,7 @@ function DefinitionEditor({
 	onClose: () => void;
 }) {
 	const { create, update } = usePipelineDefinitionMutations(projectId);
-	const { yamlSource, setYamlSource, draft, setDraft, validation } = usePipelineDraft(
+	const { yamlSource, setYamlSource, draft, parseError, setDraft, validation } = usePipelineDraft(
 		def ? def.yamlSource : DEFAULT_PIPELINE_YAML,
 	);
 	// One selection instance for the editor area: the canvas writes on node
@@ -187,22 +192,71 @@ function DefinitionEditor({
 	const selection = useStageSelection();
 	const [view, setView] = useState<ViewMode>("yaml");
 	const [settingsOpen, setSettingsOpen] = useState(false);
-	const [issues, setIssues] = useState<PipelineValidationIssue[] | null>(null);
+	// Issues a rejected save reported; live validation covers the same ground,
+	// so these only matter in the race where a save beat the debounce. Cleared
+	// on the next buffer change (they describe a buffer that no longer exists).
+	const [saveIssues, setSaveIssues] = useState<PipelineValidationIssue[] | null>(null);
 	const [genericError, setGenericError] = useState<string | null>(null);
+	const [conditionOpen, setConditionOpen] = useState(false);
+
+	useEffect(() => setSaveIssues(null), [yamlSource]);
 
 	const mutation = def ? update : create;
 	const isSaving = mutation.isPending;
 
+	const selectedIndex = selection.selectedStage
+		? draft.stages.findIndex((s) => s.name === selection.selectedStage)
+		: -1;
+	const selectedStageDraft = selectedIndex >= 0 ? draft.stages[selectedIndex] : null;
+	const stageNames = draft.stages.map((s) => s.name).filter(Boolean);
+
+	// Inspector edits replace the selected stage in place; a rename moves the
+	// selection with the stage (names are the selection identity).
+	const updateSelectedStage = (next: StageDraft) => {
+		if (selectedIndex < 0) return;
+		setDraft({ ...draft, stages: draft.stages.map((s, i) => (i === selectedIndex ? next : s)) });
+		if (next.name !== selection.selectedStage) selection.selectStage(next.name || null);
+	};
+
+	// The blocking problem list (mockup 1d): the YAML parse error, the live
+	// /validate issues, and any leftover save-rejection issues, each resolved to
+	// the stage it points at so Reveal and the node badges can target it.
+	const liveIssues = validation.valid === false ? validation.issues : EMPTY_ISSUES;
+	const problems: PipelineProblem[] = [
+		...(parseError ? [{ path: "", message: `YAML syntax error: ${parseError}`, stage: null }] : []),
+		...dedupeIssues([...liveIssues, ...(saveIssues ?? [])]).map((issue) => ({
+			path: issue.path,
+			message: issue.message,
+			stage: issueStageName(draft, issue),
+		})),
+	];
+	const stageIssues = useMemo(
+		() => stageIssueMessages(draft, [...liveIssues, ...(saveIssues ?? [])]),
+		[draft, liveIssues, saveIssues],
+	);
+	// Save is gated on blocking problems (mockup 1d: "must resolve before
+	// saving"); "still checking" alone does not block.
+	const blocked = problems.length > 0;
+
+	// Reveal + node select scroll the YAML pane to the stage's block. The buffer
+	// is read through a ref so scrolling happens on selection changes only, not
+	// on every keystroke.
+	const yamlRef = useRef(yamlSource);
+	yamlRef.current = yamlSource;
+	const revealLine = useMemo(
+		() => (selection.selectedStage ? stageYamlLine(yamlRef.current, selection.selectedStage) : null),
+		[selection.selectedStage],
+	);
+
 	// Save serializes the draft to config and reuses the existing create/update
 	// endpoints. In YAML mode the buffer IS that config verbatim (so raw
-	// formatting survives); a canvas-only edit path (V2+) would setYamlSource via
-	// the draft first.
+	// formatting survives); canvas/inspector edits reserialize through setDraft.
 	const save = () => {
-		setIssues(null);
+		setSaveIssues(null);
 		setGenericError(null);
 		const onError = (error: unknown) => {
 			const parsed = parsePipelineValidationIssues(error);
-			if (parsed) setIssues(parsed);
+			if (parsed) setSaveIssues(parsed);
 			else setGenericError(apiErrorMessage(error));
 		};
 		if (def) update.mutate({ id: def.id, yamlSource }, { onSuccess: onClose, onError });
@@ -224,11 +278,11 @@ function DefinitionEditor({
 						<Settings2 className="size-icon-sm" aria-hidden="true" />
 						Settings
 					</Button>
-					<ValidityIndicator validation={validation} />
+					<ValidityIndicator validation={validation} problemCount={problems.length} />
 					<Button size="sm" variant="ghost" onClick={onClose} disabled={isSaving}>
 						Cancel
 					</Button>
-					<Button size="sm" variant="primary" onClick={save} disabled={isSaving}>
+					<Button size="sm" variant="primary" onClick={save} disabled={isSaving || blocked}>
 						{isSaving && <Loader2 className="size-icon-sm animate-spin" aria-hidden="true" />}
 						{isSaving ? "Saving…" : "Save"}
 					</Button>
@@ -237,23 +291,57 @@ function DefinitionEditor({
 
 			<div className="min-h-0 flex-1 overflow-hidden bg-surface/40">
 				{view === "canvas" ? (
-					<PipelineCanvas draft={draft} onDraftChange={setDraft} selection={selection} />
+					<div className="flex h-full min-h-0">
+						<div className="min-w-0 flex-1">
+							<PipelineCanvas draft={draft} onDraftChange={setDraft} selection={selection} stageIssues={stageIssues} />
+						</div>
+						{selectedStageDraft && (
+							<div className="w-80 shrink-0">
+								<StageInspector
+									stage={selectedStageDraft}
+									stageNames={stageNames}
+									onChange={updateSelectedStage}
+									onEditCondition={() => setConditionOpen(true)}
+									onClose={() => selection.selectStage(null)}
+								/>
+							</div>
+						)}
+					</div>
 				) : view === "split" ? (
 					<div className="flex h-full min-h-0">
 						<div className="min-w-0 flex-1 border-r border-border">
-							<PipelineCanvas draft={draft} onDraftChange={setDraft} selection={selection} />
+							<PipelineCanvas draft={draft} onDraftChange={setDraft} selection={selection} stageIssues={stageIssues} />
 						</div>
-						<div className="min-h-0 flex-1 overflow-hidden">
-							<YamlEditor
-								value={yamlSource}
-								onChange={setYamlSource}
-								aria-label="Pipeline YAML"
-								className="px-1 py-2"
-							/>
+						<div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+							<div
+								data-testid="yaml-parse-status"
+								className="flex shrink-0 items-center justify-end border-b border-border px-3 py-1"
+							>
+								{parseError ? (
+									<span className="truncate font-mono text-micro text-error">YAML error: {parseError}</span>
+								) : (
+									<span className="font-mono text-micro text-success">✓ parsed</span>
+								)}
+							</div>
+							<div className="min-h-0 flex-1 overflow-hidden">
+								<YamlEditor
+									value={yamlSource}
+									onChange={setYamlSource}
+									revealLine={revealLine}
+									aria-label="Pipeline YAML"
+									className="px-1 py-2"
+								/>
+							</div>
 						</div>
 					</div>
 				) : (
-					<YamlEditor value={yamlSource} onChange={setYamlSource} aria-label="Pipeline YAML" className="px-1 py-2" />
+					<YamlEditor
+						value={yamlSource}
+						onChange={setYamlSource}
+						revealLine={revealLine}
+						aria-label="Pipeline YAML"
+						className="px-1 py-2"
+					/>
 				)}
 			</div>
 
@@ -274,27 +362,37 @@ function DefinitionEditor({
 				</div>
 			)}
 
-			{issues && (
-				<div className="max-h-48 shrink-0 overflow-y-auto border-t border-warning/40 bg-warning/10 px-4.5 py-3">
-					<p className="mb-1.5 flex items-center gap-1.5 text-caption font-semibold text-warning">
-						<AlertCircle className="size-icon-sm" aria-hidden="true" />
-						{issues.length === 0
-							? "Validation failed"
-							: `${issues.length} validation ${issues.length === 1 ? "issue" : "issues"}`}
-					</p>
-					<ul className="space-y-1">
-						{issues.map((issue, i) => (
-							<li key={`${issue.path}-${i}`} className="text-caption text-foreground">
-								{issue.path && <span className="font-mono text-warning">{issue.path}</span>}
-								{issue.path && ": "}
-								<span className="text-muted-foreground">{issue.message}</span>
-							</li>
-						))}
-					</ul>
-				</div>
+			<PipelineProblemsPanel problems={problems} onReveal={(stage) => selection.selectStage(stage)} />
+
+			{selectedStageDraft && (
+				<PredicateBuilderModal
+					open={conditionOpen}
+					title={`Run condition · ${selectedStageDraft.name || "(unnamed)"}`}
+					value={selectedStageDraft.routes?.when}
+					stageNames={stageNames}
+					onCancel={() => setConditionOpen(false)}
+					onDone={(value) => {
+						setConditionOpen(false);
+						const { routes: _routes, ...rest } = selectedStageDraft;
+						updateSelectedStage(value ? { ...selectedStageDraft, routes: { when: value } } : rest);
+					}}
+				/>
 			)}
 		</div>
 	);
+}
+
+// A save rejection and the live validation of the same buffer report the same
+// issues; keep one row each.
+const EMPTY_ISSUES: PipelineValidationIssue[] = [];
+function dedupeIssues(issues: PipelineValidationIssue[]): PipelineValidationIssue[] {
+	const seen = new Set<string>();
+	return issues.filter((issue) => {
+		const key = `${issue.path} ${issue.message}`;
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
 }
 
 // ViewToggle is the top-bar Canvas / Split / YAML segmented control (mockups
@@ -327,9 +425,27 @@ function ViewToggle({ value, onChange }: { value: ViewMode; onChange: (next: Vie
 	);
 }
 
-// ValidityIndicator is the placeholder Valid / N-problems status wired to the
-// draft hook's live validation. V6 expands this into the full Problems panel.
-function ValidityIndicator({ validation }: { validation: PipelineDraftValidation }) {
+// ValidityIndicator is the top-bar Valid / N-problems status (mockups 1a/1d),
+// counting every blocking problem the panel shows (validate issues + YAML
+// parse errors), not just the last validate response.
+function ValidityIndicator({
+	validation,
+	problemCount,
+}: {
+	validation: PipelineDraftValidation;
+	problemCount: number;
+}) {
+	if (problemCount > 0) {
+		return (
+			<span
+				className="flex items-center gap-1 rounded-full border border-error/40 bg-error/10 px-2 py-0.5 text-caption text-error"
+				aria-live="polite"
+			>
+				<AlertCircle className="size-icon-sm" aria-hidden="true" />
+				{`${problemCount} ${problemCount === 1 ? "problem" : "problems"}`}
+			</span>
+		);
+	}
 	if (validation.isValidating) {
 		return (
 			<span className="flex items-center gap-1 text-caption text-passive" aria-live="polite">
@@ -347,11 +463,10 @@ function ValidityIndicator({ validation }: { validation: PipelineDraftValidation
 		);
 	}
 	if (validation.valid === false) {
-		const n = validation.issues.length;
 		return (
 			<span className="flex items-center gap-1 text-caption text-warning" aria-live="polite">
 				<AlertCircle className="size-icon-sm" aria-hidden="true" />
-				{n === 0 ? "Invalid" : `${n} ${n === 1 ? "problem" : "problems"}`}
+				Invalid
 			</span>
 		);
 	}

--- a/frontend/src/renderer/components/PipelineProblemsPanel.tsx
+++ b/frontend/src/renderer/components/PipelineProblemsPanel.tsx
@@ -1,0 +1,61 @@
+import { AlertCircle } from "lucide-react";
+import { Button } from "./ui/button";
+
+// The Problems panel (mockup 1d): docked under the editor surface, one row per
+// blocking problem with the config path, the message, and a Reveal action that
+// selects the offending stage (the canvas highlights it, the split view scrolls
+// the YAML to its block, the inspector opens on it in canvas view).
+
+export interface PipelineProblem {
+	// Dotted config path; "" for document-level problems (YAML parse errors).
+	path: string;
+	message: string;
+	// Stage the problem resolves to, when it does; enables the Reveal action.
+	stage: string | null;
+}
+
+export function PipelineProblemsPanel({
+	problems,
+	onReveal,
+}: {
+	problems: PipelineProblem[];
+	onReveal: (stage: string) => void;
+}) {
+	if (problems.length === 0) return null;
+	return (
+		<div data-testid="problems-panel" className="max-h-48 shrink-0 overflow-y-auto border-t border-border bg-surface/60">
+			<div className="flex items-center justify-between px-4.5 pt-2.5 pb-1.5">
+				<p className="flex items-center gap-1.5 text-caption font-semibold text-foreground">
+					Problems
+					<span className="rounded-full bg-error/15 px-1.5 font-mono text-2xs text-error">{problems.length}</span>
+				</p>
+				<p className="text-caption text-passive">Must resolve before saving</p>
+			</div>
+			<ul>
+				{problems.map((problem, i) => (
+					<li
+						key={`${problem.path}-${i}`}
+						className="flex items-start gap-2 border-t border-border/50 px-4.5 py-2 text-caption"
+					>
+						<AlertCircle className="mt-0.5 size-icon-sm shrink-0 text-error" aria-hidden="true" />
+						<span className="min-w-0 flex-1">
+							{problem.path && <span className="font-mono text-muted-foreground">{problem.path}</span>}
+							{problem.path && ": "}
+							<span className="text-foreground">{problem.message}</span>
+						</span>
+						{problem.stage && (
+							<Button
+								size="sm"
+								variant="ghost"
+								className="h-5 shrink-0 px-2 text-caption text-accent hover:text-accent"
+								onClick={() => onReveal(problem.stage!)}
+							>
+								Reveal
+							</Button>
+						)}
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/PipelineProblemsPanel.tsx
+++ b/frontend/src/renderer/components/PipelineProblemsPanel.tsx
@@ -23,7 +23,10 @@ export function PipelineProblemsPanel({
 }) {
 	if (problems.length === 0) return null;
 	return (
-		<div data-testid="problems-panel" className="max-h-48 shrink-0 overflow-y-auto border-t border-border bg-surface/60">
+		<div
+			data-testid="problems-panel"
+			className="max-h-48 shrink-0 overflow-y-auto border-t border-border bg-surface/60"
+		>
 			<div className="flex items-center justify-between px-4.5 pt-2.5 pb-1.5">
 				<p className="flex items-center gap-1.5 text-caption font-semibold text-foreground">
 					Problems

--- a/frontend/src/renderer/components/YamlEditor.tsx
+++ b/frontend/src/renderer/components/YamlEditor.tsx
@@ -73,6 +73,9 @@ export type YamlEditorProps = {
 	value: string;
 	onChange: (value: string) => void;
 	readOnly?: boolean;
+	// 1-based line to scroll into view (top-aligned). The split view sets this
+	// to the selected stage's block; out-of-range or null values are no-ops.
+	revealLine?: number | null;
 	className?: string;
 	"aria-label"?: string;
 };
@@ -81,7 +84,7 @@ export type YamlEditorProps = {
 // changes in only when they diverge from the live doc (so typing never fights a
 // re-render). `onChange` is read through a ref so the update listener stays
 // stable across renders.
-export function YamlEditor({ value, onChange, readOnly = false, className, ...aria }: YamlEditorProps) {
+export function YamlEditor({ value, onChange, readOnly = false, revealLine, className, ...aria }: YamlEditorProps) {
 	const hostRef = useRef<HTMLDivElement | null>(null);
 	const viewRef = useRef<EditorView | null>(null);
 	const onChangeRef = useRef(onChange);
@@ -117,6 +120,17 @@ export function YamlEditor({ value, onChange, readOnly = false, className, ...ar
 		if (current === value) return;
 		view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
 	}, [value]);
+
+	// Best-effort reveal: scroll the requested line to the top of the pane when
+	// it changes (node select in split view). Never touches the selection, so it
+	// cannot fight active typing.
+	useEffect(() => {
+		const view = viewRef.current;
+		if (!view || revealLine == null) return;
+		if (revealLine < 1 || revealLine > view.state.doc.lines) return;
+		const pos = view.state.doc.line(revealLine).from;
+		view.dispatch({ effects: EditorView.scrollIntoView(pos, { y: "start", yMargin: 8 }) });
+	}, [revealLine]);
 
 	return (
 		<div

--- a/frontend/src/renderer/hooks/usePipelineDraft.test.tsx
+++ b/frontend/src/renderer/hooks/usePipelineDraft.test.tsx
@@ -77,4 +77,36 @@ describe("usePipelineDraft", () => {
 		expect(result.current.draft.name).toBe("review");
 		expect(result.current.draft.stages).toHaveLength(1);
 	});
+
+	it("keeps the last good draft and surfaces parseError on a YAML syntax error", async () => {
+		const { result } = renderHook(() => usePipelineDraft(VALID_YAML), { wrapper });
+		expect(result.current.draft.name).toBe("review");
+
+		act(() => result.current.setYamlSource("name: [broken"));
+
+		await waitFor(() => expect(result.current.parseError).toBeTruthy());
+		// The graph is the pre-error one, not the empty fallback draft.
+		expect(result.current.draft.name).toBe("review");
+		expect(result.current.draft.stages).toHaveLength(1);
+
+		// A corrected buffer clears the error and re-derives the draft.
+		act(() => result.current.setYamlSource("name: fixed\nstages: []\n"));
+		await waitFor(() => expect(result.current.draft.name).toBe("fixed"));
+		expect(result.current.parseError).toBeUndefined();
+	});
+
+	it("applies canvas draft edits immediately and reserializes the buffer", () => {
+		const { result } = renderHook(() => usePipelineDraft(VALID_YAML), { wrapper });
+
+		act(() =>
+			result.current.setDraft({
+				name: "renamed",
+				stages: [{ name: "s", trigger: { on: ["manual"] }, executor: { kind: "agent" } }],
+			}),
+		);
+
+		// No debounce on the draft -> YAML direction: both update synchronously.
+		expect(result.current.draft.name).toBe("renamed");
+		expect(result.current.yamlSource).toContain("name: renamed");
+	});
 });

--- a/frontend/src/renderer/hooks/usePipelineDraft.ts
+++ b/frontend/src/renderer/hooks/usePipelineDraft.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "../lib/api-client";
 import { parseYamlToDraft, serializeToYaml, type PipelineDraft } from "../lib/pipeline-draft";
@@ -52,11 +52,30 @@ function useDebouncedValue<T>(value: T, delayMs: number): T {
 }
 
 export function usePipelineDraft(initialYaml: string): UsePipelineDraftResult {
-	const [yamlSource, setYamlSource] = useState(initialYaml);
-	const parsed = useMemo(() => parseYamlToDraft(yamlSource), [yamlSource]);
-	const setDraft = useCallback((next: PipelineDraft) => setYamlSource(serializeToYaml(next)), []);
+	const [yamlSource, setYamlSourceState] = useState(initialYaml);
+	// Canvas/inspector edits produce the next draft directly; hold it so those
+	// edits render immediately while the debounced re-parse of the reserialized
+	// buffer catches up. A YAML-pane edit clears it: the buffer is canonical.
+	const [pending, setPending] = useState<PipelineDraft | null>(null);
 
 	const debounced = useDebouncedValue(yamlSource, VALIDATE_DEBOUNCE_MS);
+	// Parse on the debounced buffer, not per keystroke, so YAML typing stays
+	// smooth (a parse rebuilds the whole canvas node set downstream).
+	const parsed = useMemo(() => parseYamlToDraft(debounced), [debounced]);
+	// On a YAML syntax error keep the last good graph (the split view must not
+	// blank the canvas mid-edit); the error itself surfaces as parseError.
+	const lastGoodRef = useRef(parsed.draft);
+	if (!parsed.error) lastGoodRef.current = parsed.draft;
+
+	const setYamlSource = useCallback((next: string) => {
+		setPending(null);
+		setYamlSourceState(next);
+	}, []);
+	const setDraft = useCallback((next: PipelineDraft) => {
+		setPending(next);
+		setYamlSourceState(serializeToYaml(next));
+	}, []);
+
 	const enabled = debounced.trim().length > 0;
 	const query = useQuery({
 		queryKey: pipelineValidateQueryKey(debounced),
@@ -75,5 +94,10 @@ export function usePipelineDraft(initialYaml: string): UsePipelineDraftResult {
 		issues: query.data?.issues ?? [],
 	};
 
-	return { yamlSource, setYamlSource, draft: parsed.draft, parseError: parsed.error, setDraft, validation };
+	const draft = pending ?? (parsed.error ? lastGoodRef.current : parsed.draft);
+	// While a pending canvas edit awaits its round-trip re-parse, the buffer was
+	// serialized by us and cannot be broken; suppress the stale error.
+	const parseError = pending ? undefined : parsed.error;
+
+	return { yamlSource, setYamlSource, draft, parseError, setDraft, validation };
 }

--- a/frontend/src/renderer/lib/pipeline-problems.test.ts
+++ b/frontend/src/renderer/lib/pipeline-problems.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { PipelineDraft, StageDraft } from "./pipeline-draft";
+import { issueStageName, stageIssueMessages, stageYamlLine } from "./pipeline-problems";
+
+function stage(name: string): StageDraft {
+	return { name, trigger: { on: ["manual"] }, executor: { kind: "agent" } };
+}
+
+const draft: PipelineDraft = { name: "review", stages: [stage("a"), stage("b")] };
+
+describe("issueStageName", () => {
+	it("resolves a stage-scoped path to the stage's name", () => {
+		expect(issueStageName(draft, { path: "stages[1].executor.kind", message: "m" })).toBe("b");
+		expect(issueStageName(draft, { path: "stages[0]", message: "m" })).toBe("a");
+	});
+
+	it("returns null for document-level and dangling paths", () => {
+		expect(issueStageName(draft, { path: "name", message: "m" })).toBeNull();
+		expect(issueStageName(draft, { path: "exitPredicates.done", message: "m" })).toBeNull();
+		expect(issueStageName(draft, { path: "stages[9].name", message: "m" })).toBeNull();
+	});
+});
+
+describe("stageIssueMessages", () => {
+	it("groups messages by the stage they resolve to and drops the rest", () => {
+		const grouped = stageIssueMessages(draft, [
+			{ path: "stages[0].name", message: "first" },
+			{ path: "stages[0].executor", message: "second" },
+			{ path: "stages[1].trigger", message: "other" },
+			{ path: "name", message: "document-level" },
+		]);
+		expect(grouped).toEqual({ a: ["first", "second"], b: ["other"] });
+	});
+});
+
+describe("stageYamlLine", () => {
+	const source = "name: fix\nstages:\n  - name: intake\n    executor:\n      kind: agent\n  - name: fix\n";
+
+	it("finds the 1-based line of the stage's name entry", () => {
+		expect(stageYamlLine(source, "intake")).toBe(3);
+	});
+
+	it("matches inside the stages block only, never the pipeline-level name", () => {
+		// The pipeline is also called "fix" (line 1); the stage is on line 6.
+		expect(stageYamlLine(source, "fix")).toBe(6);
+	});
+
+	it("returns null when the stage cannot be located", () => {
+		expect(stageYamlLine(source, "missing")).toBeNull();
+		expect(stageYamlLine(source, "")).toBeNull();
+	});
+});

--- a/frontend/src/renderer/lib/pipeline-problems.ts
+++ b/frontend/src/renderer/lib/pipeline-problems.ts
@@ -1,0 +1,53 @@
+// Helpers tying /validate issues and the YAML buffer to the editor's
+// validation surfaces (V6): which stage an issue points at (inline node badges
+// + the Problems panel's Reveal) and which YAML line a stage's block starts on
+// (split view scrolls there on node select).
+
+import type { PipelineDraft } from "./pipeline-draft";
+import type { PipelineValidationIssue } from "./pipeline-yaml";
+
+// Issue paths from the daemon address stages positionally: `stages[2].name`.
+// Returns the stage's name in the draft, or null when the path is not
+// stage-scoped (or points past the stage list / at an unnamed stage).
+export function issueStageName(draft: PipelineDraft, issue: PipelineValidationIssue): string | null {
+	const match = /^stages\[(\d+)\]/.exec(issue.path);
+	if (!match) return null;
+	return draft.stages[Number(match[1])]?.name || null;
+}
+
+// Groups issue messages by the stage they resolve to, for the canvas badges.
+export function stageIssueMessages(
+	draft: PipelineDraft,
+	issues: PipelineValidationIssue[],
+): Record<string, string[]> {
+	const out: Record<string, string[]> = {};
+	for (const issue of issues) {
+		const name = issueStageName(draft, issue);
+		if (!name) continue;
+		(out[name] ??= []).push(issue.message);
+	}
+	return out;
+}
+
+// stageYamlLine finds the 1-based line of `name: <stage>` inside the stages
+// block. Best-effort text scan (per spec); exotic quoting or a name split
+// across lines just means the caller does not scroll.
+export function stageYamlLine(source: string, stageName: string): number | null {
+	if (!stageName) return null;
+	const escaped = stageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const nameLine = new RegExp(`^\\s*-?\\s*name:\\s*["']?${escaped}["']?\\s*(#.*)?$`);
+	const lines = source.split("\n");
+	let inStages = false;
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		if (/^stages\s*:/.test(line)) {
+			inStages = true;
+			continue;
+		}
+		// A new top-level key ends the stages block (so the pipeline-level
+		// `name:` never matches a stage of the same name).
+		if (inStages && /^\S/.test(line)) inStages = false;
+		if (inStages && nameLine.test(line)) return i + 1;
+	}
+	return null;
+}

--- a/frontend/src/renderer/lib/pipeline-problems.ts
+++ b/frontend/src/renderer/lib/pipeline-problems.ts
@@ -16,10 +16,7 @@ export function issueStageName(draft: PipelineDraft, issue: PipelineValidationIs
 }
 
 // Groups issue messages by the stage they resolve to, for the canvas badges.
-export function stageIssueMessages(
-	draft: PipelineDraft,
-	issues: PipelineValidationIssue[],
-): Record<string, string[]> {
+export function stageIssueMessages(draft: PipelineDraft, issues: PipelineValidationIssue[]): Record<string, string[]> {
 	const out: Record<string, string[]> = {};
 	for (const issue of issues) {
 		const name = issueStageName(draft, issue);


### PR DESCRIPTION
Closes #259

Integration task tying the visual editor together (spec §4 V6, mockups 1c/1d).

## What

**Split/YAML two-way sync (mockup 1c)**
- The draft stays the single source of truth: canvas/inspector edits apply immediately and reserialize into the YAML pane; YAML edits parse back into the draft on the existing 400ms debounce so typing stays smooth.
- On a YAML syntax error the last good graph is kept (the canvas never blanks mid-edit); the split view's YAML pane shows a `parsed` / `YAML error: ...` status.
- Selecting a node scrolls the YAML pane to that stage's block (best-effort line mapping via `lib/pipeline-problems.ts`; new `revealLine` prop on `YamlEditor`).

**Validation surfacing (mockup 1d)**
- Problems panel ("Must resolve before saving") fed by the live `/validate` issues, the YAML parse error, and any save-rejection issues (deduped); each row resolves its `stages[N].*` path to a stage and offers Reveal, which selects that stage (canvas highlight, inspector, YAML scroll).
- Inline error badges + first message on affected canvas nodes (new `stageIssues` prop on `PipelineCanvas`; the red dashed cycle edge from V2 is untouched and still renders).
- Top-bar indicator is now the N-problems pill / Valid state; **Save is disabled while blocking problems exist**.

**routes.when wiring**
- Mounts V3's `StageInspector` in canvas view on node select and wires its `onEditCondition` to V4's `PredicateBuilderModal`, writing the result back into the selected stage's `routes.when` (or clearing it). Completes the loop left open in Batch B.

## Tests

New/updated coverage in `PipelineDefinitionsPage.test.tsx`, `usePipelineDraft.test.tsx`, `PipelineCanvas.test.tsx`, plus unit tests for `lib/pipeline-problems.ts`: canvas edit updates YAML and vice versa, parse error preserves the last graph and gates Save, problems render from a validate response with Reveal selecting the stage, save-422 issues land in the panel, edit-condition opens the builder and writes routes.when back, node badges render.

Full frontend suite: **773 passed, 0 failed**. Typecheck clean, prettier clean.

## Notes / risks

- No new deps, no backend changes, no changes to PredicateBuilder (V4) internals or the canvas beyond the badge prop. Routes untouched, so `routeTree.gen.ts` is unchanged.
- Stage-to-YAML line mapping is a text scan (`- name: <stage>` within the `stages:` block); exotic quoting/flow-style just means no scroll, per the best-effort allowance in the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)