### PR TITLE
feat(landing): deploy landing + docs to GitHub Pages at aoagents.dev

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -1,0 +1,49 @@
+name: Deploy landing to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/src/landing/**"
+      - ".github/workflows/deploy-landing.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/src/landing/package-lock.json
+      - name: Install
+        working-directory: frontend/src/landing
+        run: npm ci
+      - name: Build static export
+        working-directory: frontend/src/landing
+        run: npm run build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: frontend/src/landing/out
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/frontend/src/landing/app/not-found.tsx
+++ b/frontend/src/landing/app/not-found.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+// Root not-found: also emitted as 404.html in the static export, which GitHub
+// Pages serves for every missing URL on the site.
+export default function NotFound() {
+	return (
+		<main className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
+			<p className="font-mono text-sm text-[color:var(--fg-muted,#646a73)]">404</p>
+			<h1 className="text-2xl font-bold tracking-tight">This page does not exist.</h1>
+			<p className="max-w-md text-sm text-[color:var(--fg-muted,#646a73)]">
+				The URL may have moved during a rebuild. Start from the home page or the docs index.
+			</p>
+			<div className="flex gap-4 text-sm underline underline-offset-4">
+				<Link href="/">Home</Link>
+				<Link href="/docs">Docs</Link>
+			</div>
+		</main>
+	);
+}

--- a/frontend/src/landing/next.config.mjs
+++ b/frontend/src/landing/next.config.mjs
@@ -1,7 +1,12 @@
 import { createMDX } from "fumadocs-mdx/next";
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+	// Static export for GitHub Pages: no server, so images must be unoptimized
+	// and every route (including /api/search via staticGET) is emitted at build.
+	output: "export",
+	images: { unoptimized: true },
+};
 
 const withMDX = createMDX();
 

--- a/frontend/src/landing/public/CNAME
+++ b/frontend/src/landing/public/CNAME
@@ -1,0 +1,1 @@
+aoagents.dev


### PR DESCRIPTION
## Summary

Serves the landing page and docs from this repo via GitHub Pages, replacing the current opaque deployment (whose /docs routes are stuck in a 307 self-redirect loop and unreachable).

- `next.config.mjs`: `output: "export"` + `images: { unoptimized: true }` for a fully static build
- `.github/workflows/deploy-landing.yml`: builds `frontend/src/landing` and deploys `out/` to Pages on every main push touching the landing app (plus manual dispatch)
- `public/CNAME`: `aoagents.dev` custom domain
- `public/.nojekyll`: keep `_next/` assets servable
- `app/not-found.tsx`: root not-found so the exported `404.html` (served by Pages for every missing URL) is branded instead of Next's default error page

The app was already static-export ready: docs search uses fumadocs `staticGET` (client-side index), and the docs catch-all has `generateStaticParams`.

## Verification

Local `npm ci && npm run build` in `frontend/src/landing` exports 63 routes: landing at `index.html`, all 55 doc pages as `docs/**.html` (Pages serves extensionless URLs via the `.html` fallback), `api/search` as a 1.7 MB static index file, plus `404.html`, `CNAME`, `.nojekyll`.

## Post-merge setup (one-time, repo settings)

1. Settings -> Pages -> Source: **GitHub Actions**
2. Run the `Deploy landing to GitHub Pages` workflow once (workflow_dispatch) or push to main
3. Settings -> Pages -> Custom domain: `aoagents.dev`, then enable Enforce HTTPS once the cert is issued
4. Cloudflare DNS changes (apex A records to Pages, DNS-only) are handled separately

## Risks

- `api/search` is served by Pages without a JSON content-type; fumadocs' static search client uses `res.json()` which does not check content-type, so search still works
- Any future landing feature that needs a server (ISR, dynamic routes without `generateStaticParams`) will fail the export build loudly in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)