### PR TITLE
fix(pipelines): stage identity by index; working stage delete

### DIFF
--- a/frontend/src/renderer/components/PipelineCanvas.test.tsx
+++ b/frontend/src/renderer/components/PipelineCanvas.test.tsx
@@ -70,8 +70,8 @@ describe("PipelineCanvas", () => {
 		const next = onDraftChange.mock.calls[0][0] as PipelineDraft;
 		expect(next.stages.map((s) => s.name)).toEqual(["review", "stage-2"]);
 		expect(next.stages[1].executor.kind).toBe("agent");
-		// The new stage becomes the selection for the inspector.
-		expect(selection.selectStage).toHaveBeenCalledWith("stage-2");
+		// The new stage's node id (its index) becomes the selection.
+		expect(selection.selectStage).toHaveBeenCalledWith("1");
 	});
 
 	it("disables Add stage when the canvas is read-only", () => {
@@ -79,7 +79,7 @@ describe("PipelineCanvas", () => {
 		expect(screen.getByRole("button", { name: /Add stage/ })).toBeDisabled();
 	});
 
-	it("publishes the clicked node through the shared selection", () => {
+	it("publishes the clicked node's id (its index) through the shared selection", () => {
 		const selection = selectionOf();
 		render(
 			<PipelineCanvas draft={draftOf(stage("review"), stage("fix"))} onDraftChange={vi.fn()} selection={selection} />,
@@ -89,14 +89,34 @@ describe("PipelineCanvas", () => {
 		// mousedown handling, which jsdom cannot satisfy.
 		fireEvent.click(screen.getByText("fix"));
 
-		expect(selection.selectStage).toHaveBeenCalledWith("fix");
+		expect(selection.selectStage).toHaveBeenCalledWith("1");
 	});
 
 	it("highlights the node the shared selection points at", () => {
-		render(<PipelineCanvas draft={draftOf(stage("review"), stage("fix"))} selection={selectionOf("fix")} />);
+		render(<PipelineCanvas draft={draftOf(stage("review"), stage("fix"))} selection={selectionOf("1")} />);
 
-		expect(document.querySelector('.react-flow__node[data-id="fix"]')).toHaveClass("selected");
-		expect(document.querySelector('.react-flow__node[data-id="review"]')).not.toHaveClass("selected");
+		expect(document.querySelector('.react-flow__node[data-id="1"]')).toHaveClass("selected");
+		expect(document.querySelector('.react-flow__node[data-id="0"]')).not.toHaveClass("selected");
+	});
+
+	it("renders empty- and duplicate-named stages as distinct selectable nodes", () => {
+		const selection = selectionOf();
+		render(
+			<PipelineCanvas
+				draft={draftOf(stage(""), stage("dup"), stage("dup"))}
+				onDraftChange={vi.fn()}
+				selection={selection}
+			/>,
+		);
+
+		expect(screen.getByText("(unnamed)")).toBeInTheDocument();
+		expect(screen.getAllByText("dup")).toHaveLength(2);
+
+		fireEvent.click(screen.getByText("(unnamed)"));
+		expect(selection.selectStage).toHaveBeenLastCalledWith("0");
+
+		fireEvent.click(screen.getAllByText("dup")[1]);
+		expect(selection.selectStage).toHaveBeenLastCalledWith("2");
 	});
 
 	it("auto-layouts dependencies left of dependents", () => {
@@ -107,8 +127,8 @@ describe("PipelineCanvas", () => {
 		);
 		const { container } = render(<PipelineCanvas draft={draft} />);
 
-		expect(nodeX(container, "intake")).toBeLessThan(nodeX(container, "review"));
-		expect(nodeX(container, "review")).toBeLessThan(nodeX(container, "fix"));
+		expect(nodeX(container, "0")).toBeLessThan(nodeX(container, "1"));
+		expect(nodeX(container, "1")).toBeLessThan(nodeX(container, "2"));
 	});
 
 	it("re-runs layout from the Auto-layout button", async () => {
@@ -118,7 +138,25 @@ describe("PipelineCanvas", () => {
 
 		await userEvent.setup().click(screen.getByRole("button", { name: /Auto-layout/ }));
 
-		expect(nodeX(container, "a")).toBeLessThan(nodeX(container, "b"));
+		expect(nodeX(container, "0")).toBeLessThan(nodeX(container, "1"));
+	});
+
+	it("removes the selected stage from the draft on Delete/Backspace", async () => {
+		const onDraftChange = vi.fn();
+		const selection = selectionOf("0");
+		const draft = draftOf(stage("review"), stage("fix", { dependsOn: ["review"] }));
+		render(<PipelineCanvas draft={draft} onDraftChange={onDraftChange} selection={selection} />);
+
+		fireEvent.keyDown(document.querySelector(".react-flow")!, { key: "Backspace" });
+
+		await screen.findByText("fix");
+		expect(onDraftChange).toHaveBeenCalledTimes(1);
+		const next = onDraftChange.mock.calls[0][0] as PipelineDraft;
+		expect(next.stages.map((s) => s.name)).toEqual(["fix"]);
+		// The removed stage is scrubbed from the survivor's dependsOn.
+		expect(next.stages[0].dependsOn).toBeUndefined();
+		// The selection no longer points at anything.
+		expect(selection.selectStage).toHaveBeenCalledWith(null);
 	});
 
 	// Edge DOM rendering needs measured node dimensions React Flow only gets in
@@ -143,7 +181,7 @@ describe("PipelineCanvas", () => {
 		render(
 			<PipelineCanvas
 				draft={draftOf(stage("review"), stage("fix"))}
-				stageIssues={{ review: ["task.prompt is required", "unknown plugin"] }}
+				stageIssues={{ "0": ["task.prompt is required", "unknown plugin"] }}
 			/>,
 		);
 

--- a/frontend/src/renderer/components/PipelineCanvas.test.tsx
+++ b/frontend/src/renderer/components/PipelineCanvas.test.tsx
@@ -150,8 +150,9 @@ describe("PipelineCanvas", () => {
 		fireEvent.keyDown(document.querySelector(".react-flow")!, { key: "Backspace" });
 
 		await screen.findByText("fix");
-		expect(onDraftChange).toHaveBeenCalledTimes(1);
-		const next = onDraftChange.mock.calls[0][0] as PipelineDraft;
+		// react-flow emits a remove for the connected edge too; the last draft
+		// carries the final state (edge scrub folded into the stage removal).
+		const next = onDraftChange.mock.calls.at(-1)![0] as PipelineDraft;
 		expect(next.stages.map((s) => s.name)).toEqual(["fix"]);
 		// The removed stage is scrubbed from the survivor's dependsOn.
 		expect(next.stages[0].dependsOn).toBeUndefined();

--- a/frontend/src/renderer/components/PipelineCanvas.tsx
+++ b/frontend/src/renderer/components/PipelineCanvas.tsx
@@ -27,8 +27,10 @@ import {
 	isEdgeInCycle,
 	layoutPositions,
 	removeDependency,
+	removeStage,
 	STAGE_NODE_HEIGHT,
 	STAGE_NODE_WIDTH,
+	stageIndexFromNodeId,
 	stageNodeId,
 	type StagePosition,
 } from "../lib/pipeline-graph";
@@ -41,8 +43,9 @@ import { cn } from "../lib/utils";
 // dependency -> dependent (execution order). Every edit routes through the
 // draft via onDraftChange (usePipelineDraft.setDraft), so serialization and
 // validation stay centralized. Selection flows through the editor shell's
-// useStageSelection instance (V3's shared hook): node clicks call selectStage,
-// and the inspector binds to the same selectedStage name.
+// useStageSelection instance (V3's shared hook): node clicks call selectStage
+// with the node id (the stage's index, see stageNodeId), and the inspector
+// binds to the same id, so empty- and duplicate-named stages stay selectable.
 //
 // Cycle handling (mockup 1d): a connect attempt that would close a dependency
 // cycle is blocked and flashed as a red dashed edge; cycles already present in
@@ -54,7 +57,7 @@ export interface PipelineCanvasProps {
 	onDraftChange?: (next: PipelineDraft) => void;
 	// The editor area's useStageSelection instance, shared with the inspector.
 	selection?: StageSelection;
-	// Validation issue messages keyed by stage name (V6, mockup 1d): affected
+	// Validation issue messages keyed by node id (V6, mockup 1d): affected
 	// nodes render an inline error badge plus the first message.
 	stageIssues?: Record<string, string[]>;
 }
@@ -77,8 +80,9 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 	const selectStage = selection?.selectStage;
 	const [positions, setPositions] = useState<Record<string, StagePosition>>(() => layoutPositions(draft));
 	const [selectedEdgeIds, setSelectedEdgeIds] = useState<ReadonlySet<string>>(new Set());
-	// The blocked connect attempt currently flashing red, if any.
-	const [flash, setFlash] = useState<{ dep: string; dependent: string; path: string[] } | null>(null);
+	// The blocked connect attempt currently flashing red, if any: the endpoint
+	// node ids for the transient edge plus the cycle path as stage names.
+	const [flash, setFlash] = useState<{ sourceId: string; targetId: string; path: string[] } | null>(null);
 	const flashTimer = useRef<number | undefined>(undefined);
 
 	// The handlers read the latest draft through a ref so their identity stays
@@ -88,7 +92,7 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 
 	// Stages that appear after mount (Add stage, YAML edits) get stacked below
 	// the existing nodes instead of re-layouting the user's arrangement.
-	const nodeIds = draft.stages.map(stageNodeId).join("\n");
+	const nodeIds = draft.stages.map((_, i) => stageNodeId(i)).join("\n");
 	useEffect(() => {
 		setPositions((prev) => {
 			const ids = nodeIds ? nodeIds.split("\n") : [];
@@ -108,28 +112,24 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 
 	const nodes = useMemo<StageNodeType[]>(() => {
 		const persistent = cycleMembers(draft);
-		const seen = new Set<string>();
-		const out: StageNodeType[] = [];
-		draft.stages.forEach((stage, i) => {
-			const id = stageNodeId(stage, i);
-			// Duplicate names are invalid config (the daemon reports them); render
-			// the first occurrence only so node ids stay unique.
-			if (seen.has(id)) return;
-			seen.add(id);
-			out.push({
+		// Index-based ids are unique by construction, so every stage renders,
+		// including duplicate-named ones (each independently selectable to fix).
+		return draft.stages.map((stage, i): StageNodeType => {
+			const id = stageNodeId(i);
+			return {
 				id,
 				type: "stage",
 				position: positions[id] ?? { x: 32, y: i * (STAGE_NODE_HEIGHT + 32) },
 				width: STAGE_NODE_WIDTH,
 				data: {
 					stage,
-					inCycle: persistent.has(id) || (flash?.path.includes(id) ?? false),
+					// Cycle membership is a config-level (name) property.
+					inCycle: persistent.has(stage.name) || (flash?.path.includes(stage.name) ?? false),
 					issues: stageIssues?.[id] ?? [],
 				},
 				selected: selected === id,
-			});
+			};
 		});
-		return out;
 	}, [draft, positions, selected, flash, stageIssues]);
 
 	const edges = useMemo<Edge[]>(() => {
@@ -138,8 +138,8 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 			const stroke = inCycle ? "var(--color-error)" : "var(--color-border-strong)";
 			return {
 				id: edge.id,
-				source: edge.dep,
-				target: edge.dependent,
+				source: edge.source,
+				target: edge.target,
 				data: { dep: edge.dep, dependent: edge.dependent },
 				selected: selectedEdgeIds.has(edge.id),
 				style: { stroke, strokeWidth: 1.5, ...(inCycle ? { strokeDasharray: "6 4" } : {}) },
@@ -149,11 +149,11 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 		});
 		// The blocked attempt renders as a transient red dashed edge (mockup 1d);
 		// a blocked self-edge shows only the node highlight.
-		if (flash && flash.dep !== flash.dependent) {
+		if (flash && flash.sourceId !== flash.targetId) {
 			out.push({
 				id: "__cycle-flash",
-				source: flash.dep,
-				target: flash.dependent,
+				source: flash.sourceId,
+				target: flash.targetId,
 				animated: true,
 				selectable: false,
 				deletable: false,
@@ -175,8 +175,40 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 					selectStage?.(change.selected ? change.id : null);
 				}
 			}
+			// Delete/Backspace on selected nodes arrives as `remove` changes; apply
+			// them to the draft (react-flow only drops the node visually). Highest
+			// index first so earlier removals do not shift later ones.
+			const removedIndices = changes
+				.filter((c) => c.type === "remove")
+				.map((c) => stageIndexFromNodeId(c.id))
+				.filter((i) => i >= 0)
+				.sort((a, b) => b - a);
+			if (removedIndices.length === 0 || !onDraftChange) return;
+			const before = draftRef.current;
+			let next = before;
+			for (const i of removedIndices) next = removeStage(next, i);
+			// Keep the ref in step so a same-tick edge-remove callback cannot
+			// compute from the pre-delete draft and resurrect the stage.
+			draftRef.current = next;
+			onDraftChange(next);
+			// The removed stage is gone; a stale index would point at its neighbor.
+			selectStage?.(null);
+			// Node ids above the removed indices shift down; move their saved
+			// positions along so the surviving nodes stay where the user put them.
+			const removedSet = new Set(removedIndices);
+			setPositions((prev) => {
+				const remapped: Record<string, StagePosition> = {};
+				let j = 0;
+				for (let i = 0; i < before.stages.length; i++) {
+					if (removedSet.has(i)) continue;
+					const p = prev[stageNodeId(i)];
+					if (p) remapped[stageNodeId(j)] = p;
+					j += 1;
+				}
+				return remapped;
+			});
 		},
-		[selectStage],
+		[selectStage, onDraftChange],
 	);
 
 	const onEdgesChange = useCallback(
@@ -194,11 +226,16 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 				} else if (change.type === "remove" && onDraftChange) {
 					const edge = draftEdges(next).find((e) => e.id === change.id);
 					if (!edge) continue;
-					next = removeDependency(next, edge.dependent, edge.dep);
+					next = removeDependency(next, stageIndexFromNodeId(edge.target), edge.dep);
 					removed = true;
 				}
 			}
-			if (removed && onDraftChange) onDraftChange(next);
+			if (removed && onDraftChange) {
+				// Same-tick node-remove callbacks must see this edit (see the ref
+				// note in onNodesChange).
+				draftRef.current = next;
+				onDraftChange(next);
+			}
 		},
 		[onDraftChange],
 	);
@@ -208,9 +245,10 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 			if (!onDraftChange || !connection.source || !connection.target) return;
 			const result = applyConnection(draftRef.current, connection.source, connection.target);
 			if (result.kind === "added") {
+				draftRef.current = result.draft;
 				onDraftChange(result.draft);
 			} else if (result.kind === "cycle") {
-				setFlash({ dep: connection.source, dependent: connection.target, path: result.path });
+				setFlash({ sourceId: connection.source, targetId: connection.target, path: result.path });
 				window.clearTimeout(flashTimer.current);
 				flashTimer.current = window.setTimeout(() => setFlash(null), CYCLE_FLASH_MS);
 			}
@@ -220,9 +258,11 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 
 	const handleAddStage = useCallback(() => {
 		if (!onDraftChange) return;
-		const { draft: next, name } = addStage(draftRef.current);
+		const { draft: next } = addStage(draftRef.current);
+		draftRef.current = next;
 		onDraftChange(next);
-		selectStage?.(name);
+		// The appended stage's node id is its index (the new last slot).
+		selectStage?.(stageNodeId(next.stages.length - 1));
 	}, [onDraftChange, selectStage]);
 
 	const handleAutoLayout = useCallback(() => {

--- a/frontend/src/renderer/components/PipelineDefinitionsPage.test.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.test.tsx
@@ -46,6 +46,7 @@ vi.mock("./YamlEditor", () => ({
 // React Flow needs ResizeObserver + real layout jsdom lacks; stub the canvas
 // with hooks that expose what the shell passes in (draft, selection, issue
 // badges) and drive draft edits / node selection like real canvas gestures.
+// Selection speaks node ids (the stage's index), matching the real canvas.
 vi.mock("./PipelineCanvas", () => ({
 	PipelineCanvas: ({
 		draft,
@@ -55,14 +56,15 @@ vi.mock("./PipelineCanvas", () => ({
 	}: {
 		draft: { stages: { name: string }[] };
 		onDraftChange?: (next: unknown) => void;
-		selection?: { selectedStage: string | null; selectStage: (name: string | null) => void };
+		selection?: { selectedStage: string | null; selectStage: (nodeId: string | null) => void };
 		stageIssues?: Record<string, string[]>;
 	}) => (
 		<div data-testid="pipeline-canvas">
 			<span data-testid="canvas-stages">{draft.stages.map((s) => s.name).join(",")}</span>
 			<span data-testid="canvas-selected">{selection?.selectedStage ?? ""}</span>
 			<span data-testid="canvas-issues">{JSON.stringify(stageIssues ?? {})}</span>
-			<button onClick={() => selection?.selectStage(draft.stages[0]?.name ?? null)}>mock-select-first</button>
+			<button onClick={() => selection?.selectStage(draft.stages.length > 0 ? "0" : null)}>mock-select-first</button>
+			<button onClick={() => selection?.selectStage(draft.stages.length > 1 ? "1" : null)}>mock-select-second</button>
 			<button
 				onClick={() =>
 					onDraftChange?.({
@@ -427,13 +429,14 @@ describe("PipelineDefinitionsPage", () => {
 		expect(within(panel).getByText("unknown executor kind")).toBeInTheDocument();
 		expect(screen.getByText("1 problem")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
-		// The affected node gets its badge messages.
-		expect(screen.getByTestId("canvas-issues")).toHaveTextContent('{"a":["unknown executor kind"]}');
+		// The affected node gets its badge messages, keyed by node id.
+		expect(screen.getByTestId("canvas-issues")).toHaveTextContent('{"0":["unknown executor kind"]}');
 
-		// Reveal selects the offending stage; the split view scrolls the YAML
-		// pane to its block (stage `a` starts on line 3 of TWO_STAGE_YAML).
+		// Reveal selects the offending stage by node id; the split view scrolls
+		// the YAML pane to its block (stage `a` starts on line 3 of
+		// TWO_STAGE_YAML).
 		await user.click(within(panel).getByRole("button", { name: "Reveal" }));
-		expect(screen.getByTestId("canvas-selected")).toHaveTextContent("a");
+		expect(screen.getByTestId("canvas-selected")).toHaveTextContent("0");
 		expect(screen.getByLabelText("Pipeline YAML")).toHaveAttribute("data-reveal-line", "3");
 	});
 
@@ -459,6 +462,106 @@ describe("PipelineDefinitionsPage", () => {
 		// The draft edit reserialized into the YAML buffer.
 		await user.click(screen.getByRole("radio", { name: "YAML" }));
 		expect((screen.getByLabelText("Pipeline YAML") as HTMLTextAreaElement).value).toContain("no_open_findings");
+	});
+
+	it("opens the inspector for an unnamed stage and lets the user name it", async () => {
+		// stages[1] has no name: exactly the state the daemon rejects with
+		// "stage name must not be empty", which the user must be able to fix.
+		getMock.mockReset().mockResolvedValue({
+			data: {
+				definitions: [def("pl-1", "review", "name: review\nstages:\n  - name: a\n  - executor:\n      kind: agent\n")],
+			},
+			error: undefined,
+		});
+		renderPage();
+		const user = userEvent.setup();
+
+		await user.click(await screen.findByRole("button", { name: "Edit" }));
+		await user.click(screen.getByRole("radio", { name: "Canvas" }));
+		await user.click(screen.getByRole("button", { name: "mock-select-second" }));
+
+		const inspector = await screen.findByTestId("stage-inspector");
+		expect(within(inspector).getByText("Stage: (unnamed)")).toBeInTheDocument();
+
+		// Naming it keeps the selection (index identity survives the rename and
+		// the debounced YAML re-parse) and lands in the draft.
+		await user.type(within(inspector).getByRole("textbox", { name: "Stage name" }), "fix");
+		await waitFor(() => expect(screen.getByTestId("canvas-stages")).toHaveTextContent("a,fix"), { timeout: 2000 });
+		expect(screen.getByTestId("canvas-selected")).toHaveTextContent("1");
+		expect(within(screen.getByTestId("stage-inspector")).getByText("Stage: fix")).toBeInTheDocument();
+	});
+
+	it("selects duplicate-named stages independently", async () => {
+		getMock.mockReset().mockResolvedValue({
+			data: { definitions: [def("pl-1", "review", "name: review\nstages:\n  - name: a\n  - name: a\n")] },
+			error: undefined,
+		});
+		renderPage();
+		const user = userEvent.setup();
+
+		await user.click(await screen.findByRole("button", { name: "Edit" }));
+		await user.click(screen.getByRole("radio", { name: "Canvas" }));
+		await user.click(screen.getByRole("button", { name: "mock-select-second" }));
+
+		const inspector = await screen.findByTestId("stage-inspector");
+		expect(screen.getByTestId("canvas-selected")).toHaveTextContent("1");
+
+		// Renaming edits the second stage only, resolving the duplicate.
+		await user.type(within(inspector).getByRole("textbox", { name: "Stage name" }), "2");
+		await waitFor(() => expect(screen.getByTestId("canvas-stages")).toHaveTextContent("a,a2"), { timeout: 2000 });
+	});
+
+	it("deletes the selected stage from the inspector, scrubbing dependsOn", async () => {
+		getMock.mockReset().mockResolvedValue({
+			data: {
+				definitions: [
+					def("pl-1", "review", "name: review\nstages:\n  - name: a\n  - name: b\n    dependsOn:\n      - a\n"),
+				],
+			},
+			error: undefined,
+		});
+		renderPage();
+		const user = userEvent.setup();
+
+		await user.click(await screen.findByRole("button", { name: "Edit" }));
+		await user.click(screen.getByRole("radio", { name: "Canvas" }));
+		await user.click(screen.getByRole("button", { name: "mock-select-first" }));
+		await screen.findByTestId("stage-inspector");
+
+		await user.click(screen.getByRole("button", { name: "Delete stage" }));
+
+		// The stage is gone from the draft, the survivor's dependsOn is
+		// scrubbed, and the now-dangling selection is cleared (inspector closes).
+		expect(screen.getByTestId("canvas-stages")).toHaveTextContent(/^b$/);
+		expect(screen.queryByTestId("stage-inspector")).not.toBeInTheDocument();
+		expect(screen.getByTestId("canvas-selected")).toHaveTextContent(/^$/);
+
+		await user.click(screen.getByRole("radio", { name: "YAML" }));
+		const yaml = (screen.getByLabelText("Pipeline YAML") as HTMLTextAreaElement).value;
+		expect(yaml).not.toContain("name: a");
+		expect(yaml).not.toContain("dependsOn");
+	});
+
+	it("keeps the selection stable across an unrelated YAML edit and re-parse", async () => {
+		renderPage();
+		const user = userEvent.setup();
+
+		await user.click(await screen.findByRole("button", { name: "Edit" }));
+		await user.click(screen.getByRole("radio", { name: "Split" }));
+		await user.click(screen.getByRole("button", { name: "mock-select-first" }));
+		expect(screen.getByTestId("canvas-selected")).toHaveTextContent("0");
+
+		// An edit elsewhere in the document (the pipeline name) triggers the
+		// debounced re-parse; the index identity must not churn.
+		fireEvent.change(screen.getByLabelText("Pipeline YAML"), {
+			target: { value: "name: renamed\nstages:\n  - name: a\n  - name: b\n" },
+		});
+
+		await waitFor(() => expect(screen.getByTestId("yaml-parse-status")).toHaveTextContent("parsed"), {
+			timeout: 2000,
+		});
+		expect(screen.getByTestId("canvas-stages")).toHaveTextContent("a,b");
+		expect(screen.getByTestId("canvas-selected")).toHaveTextContent("0");
 	});
 
 	it("confirms before deleting a definition", async () => {

--- a/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
@@ -3,7 +3,8 @@ import { AlertCircle, CheckCircle2, Loader2, Pencil, Plus, Settings2, Trash2, Wo
 import { apiErrorMessage } from "../lib/api-client";
 import { formatTimeCompact } from "../lib/format-time";
 import { serializeToYaml, type StageDraft } from "../lib/pipeline-draft";
-import { issueStageName, stageIssueMessages, stageYamlLine } from "../lib/pipeline-problems";
+import { removeStage, stageIndexFromNodeId } from "../lib/pipeline-graph";
+import { issueStageNodeId, stageIssueMessages, stageYamlLine } from "../lib/pipeline-problems";
 import { countStagesFromYaml, parsePipelineValidationIssues, type PipelineValidationIssue } from "../lib/pipeline-yaml";
 import {
 	type PipelineDefinitionSummary,
@@ -230,7 +231,8 @@ function DefinitionEditor({
 		def ? def.yamlSource : initialYaml,
 	);
 	// One selection instance for the editor area: the canvas writes on node
-	// click, the stage inspector (V3) binds to the same stage name.
+	// click, the stage inspector (V3) binds to the same node id (the stage's
+	// index; see stageNodeId), so empty/duplicate-named stages stay editable.
 	const selection = useStageSelection();
 	const [view, setView] = useState<ViewMode>(def ? "yaml" : initialView);
 	const [settingsOpen, setSettingsOpen] = useState(false);
@@ -246,18 +248,26 @@ function DefinitionEditor({
 	const mutation = def ? update : create;
 	const isSaving = mutation.isPending;
 
-	const selectedIndex = selection.selectedStage
-		? draft.stages.findIndex((s) => s.name === selection.selectedStage)
-		: -1;
-	const selectedStageDraft = selectedIndex >= 0 ? draft.stages[selectedIndex] : null;
+	// The selection holds the node id (the stage's index), so the lookup works
+	// for empty and duplicate names too; a YAML edit that shrank the stage list
+	// past the index just resolves to no stage (the inspector closes).
+	const selectedIndex = stageIndexFromNodeId(selection.selectedStage);
+	const selectedStageDraft = selectedIndex >= 0 ? (draft.stages[selectedIndex] ?? null) : null;
 	const stageNames = draft.stages.map((s) => s.name).filter(Boolean);
 
-	// Inspector edits replace the selected stage in place; a rename moves the
-	// selection with the stage (names are the selection identity).
+	// Inspector edits replace the selected stage in place; a rename keeps the
+	// selection (the index identity is name-independent).
 	const updateSelectedStage = (next: StageDraft) => {
-		if (selectedIndex < 0) return;
+		if (!selectedStageDraft) return;
 		setDraft({ ...draft, stages: draft.stages.map((s, i) => (i === selectedIndex ? next : s)) });
-		if (next.name !== selection.selectedStage) selection.selectStage(next.name || null);
+	};
+
+	// Delete from the inspector: drop the stage, scrub dependsOn (removeStage),
+	// and clear the now-dangling selection.
+	const deleteSelectedStage = () => {
+		if (!selectedStageDraft) return;
+		setDraft(removeStage(draft, selectedIndex));
+		selection.selectStage(null);
 	};
 
 	// The blocking problem list (mockup 1d): the YAML parse error, the live
@@ -269,7 +279,7 @@ function DefinitionEditor({
 		...dedupeIssues([...liveIssues, ...(saveIssues ?? [])]).map((issue) => ({
 			path: issue.path,
 			message: issue.message,
-			stage: issueStageName(draft, issue),
+			stage: issueStageNodeId(draft, issue),
 		})),
 	];
 	const stageIssues = useMemo(
@@ -280,13 +290,16 @@ function DefinitionEditor({
 	// saving"); "still checking" alone does not block.
 	const blocked = problems.length > 0;
 
-	// Reveal + node select scroll the YAML pane to the stage's block. The buffer
-	// is read through a ref so scrolling happens on selection changes only, not
+	// Reveal + node select scroll the YAML pane to the stage's block (located by
+	// name; an unnamed stage has no block to target). The buffer and the name
+	// are read through refs so scrolling happens on selection changes only, not
 	// on every keystroke.
 	const yamlRef = useRef(yamlSource);
 	yamlRef.current = yamlSource;
+	const selectedNameRef = useRef(selectedStageDraft?.name ?? "");
+	selectedNameRef.current = selectedStageDraft?.name ?? "";
 	const revealLine = useMemo(
-		() => (selection.selectedStage ? stageYamlLine(yamlRef.current, selection.selectedStage) : null),
+		() => (selection.selectedStage !== null ? stageYamlLine(yamlRef.current, selectedNameRef.current) : null),
 		[selection.selectedStage],
 	);
 
@@ -340,11 +353,15 @@ function DefinitionEditor({
 						{selectedStageDraft && (
 							<div className="w-80 shrink-0">
 								<StageInspector
+									// Remount per node id so field-local state never leaks
+									// between stages (duplicate names share no identity).
+									key={selection.selectedStage}
 									stage={selectedStageDraft}
 									stageNames={stageNames}
 									onChange={updateSelectedStage}
 									onEditCondition={() => setConditionOpen(true)}
 									onClose={() => selection.selectStage(null)}
+									onDelete={deleteSelectedStage}
 								/>
 							</div>
 						)}

--- a/frontend/src/renderer/components/PipelineProblemsPanel.tsx
+++ b/frontend/src/renderer/components/PipelineProblemsPanel.tsx
@@ -10,7 +10,8 @@ export interface PipelineProblem {
 	// Dotted config path; "" for document-level problems (YAML parse errors).
 	path: string;
 	message: string;
-	// Stage the problem resolves to, when it does; enables the Reveal action.
+	// Canvas node id of the stage the problem resolves to, when it does;
+	// enables the Reveal action (unnamed stages included).
 	stage: string | null;
 }
 

--- a/frontend/src/renderer/components/StageInspector.test.tsx
+++ b/frontend/src/renderer/components/StageInspector.test.tsx
@@ -214,4 +214,16 @@ describe("StageInspector", () => {
 		await userEvent.click(screen.getByRole("button", { name: "Close inspector" }));
 		expect(onClose).toHaveBeenCalledTimes(1);
 	});
+
+	it("calls onDelete from the header delete button", async () => {
+		const onDelete = vi.fn();
+		renderInspector(agentStage(), { onDelete });
+		await userEvent.click(screen.getByRole("button", { name: "Delete stage" }));
+		expect(onDelete).toHaveBeenCalledTimes(1);
+	});
+
+	it("hides the delete button while onDelete is unwired", () => {
+		renderInspector(agentStage());
+		expect(screen.queryByRole("button", { name: "Delete stage" })).not.toBeInTheDocument();
+	});
 });

--- a/frontend/src/renderer/components/StageInspector.tsx
+++ b/frontend/src/renderer/components/StageInspector.tsx
@@ -53,7 +53,14 @@ const EXECUTOR_SUBTITLE: Record<ExecutorKind, string> = {
 	builtin: "Builtin executor",
 };
 
-export function StageInspector({ stage, stageNames, onChange, onEditCondition, onClose, onDelete }: StageInspectorProps) {
+export function StageInspector({
+	stage,
+	stageNames,
+	onChange,
+	onEditCondition,
+	onClose,
+	onDelete,
+}: StageInspectorProps) {
 	const update = (patch: Partial<StageDraft>) => onChange({ ...stage, ...patch });
 
 	// Merges a task patch and drops the task object entirely once every field is

--- a/frontend/src/renderer/components/StageInspector.tsx
+++ b/frontend/src/renderer/components/StageInspector.tsx
@@ -1,5 +1,5 @@
 import { useId, useState } from "react";
-import { Pencil, X } from "lucide-react";
+import { Pencil, Trash2, X } from "lucide-react";
 import { cn } from "../lib/utils";
 import { AGENT_OPTIONS } from "../lib/agent-options";
 import {
@@ -34,6 +34,9 @@ export interface StageInspectorProps {
 	// C; while undefined the Edit-condition button is a disabled coming-soon stub.
 	onEditCondition?: () => void;
 	onClose?: () => void;
+	// Removes the inspected stage from the draft (the parent scrubs dependsOn
+	// and clears the selection). The delete button renders only when wired.
+	onDelete?: () => void;
 }
 
 const TASK_MODES: TaskMode[] = ["review", "code", "answer"];
@@ -50,7 +53,7 @@ const EXECUTOR_SUBTITLE: Record<ExecutorKind, string> = {
 	builtin: "Builtin executor",
 };
 
-export function StageInspector({ stage, stageNames, onChange, onEditCondition, onClose }: StageInspectorProps) {
+export function StageInspector({ stage, stageNames, onChange, onEditCondition, onClose, onDelete }: StageInspectorProps) {
 	const update = (patch: Partial<StageDraft>) => onChange({ ...stage, ...patch });
 
 	// Merges a task patch and drops the task object entirely once every field is
@@ -93,11 +96,24 @@ export function StageInspector({ stage, stageNames, onChange, onEditCondition, o
 					<h2 className="truncate text-control font-semibold text-foreground">Stage: {stage.name || "(unnamed)"}</h2>
 					<p className="text-caption text-passive">{EXECUTOR_SUBTITLE[stage.executor.kind]}</p>
 				</div>
-				{onClose && (
-					<Button size="icon-sm" variant="ghost" onClick={onClose} aria-label="Close inspector">
-						<X className="size-icon-sm" aria-hidden="true" />
-					</Button>
-				)}
+				<div className="flex shrink-0 items-center gap-1">
+					{onDelete && (
+						<Button
+							size="icon-sm"
+							variant="ghost"
+							className="text-destructive hover:text-destructive"
+							onClick={onDelete}
+							aria-label="Delete stage"
+						>
+							<Trash2 className="size-icon-sm" aria-hidden="true" />
+						</Button>
+					)}
+					{onClose && (
+						<Button size="icon-sm" variant="ghost" onClick={onClose} aria-label="Close inspector">
+							<X className="size-icon-sm" aria-hidden="true" />
+						</Button>
+					)}
+				</div>
 			</div>
 
 			<div className="flex flex-col gap-5 px-4 py-4">

--- a/frontend/src/renderer/hooks/useStageSelection.ts
+++ b/frontend/src/renderer/hooks/useStageSelection.ts
@@ -1,18 +1,17 @@
 import { useCallback, useState } from "react";
 
 // Shared stage-selection state for the visual editor area: the canvas (V2)
-// selects a stage by name, the inspector (V3) binds to it. V3 defined this
-// minimal version first (V2 had not landed one yet); V2/Batch-C reconcile on
-// this name and shape when the canvas wires node clicks into it. The editor
-// area holds one instance and passes selectedStage/selectStage down; names are
-// the stable stage identity in the draft model (dependsOn/routes refer by name).
+// selects a stage, the inspector (V3) binds to it. The stored value is the
+// stage's canvas node id (see stageNodeId in lib/pipeline-graph: the array
+// index), NOT the stage name: names can be empty or duplicated mid-edit and
+// selection must still resolve so the inspector can open and fix them.
 export interface StageSelection {
 	selectedStage: string | null;
-	selectStage: (name: string | null) => void;
+	selectStage: (nodeId: string | null) => void;
 }
 
 export function useStageSelection(): StageSelection {
 	const [selectedStage, setSelectedStage] = useState<string | null>(null);
-	const selectStage = useCallback((name: string | null) => setSelectedStage(name), []);
+	const selectStage = useCallback((nodeId: string | null) => setSelectedStage(nodeId), []);
 	return { selectedStage, selectStage };
 }

--- a/frontend/src/renderer/lib/pipeline-graph.test.ts
+++ b/frontend/src/renderer/lib/pipeline-graph.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { PipelineDraft, StageDraft } from "./pipeline-draft";
 import {
-	addDependency,
 	addStage,
 	applyConnection,
 	cycleMembers,
@@ -10,6 +9,8 @@ import {
 	isEdgeInCycle,
 	layoutPositions,
 	removeDependency,
+	removeStage,
+	stageIndexFromNodeId,
 	stageNodeId,
 } from "./pipeline-graph";
 
@@ -27,10 +28,19 @@ function draftOf(...stages: StageDraft[]): PipelineDraft {
 	return { name: "p", stages };
 }
 
-describe("stageNodeId", () => {
-	it("uses the stage name and falls back to a placeholder for unnamed stages", () => {
-		expect(stageNodeId(stage("build"), 0)).toBe("build");
-		expect(stageNodeId(stage(""), 3)).toBe("__stage-3");
+describe("stageNodeId / stageIndexFromNodeId", () => {
+	it("round-trips the array index, independent of the stage name", () => {
+		expect(stageNodeId(0)).toBe("0");
+		expect(stageNodeId(3)).toBe("3");
+		expect(stageIndexFromNodeId(stageNodeId(3))).toBe(3);
+	});
+
+	it("rejects null and non-index ids", () => {
+		expect(stageIndexFromNodeId(null)).toBe(-1);
+		expect(stageIndexFromNodeId(undefined)).toBe(-1);
+		expect(stageIndexFromNodeId("build")).toBe(-1);
+		expect(stageIndexFromNodeId("-1")).toBe(-1);
+		expect(stageIndexFromNodeId("")).toBe(-1);
 	});
 });
 
@@ -38,31 +48,67 @@ describe("draftEdges", () => {
 	it("maps every dependsOn entry to a dependency -> dependent edge", () => {
 		const draft = draftOf(stage("a"), stage("b", ["a"]), stage("c", ["a", "b"]));
 		expect(draftEdges(draft)).toEqual([
-			{ id: "a->b", dep: "a", dependent: "b" },
-			{ id: "a->c", dep: "a", dependent: "c" },
-			{ id: "b->c", dep: "b", dependent: "c" },
+			{ id: "0->1", source: "0", target: "1", dep: "a", dependent: "b" },
+			{ id: "0->2", source: "0", target: "2", dep: "a", dependent: "c" },
+			{ id: "1->2", source: "1", target: "2", dep: "b", dependent: "c" },
 		]);
 	});
 
 	it("skips dependsOn references to stages that do not exist", () => {
 		const draft = draftOf(stage("a"), stage("b", ["a", "ghost"]));
-		expect(draftEdges(draft)).toEqual([{ id: "a->b", dep: "a", dependent: "b" }]);
+		expect(draftEdges(draft)).toEqual([{ id: "0->1", source: "0", target: "1", dep: "a", dependent: "b" }]);
+	});
+
+	it("keeps edges to duplicate-named dependents distinct", () => {
+		const draft = draftOf(stage("a"), stage("dup", ["a"]), stage("dup", ["a"]));
+		expect(draftEdges(draft).map((e) => e.id)).toEqual(["0->1", "0->2"]);
 	});
 });
 
-describe("addDependency / removeDependency", () => {
-	it("adds a dependency without duplicating and without mutating the input", () => {
-		const draft = draftOf(stage("a"), stage("b"));
-		const next = addDependency(draft, "b", "a");
-		expect(next.stages[1].dependsOn).toEqual(["a"]);
-		expect(draft.stages[1].dependsOn).toBeUndefined();
-		expect(addDependency(next, "b", "a").stages[1].dependsOn).toEqual(["a"]);
+describe("removeDependency", () => {
+	it("removes a dependency from the exact stage index and drops the empty key", () => {
+		const draft = draftOf(stage("a"), stage("b", ["a"]));
+		const next = removeDependency(draft, 1, "a");
+		expect(next.stages[1].dependsOn).toBeUndefined();
+		expect(draft.stages[1].dependsOn).toEqual(["a"]);
 	});
 
-	it("removes a dependency and drops the empty dependsOn key", () => {
+	it("is a no-op for an out-of-range index", () => {
 		const draft = draftOf(stage("a"), stage("b", ["a"]));
-		const next = removeDependency(draft, "b", "a");
-		expect(next.stages[1].dependsOn).toBeUndefined();
+		expect(removeDependency(draft, 9, "a")).toBe(draft);
+	});
+});
+
+describe("removeStage", () => {
+	it("removes the stage and scrubs it from other stages' dependsOn without mutating", () => {
+		const draft = draftOf(stage("a"), stage("b", ["a"]), stage("c", ["a", "b"]));
+		const next = removeStage(draft, 0);
+		expect(next.stages.map((s) => s.name)).toEqual(["b", "c"]);
+		expect(next.stages[0].dependsOn).toBeUndefined();
+		expect(next.stages[1].dependsOn).toEqual(["b"]);
+		// Input untouched.
+		expect(draft.stages.map((s) => s.name)).toEqual(["a", "b", "c"]);
+		expect(draft.stages[1].dependsOn).toEqual(["a"]);
+		expect(draft.stages[2].dependsOn).toEqual(["a", "b"]);
+	});
+
+	it("removes an unnamed stage without touching other dependsOn lists", () => {
+		const draft = draftOf(stage("a"), stage(""), stage("b", ["a"]));
+		const next = removeStage(draft, 1);
+		expect(next.stages.map((s) => s.name)).toEqual(["a", "b"]);
+		expect(next.stages[1].dependsOn).toEqual(["a"]);
+	});
+
+	it("keeps dependsOn intact when a duplicate of the removed name survives", () => {
+		const draft = draftOf(stage("dup"), stage("dup"), stage("c", ["dup"]));
+		const next = removeStage(draft, 0);
+		expect(next.stages.map((s) => s.name)).toEqual(["dup", "c"]);
+		expect(next.stages[1].dependsOn).toEqual(["dup"]);
+	});
+
+	it("is a no-op for an out-of-range index", () => {
+		const draft = draftOf(stage("a"));
+		expect(removeStage(draft, 5)).toBe(draft);
 	});
 });
 
@@ -90,27 +136,28 @@ describe("findCycle", () => {
 });
 
 describe("applyConnection", () => {
-	it("adds source to target's dependsOn (drawing dep -> dependent)", () => {
-		const result = applyConnection(draftOf(stage("a"), stage("b")), "a", "b");
+	it("adds source to target's dependsOn (drawing dep -> dependent, by node id)", () => {
+		const result = applyConnection(draftOf(stage("a"), stage("b")), "0", "1");
 		expect(result.kind).toBe("added");
 		if (result.kind === "added") expect(result.draft.stages[1].dependsOn).toEqual(["a"]);
 	});
 
 	it("blocks a self-edge as a cycle", () => {
-		const result = applyConnection(draftOf(stage("a")), "a", "a");
+		const result = applyConnection(draftOf(stage("a")), "0", "0");
 		expect(result).toEqual({ kind: "cycle", path: ["a"] });
 	});
 
 	it("blocks an edge that would close a dependency cycle", () => {
 		const draft = draftOf(stage("a"), stage("b", ["a"]), stage("c", ["b"]));
-		const result = applyConnection(draft, "c", "a");
+		const result = applyConnection(draft, "2", "0");
 		expect(result).toEqual({ kind: "cycle", path: ["c", "b", "a"] });
 	});
 
-	it("is a noop for an existing dependency or unknown endpoints", () => {
+	it("is a noop for an existing dependency, unknown endpoints, or unnamed stages", () => {
 		const draft = draftOf(stage("a"), stage("b", ["a"]));
-		expect(applyConnection(draft, "a", "b")).toEqual({ kind: "noop" });
-		expect(applyConnection(draft, "ghost", "b")).toEqual({ kind: "noop" });
+		expect(applyConnection(draft, "0", "1")).toEqual({ kind: "noop" });
+		expect(applyConnection(draft, "9", "1")).toEqual({ kind: "noop" });
+		expect(applyConnection(draftOf(stage(""), stage("b")), "0", "1")).toEqual({ kind: "noop" });
 	});
 });
 
@@ -118,8 +165,8 @@ describe("cycleMembers / isEdgeInCycle", () => {
 	it("marks the stages and edges on a cycle already present in the draft", () => {
 		const draft = draftOf(stage("intake"), stage("fix", ["verify", "intake"]), stage("verify", ["fix"]));
 		expect(cycleMembers(draft)).toEqual(new Set(["fix", "verify"]));
-		expect(isEdgeInCycle(draft, { id: "verify->fix", dep: "verify", dependent: "fix" })).toBe(true);
-		expect(isEdgeInCycle(draft, { id: "intake->fix", dep: "intake", dependent: "fix" })).toBe(false);
+		expect(isEdgeInCycle(draft, { id: "2->1", source: "2", target: "1", dep: "verify", dependent: "fix" })).toBe(true);
+		expect(isEdgeInCycle(draft, { id: "0->1", source: "0", target: "1", dep: "intake", dependent: "fix" })).toBe(false);
 	});
 
 	it("is empty for an acyclic draft", () => {
@@ -131,14 +178,14 @@ describe("layoutPositions", () => {
 	it("assigns every stage a position with dependencies left of dependents", () => {
 		const draft = draftOf(stage("a"), stage("b", ["a"]), stage("c", ["b"]));
 		const positions = layoutPositions(draft);
-		expect(Object.keys(positions).sort()).toEqual(["a", "b", "c"]);
-		expect(positions.a.x).toBeLessThan(positions.b.x);
-		expect(positions.b.x).toBeLessThan(positions.c.x);
+		expect(Object.keys(positions).sort()).toEqual(["0", "1", "2"]);
+		expect(positions["0"].x).toBeLessThan(positions["1"].x);
+		expect(positions["1"].x).toBeLessThan(positions["2"].x);
 	});
 
 	it("separates independent stages instead of stacking them at one point", () => {
 		const positions = layoutPositions(draftOf(stage("a"), stage("b")));
-		expect(positions.a).not.toEqual(positions.b);
+		expect(positions["0"]).not.toEqual(positions["1"]);
 	});
 });
 

--- a/frontend/src/renderer/lib/pipeline-graph.ts
+++ b/frontend/src/renderer/lib/pipeline-graph.ts
@@ -20,37 +20,56 @@ export interface StagePosition {
 	y: number;
 }
 
-// stageNodeId gives every stage a stable non-empty node id. Unnamed stages
-// (mid-edit drafts) get a placeholder id that dependsOn can never reference,
-// so they render but stay unconnectable.
-export function stageNodeId(stage: StageDraft, index: number): string {
-	return stage.name || `__stage-${index}`;
+// Stage identity is the array index, not the name: it is unique even for
+// empty or duplicate names (which the user must be able to select to fix) and
+// deterministic across the debounced YAML re-parse, so selection and node
+// positions survive typing. Names remain the config reference (dependsOn,
+// routes, predicates); helpers below translate at the boundary.
+export function stageNodeId(index: number): string {
+	return String(index);
+}
+
+// stageIndexFromNodeId is the inverse of stageNodeId; -1 for null/garbage.
+export function stageIndexFromNodeId(id: string | null | undefined): number {
+	if (id == null || !/^\d+$/.test(id)) return -1;
+	return Number(id);
 }
 
 export interface DraftEdge {
 	id: string;
-	// dep runs first (edge source), dependent declares `dependsOn: [dep]`.
+	// Node ids: the dep stage runs first (edge source), the dependent stage
+	// declares `dependsOn: [dep]` (edge target).
+	source: string;
+	target: string;
+	// The same endpoints as config references (stage names).
 	dep: string;
 	dependent: string;
 }
 
-export function edgeId(dep: string, dependent: string): string {
-	return `${dep}->${dependent}`;
+export function edgeId(source: string, target: string): string {
+	return `${source}->${target}`;
 }
 
 // draftEdges maps every dependsOn entry that references an existing stage to an
 // edge. Dangling references have no node to attach to; the /validate endpoint
-// reports them, so they are skipped here rather than guessed at.
+// reports them, so they are skipped here rather than guessed at. A dependsOn
+// name resolves to its first occurrence when names are duplicated.
 export function draftEdges(draft: PipelineDraft): DraftEdge[] {
-	const names = new Set(draft.stages.map((s) => s.name).filter(Boolean));
+	const indexByName = new Map<string, number>();
+	draft.stages.forEach((s, i) => {
+		if (s.name && !indexByName.has(s.name)) indexByName.set(s.name, i);
+	});
 	const edges: DraftEdge[] = [];
-	for (const stage of draft.stages) {
-		if (!stage.name) continue;
+	draft.stages.forEach((stage, i) => {
+		if (!stage.name) return;
 		for (const dep of stage.dependsOn ?? []) {
-			if (!names.has(dep)) continue;
-			edges.push({ id: edgeId(dep, stage.name), dep, dependent: stage.name });
+			const depIndex = indexByName.get(dep);
+			if (depIndex === undefined) continue;
+			const source = stageNodeId(depIndex);
+			const target = stageNodeId(i);
+			edges.push({ id: edgeId(source, target), source, target, dep, dependent: stage.name });
 		}
-	}
+	});
 	return edges;
 }
 
@@ -60,15 +79,15 @@ export function layoutPositions(draft: PipelineDraft): Record<string, StagePosit
 	const g = new dagre.graphlib.Graph();
 	g.setGraph({ rankdir: "LR", nodesep: 32, ranksep: 64 });
 	g.setDefaultEdgeLabel(() => ({}));
-	draft.stages.forEach((stage, i) => {
-		g.setNode(stageNodeId(stage, i), { width: STAGE_NODE_WIDTH, height: STAGE_NODE_HEIGHT });
+	draft.stages.forEach((_stage, i) => {
+		g.setNode(stageNodeId(i), { width: STAGE_NODE_WIDTH, height: STAGE_NODE_HEIGHT });
 	});
-	for (const edge of draftEdges(draft)) g.setEdge(edge.dep, edge.dependent);
+	for (const edge of draftEdges(draft)) g.setEdge(edge.source, edge.target);
 	dagre.layout(g);
 
 	const positions: Record<string, StagePosition> = {};
-	draft.stages.forEach((stage, i) => {
-		const id = stageNodeId(stage, i);
+	draft.stages.forEach((_stage, i) => {
+		const id = stageNodeId(i);
 		const node = g.node(id);
 		if (node) positions[id] = { x: node.x - STAGE_NODE_WIDTH / 2, y: node.y - STAGE_NODE_HEIGHT / 2 };
 	});
@@ -119,17 +138,11 @@ export function isEdgeInCycle(draft: PipelineDraft, edge: DraftEdge): boolean {
 	return findCycle(draft, edge.dependent, edge.dep) !== null;
 }
 
-// addDependency / removeDependency return a new draft with the dependsOn edit
-// applied; unknown stage names are a no-op.
-export function addDependency(draft: PipelineDraft, dependent: string, dep: string): PipelineDraft {
-	return mapStage(draft, dependent, (stage) => {
-		if ((stage.dependsOn ?? []).includes(dep)) return stage;
-		return { ...stage, dependsOn: [...(stage.dependsOn ?? []), dep] };
-	});
-}
-
-export function removeDependency(draft: PipelineDraft, dependent: string, dep: string): PipelineDraft {
-	return mapStage(draft, dependent, (stage) => {
+// removeDependency returns a new draft with `dep` dropped from the stage at
+// dependentIndex (the exact stage, so duplicate names cannot misroute the
+// edit); the empty dependsOn key is removed entirely. Out-of-range is a no-op.
+export function removeDependency(draft: PipelineDraft, dependentIndex: number, dep: string): PipelineDraft {
+	return mapStageAt(draft, dependentIndex, (stage) => {
 		const next = (stage.dependsOn ?? []).filter((d) => d !== dep);
 		const out = { ...stage };
 		if (next.length > 0) out.dependsOn = next;
@@ -138,25 +151,53 @@ export function removeDependency(draft: PipelineDraft, dependent: string, dep: s
 	});
 }
 
-function mapStage(draft: PipelineDraft, name: string, fn: (stage: StageDraft) => StageDraft): PipelineDraft {
-	return { ...draft, stages: draft.stages.map((s) => (s.name === name ? fn(s) : s)) };
+function mapStageAt(draft: PipelineDraft, index: number, fn: (stage: StageDraft) => StageDraft): PipelineDraft {
+	if (!draft.stages[index]) return draft;
+	return { ...draft, stages: draft.stages.map((s, i) => (i === index ? fn(s) : s)) };
+}
+
+// removeStage returns a new draft without the stage at `index`, with the
+// removed stage's name scrubbed from every other stage's dependsOn (dropping
+// the key once empty). The scrub is skipped while another stage still carries
+// the same name (a duplicate): its edges must survive. Out-of-range is a no-op.
+export function removeStage(draft: PipelineDraft, index: number): PipelineDraft {
+	const removed = draft.stages[index];
+	if (!removed) return draft;
+	const remaining = draft.stages.filter((_, i) => i !== index);
+	const scrub = removed.name && !remaining.some((s) => s.name === removed.name);
+	const stages = !scrub
+		? remaining
+		: remaining.map((s) => {
+				if (!(s.dependsOn ?? []).includes(removed.name)) return s;
+				const next = (s.dependsOn ?? []).filter((d) => d !== removed.name);
+				const out = { ...s };
+				if (next.length > 0) out.dependsOn = next;
+				else delete out.dependsOn;
+				return out;
+			});
+	return { ...draft, stages };
 }
 
 // applyConnection is the canvas' connect handler semantics as a pure function:
-// drawing source -> target makes target depend on source, unless the edge is a
-// self-edge or would close a dependency cycle (blocked, with the offending
-// path returned for the instant red highlight).
+// drawing source -> target (node ids) makes the target stage depend on the
+// source stage, unless the edge is a self-edge or would close a dependency
+// cycle (blocked, with the offending path returned for the instant red
+// highlight). Unnamed endpoints stay unconnectable: dependsOn refers by name.
 export type ConnectionResult =
 	{ kind: "added"; draft: PipelineDraft } | { kind: "cycle"; path: string[] } | { kind: "noop" };
 
-export function applyConnection(draft: PipelineDraft, source: string, target: string): ConnectionResult {
-	const names = new Set(draft.stages.map((s) => s.name).filter(Boolean));
-	if (!names.has(source) || !names.has(target)) return { kind: "noop" };
+export function applyConnection(draft: PipelineDraft, sourceId: string, targetId: string): ConnectionResult {
+	const source = draft.stages[stageIndexFromNodeId(sourceId)]?.name;
+	const targetIndex = stageIndexFromNodeId(targetId);
+	const target = draft.stages[targetIndex]?.name;
+	if (!source || !target) return { kind: "noop" };
 	const cycle = findCycle(draft, target, source);
 	if (cycle) return { kind: "cycle", path: cycle };
-	const stage = draft.stages.find((s) => s.name === target);
-	if ((stage?.dependsOn ?? []).includes(source)) return { kind: "noop" };
-	return { kind: "added", draft: addDependency(draft, target, source) };
+	if ((draft.stages[targetIndex].dependsOn ?? []).includes(source)) return { kind: "noop" };
+	return {
+		kind: "added",
+		draft: mapStageAt(draft, targetIndex, (s) => ({ ...s, dependsOn: [...(s.dependsOn ?? []), source] })),
+	};
 }
 
 // addStage appends a default agent stage under the first unused stage-N name

--- a/frontend/src/renderer/lib/pipeline-graph.ts
+++ b/frontend/src/renderer/lib/pipeline-graph.ts
@@ -184,9 +184,7 @@ export function removeStage(draft: PipelineDraft, index: number): PipelineDraft 
 // cycle (blocked, with the offending path returned for the instant red
 // highlight). Unnamed endpoints stay unconnectable: dependsOn refers by name.
 export type ConnectionResult =
-	| { kind: "added"; draft: PipelineDraft }
-	| { kind: "cycle"; path: string[] }
-	| { kind: "noop" };
+	{ kind: "added"; draft: PipelineDraft } | { kind: "cycle"; path: string[] } | { kind: "noop" };
 
 export function applyConnection(draft: PipelineDraft, sourceId: string, targetId: string): ConnectionResult {
 	const source = draft.stages[stageIndexFromNodeId(sourceId)]?.name;

--- a/frontend/src/renderer/lib/pipeline-graph.ts
+++ b/frontend/src/renderer/lib/pipeline-graph.ts
@@ -184,7 +184,9 @@ export function removeStage(draft: PipelineDraft, index: number): PipelineDraft 
 // cycle (blocked, with the offending path returned for the instant red
 // highlight). Unnamed endpoints stay unconnectable: dependsOn refers by name.
 export type ConnectionResult =
-	{ kind: "added"; draft: PipelineDraft } | { kind: "cycle"; path: string[] } | { kind: "noop" };
+	| { kind: "added"; draft: PipelineDraft }
+	| { kind: "cycle"; path: string[] }
+	| { kind: "noop" };
 
 export function applyConnection(draft: PipelineDraft, sourceId: string, targetId: string): ConnectionResult {
 	const source = draft.stages[stageIndexFromNodeId(sourceId)]?.name;

--- a/frontend/src/renderer/lib/pipeline-problems.test.ts
+++ b/frontend/src/renderer/lib/pipeline-problems.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { PipelineDraft, StageDraft } from "./pipeline-draft";
-import { issueStageName, stageIssueMessages, stageYamlLine } from "./pipeline-problems";
+import { issueStageNodeId, stageIssueMessages, stageYamlLine } from "./pipeline-problems";
 
 function stage(name: string): StageDraft {
 	return { name, trigger: { on: ["manual"] }, executor: { kind: "agent" } };
@@ -8,28 +8,33 @@ function stage(name: string): StageDraft {
 
 const draft: PipelineDraft = { name: "review", stages: [stage("a"), stage("b")] };
 
-describe("issueStageName", () => {
-	it("resolves a stage-scoped path to the stage's name", () => {
-		expect(issueStageName(draft, { path: "stages[1].executor.kind", message: "m" })).toBe("b");
-		expect(issueStageName(draft, { path: "stages[0]", message: "m" })).toBe("a");
+describe("issueStageNodeId", () => {
+	it("resolves a stage-scoped path to the stage's node id", () => {
+		expect(issueStageNodeId(draft, { path: "stages[1].executor.kind", message: "m" })).toBe("1");
+		expect(issueStageNodeId(draft, { path: "stages[0]", message: "m" })).toBe("0");
+	});
+
+	it("resolves paths for unnamed stages (they need a Reveal target)", () => {
+		const unnamed: PipelineDraft = { name: "review", stages: [stage("")] };
+		expect(issueStageNodeId(unnamed, { path: "stages[0].name", message: "must not be empty" })).toBe("0");
 	});
 
 	it("returns null for document-level and dangling paths", () => {
-		expect(issueStageName(draft, { path: "name", message: "m" })).toBeNull();
-		expect(issueStageName(draft, { path: "exitPredicates.done", message: "m" })).toBeNull();
-		expect(issueStageName(draft, { path: "stages[9].name", message: "m" })).toBeNull();
+		expect(issueStageNodeId(draft, { path: "name", message: "m" })).toBeNull();
+		expect(issueStageNodeId(draft, { path: "exitPredicates.done", message: "m" })).toBeNull();
+		expect(issueStageNodeId(draft, { path: "stages[9].name", message: "m" })).toBeNull();
 	});
 });
 
 describe("stageIssueMessages", () => {
-	it("groups messages by the stage they resolve to and drops the rest", () => {
+	it("groups messages by the node id they resolve to and drops the rest", () => {
 		const grouped = stageIssueMessages(draft, [
 			{ path: "stages[0].name", message: "first" },
 			{ path: "stages[0].executor", message: "second" },
 			{ path: "stages[1].trigger", message: "other" },
 			{ path: "name", message: "document-level" },
 		]);
-		expect(grouped).toEqual({ a: ["first", "second"], b: ["other"] });
+		expect(grouped).toEqual({ "0": ["first", "second"], "1": ["other"] });
 	});
 });
 

--- a/frontend/src/renderer/lib/pipeline-problems.ts
+++ b/frontend/src/renderer/lib/pipeline-problems.ts
@@ -4,24 +4,27 @@
 // (split view scrolls there on node select).
 
 import type { PipelineDraft } from "./pipeline-draft";
+import { stageNodeId } from "./pipeline-graph";
 import type { PipelineValidationIssue } from "./pipeline-yaml";
 
 // Issue paths from the daemon address stages positionally: `stages[2].name`.
-// Returns the stage's name in the draft, or null when the path is not
-// stage-scoped (or points past the stage list / at an unnamed stage).
-export function issueStageName(draft: PipelineDraft, issue: PipelineValidationIssue): string | null {
+// Returns that stage's canvas node id (the index-based stage identity), or
+// null when the path is not stage-scoped or points past the stage list.
+// Unnamed stages resolve too: "name must not be empty" needs a Reveal target.
+export function issueStageNodeId(draft: PipelineDraft, issue: PipelineValidationIssue): string | null {
 	const match = /^stages\[(\d+)\]/.exec(issue.path);
 	if (!match) return null;
-	return draft.stages[Number(match[1])]?.name || null;
+	const index = Number(match[1]);
+	return index < draft.stages.length ? stageNodeId(index) : null;
 }
 
-// Groups issue messages by the stage they resolve to, for the canvas badges.
+// Groups issue messages by the node id they resolve to, for the canvas badges.
 export function stageIssueMessages(draft: PipelineDraft, issues: PipelineValidationIssue[]): Record<string, string[]> {
 	const out: Record<string, string[]> = {};
 	for (const issue of issues) {
-		const name = issueStageName(draft, issue);
-		if (!name) continue;
-		(out[name] ??= []).push(issue.message);
+		const id = issueStageNodeId(draft, issue);
+		if (id === null) continue;
+		(out[id] ??= []).push(issue.message);
 	}
 	return out;
 }


### PR DESCRIPTION
Closes #264.

## What

Two visual-editor dogfood bugs shared one root cause: stage identity was keyed on the stage name, which breaks for empty and duplicate names.

1. Delete did nothing: `onNodesChange` ignored node `remove` changes, so react-flow dropped the node visually while the draft kept the stage, and no inspector delete existed.
2. Empty/duplicate-named stages could not be opened: `findIndex(s => s.name === selection.selectedStage)` never matched an unnamed stage's placeholder node id, so the inspector never opened exactly when the user needed to fill in the name.

## How

- **Identity = array index.** `stageNodeId(index)` is the react-flow node id, the `useStageSelection` value, and the selected-stage lookup. It is unique for empty/duplicate names and deterministic across the debounced YAML re-parse, so selection and node positions survive typing. Names remain the config reference: `dependsOn`, `routes.when`, and predicate serialization are untouched; `draftEdges` maps dependsOn names to node ids (first occurrence).
- **Working delete.** New `removeStage(draft, index)` returns a new draft with the stage removed and its name scrubbed from every other stage's `dependsOn` (empty key dropped; scrub skipped while a duplicate of the name survives). `onNodesChange` now applies node `remove` changes (Delete/Backspace), remaps saved node positions across the index shift, and clears the selection. The inspector gains a destructive **Delete stage** button (`onDelete` prop) alongside Close.
- Duplicate-named stages now all render (index ids are unique), each independently selectable; validation issues and Reveal resolve positionally (`stages[i]`), so unnamed stages get badges and a Reveal target too.

## Tests

- `removeStage` immutability, dependsOn scrub, duplicate-name guard, out-of-range no-op.
- Canvas: empty/duplicate-named stages render as distinct selectable nodes; Delete/Backspace removes the selected stage and scrubs dependsOn; selection clears.
- Page: unnamed stage opens the inspector and can be named (regression for bug 2); duplicate stages selectable/renamable independently; inspector delete scrubs dependsOn and closes; selection stable across an unrelated YAML edit + re-parse.
- Full renderer suite as CI runs it: 83 files, 909 tests, green. Routes unchanged, so `routeTree.gen.ts` untouched.

## Risks / notes

- Index identity means a YAML edit that reorders stages moves the selection with the position, not the name; acceptable per spec (index recommended) and only observable mid-edit in Split view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)