### PR TITLE
feat(pipelines): V7 new-pipeline modal, templates, Definitions integration

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -28,7 +28,7 @@ environment before it boots, following the same on/off convention as AO's other
 it.
 
 **Precedence.** When `AO_PIPELINES` is set (to on OR off) it wins and the
-persisted setting is ignored — it is a hard override. When `AO_PIPELINES` is
+persisted setting is ignored: it is a hard override. When `AO_PIPELINES` is
 unset, the persisted `pipelines.enabled` setting decides. With neither set,
 pipelines stay off.
 
@@ -136,6 +136,64 @@ definition; unknown kinds and cross-kind fields fail validation with a
 path-scoped issue (e.g. `stages[1].routes.when: field "max" is not valid
 for predicate kind "all_pass"`).
 
+## Authoring in the visual editor
+
+YAML and the CRUD API stay first-class: everything the visual editor saves
+goes through the same create/update endpoints as a hand-written document,
+and the daemon's `/validate` route remains the single source of semantic
+truth. The visual editor is an additive front end over that same document,
+for authors who would rather draw the DAG than write it by hand.
+
+**View toggle.** The definition editor opens with a Canvas / Split / YAML
+segmented control. Canvas shows only the node graph, YAML shows only the raw
+document, and Split shows both side by side. All three edit the same
+in-memory draft: an edit made on the canvas reserializes into the YAML buffer
+immediately, and a YAML edit reparses into the draft after a short debounce.
+The YAML buffer is the bridge back to the canonical document, so switching
+views never loses information a mode does not itself display.
+
+**The canvas.** Each stage renders as one node, styled distinctly by
+executor kind (agent, command, builtin) so the shape of the pipeline is
+readable at a glance. Edges are `dependsOn`: drawing an edge between two
+nodes adds the dependency, deleting an edge removes it. A dependency cycle
+is blocked before it lands in the draft and the offending edges are
+highlighted in place so the author can see exactly what would have looped.
+An auto-layout pass keeps the graph readable as stages and dependencies are
+added, rather than requiring authors to place nodes by hand.
+
+**The stage inspector.** Selecting a node opens an inspector for that
+stage: name, trigger events, the executor's kind-specific fields (agent's
+`plugin`/`mode`, command's `command`/`args`/`env`/`cwd`, builtin's `name`),
+the task prompt, depends-on, the run condition (`routes.when`), workspace
+mode, and an advanced-knobs group for retries, timeout, max loop rounds, and
+budget (max USD, max duration).
+
+**The predicate builder.** `routes.when` and each of the three exit
+conditions (`done`, `stalled`, `blocksMerge`) are authored through the same
+predicate builder: nested ALL/ANY groups, one row per predicate kind with
+its kind-specific fields, a not-wrap toggle for negating a predicate or
+group, and a live readout of the compiled predicate DSL so the author can
+confirm what will actually be saved.
+
+**Pipeline settings.** A settings modal covers the pipeline-level fields
+that do not belong to any one stage: name, max concurrent stages, allow
+fork PRs, and the three exit conditions (each edited with the same
+predicate builder described above).
+
+**Live validation.** As the draft changes, the editor debounces a call to
+`POST /api/v1/pipelines/validate` and surfaces the result two ways: a
+problems panel listing every issue with a Reveal action that selects the
+offending stage, and a badge on the affected node in the canvas. Save stays
+disabled while any problem, a YAML parse error or a validation issue, is
+outstanding.
+
+**The New pipeline modal.** Creating a definition starts with a choice of
+three paths: Blank canvas (an empty draft, canvas view), From template (one
+of three built-in starting points: PR review loop, 8 stages; Nightly triage
+sweep, 4 stages; Release gate, 5 stages, each opened in canvas view), or
+Paste YAML (import an existing document verbatim, opened in YAML view). All
+three land in the same editor described above.
+
 ## Triggers
 
 A stage fires on `manual` or on PR lifecycle events delivered through the
@@ -210,13 +268,14 @@ that record.
 
 ## UI overview
 
