### PR TITLE
feat(pipelines): thread PR RunContext from trigger bridge to executors

### DIFF
--- a/backend/internal/pipeline/engine/adapters.go
+++ b/backend/internal/pipeline/engine/adapters.go
@@ -64,6 +64,7 @@ func (a *sessionSpawnerAdapter) Spawn(ctx context.Context, req executors.SpawnRe
 		IssueID:   domain.IssueID(req.IssueID),
 		Kind:      domain.KindWorker,
 		Harness:   domain.AgentHarness(req.Harness),
+		Branch:    req.Branch,
 		Prompt:    req.Prompt,
 	})
 	if err != nil {

--- a/backend/internal/pipeline/engine/engine.go
+++ b/backend/internal/pipeline/engine/engine.go
@@ -99,9 +99,6 @@ type Engine struct {
 	// lock: only the mailbox closures (which run on that goroutine) touch them.
 	state    pipeline.EngineState
 	inflight map[pipeline.StageRunID]executors.Handle
-	// issueByRun threads the trigger's issue id to START_STAGE, out-of-band from
-	// RunState (which does not carry it). Pruned when a run goes terminal.
-	issueByRun map[pipeline.RunID]string
 }
 
 // New builds an Engine. It does not touch the store or start any goroutine;
@@ -121,7 +118,6 @@ func New(cfg Config) *Engine {
 		quit:          make(chan struct{}),
 		state:         pipeline.EmptyEngineState(),
 		inflight:      map[pipeline.StageRunID]executors.Handle{},
-		issueByRun:    map[pipeline.RunID]string{},
 	}
 	if e.log == nil {
 		e.log = slog.Default()
@@ -186,8 +182,8 @@ func (e *Engine) Stop(ctx context.Context) error {
 	return nil
 }
 
-// runLoop is the single actor goroutine: the only place e.state, e.inflight, and
-// e.issueByRun are read or written after Start.
+// runLoop is the single actor goroutine: the only place e.state and e.inflight
+// are read or written after Start.
 func (e *Engine) runLoop() {
 	defer e.wg.Done()
 	ticker := time.NewTicker(e.tickInterval)
@@ -226,8 +222,9 @@ type TriggerRequest struct {
 	// Trigger defaults to pipeline.TriggerManual when empty.
 	Trigger pipeline.StageTriggerEvent
 	HeadSHA string
-	// IssueID is forwarded into spawned agent-stage sessions.
-	IssueID string
+	// Context carries PR identity, issue id, and session facts threaded into
+	// the run and its stage executors. PR fields are empty for manual triggers.
+	Context pipeline.RunContext
 }
 
 // TriggerRun allocates a RunID plus one StageRunID per stage, then dispatches
@@ -250,15 +247,13 @@ func (e *Engine) TriggerRun(req TriggerRequest) (pipeline.RunID, error) {
 	}
 
 	e.do(func() {
-		if req.IssueID != "" {
-			e.issueByRun[runID] = req.IssueID
-		}
 		e.reduceAndExecute(pipeline.TriggerFired{
 			Now:         e.now(),
 			Trigger:     trigger,
 			SessionID:   req.SessionID,
 			Pipeline:    req.Pipeline,
 			HeadSHA:     req.HeadSHA,
+			Context:     req.Context,
 			RunID:       runID,
 			StageRunIDs: stageRunIDs,
 		})
@@ -365,7 +360,6 @@ func (e *Engine) reduceAndExecute(event pipeline.Event) {
 	for _, eff := range effects {
 		e.executeEffect(eff)
 	}
-	e.pruneRunMeta()
 }
 
 func (e *Engine) executeEffect(eff pipeline.Effect) {
@@ -430,10 +424,11 @@ func (e *Engine) startInput(run pipeline.RunState, eff pipeline.StartStage) exec
 		RunID:           eff.RunID,
 		StageRunID:      eff.StageRunID,
 		Stage:           eff.Stage,
-		IssueID:         e.issueByRun[eff.RunID],
+		IssueID:         run.Context.IssueID,
 		LoopRound:       &loopRound,
 		LinkedSessionID: run.SessionID,
 		AllowForkPRs:    allowFork,
+		Context:         run.Context,
 	}
 }
 
@@ -558,17 +553,6 @@ func (e *Engine) observe(name string, data map[string]any) {
 		data = enriched
 	}
 	e.sink.Observe(name, data)
-}
-
-// pruneRunMeta drops issue-id side-table entries for runs the reducer has moved
-// to a terminal loop state, so the map does not grow unbounded.
-func (e *Engine) pruneRunMeta() {
-	for id := range e.issueByRun {
-		run, ok := e.state.Runs[id]
-		if !ok || run.LoopState.IsTerminal() {
-			delete(e.issueByRun, id)
-		}
-	}
 }
 
 // slogSink is the default ObservationSink: structured logging that never drops.

--- a/backend/internal/pipeline/events.go
+++ b/backend/internal/pipeline/events.go
@@ -49,6 +49,10 @@ type TriggerFired struct {
 	Pipeline  Pipeline
 	HeadSHA   string
 
+	// Context carries PR identity, issue id, and session facts for the run.
+	// PR fields are empty for manual triggers with no PR.
+	Context RunContext
+
 	RunID       RunID
 	StageRunIDs map[string]StageRunID
 }

--- a/backend/internal/pipeline/executors/agent.go
+++ b/backend/internal/pipeline/executors/agent.go
@@ -20,6 +20,10 @@ type SpawnRequest struct {
 	// Harness is the agent plugin the stage requested (stage.executor.plugin).
 	// Empty lets the project default pick the harness.
 	Harness string
+	// Branch is the PR source branch to check the spawned session out onto, so
+	// review sessions see the PR diff and can push to it. Empty spawns a fresh
+	// worktree off the project default branch.
+	Branch string
 }
 
 // SpawnedSession is what the session manager returns for a fresh spawn.
@@ -81,12 +85,13 @@ func (e *AgentExecutor) Start(ctx context.Context, in StartInput) (Handle, error
 		return nil, fmt.Errorf("agent executor cannot start stage %q with executor.kind=%s", in.Stage.Name, in.Stage.Executor.Kind)
 	}
 
-	prompt := buildStagePrompt(in.PipelineName, in.Stage, in.LoopRound)
+	prompt := buildStagePrompt(in.PipelineName, in.Stage, in.LoopRound, in.Context)
 	session, err := e.sessions.Spawn(ctx, SpawnRequest{
 		ProjectID: in.ProjectID,
 		IssueID:   in.IssueID,
 		Prompt:    prompt,
 		Harness:   in.Stage.Executor.Plugin,
+		Branch:    in.Context.SourceBranch,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("agent executor: spawn session for stage %q: %w", in.Stage.Name, err)

--- a/backend/internal/pipeline/executors/agent_test.go
+++ b/backend/internal/pipeline/executors/agent_test.go
@@ -18,6 +18,7 @@ type mockSpawner struct {
 	spawnErr   error
 	spawnCalls int
 	killCalls  int
+	lastReq    SpawnRequest
 
 	// snapshot state, mutated by tests between polls.
 	activity   string
@@ -25,8 +26,9 @@ type mockSpawner struct {
 	exists     bool
 }
 
-func (m *mockSpawner) Spawn(_ context.Context, _ SpawnRequest) (SpawnedSession, error) {
+func (m *mockSpawner) Spawn(_ context.Context, req SpawnRequest) (SpawnedSession, error) {
 	m.spawnCalls++
+	m.lastReq = req
 	if m.spawnErr != nil {
 		return SpawnedSession{}, m.spawnErr
 	}
@@ -216,6 +218,30 @@ func TestAgent_NoWorkspaceKillsAndFails(t *testing.T) {
 	}
 	if m.killCalls != 1 {
 		t.Errorf("want the workspace-less orphan killed, got %d", m.killCalls)
+	}
+}
+
+func TestAgent_SpawnSetsBranchFromPRContext(t *testing.T) {
+	m := &mockSpawner{workspace: t.TempDir(), activity: "active"}
+	exec := NewAgentExecutor(m)
+	in := agentStartInput(m.workspace)
+	in.Context = pipeline.RunContext{SourceBranch: "feature", PRNumber: 3}
+	if _, err := exec.Start(context.Background(), in); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if m.lastReq.Branch != "feature" {
+		t.Fatalf("spawn branch = %q, want %q", m.lastReq.Branch, "feature")
+	}
+}
+
+func TestAgent_SpawnNoBranchWithoutPRContext(t *testing.T) {
+	m := &mockSpawner{workspace: t.TempDir(), activity: "active"}
+	exec := NewAgentExecutor(m)
+	if _, err := exec.Start(context.Background(), agentStartInput(m.workspace)); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if m.lastReq.Branch != "" {
+		t.Fatalf("spawn branch = %q, want empty for a run with no PR", m.lastReq.Branch)
 	}
 }
 

--- a/backend/internal/pipeline/executors/command.go
+++ b/backend/internal/pipeline/executors/command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
@@ -163,7 +164,7 @@ func (e *CommandExecutor) Start(ctx context.Context, in StartInput) (Handle, err
 	child, err := e.runner.Start(ctx, CommandSpec{
 		Command:   spec.Command,
 		Args:      spec.Args,
-		Env:       spec.Env,
+		Env:       pipelineEnv(in, spec.Env),
 		Dir:       dir,
 		OutputCap: commandOutputCapBytes,
 	})
@@ -237,6 +238,36 @@ func resolveCwd(base, rel string) (string, error) {
 func isWindowsAbs(rel string) bool {
 	return len(rel) >= 2 && rel[1] == ':' &&
 		((rel[0] >= 'a' && rel[0] <= 'z') || (rel[0] >= 'A' && rel[0] <= 'Z'))
+}
+
+// pipelineEnv merges a fixed pipeline/PR context env block under the stage's own
+// env map. The stage's YAML env wins on any key collision (it is applied last).
+// Unset PR values are omitted so the subprocess never sees an empty AO_PR_* key.
+func pipelineEnv(in StartInput, stageEnv map[string]string) map[string]string {
+	c := in.Context
+	env := make(map[string]string, len(stageEnv)+7)
+	env["AO_PIPELINE_RUN_ID"] = string(in.RunID)
+	env["AO_PIPELINE_STAGE"] = in.Stage.Name
+	if c.PRNumber > 0 {
+		env["AO_PR_NUMBER"] = strconv.Itoa(c.PRNumber)
+	}
+	if c.PRURL != "" {
+		env["AO_PR_URL"] = c.PRURL
+	}
+	if c.SourceBranch != "" {
+		env["AO_PR_BRANCH"] = c.SourceBranch
+	}
+	if c.TargetBranch != "" {
+		env["AO_PR_BASE_BRANCH"] = c.TargetBranch
+	}
+	if c.HeadSHA != "" {
+		env["AO_PR_HEAD_SHA"] = c.HeadSHA
+	}
+	// Stage env applied last so an author's explicit value overrides the block.
+	for k, v := range stageEnv {
+		env[k] = v
+	}
+	return env
 }
 
 // commandTaskResult is the single JSON object a command shim writes to stdout.

--- a/backend/internal/pipeline/executors/command_test.go
+++ b/backend/internal/pipeline/executors/command_test.go
@@ -137,6 +137,54 @@ func TestCommand_NonForkRuns(t *testing.T) {
 	}
 }
 
+func TestCommand_EnvIncludesPipelineAndPRBlock(t *testing.T) {
+	runner := &fakeRunner{res: CommandResult{ExitCode: 0, Stdout: `{"outcome":"succeeded"}`}}
+	sessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "/ws", Fork: ForkNo}}
+	in := baseCommandInput()
+	in.Context = pipeline.RunContext{
+		PRNumber: 12, PRURL: "https://x/pull/12", SourceBranch: "feat",
+		TargetBranch: "main", HeadSHA: "deadbeef",
+	}
+	// Stage env must win on collision, and its own keys survive the merge.
+	in.Stage.Executor.Env = map[string]string{"AO_PR_NUMBER": "override", "CUSTOM": "1"}
+
+	runCommand(t, runner, sessions, in)
+
+	env := runner.lastSpec.Env
+	want := map[string]string{
+		"AO_PIPELINE_RUN_ID": "run-1",
+		"AO_PIPELINE_STAGE":  "typecheck",
+		"AO_PR_URL":          "https://x/pull/12",
+		"AO_PR_BRANCH":       "feat",
+		"AO_PR_BASE_BRANCH":  "main",
+		"AO_PR_HEAD_SHA":     "deadbeef",
+		"AO_PR_NUMBER":       "override", // stage env wins
+		"CUSTOM":             "1",
+	}
+	for k, v := range want {
+		if env[k] != v {
+			t.Errorf("env[%q] = %q, want %q", k, env[k], v)
+		}
+	}
+}
+
+func TestCommand_EnvOmitsUnsetPRValues(t *testing.T) {
+	runner := &fakeRunner{res: CommandResult{ExitCode: 0, Stdout: `{"outcome":"succeeded"}`}}
+	sessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "/ws", Fork: ForkNo}}
+	// A manual run: no PR context, so no AO_PR_* keys, but the pipeline keys stay.
+	runCommand(t, runner, sessions, baseCommandInput())
+
+	env := runner.lastSpec.Env
+	if env["AO_PIPELINE_RUN_ID"] != "run-1" || env["AO_PIPELINE_STAGE"] != "typecheck" {
+		t.Fatalf("pipeline env keys must always be present, got %+v", env)
+	}
+	for _, k := range []string{"AO_PR_NUMBER", "AO_PR_URL", "AO_PR_BRANCH", "AO_PR_BASE_BRANCH", "AO_PR_HEAD_SHA"} {
+		if _, ok := env[k]; ok {
+			t.Errorf("unset PR value must be omitted, but %q is present", k)
+		}
+	}
+}
+
 func TestCommand_ExitCodeSemantics(t *testing.T) {
 	sessions := &fakeCommandSessions{exists: true, session: CommandSession{WorkspacePath: "/ws", Fork: ForkNo}}
 	cases := []struct {

--- a/backend/internal/pipeline/executors/executor.go
+++ b/backend/internal/pipeline/executors/executor.go
@@ -87,6 +87,10 @@ type StartInput struct {
 	// AllowForkPRs opts command stages into running for fork PRs. Default false
 	// skips them before any subprocess spawns.
 	AllowForkPRs bool
+	// Context carries the run's PR identity and session facts. Agent stages use
+	// SourceBranch to spawn on the PR branch and render a PR block in the
+	// prompt; command stages surface it as AO_PR_* env vars.
+	Context pipeline.RunContext
 }
 
 // StageExecutor is the contract the engine drives. Start begins the work and

--- a/backend/internal/pipeline/executors/stageprompt.go
+++ b/backend/internal/pipeline/executors/stageprompt.go
@@ -15,7 +15,7 @@ import (
 //
 // The findings path is documented relative to the workspace root so the agent
 // does not need the absolute path.
-func buildStagePrompt(pipelineName string, stage pipeline.Stage, loopRound *int) string {
+func buildStagePrompt(pipelineName string, stage pipeline.Stage, loopRound *int, prCtx pipeline.RunContext) string {
 	var mode pipeline.TaskMode
 	if stage.Executor.Kind == pipeline.ExecutorAgent {
 		mode = stage.Executor.Mode
@@ -33,6 +33,8 @@ func buildStagePrompt(pipelineName string, stage pipeline.Stage, loopRound *int)
 		lines = append(lines, "This stage's findings will block merge until they are resolved.")
 	}
 
+	lines = append(lines, prBlock(prCtx)...)
+
 	if stage.Task.Prompt != "" {
 		lines = append(lines, "", "## Task", stage.Task.Prompt)
 	}
@@ -44,6 +46,30 @@ func buildStagePrompt(pipelineName string, stage pipeline.Stage, loopRound *int)
 	lines = append(lines, "", "## Reporting Findings", formatFindingsInstructions(mode))
 
 	return strings.Join(lines, "\n")
+}
+
+// prBlock renders a "## Pull request" section describing the run's PR when the
+// context carries one, so the agent knows it is working on a specific PR branch.
+// It returns nil for runs with no PR (e.g. manual triggers), leaving the prompt
+// unchanged. Only the fields that are set are rendered.
+func prBlock(prCtx pipeline.RunContext) []string {
+	if prCtx.PRNumber == 0 && prCtx.PRURL == "" {
+		return nil
+	}
+	lines := []string{"", "## Pull request"}
+	if prCtx.PRNumber > 0 {
+		lines = append(lines, "Number: #"+strconv.Itoa(prCtx.PRNumber))
+	}
+	if prCtx.PRURL != "" {
+		lines = append(lines, "URL: "+prCtx.PRURL)
+	}
+	if prCtx.SourceBranch != "" || prCtx.TargetBranch != "" {
+		lines = append(lines, "Branch: "+prCtx.SourceBranch+" -> "+prCtx.TargetBranch)
+	}
+	if prCtx.HeadSHA != "" {
+		lines = append(lines, "Head SHA: "+prCtx.HeadSHA)
+	}
+	return lines
 }
 
 // formatFindingsInstructions mirrors the old JSONL write-then-rename contract:

--- a/backend/internal/pipeline/executors/stageprompt_test.go
+++ b/backend/internal/pipeline/executors/stageprompt_test.go
@@ -17,7 +17,7 @@ func agentStage(mode pipeline.TaskMode) pipeline.Stage {
 
 func TestBuildStagePrompt_CoreShape(t *testing.T) {
 	round := 3
-	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), &round)
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), &round, pipeline.RunContext{})
 
 	for _, want := range []string{
 		"## Pipeline Stage",
@@ -38,7 +38,7 @@ func TestBuildStagePrompt_CoreShape(t *testing.T) {
 }
 
 func TestBuildStagePrompt_ReviewModeFindingSchema(t *testing.T) {
-	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil)
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil, pipeline.RunContext{})
 	if !strings.Contains(got, `"finding"`) || !strings.Contains(got, "severity") {
 		t.Errorf("review mode must document the finding record schema\n%s", got)
 	}
@@ -48,7 +48,7 @@ func TestBuildStagePrompt_ReviewModeFindingSchema(t *testing.T) {
 }
 
 func TestBuildStagePrompt_AnswerModeJSONSchema(t *testing.T) {
-	got := buildStagePrompt("ci", agentStage(pipeline.ModeAnswer), nil)
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeAnswer), nil, pipeline.RunContext{})
 	if !strings.Contains(got, `"json"`) || !strings.Contains(got, "outputSchema") {
 		t.Errorf("answer mode must document the json record schema\n%s", got)
 	}
@@ -58,7 +58,7 @@ func TestBuildStagePrompt_BlocksMergeNotice(t *testing.T) {
 	stage := agentStage(pipeline.ModeReview)
 	blocks := true
 	stage.Policy = &pipeline.StagePolicy{BlocksMerge: &blocks}
-	got := buildStagePrompt("ci", stage, nil)
+	got := buildStagePrompt("ci", stage, nil, pipeline.RunContext{})
 	if !strings.Contains(got, "block merge") {
 		t.Errorf("blocksMerge stage must warn about blocking merge\n%s", got)
 	}
@@ -67,9 +67,38 @@ func TestBuildStagePrompt_BlocksMergeNotice(t *testing.T) {
 func TestBuildStagePrompt_InputsRendered(t *testing.T) {
 	stage := agentStage(pipeline.ModeReview)
 	stage.Task.Inputs = map[string]any{"threshold": 5}
-	got := buildStagePrompt("ci", stage, nil)
+	got := buildStagePrompt("ci", stage, nil, pipeline.RunContext{})
 	if !strings.Contains(got, "## Inputs") || !strings.Contains(got, "threshold") {
 		t.Errorf("inputs must be rendered as a JSON block\n%s", got)
+	}
+}
+
+func TestBuildStagePrompt_PRBlockRendered(t *testing.T) {
+	prCtx := pipeline.RunContext{
+		PRNumber:     42,
+		PRURL:        "https://github.com/o/r/pull/42",
+		SourceBranch: "feature",
+		TargetBranch: "main",
+		HeadSHA:      "abc123",
+	}
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil, prCtx)
+	for _, want := range []string{
+		"## Pull request",
+		"Number: #42",
+		"URL: https://github.com/o/r/pull/42",
+		"Branch: feature -> main",
+		"Head SHA: abc123",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("PR block missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
+func TestBuildStagePrompt_NoPRContextOmitsBlock(t *testing.T) {
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil, pipeline.RunContext{})
+	if strings.Contains(got, "## Pull request") {
+		t.Errorf("empty PR context must not render a PR block\n%s", got)
 	}
 }
 
@@ -78,7 +107,7 @@ func TestBuildStagePrompt_NonAgentStageOmitsMode(t *testing.T) {
 		Name:     "typecheck",
 		Executor: pipeline.StageExecutor{Kind: pipeline.ExecutorCommand, Command: "tsc"},
 	}
-	got := buildStagePrompt("ci", stage, nil)
+	got := buildStagePrompt("ci", stage, nil, pipeline.RunContext{})
 	if strings.Contains(got, "Mode:") {
 		t.Errorf("command stage has no agent mode line\n%s", got)
 	}

--- a/backend/internal/pipeline/reducer.go
+++ b/backend/internal/pipeline/reducer.go
@@ -78,6 +78,7 @@ func reduceTriggerFired(state EngineState, event TriggerFired) (EngineState, []E
 		SessionID:              event.SessionID,
 		PipelineConfigSnapshot: event.Pipeline,
 		HeadSHA:                event.HeadSHA,
+		Context:                event.Context,
 		LoopState:              LoopRunning,
 		LoopRounds:             loopRounds,
 		Stages:                 stages,

--- a/backend/internal/pipeline/reducer_test.go
+++ b/backend/internal/pipeline/reducer_test.go
@@ -57,6 +57,36 @@ func TestReduceTriggerFired(t *testing.T) {
 		}
 	})
 
+	t.Run("stores the run context on the new run", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		ev := triggerFor(p, TriggerPROpened, "r1")
+		fork := false
+		ev.Context = RunContext{
+			PRNumber: 9, PRURL: "https://x/pull/9", SourceBranch: "feat",
+			TargetBranch: "main", HeadSHA: "sha-1", SessionID: "sess-1", IsFromFork: &fork,
+		}
+		state, _ := Reduce(EmptyEngineState(), ev)
+		got := state.Runs["r1"].Context
+		if !reflect.DeepEqual(got, ev.Context) {
+			t.Fatalf("run context = %+v, want %+v", got, ev.Context)
+		}
+	})
+
+	t.Run("manual trigger leaves PR fields empty", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		ev := triggerFor(p, TriggerManual, "r1")
+		ev.Context = RunContext{SessionID: "sess-1", HeadSHA: "sha-1"}
+		state, _ := Reduce(EmptyEngineState(), ev)
+		got := state.Runs["r1"].Context
+		if got.PRNumber != 0 || got.PRURL != "" || got.SourceBranch != "" ||
+			got.TargetBranch != "" || got.IsFromFork != nil {
+			t.Fatalf("manual run must have empty PR fields, got %+v", got)
+		}
+		if got.SessionID != "sess-1" || got.HeadSHA != "sha-1" {
+			t.Fatalf("manual run should keep session/head sha, got %+v", got)
+		}
+	})
+
 	t.Run("second trigger for a live loop is a no-op", func(t *testing.T) {
 		p := pipelineOf("p", 1, stageDef("a"))
 		state, _ := Reduce(EmptyEngineState(), triggerFor(p, TriggerManual, "r1"))

--- a/backend/internal/pipeline/triggers/bridge.go
+++ b/backend/internal/pipeline/triggers/bridge.go
@@ -220,6 +220,19 @@ func (b *Bridge) process(ctx context.Context, e cdc.Event) {
 	prev, seen := b.prev[p.URL]
 	cur := prSnapshot{mergeReady: isMergeReady(facts), merged: facts.Merged, headSHA: facts.HeadSHA}
 
+	// Capture PR identity once so every triggered run carries it to its stage
+	// executors (agent branch + prompt, command env). Manual runs go through the
+	// service path, not the bridge, so this always has real PR facts.
+	runCtx := pipeline.RunContext{
+		PRNumber:     facts.Number,
+		PRURL:        facts.URL,
+		SourceBranch: facts.SourceBranch,
+		TargetBranch: facts.TargetBranch,
+		HeadSHA:      facts.HeadSHA,
+		SessionID:    session,
+		IsFromFork:   facts.IsFromFork,
+	}
+
 	opened := e.Type == cdc.EventPRCreated
 	fireOpened := opened
 	fireUpdated := !opened
@@ -242,26 +255,27 @@ func (b *Bridge) process(ctx context.Context, e cdc.Event) {
 			eng.Dispatch(pipeline.NewSHADetected{Now: b.now(), SessionID: session, PipelineName: cfg.Name, SHA: cur.headSHA})
 		}
 
-		b.fireIf(eng, fireOpened && defSubscribes(cfg, pipeline.TriggerPROpened), cfg, session, pipeline.TriggerPROpened, cur.headSHA)
-		b.fireIf(eng, fireUpdated && subsUpdated, cfg, session, pipeline.TriggerPRUpdated, cur.headSHA)
-		b.fireIf(eng, fireMergeReady && defSubscribes(cfg, pipeline.TriggerPRMergeReady), cfg, session, pipeline.TriggerPRMergeReady, cur.headSHA)
-		b.fireIf(eng, fireMerged && defSubscribes(cfg, pipeline.TriggerPRMerged), cfg, session, pipeline.TriggerPRMerged, cur.headSHA)
+		b.fireIf(eng, fireOpened && defSubscribes(cfg, pipeline.TriggerPROpened), cfg, runCtx, pipeline.TriggerPROpened)
+		b.fireIf(eng, fireUpdated && subsUpdated, cfg, runCtx, pipeline.TriggerPRUpdated)
+		b.fireIf(eng, fireMergeReady && defSubscribes(cfg, pipeline.TriggerPRMergeReady), cfg, runCtx, pipeline.TriggerPRMergeReady)
+		b.fireIf(eng, fireMerged && defSubscribes(cfg, pipeline.TriggerPRMerged), cfg, runCtx, pipeline.TriggerPRMerged)
 	}
 
 	b.prev[p.URL] = cur
 }
 
-func (b *Bridge) fireIf(eng Engine, cond bool, cfg pipeline.Pipeline, session string, ev pipeline.StageTriggerEvent, sha string) {
+func (b *Bridge) fireIf(eng Engine, cond bool, cfg pipeline.Pipeline, runCtx pipeline.RunContext, ev pipeline.StageTriggerEvent) {
 	if !cond {
 		return
 	}
 	if _, err := eng.TriggerRun(engine.TriggerRequest{
 		Pipeline:  cfg,
-		SessionID: session,
+		SessionID: runCtx.SessionID,
 		Trigger:   ev,
-		HeadSHA:   sha,
+		HeadSHA:   runCtx.HeadSHA,
+		Context:   runCtx,
 	}); err != nil {
-		b.log.Warn("pipeline trigger bridge: trigger run", "pipeline", cfg.Name, "trigger", ev, "session", session, "err", err)
+		b.log.Warn("pipeline trigger bridge: trigger run", "pipeline", cfg.Name, "trigger", ev, "session", runCtx.SessionID, "err", err)
 	}
 }
 

--- a/backend/internal/pipeline/triggers/bridge_test.go
+++ b/backend/internal/pipeline/triggers/bridge_test.go
@@ -162,6 +162,31 @@ func TestPROpenedTriggersMatchingDefinition(t *testing.T) {
 	}
 }
 
+func TestTriggerForwardsPRContext(t *testing.T) {
+	ctx := context.Background()
+	fork := true
+	facts := domain.PRFacts{
+		URL: testURL, Number: 7, CI: domain.CIPassing, Review: domain.ReviewApproved,
+		Mergeability: domain.MergeMergeable, HeadSHA: "sha1",
+		SourceBranch: "feature", TargetBranch: "main", IsFromFork: &fork,
+	}
+	b, eng := newBridge([]pipeline.Definition{defOn("opener", pipeline.TriggerPROpened)}, map[string]domain.PRFacts{testURL: facts})
+
+	b.process(ctx, prEvent(cdc.EventPRCreated))
+
+	if len(eng.triggers) != 1 {
+		t.Fatalf("triggers = %d, want 1", len(eng.triggers))
+	}
+	c := eng.triggers[0].Context
+	if c.PRNumber != 7 || c.PRURL != testURL || c.SourceBranch != "feature" ||
+		c.TargetBranch != "main" || c.HeadSHA != "sha1" || c.SessionID != testSession {
+		t.Fatalf("forwarded PR context = %+v", c)
+	}
+	if c.IsFromFork == nil || !*c.IsFromFork {
+		t.Fatalf("fork tri-state not forwarded: %+v", c.IsFromFork)
+	}
+}
+
 func TestNonMatchingDefinitionDoesNotTrigger(t *testing.T) {
 	ctx := context.Background()
 	facts := map[string]domain.PRFacts{testURL: readyFacts("sha1")}

--- a/backend/internal/pipeline/types.go
+++ b/backend/internal/pipeline/types.go
@@ -545,6 +545,27 @@ type Pipeline struct {
 // They are JSON-serialized for persistence but are never parsed from YAML
 // config, so they carry only json tags.
 
+// RunContext carries the pull-request identity and session facts for a run. It
+// is populated once at trigger time (from PRFacts in the trigger bridge, or the
+// session/head SHA a manual trigger has) and threaded to every stage executor,
+// so agent stages spawn on the PR branch with PR facts in their prompt and
+// command stages receive AO_PR_* env vars. PR fields are empty for manual
+// triggers with no PR. It is JSON-serializable because it is persisted as part
+// of RunState.
+type RunContext struct {
+	PRNumber     int    `json:"prNumber,omitempty"`
+	PRURL        string `json:"prUrl,omitempty"`
+	SourceBranch string `json:"sourceBranch,omitempty"`
+	TargetBranch string `json:"targetBranch,omitempty"`
+	HeadSHA      string `json:"headSha,omitempty"`
+	SessionID    string `json:"sessionId,omitempty"`
+	IssueID      string `json:"issueId,omitempty"`
+	// IsFromFork mirrors domain.PRFacts fork provenance tri-state: nil =
+	// unknown, false = same-repo PR (or no PR), true = the PR head lives in a
+	// fork.
+	IsFromFork *bool `json:"isFromFork,omitempty"`
+}
+
 // StageState is one stage's runtime state within a run.
 type StageState struct {
 	StageRunID StageRunID   `json:"stageRunId"`
@@ -571,6 +592,10 @@ type RunState struct {
 	PipelineConfigSnapshot Pipeline `json:"pipelineConfigSnapshot"`
 
 	HeadSHA string `json:"headSha"`
+
+	// Context carries per-run PR identity, issue id, and session facts,
+	// populated once at trigger time and threaded to every stage executor.
+	Context RunContext `json:"context,omitempty"`
 
 	LoopState         LoopStateName        `json:"loopState"`
 	TerminationReason RunTerminationReason `json:"terminationReason,omitempty"`

--- a/backend/internal/service/pipeline/pipeline.go
+++ b/backend/internal/service/pipeline/pipeline.go
@@ -361,6 +361,12 @@ func (s *Service) TriggerRun(ctx context.Context, projectID domain.ProjectID, in
 		SessionID: in.SessionID,
 		Trigger:   pipeline.TriggerManual,
 		HeadSHA:   in.HeadSHA,
+		// Manual runs have no PR; fill only what we know so command stages still
+		// get AO_PIPELINE_* env and any linked-session facts are preserved.
+		Context: pipeline.RunContext{
+			SessionID: in.SessionID,
+			HeadSHA:   in.HeadSHA,
+		},
 	})
 	if err != nil {
 		// A structurally invalid snapshot (cycle) is the only TriggerRun error;


### PR DESCRIPTION
## What

Threads PR context end to end through the pipelines subsystem so agent stages spawn on the PR branch with PR facts in their prompt, and command stages receive context env vars. Previously PR identity was thrown away at three boundaries (bridge forwarded only HeadSHA, RunState stored no PR fields, the agent adapter left `SpawnConfig.Branch` empty).

Closes #268

## Changes

- **`RunContext`** (new, `pipeline/types.go`): PR number/url, source/target branch, head SHA, session id, issue id, and the fork tri-state (`*bool`, mirroring `domain.PRFacts`). Additive and JSON-serializable; stored on `RunState.Context`.
- **Populated once, carried through**: the trigger bridge builds it from `PRFacts` and carries it on `TriggerRequest` -> `TriggerFired` -> `RunState`. Manual triggers (service `TriggerRun`) fill session + optional head SHA and leave PR fields empty.
- **Agent stages**: `SpawnRequest` gains `Branch`, set from `SourceBranch`; the adapter maps it to `SpawnConfig.Branch` so the spawned session checks out the PR branch. `stageprompt.go` renders a `## Pull request` block (number, url, source -> target, head SHA) when PR context exists.
- **Command stages**: a fixed env block (`AO_PIPELINE_RUN_ID`, `AO_PIPELINE_STAGE`, `AO_PR_NUMBER`, `AO_PR_URL`, `AO_PR_BRANCH`, `AO_PR_BASE_BRANCH`, `AO_PR_HEAD_SHA`) is merged under the stage's own env (stage env wins on collision, unset values omitted).
- **Deleted** the engine's `issueByRun` side-table (and `pruneRunMeta`); `IssueID` now rides `RunContext`.

Out of scope (owned by other tasks): workspace modes, loop-key changes, fork gating for agent stages. `AO_PIPELINES` flag wiring untouched. The HTTP API surface is unchanged (run DTOs map explicit fields; the new `RunState.Context` is not serialized to the wire), so no OpenAPI/schema regen.

## Tests

- bridge forwards the full PR context into the trigger
- reducer stores `RunContext` on `TRIGGER_FIRED`; manual trigger leaves PR fields empty
- agent spawn sets `Branch` from PR context (and stays empty without one)
- command env contains the `AO_*` block, stage env wins, unset PR values omitted
- stage prompt renders / omits the PR block

`go build ./...`, `go vet`, and `go test ./...` pass (the 4 pre-existing `cli` spawn-test failures reproduce identically on the `pipelines` base: they need a built daemon binary locally and are unrelated). `gofmt -l` clean on touched files.