-The Pipelines section (hidden entirely when pipelines are off — see Enabling the
+The Pipelines section (hidden entirely when pipelines are off, see Enabling the
 feature) has two tabs:
 
 - **Definitions**: a table of the project's stored pipelines plus a
-  CodeMirror YAML editor for create/update. Validation happens
-  server-side; the editor surfaces every returned issue inline rather than
-  stopping at the first one.
+  definition editor that offers a visual canvas alongside the raw
+  CodeMirror YAML editor for create/update (see Authoring in the visual
+  editor below). Validation happens server-side; the editor surfaces every
+  returned issue inline rather than stopping at the first one.
 - **Runs**: a 5-column Kanban workbench (Running, Awaiting context, Done,
   Stalled, Terminated) grouped by loop state, filterable by pipeline name,
   spanning every project. Runs update live over the existing CDC-backed

--- a/frontend/src/renderer/components/NewPipelineModal.test.tsx
+++ b/frontend/src/renderer/components/NewPipelineModal.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { NewPipelineModal, type NewPipelineChoice } from "./NewPipelineModal";
+
+function renderModal(onCreate = vi.fn(), onCancel = vi.fn()) {
+	render(<NewPipelineModal open onCancel={onCancel} onCreate={onCreate} />);
+	return { onCreate, onCancel };
+}
+
+describe("NewPipelineModal", () => {
+	it("defaults to Blank canvas and creates a blank draft", async () => {
+		const user = userEvent.setup();
+		const { onCreate } = renderModal();
+
+		expect(screen.getByRole("radio", { name: /Blank canvas/ })).toHaveAttribute("aria-checked", "true");
+		await user.click(screen.getByRole("button", { name: "Create" }));
+		expect(onCreate).toHaveBeenCalledWith({ kind: "blank" });
+	});
+
+	it("gates Create on a template pick and creates the chosen template", async () => {
+		const user = userEvent.setup();
+		const { onCreate } = renderModal();
+
+		await user.click(screen.getByRole("radio", { name: /From template/ }));
+		expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
+
+		await user.click(screen.getByRole("radio", { name: "PR review loop" }));
+		expect(screen.getByRole("button", { name: "Create" })).toBeEnabled();
+
+		await user.click(screen.getByRole("button", { name: "Create" }));
+		const choice = onCreate.mock.calls[0][0] as NewPipelineChoice;
+		expect(choice.kind).toBe("template");
+		if (choice.kind === "template") expect(choice.template.id).toBe("pr-review-loop");
+	});
+
+	it("clicking a template row while Blank canvas is active switches the path", async () => {
+		const user = userEvent.setup();
+		renderModal();
+
+		expect(screen.getByRole("radio", { name: /Blank canvas/ })).toHaveAttribute("aria-checked", "true");
+		await user.click(screen.getByRole("radio", { name: "PR review loop" }));
+
+		expect(screen.getByRole("radio", { name: /From template/ })).toHaveAttribute("aria-checked", "true");
+		expect(screen.getByRole("radio", { name: /Blank canvas/ })).toHaveAttribute("aria-checked", "false");
+		expect(screen.getByRole("radio", { name: "PR review loop" })).toHaveAttribute("aria-checked", "true");
+	});
+
+	it("shows each template's stage count", () => {
+		renderModal();
+
+		expect(screen.getByRole("radio", { name: "PR review loop" })).toHaveTextContent("8 stages");
+		expect(screen.getByRole("radio", { name: "Nightly triage sweep" })).toHaveTextContent("4 stages");
+		expect(screen.getByRole("radio", { name: "Release gate" })).toHaveTextContent("5 stages");
+	});
+
+	it("imports pasted YAML through the Paste YAML path", async () => {
+		const user = userEvent.setup();
+		const { onCreate } = renderModal();
+
+		await user.click(screen.getByRole("radio", { name: /Paste YAML/ }));
+		const textarea = screen.getByLabelText("Paste YAML");
+		expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
+
+		await user.type(textarea, "name: imported");
+		expect(screen.getByRole("button", { name: "Create" })).toBeEnabled();
+
+		await user.click(screen.getByRole("button", { name: "Create" }));
+		expect(onCreate).toHaveBeenCalledWith({ kind: "yaml", yamlSource: "name: imported" });
+	});
+
+	it("fires onCancel when dismissed", async () => {
+		const user = userEvent.setup();
+		const { onCancel } = renderModal();
+
+		await user.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(onCancel).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/renderer/components/NewPipelineModal.tsx
+++ b/frontend/src/renderer/components/NewPipelineModal.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useMemo, useState } from "react";
+import { Braces, LayoutTemplate, Plus } from "lucide-react";
+import { PIPELINE_TEMPLATES, type PipelineTemplate } from "../lib/pipeline-templates";
+import { cn } from "../lib/utils";
+import { Button } from "./ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
+
+// NewPipelineModal is the "New pipeline" entry point (mockup 1e), restyled to
+// AO tokens. It only decides HOW a new draft starts: a blank canvas, one of
+// the three built-in templates (lib/pipeline-templates.ts), or an imported
+// YAML document. The caller (PipelineDefinitionsPage) turns the choice into an
+// initial YAML buffer and opens the same visual editor every path shares.
+
+export type NewPipelineChoice =
+	{ kind: "blank" } | { kind: "template"; template: PipelineTemplate } | { kind: "yaml"; yamlSource: string };
+
+type Path = "blank" | "template" | "yaml";
+
+const PATH_CARDS: { key: Path; label: string; caption: string; icon: typeof Plus }[] = [
+	{ key: "blank", label: "Blank canvas", caption: "Drag stages onto an empty graph", icon: Plus },
+	{ key: "template", label: "From template", caption: "Start from a proven pipeline", icon: LayoutTemplate },
+	{ key: "yaml", label: "Paste YAML", caption: "Import an existing definition", icon: Braces },
+];
+
+// Stage counts only depend on the static templates, not on anything the modal
+// renders per instance, so compute them once instead of per row per render.
+const TEMPLATE_STAGE_COUNTS: Record<string, number> = Object.fromEntries(
+	PIPELINE_TEMPLATES.map((template) => [template.id, template.draft().stages.length]),
+);
+
+export function NewPipelineModal({
+	open,
+	onCancel,
+	onCreate,
+}: {
+	open: boolean;
+	onCancel: () => void;
+	onCreate: (choice: NewPipelineChoice) => void;
+}) {
+	const [path, setPath] = useState<Path>("blank");
+	const [templateId, setTemplateId] = useState<PipelineTemplate["id"] | null>(null);
+	const [yamlText, setYamlText] = useState("");
+
+	// Reseed every time the modal opens, same convention as PipelineSettingsModal:
+	// a dismissed modal never leaks its half-filled state into the next open.
+	useEffect(() => {
+		if (open) {
+			setPath("blank");
+			setTemplateId(null);
+			setYamlText("");
+		}
+	}, [open]);
+
+	const selectedTemplate = useMemo(() => PIPELINE_TEMPLATES.find((t) => t.id === templateId) ?? null, [templateId]);
+
+	const createDisabled = (path === "template" && !selectedTemplate) || (path === "yaml" && yamlText.trim() === "");
+
+	const create = () => {
+		if (path === "blank") onCreate({ kind: "blank" });
+		else if (path === "template" && selectedTemplate) onCreate({ kind: "template", template: selectedTemplate });
+		else if (path === "yaml") onCreate({ kind: "yaml", yamlSource: yamlText });
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={(next) => !next && onCancel()}>
+			<DialogContent showCloseButton={false} aria-describedby={undefined} className="max-w-2xl">
+				<DialogHeader className="flex-row items-center justify-between">
+					<div className="min-w-0">
+						<DialogTitle>New pipeline</DialogTitle>
+						<p className="mt-0.5 text-caption text-passive">
+							Author visually. YAML is generated and validated on save.
+						</p>
+					</div>
+					<div className="flex shrink-0 items-center gap-2">
+						<Button variant="outline" size="sm" onClick={onCancel}>
+							Cancel
+						</Button>
+						<Button size="sm" variant="primary" disabled={createDisabled} onClick={create}>
+							Create
+						</Button>
+					</div>
+				</DialogHeader>
+
+				<div className="flex flex-col gap-4">
+					<div role="radiogroup" aria-label="Creation path" className="grid grid-cols-3 gap-2.5">
+						{PATH_CARDS.map(({ key, label, caption, icon: Icon }) => {
+							const selected = path === key;
+							return (
+								<button
+									key={key}
+									type="button"
+									role="radio"
+									aria-checked={selected}
+									onClick={() => setPath(key)}
+									className={cn(
+										"flex flex-col items-start gap-1.5 rounded-md border p-3 text-left transition-colors",
+										selected
+											? "border-accent bg-accent/10"
+											: "border-border bg-surface hover:border-accent-dim hover:bg-raised",
+									)}
+								>
+									<Icon
+										className={cn("size-icon-md", selected ? "text-accent" : "text-muted-foreground")}
+										aria-hidden="true"
+									/>
+									<span className="text-control font-medium text-foreground">{label}</span>
+									<span className="text-caption text-passive">{caption}</span>
+								</button>
+							);
+						})}
+					</div>
+
+					{path === "yaml" ? (
+						<div className="flex flex-col gap-1.5">
+							<FieldLabel>Paste YAML</FieldLabel>
+							<textarea
+								aria-label="Paste YAML"
+								rows={10}
+								value={yamlText}
+								onChange={(e) => setYamlText(e.target.value)}
+								placeholder={"name: my-pipeline\nstages:\n  - name: review\n    ..."}
+								className="w-full resize-y rounded-md border border-border bg-transparent px-3 py-2 font-mono text-caption leading-relaxed text-foreground outline-none transition placeholder:text-passive focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent-weak"
+							/>
+						</div>
+					) : (
+						<div className="flex flex-col gap-1.5">
+							<FieldLabel>Templates</FieldLabel>
+							<div role="radiogroup" aria-label="Templates" className="flex flex-col gap-1.5">
+								{PIPELINE_TEMPLATES.map((template) => {
+									const selected = path === "template" && templateId === template.id;
+									return (
+										<button
+											key={template.id}
+											type="button"
+											role="radio"
+											aria-checked={selected}
+											aria-label={template.name}
+											onClick={() => {
+												setTemplateId(template.id);
+												setPath("template");
+											}}
+											className={cn(
+												"flex items-center gap-2.5 rounded-md border px-3 py-2 text-left transition-colors",
+												selected
+													? "border-accent bg-accent/10"
+													: "border-border bg-surface hover:border-accent-dim hover:bg-raised",
+											)}
+										>
+											<span className={cn("size-1.5 shrink-0 rounded-full", template.dotClass)} aria-hidden="true" />
+											<div className="min-w-0 flex-1">
+												<div className="truncate text-control text-foreground">{template.name}</div>
+												<div className="truncate text-caption text-passive">{template.description}</div>
+											</div>
+											<span className="shrink-0 font-mono text-caption text-muted-foreground">
+												{TEMPLATE_STAGE_COUNTS[template.id]} stages
+											</span>
+										</button>
+									);
+								})}
+							</div>
+						</div>
+					)}
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+	return <span className="font-mono text-micro font-medium uppercase tracking-wide text-passive">{children}</span>;
+}

--- a/frontend/src/renderer/components/PipelineDefinitionsPage.test.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.test.tsx
@@ -147,6 +147,13 @@ describe("PipelineDefinitionsPage", () => {
 		const user = userEvent.setup();
 
 		await user.click(screen.getByRole("button", { name: /New pipeline/ }));
+		await user.click(screen.getByRole("radio", { name: /Blank canvas/ }));
+		await user.click(screen.getByRole("button", { name: "Create" }));
+
+		// Blank canvas opens the editor in canvas view.
+		expect(screen.getByTestId("pipeline-canvas")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("radio", { name: "YAML" }));
 		const editor = screen.getByLabelText("Pipeline YAML");
 		await user.clear(editor);
 		await user.type(editor, "name: created");
@@ -164,10 +171,9 @@ describe("PipelineDefinitionsPage", () => {
 
 	it("toggles between YAML and Canvas views and defaults to YAML", async () => {
 		renderPage();
-		await screen.findByText("review");
 		const user = userEvent.setup();
 
-		await user.click(screen.getByRole("button", { name: /New pipeline/ }));
+		await user.click(await screen.findByRole("button", { name: "Edit" }));
 		// YAML mode by default: the editor is mounted, the canvas is not.
 		expect(screen.getByLabelText("Pipeline YAML")).toBeInTheDocument();
 		expect(screen.queryByTestId("pipeline-canvas")).not.toBeInTheDocument();
@@ -180,6 +186,83 @@ describe("PipelineDefinitionsPage", () => {
 		await user.click(screen.getByRole("radio", { name: "Split" }));
 		expect(screen.getByTestId("pipeline-canvas")).toBeInTheDocument();
 		expect(screen.getByLabelText("Pipeline YAML")).toBeInTheDocument();
+	});
+
+	it("creates from a blank canvas with an empty graph", async () => {
+		renderPage();
+		await screen.findByText("review");
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: /New pipeline/ }));
+		await user.click(screen.getByRole("radio", { name: /Blank canvas/ }));
+		await user.click(screen.getByRole("button", { name: "Create" }));
+
+		expect(screen.getByTestId("pipeline-canvas")).toBeInTheDocument();
+		expect(screen.getByTestId("canvas-stages")).toHaveTextContent("");
+		expect(screen.queryByLabelText("Pipeline YAML")).not.toBeInTheDocument();
+	});
+
+	it("creates from a template, edits, saves, and returns to the list", async () => {
+		renderPage();
+		await screen.findByText("review");
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: /New pipeline/ }));
+		await user.click(screen.getByRole("radio", { name: /From template/ }));
+		await user.click(screen.getByRole("radio", { name: "PR review loop" }));
+		await user.click(screen.getByRole("button", { name: "Create" }));
+
+		expect(screen.getByTestId("canvas-stages")).toHaveTextContent(
+			"review-correctness,review-security,review-style,compose-findings,triage,fix,verify,route",
+		);
+
+		await user.click(screen.getByRole("button", { name: "mock-add-stage" }));
+		await user.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			const call = postMock.mock.calls.find(([url]) => url === "/api/v1/pipelines");
+			expect(call).toBeDefined();
+			const body = (call as [string, { body: { yamlSource: string } }])[1].body;
+			expect(body.yamlSource).toContain("review-correctness");
+			expect(body.yamlSource).toContain("added");
+		});
+
+		// Back to the list view.
+		await screen.findByRole("button", { name: /New pipeline/ });
+	});
+
+	it("imports pasted YAML through the modal", async () => {
+		renderPage();
+		await screen.findByText("review");
+		const user = userEvent.setup();
+		const pasted = "name: imported\nstages:\n  - name: one\n";
+
+		await user.click(screen.getByRole("button", { name: /New pipeline/ }));
+		await user.click(screen.getByRole("radio", { name: /Paste YAML/ }));
+		fireEvent.change(screen.getByLabelText("Paste YAML"), { target: { value: pasted } });
+		await user.click(screen.getByRole("button", { name: "Create" }));
+
+		expect(screen.getByLabelText("Pipeline YAML")).toHaveValue(pasted);
+
+		await user.click(screen.getByRole("button", { name: "Save" }));
+		await waitFor(() =>
+			expect(postMock).toHaveBeenCalledWith("/api/v1/pipelines", {
+				params: { query: { project: "proj-1" } },
+				body: { yamlSource: pasted },
+			}),
+		);
+	});
+
+	it("renders the empty state with a create call to action", async () => {
+		getMock.mockReset().mockResolvedValue({ data: { definitions: [] }, error: undefined });
+		renderPage();
+		const user = userEvent.setup();
+
+		const empty = await screen.findByTestId("pipelines-empty-state");
+		expect(within(empty).getByText("No pipelines yet")).toBeInTheDocument();
+
+		await user.click(within(empty).getByRole("button", { name: /New pipeline/ }));
+		expect(screen.getByRole("dialog", { name: "New pipeline" })).toBeInTheDocument();
 	});
 
 	it("opens the settings modal from the top bar and commits edits into the draft", async () => {
@@ -255,6 +338,9 @@ describe("PipelineDefinitionsPage", () => {
 		const user = userEvent.setup();
 
 		await user.click(screen.getByRole("button", { name: /New pipeline/ }));
+		await user.click(screen.getByRole("radio", { name: /Blank canvas/ }));
+		await user.click(screen.getByRole("button", { name: "Create" }));
+		await user.click(screen.getByRole("radio", { name: "YAML" }));
 		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		const panel = await screen.findByTestId("problems-panel");

--- a/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
@@ -1,15 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { AlertCircle, CheckCircle2, Loader2, Pencil, Plus, Settings2, Trash2 } from "lucide-react";
+import { AlertCircle, CheckCircle2, Loader2, Pencil, Plus, Settings2, Trash2, Workflow } from "lucide-react";
 import { apiErrorMessage } from "../lib/api-client";
 import { formatTimeCompact } from "../lib/format-time";
-import type { StageDraft } from "../lib/pipeline-draft";
+import { serializeToYaml, type StageDraft } from "../lib/pipeline-draft";
 import { issueStageName, stageIssueMessages, stageYamlLine } from "../lib/pipeline-problems";
-import {
-	countStagesFromYaml,
-	DEFAULT_PIPELINE_YAML,
-	parsePipelineValidationIssues,
-	type PipelineValidationIssue,
-} from "../lib/pipeline-yaml";
+import { countStagesFromYaml, parsePipelineValidationIssues, type PipelineValidationIssue } from "../lib/pipeline-yaml";
 import {
 	type PipelineDefinitionSummary,
 	usePipelineDefinitionMutations,
@@ -18,6 +13,7 @@ import {
 import { usePipelineDraft, type PipelineDraftValidation } from "../hooks/usePipelineDraft";
 import { useStageSelection } from "../hooks/useStageSelection";
 import { ConfirmDialog } from "./ConfirmDialog";
+import { NewPipelineModal, type NewPipelineChoice } from "./NewPipelineModal";
 import { PipelineCanvas } from "./PipelineCanvas";
 import { PipelineProblemsPanel, type PipelineProblem } from "./PipelineProblemsPanel";
 import { PipelineSettingsModal } from "./PipelineSettingsModal";
@@ -34,9 +30,14 @@ import { cn } from "../lib/utils";
 type ViewMode = "canvas" | "split" | "yaml";
 
 // One of: browsing the list, editing an existing definition, or drafting a new
-// one. The editor buffer lives in EditorView while a draft is open, so switching
-// modes here is what mounts/unmounts the CodeMirror instance.
-type Mode = { kind: "list" } | { kind: "edit"; def: PipelineDefinitionSummary } | { kind: "create" };
+// one from the New pipeline modal's choice (blank/template/YAML, each resolved
+// to a starting buffer + view before the editor mounts). The editor buffer
+// lives in EditorView while a draft is open, so switching modes here is what
+// mounts/unmounts the CodeMirror instance.
+type Mode =
+	| { kind: "list" }
+	| { kind: "edit"; def: PipelineDefinitionSummary }
+	| { kind: "create"; initialYaml: string; initialView: ViewMode };
 
 // The Definitions tab: a list of the project's stored pipelines plus a CodeMirror
 // YAML editor for create/update. Server-side validation is authoritative; on
@@ -44,12 +45,34 @@ type Mode = { kind: "list" } | { kind: "edit"; def: PipelineDefinitionSummary } 
 export function PipelineDefinitionsPage({ projectId }: { projectId?: string }) {
 	const definitionsQuery = usePipelineDefinitionsQuery(projectId);
 	const [mode, setMode] = useState<Mode>({ kind: "list" });
+	const [newOpen, setNewOpen] = useState(false);
+
+	// The modal only decides how the draft starts; every path resolves to a
+	// starting YAML buffer + view before the (shared) visual editor mounts.
+	const handleCreate = (choice: NewPipelineChoice) => {
+		let initialYaml: string;
+		let initialView: ViewMode;
+		if (choice.kind === "blank") {
+			initialYaml = serializeToYaml({ name: "my-pipeline", stages: [] });
+			initialView = "canvas";
+		} else if (choice.kind === "template") {
+			initialYaml = serializeToYaml(choice.template.draft());
+			initialView = "canvas";
+		} else {
+			initialYaml = choice.yamlSource;
+			initialView = "yaml";
+		}
+		setNewOpen(false);
+		setMode({ kind: "create", initialYaml, initialView });
+	};
 
 	if (mode.kind !== "list" && projectId) {
 		return (
 			<DefinitionEditor
 				projectId={projectId}
 				def={mode.kind === "edit" ? mode.def : null}
+				initialYaml={mode.kind === "create" ? mode.initialYaml : ""}
+				initialView={mode.kind === "create" ? mode.initialView : "yaml"}
 				onClose={() => setMode({ kind: "list" })}
 			/>
 		);
@@ -63,7 +86,7 @@ export function PipelineDefinitionsPage({ projectId }: { projectId?: string }) {
 				<p className="text-md-sm text-passive">
 					Pipeline definitions authored as YAML. A run snapshots its definition at trigger time.
 				</p>
-				<Button size="sm" variant="primary" disabled={!projectId} onClick={() => setMode({ kind: "create" })}>
+				<Button size="sm" variant="primary" disabled={!projectId} onClick={() => setNewOpen(true)}>
 					<Plus className="size-icon-md" aria-hidden="true" />
 					New pipeline
 				</Button>
@@ -79,9 +102,19 @@ export function PipelineDefinitionsPage({ projectId }: { projectId?: string }) {
 						Could not load pipelines. {apiErrorMessage(definitionsQuery.error)}
 					</p>
 				) : definitions.length === 0 ? (
-					<p className="py-10 text-center text-xs text-passive">
-						No pipelines yet. Click <span className="text-foreground">New pipeline</span> to author one.
-					</p>
+					<div data-testid="pipelines-empty-state" className="flex h-full min-h-0 items-center justify-center">
+						<div className="flex max-w-sm flex-col items-center pb-10 text-center">
+							<Workflow className="size-icon-lg text-passive" aria-hidden="true" />
+							<h2 className="mt-3 text-control font-semibold text-foreground">No pipelines yet</h2>
+							<p className="mt-1.5 text-caption text-passive">
+								Author your first pipeline visually, start from a template, or import YAML.
+							</p>
+							<Button size="sm" variant="primary" className="mt-4" onClick={() => setNewOpen(true)}>
+								<Plus className="size-icon-md" aria-hidden="true" />
+								New pipeline
+							</Button>
+						</div>
+					</div>
 				) : (
 					<Table>
 						<TableHeader>
@@ -105,6 +138,8 @@ export function PipelineDefinitionsPage({ projectId }: { projectId?: string }) {
 					</Table>
 				)}
 			</div>
+
+			<NewPipelineModal open={newOpen} onCancel={() => setNewOpen(false)} onCreate={handleCreate} />
 		</div>
 	);
 }
@@ -177,20 +212,27 @@ function DefinitionRow({
 function DefinitionEditor({
 	projectId,
 	def,
+	initialYaml,
+	initialView,
 	onClose,
 }: {
 	projectId: string;
 	def: PipelineDefinitionSummary | null;
+	// Only consulted when def is null (a fresh draft): the New pipeline modal's
+	// resolved starting buffer + view. Editing an existing definition always
+	// starts from its stored YAML, in YAML view, regardless of these.
+	initialYaml: string;
+	initialView: ViewMode;
 	onClose: () => void;
 }) {
 	const { create, update } = usePipelineDefinitionMutations(projectId);
 	const { yamlSource, setYamlSource, draft, parseError, setDraft, validation } = usePipelineDraft(
-		def ? def.yamlSource : DEFAULT_PIPELINE_YAML,
+		def ? def.yamlSource : initialYaml,
 	);
 	// One selection instance for the editor area: the canvas writes on node
 	// click, the stage inspector (V3) binds to the same stage name.
 	const selection = useStageSelection();
-	const [view, setView] = useState<ViewMode>("yaml");
+	const [view, setView] = useState<ViewMode>(def ? "yaml" : initialView);
 	const [settingsOpen, setSettingsOpen] = useState(false);
 	// Issues a rejected save reported; live validation covers the same ground,
 	// so these only matter in the race where a save beat the debounce. Cleared

--- a/frontend/src/renderer/lib/pipeline-templates.test.ts
+++ b/frontend/src/renderer/lib/pipeline-templates.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import {
+	parseYamlToDraft,
+	serializeToYaml,
+	type ExecutorDraft,
+	type PipelineDraft,
+	type PredicateDraft,
+} from "./pipeline-draft";
+import { cycleMembers } from "./pipeline-graph";
+import { PIPELINE_TEMPLATES } from "./pipeline-templates";
+
+// Templates are static config baked into the renderer, so the daemon never
+// sees them until a user hits Save. This suite mirrors the validation rules
+// of backend/internal/pipeline (config.go validatePipelineConfig +
+// predicate.go Validate) closely enough that a template violating them fails
+// here instead of at /validate in front of a user.
+
+const KNOWN_EVENTS = new Set(["pr.opened", "pr.updated", "pr.merge_ready", "pr.merged", "manual"]);
+const KNOWN_MODES = new Set(["review", "code", "answer"]);
+const KNOWN_BUILTINS = new Set(["router", "compose"]);
+const KNOWN_WORKSPACES = new Set(["shared-ro", "isolated-rw"]);
+const KNOWN_SEVERITIES = new Set(["error", "warning", "info"]);
+const KNOWN_VERDICTS = new Set(["pass", "fail", "neutral"]);
+
+// Per-kind allowed/required executor fields (config.go executorFieldRules).
+const EXECUTOR_RULES: Record<string, { allowed: string[]; required: string[] }> = {
+	agent: { allowed: ["plugin", "mode", "config"], required: ["plugin", "mode"] },
+	command: { allowed: ["command", "args", "env", "cwd"], required: ["command"] },
+	builtin: { allowed: ["name", "config"], required: ["name"] },
+};
+
+function executorViolations(executor: ExecutorDraft, path: string): string[] {
+	const rules = EXECUTOR_RULES[executor.kind];
+	if (!rules) return [`${path}: unknown executor kind ${executor.kind}`];
+	const out: string[] = [];
+	const present = Object.entries(executor)
+		.filter(([key, value]) => key !== "kind" && value !== undefined)
+		.map(([key]) => key);
+	for (const field of present) {
+		if (!rules.allowed.includes(field)) out.push(`${path}: field ${field} not valid for kind ${executor.kind}`);
+	}
+	for (const field of rules.required) {
+		if (!present.includes(field)) out.push(`${path}: kind ${executor.kind} requires field ${field}`);
+	}
+	if (executor.kind === "agent" && executor.mode && !KNOWN_MODES.has(executor.mode)) {
+		out.push(`${path}: unknown task mode ${executor.mode}`);
+	}
+	if (executor.kind === "builtin" && executor.name && !KNOWN_BUILTINS.has(executor.name)) {
+		out.push(`${path}: unknown builtin name ${executor.name}`);
+	}
+	return out;
+}
+
+// Per-kind allowed/required predicate fields (predicate.go predicateFieldRules).
+const PREDICATE_RULES: Record<string, { allowed: string[]; required: string[] }> = {
+	all_pass: { allowed: ["stages"], required: ["stages"] },
+	any_pass: { allowed: ["stages"], required: ["stages"] },
+	majority_pass: { allowed: ["stages"], required: ["stages"] },
+	no_open_findings: { allowed: ["stage"], required: [] },
+	finding_count_below: { allowed: ["max", "stage", "severity"], required: ["max"] },
+	loop_rounds_at_least: { allowed: ["n"], required: ["n"] },
+	stage_retried_at_least: { allowed: ["stage", "n"], required: ["stage", "n"] },
+	stage_verdict: { allowed: ["stage", "verdict"], required: ["stage", "verdict"] },
+	and: { allowed: ["predicates"], required: ["predicates"] },
+	or: { allowed: ["predicates"], required: ["predicates"] },
+	not: { allowed: ["predicate"], required: ["predicate"] },
+};
+
+function predicateViolations(predicate: PredicateDraft, path: string): string[] {
+	const rules = PREDICATE_RULES[predicate.kind];
+	if (!rules) return [`${path}: unknown predicate kind ${predicate.kind}`];
+	const out: string[] = [];
+	const present = Object.entries(predicate)
+		.filter(([key, value]) => key !== "kind" && value !== undefined)
+		.map(([key]) => key);
+	for (const field of present) {
+		if (!rules.allowed.includes(field)) out.push(`${path}: field ${field} not valid for kind ${predicate.kind}`);
+	}
+	for (const field of rules.required) {
+		if (!present.includes(field)) out.push(`${path}: kind ${predicate.kind} requires field ${field}`);
+	}
+	if (predicate.severity && !KNOWN_SEVERITIES.has(predicate.severity)) {
+		out.push(`${path}: unknown severity ${predicate.severity}`);
+	}
+	if (predicate.verdict && !KNOWN_VERDICTS.has(predicate.verdict)) {
+		out.push(`${path}: unknown verdict ${predicate.verdict}`);
+	}
+	if ((predicate.kind === "and" || predicate.kind === "or") && (predicate.predicates?.length ?? 0) < 1) {
+		out.push(`${path}: ${predicate.kind} requires at least one predicate`);
+	}
+	for (const [i, child] of (predicate.predicates ?? []).entries()) {
+		out.push(...predicateViolations(child, `${path}.predicates[${i}]`));
+	}
+	if (predicate.predicate) out.push(...predicateViolations(predicate.predicate, `${path}.predicate`));
+	return out;
+}
+
+// Every stage name a predicate references (predicate.go ReferencedStages).
+function referencedStages(predicate: PredicateDraft): string[] {
+	return [
+		...(predicate.stages ?? []),
+		...(predicate.stage ? [predicate.stage] : []),
+		...(predicate.predicates ?? []).flatMap(referencedStages),
+		...(predicate.predicate ? referencedStages(predicate.predicate) : []),
+	];
+}
+
+// The full config-level rule set (config.go validatePipelineConfig).
+function draftViolations(draft: PipelineDraft): string[] {
+	const out: string[] = [];
+	if (draft.name.trim() === "") out.push("name: must not be empty");
+	if (draft.scope && draft.scope !== "worker") out.push(`scope: ${draft.scope} not accepted in v1`);
+	if (draft.stages.length === 0) out.push("stages: at least one stage required");
+	if (draft.maxConcurrentStages !== undefined && draft.maxConcurrentStages < 1) {
+		out.push("maxConcurrentStages: must be >= 1");
+	}
+
+	const names = draft.stages.map((s) => s.name);
+	const nameSet = new Set(names);
+	if (nameSet.size !== names.length) out.push("stages: duplicate stage names");
+
+	for (const [i, stage] of draft.stages.entries()) {
+		const base = `stages[${i}]`;
+		if (stage.name.trim() === "") out.push(`${base}.name: must not be empty`);
+		for (const event of stage.trigger.on) {
+			if (!KNOWN_EVENTS.has(event)) out.push(`${base}.trigger.on: unknown event ${event}`);
+		}
+		out.push(...executorViolations(stage.executor, `${base}.executor`));
+		if (stage.maxLoopRounds !== undefined && stage.maxLoopRounds < 1) {
+			out.push(`${base}.maxLoopRounds: must be >= 1`);
+		}
+		if (stage.retries !== undefined && stage.retries < 0) out.push(`${base}.retries: must be >= 0`);
+		if (stage.timeoutMs !== undefined && stage.timeoutMs < 0) out.push(`${base}.timeoutMs: must be >= 0`);
+		for (const dep of stage.dependsOn ?? []) {
+			if (dep === stage.name) out.push(`${base}.dependsOn: self reference`);
+			else if (!nameSet.has(dep)) out.push(`${base}.dependsOn: unknown stage ${dep}`);
+		}
+		if (stage.routes) {
+			out.push(...predicateViolations(stage.routes.when, `${base}.routes.when`));
+			for (const ref of referencedStages(stage.routes.when)) {
+				if (ref === stage.name) out.push(`${base}.routes.when: routes to itself`);
+				else if (!nameSet.has(ref)) out.push(`${base}.routes.when: unknown stage ${ref}`);
+			}
+		}
+		if (stage.workspace && !KNOWN_WORKSPACES.has(stage.workspace)) {
+			out.push(`${base}.workspace: unknown workspace ${stage.workspace}`);
+		}
+	}
+
+	for (const key of ["done", "stalled", "blocksMerge"] as const) {
+		const predicate = draft.exitPredicates?.[key];
+		if (!predicate) continue;
+		out.push(...predicateViolations(predicate, `exitPredicates.${key}`));
+		for (const ref of referencedStages(predicate)) {
+			if (!nameSet.has(ref)) out.push(`exitPredicates.${key}: unknown stage ${ref}`);
+		}
+	}
+
+	return out;
+}
+
+// Stage counts promised by the modal's template list (mockup 1e).
+const EXPECTED_STAGE_COUNTS: Record<string, number> = {
+	"PR review loop": 8,
+	"Nightly triage sweep": 4,
+	"Release gate": 5,
+};
+
+describe("PIPELINE_TEMPLATES", () => {
+	it("matches the mockup's template list", () => {
+		expect(PIPELINE_TEMPLATES.map((t) => t.name)).toEqual(Object.keys(EXPECTED_STAGE_COUNTS));
+	});
+
+	for (const template of PIPELINE_TEMPLATES) {
+		describe(template.name, () => {
+			it("has the advertised stage count", () => {
+				expect(template.draft().stages).toHaveLength(EXPECTED_STAGE_COUNTS[template.name]);
+			});
+
+			it("returns a fresh draft per call", () => {
+				const a = template.draft();
+				const b = template.draft();
+				expect(a).not.toBe(b);
+				expect(a.stages).not.toBe(b.stages);
+				expect(a).toEqual(b);
+			});
+
+			it("round-trips through the codec unchanged", () => {
+				const draft = template.draft();
+				const parsed = parseYamlToDraft(serializeToYaml(draft));
+				expect(parsed.error).toBeUndefined();
+				expect(parsed.draft).toEqual(draft);
+			});
+
+			it("passes the mirrored backend validation rules", () => {
+				expect(draftViolations(template.draft())).toEqual([]);
+			});
+
+			it("has an acyclic dependsOn graph", () => {
+				expect(cycleMembers(template.draft()).size).toBe(0);
+			});
+		});
+	}
+});

--- a/frontend/src/renderer/lib/pipeline-templates.ts
+++ b/frontend/src/renderer/lib/pipeline-templates.ts
@@ -94,7 +94,9 @@ function nightlyTriageSweep(): PipelineDraft {
 				name: "scan",
 				trigger: { on: ["manual"] },
 				executor: { kind: "agent", plugin: "claude-code", mode: "review" },
-				task: { prompt: "Scan the open pull requests and collect actionable findings: stale PRs, red CI, unanswered reviews." },
+				task: {
+					prompt: "Scan the open pull requests and collect actionable findings: stale PRs, red CI, unanswered reviews.",
+				},
 			},
 			{
 				name: "triage",

--- a/frontend/src/renderer/lib/pipeline-templates.ts
+++ b/frontend/src/renderer/lib/pipeline-templates.ts
@@ -1,0 +1,191 @@
+// The three static "New pipeline" templates (mockup 1e). Baked into the
+// renderer for v1 (spec decision: no template API); each is a full
+// PipelineDraft in the normalized codec shape, so instantiating one is just
+// serializeToYaml(template.draft()) and the result parses clean through
+// backend ParseDefinition (/validate). pipeline-templates.test.ts mirrors the
+// Go validation rules to keep them honest.
+
+import type { PipelineDraft } from "./pipeline-draft";
+
+export interface PipelineTemplate {
+	id: "pr-review-loop" | "nightly-triage-sweep" | "release-gate";
+	name: string;
+	description: string;
+	// Accent dot in the modal's template list (mockup 1e row markers).
+	dotClass: string;
+	// Fresh draft per call so an edited instantiation never mutates the template.
+	draft: () => PipelineDraft;
+}
+
+// review -> triage -> fix -> verify, gated on findings (8 stages).
+function prReviewLoop(): PipelineDraft {
+	return {
+		name: "pr-review-loop",
+		stages: [
+			{
+				name: "review-correctness",
+				trigger: { on: ["pr.opened", "pr.updated"] },
+				executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+				task: { prompt: "Review the diff for correctness bugs: logic errors, unhandled edge cases, broken contracts." },
+			},
+			{
+				name: "review-security",
+				trigger: { on: ["pr.opened", "pr.updated"] },
+				executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+				task: { prompt: "Review the diff for security issues: injection, authz gaps, secret handling, unsafe input." },
+			},
+			{
+				name: "review-style",
+				trigger: { on: ["pr.opened", "pr.updated"] },
+				executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+				task: { prompt: "Review the diff for style and convention drift against the surrounding code." },
+			},
+			{
+				name: "compose-findings",
+				trigger: { on: ["pr.opened", "pr.updated"] },
+				executor: { kind: "builtin", name: "compose" },
+				dependsOn: ["review-correctness", "review-security", "review-style"],
+			},
+			{
+				name: "triage",
+				trigger: { on: ["pr.opened", "pr.updated"] },
+				executor: { kind: "agent", plugin: "claude-code", mode: "answer" },
+				task: { prompt: "Triage the composed findings: deduplicate, rank by severity, drop false positives." },
+				dependsOn: ["compose-findings"],
+			},
+			{
+				name: "fix",
+				trigger: { on: ["pr.opened", "pr.updated"] },
+				executor: { kind: "agent", plugin: "claude-code", mode: "code" },
+				task: { prompt: "Fix the open findings, smallest correct change first. Push the fixes to the PR branch." },
+				dependsOn: ["triage"],
+				routes: { when: { kind: "not", predicate: { kind: "no_open_findings", stage: "compose-findings" } } },
+				workspace: "isolated-rw",
+				maxLoopRounds: 3,
+			},
+			{
+				name: "verify",
+				trigger: { on: ["pr.opened", "pr.updated"] },
+				executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+				task: { prompt: "Verify each finding was actually resolved by the fixes; reopen anything still broken." },
+				dependsOn: ["fix"],
+			},
+			{
+				name: "route",
+				trigger: { on: ["pr.opened", "pr.updated"] },
+				executor: { kind: "builtin", name: "router" },
+				dependsOn: ["verify"],
+			},
+		],
+		exitPredicates: {
+			done: { kind: "no_open_findings" },
+			stalled: { kind: "loop_rounds_at_least", n: 5 },
+		},
+	};
+}
+
+// Scheduled scan across open PRs (4 stages). v1 has no cron trigger; the
+// sweep is manual-triggered so an external scheduler (or a human) fires it.
+function nightlyTriageSweep(): PipelineDraft {
+	return {
+		name: "nightly-triage-sweep",
+		stages: [
+			{
+				name: "scan",
+				trigger: { on: ["manual"] },
+				executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+				task: { prompt: "Scan the open pull requests and collect actionable findings: stale PRs, red CI, unanswered reviews." },
+			},
+			{
+				name: "triage",
+				trigger: { on: ["manual"] },
+				executor: { kind: "agent", plugin: "claude-code", mode: "answer" },
+				task: { prompt: "Classify each finding by urgency and owner; decide which PRs need action tonight." },
+				dependsOn: ["scan"],
+			},
+			{
+				name: "label",
+				trigger: { on: ["manual"] },
+				executor: { kind: "command", command: "gh", args: ["pr", "edit", "--add-label", "triaged"] },
+				dependsOn: ["triage"],
+			},
+			{
+				name: "report",
+				trigger: { on: ["manual"] },
+				executor: { kind: "agent", plugin: "claude-code", mode: "answer" },
+				task: { prompt: "Write a short sweep report: what was triaged, what is blocked, what needs a human." },
+				dependsOn: ["triage"],
+			},
+		],
+		exitPredicates: {
+			done: { kind: "all_pass", stages: ["triage", "report"] },
+			stalled: { kind: "loop_rounds_at_least", n: 3 },
+		},
+	};
+}
+
+// Compose checks, block merge on any high finding (5 stages).
+function releaseGate(): PipelineDraft {
+	return {
+		name: "release-gate",
+		stages: [
+			{
+				name: "lint",
+				trigger: { on: ["pr.merge_ready"] },
+				executor: { kind: "command", command: "pnpm", args: ["lint"] },
+			},
+			{
+				name: "test",
+				trigger: { on: ["pr.merge_ready"] },
+				executor: { kind: "command", command: "pnpm", args: ["test"] },
+			},
+			{
+				name: "security-review",
+				trigger: { on: ["pr.merge_ready"] },
+				executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+				task: { prompt: "Final security pass over the release diff; flag anything that must not ship." },
+			},
+			{
+				name: "compose-checks",
+				trigger: { on: ["pr.merge_ready"] },
+				executor: { kind: "builtin", name: "compose" },
+				dependsOn: ["lint", "test", "security-review"],
+			},
+			{
+				name: "gate",
+				trigger: { on: ["pr.merge_ready"] },
+				executor: { kind: "builtin", name: "router" },
+				dependsOn: ["compose-checks"],
+				policy: { blocksMerge: true },
+			},
+		],
+		exitPredicates: {
+			done: { kind: "all_pass", stages: ["lint", "test", "security-review"] },
+			blocksMerge: { kind: "not", predicate: { kind: "finding_count_below", max: 1, severity: "error" } },
+		},
+	};
+}
+
+export const PIPELINE_TEMPLATES: PipelineTemplate[] = [
+	{
+		id: "pr-review-loop",
+		name: "PR review loop",
+		description: "review, triage, fix, verify, gated on findings",
+		dotClass: "bg-accent",
+		draft: prReviewLoop,
+	},
+	{
+		id: "nightly-triage-sweep",
+		name: "Nightly triage sweep",
+		description: "scheduled scan across open PRs",
+		dotClass: "bg-warning",
+		draft: nightlyTriageSweep,
+	},
+	{
+		id: "release-gate",
+		name: "Release gate",
+		description: "compose checks, block merge on any high finding",
+		dotClass: "bg-success",
+		draft: releaseGate,
+	},
+];


### PR DESCRIPTION
## Summary

Final Visual Pipeline Editor task (Batch D). Replaces the plain-YAML-only create flow in the Definitions tab with the New pipeline modal (mockup 1e) and wires every path into the shared visual editor.

- **New pipeline modal** (`NewPipelineModal.tsx`): three creation paths. Blank canvas opens the editor on an empty draft in canvas view; From template instantiates one of the built-in templates in canvas view; Paste YAML imports an existing document verbatim in YAML view, keeping the import path first-class for power users and agents.
- **Templates** (`lib/pipeline-templates.ts`): three static renderer-side templates matching the mockup's stage counts. PR review loop (8 stages: three parallel reviews, compose, triage, findings-gated fix, verify, router), Nightly triage sweep (4 stages, manual-triggered), Release gate (5 stages, blocksMerge on any error finding). Each is a normalized `PipelineDraft` that round-trips the codec unchanged.
- **Empty state**: the Definitions tab with no pipelines now shows a centered call-to-action that opens the modal.
- **Docs**: `docs/pipelines.md` gains an "Authoring in the visual editor" section (view toggle, canvas, inspector, predicate builder, settings, live validation, templates) and the remaining em dashes were removed.

No backend changes, no new deps, no route changes (routeTree untouched).

## Tests

- `pipeline-templates.test.ts`: codec round-trip per template, mockup stage counts, acyclic graphs, and a test-side mirror of the backend validation rules (executor and predicate field rules, reference checks) so an invalid template fails in CI rather than at /validate in front of a user.
- `NewPipelineModal.test.tsx`: path selection, template gating and selection, stage-count rows, paste-YAML flow, cancel.
- `PipelineDefinitionsPage.test.tsx`: end-to-end flows for create-from-blank, create-from-template -> edit -> save -> back to list, paste-YAML import, and the empty-state CTA.
- Full renderer suite: 807 passed, 0 failed. Prettier run on all changed files.

## Risks / follow-ups

- Templates reference the `claude-code` plugin and `gh`/`pnpm` commands as illustrative defaults; agent-mode validation against the real plugin registry happens at runtime, not at /validate.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)