### PR TITLE
feat(pipelines): usable command stages (exit-code fallback, findings, timeout, output)

### DIFF
--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -3180,6 +3180,8 @@ components:
           - string
         errorMessage:
           type: string
+        output:
+          type: string
         stageName:
           type: string
         stageRunId:

--- a/backend/internal/httpd/controllers/pipelines.go
+++ b/backend/internal/httpd/controllers/pipelines.go
@@ -143,7 +143,10 @@ type PipelineStageView struct {
 	StartedAt    *time.Time `json:"startedAt,omitempty"`
 	CompletedAt  *time.Time `json:"completedAt,omitempty"`
 	ErrorMessage string     `json:"errorMessage,omitempty"`
-	ArtifactIDs  []string   `json:"artifactIds"`
+	// Output is a capped tail of the stage's combined stdout+stderr (command
+	// stages only), empty otherwise.
+	Output      string   `json:"output,omitempty"`
+	ArtifactIDs []string `json:"artifactIds"`
 }
 
 // PipelineRunDetail is the full reconstructed run: the summary plus per-stage
@@ -517,6 +520,7 @@ func runDetail(run pipeline.RunState) PipelineRunDetail {
 			StartedAt:    st.StartedAt,
 			CompletedAt:  st.CompletedAt,
 			ErrorMessage: st.ErrorMessage,
+			Output:       st.Output,
 			ArtifactIDs:  ids,
 		})
 	}

--- a/backend/internal/pipeline/engine/engine.go
+++ b/backend/internal/pipeline/engine/engine.go
@@ -478,9 +478,9 @@ func (e *Engine) tick() {
 		}
 		delete(e.inflight, k)
 		if outcome.Status == executors.OutcomeCompleted {
-			e.reduceAndExecute(pipeline.StageCompleted{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), Verdict: outcome.Verdict, Artifacts: outcome.Artifacts})
+			e.reduceAndExecute(pipeline.StageCompleted{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), Verdict: outcome.Verdict, Artifacts: outcome.Artifacts, Output: outcome.Output})
 		} else {
-			e.reduceAndExecute(pipeline.StageFailed{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), ErrorMessage: outcome.ErrorMessage})
+			e.reduceAndExecute(pipeline.StageFailed{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), ErrorMessage: outcome.ErrorMessage, Output: outcome.Output})
 		}
 		e.routeObservations(outcome.Observations)
 	}

--- a/backend/internal/pipeline/events.go
+++ b/backend/internal/pipeline/events.go
@@ -83,6 +83,9 @@ type StageCompleted struct {
 	StageName string
 	Verdict   Verdict
 	Artifacts []ArtifactInput
+	// Output is a capped tail of the stage's combined stdout+stderr, persisted
+	// onto the stage state for the run detail.
+	Output string
 }
 
 // Type implements Event.
@@ -96,6 +99,9 @@ type StageFailed struct {
 	RunID        RunID
 	StageName    string
 	ErrorMessage string
+	// Output is a capped tail of the stage's combined stdout+stderr, persisted
+	// onto the stage state for the run detail.
+	Output string
 }
 
 // Type implements Event.

--- a/backend/internal/pipeline/executors/command.go
+++ b/backend/internal/pipeline/executors/command.go
@@ -3,9 +3,12 @@ package executors
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
 )
@@ -13,6 +16,14 @@ import (
 // commandOutputCapBytes bounds captured stdout/stderr (1 MiB) so a runaway shim
 // cannot OOM the engine.
 const commandOutputCapBytes = 1 << 20
+
+// stageOutputTailCapBytes bounds the combined stdout+stderr tail persisted onto
+// the stage state (64 KiB) so the run detail can show what ran without the state
+// growing unbounded.
+const stageOutputTailCapBytes = 64 << 10
+
+// stderrTailCapBytes bounds the stderr snippet appended to a failure reason.
+const stderrTailCapBytes = 500
 
 // ForkStatus classifies the linked session's PR provenance for the fork gate.
 // The nil-safe Unknown value is the fail-safe default: a PR whose fork status
@@ -88,6 +99,21 @@ type commandHandle struct {
 	stageIdentity
 	child CommandProcess
 	final *Outcome
+	// workspaceDir is the stage workspace root; a .ao/pipeline-findings.jsonl
+	// dropped here is harvested after the process exits.
+	workspaceDir string
+	// timeoutCtx is non-nil only when the stage set a timeout; its
+	// DeadlineExceeded error distinguishes a timeout kill from a natural exit.
+	timeoutCtx    context.Context
+	cancelTimeout context.CancelFunc
+	timeoutMs     int64
+}
+
+// releaseTimeout frees the timeout context, if any. Idempotent.
+func (h *commandHandle) releaseTimeout() {
+	if h.cancelTimeout != nil {
+		h.cancelTimeout()
+	}
 }
 
 // CommandExecutor shells out a stage's command in the linked session's
@@ -161,7 +187,20 @@ func (e *CommandExecutor) Start(ctx context.Context, in StartInput) (Handle, err
 			ErrorMessage: fmt.Sprintf("command stage %q: %v", in.Stage.Name, err)}), nil
 	}
 
-	child, err := e.runner.Start(ctx, CommandSpec{
+	// Enforce Stage.TimeoutMs by deriving a deadline ctx: on expiry the runner's
+	// Cancel hook fires the SIGTERM->SIGKILL process-tree kill, the child exits,
+	// and Poll maps the DeadlineExceeded into a timeout failure.
+	runCtx := ctx
+	var timeoutCtx context.Context
+	var cancelTimeout context.CancelFunc
+	var timeoutMs int64
+	if in.Stage.TimeoutMs != nil && *in.Stage.TimeoutMs > 0 {
+		timeoutMs = *in.Stage.TimeoutMs
+		runCtx, cancelTimeout = context.WithTimeout(ctx, time.Duration(timeoutMs)*time.Millisecond)
+		timeoutCtx = runCtx
+	}
+
+	child, err := e.runner.Start(runCtx, CommandSpec{
 		Command:   spec.Command,
 		Args:      spec.Args,
 		Env:       pipelineEnv(in, spec.Env),
@@ -169,11 +208,21 @@ func (e *CommandExecutor) Start(ctx context.Context, in StartInput) (Handle, err
 		OutputCap: commandOutputCapBytes,
 	})
 	if err != nil {
+		if cancelTimeout != nil {
+			cancelTimeout()
+		}
 		return shortCircuit(id, Outcome{Status: OutcomeFailed,
 			ErrorMessage: fmt.Sprintf("failed to spawn command %q: %v", spec.Command, err)}), nil
 	}
 
-	return &commandHandle{stageIdentity: id, child: child}, nil
+	return &commandHandle{
+		stageIdentity: id,
+		child:         child,
+		workspaceDir:  session.WorkspacePath,
+		timeoutCtx:    timeoutCtx,
+		cancelTimeout: cancelTimeout,
+		timeoutMs:     timeoutMs,
+	}, nil
 }
 
 // Poll returns OutcomeRunning until the child exits, then interprets its exit
@@ -189,8 +238,16 @@ func (e *CommandExecutor) Poll(_ context.Context, h Handle) (Outcome, error) {
 	}
 	select {
 	case <-handle.child.Done():
-		out := interpretExit(handle.stageName, handle.child.Result())
+		timedOut := handle.timeoutCtx != nil && errors.Is(handle.timeoutCtx.Err(), context.DeadlineExceeded)
+		out := interpretExit(commandExit{
+			stageName:    handle.stageName,
+			res:          handle.child.Result(),
+			workspaceDir: handle.workspaceDir,
+			timedOut:     timedOut,
+			timeoutMs:    handle.timeoutMs,
+		})
 		handle.final = &out
+		handle.releaseTimeout()
 		return out, nil
 	default:
 		return Outcome{Status: OutcomeRunning}, nil
@@ -205,9 +262,11 @@ func (e *CommandExecutor) Cancel(_ context.Context, h Handle) error {
 		return fmt.Errorf("command executor: unexpected handle type %T", h)
 	}
 	if handle.child == nil || handle.final != nil {
+		handle.releaseTimeout()
 		return nil
 	}
 	handle.child.Kill()
+	handle.releaseTimeout()
 	return nil
 }
 
@@ -278,40 +337,77 @@ type commandTaskResult struct {
 	Reason    string                   `json:"reason,omitempty"`
 }
 
-// interpretExit maps a finished subprocess to a stage outcome per the
-// JSON-over-stdout contract:
+// commandExit bundles everything interpretExit needs to map a finished (or
+// timed-out) subprocess to a stage outcome.
+type commandExit struct {
+	stageName string
+	res       CommandResult
+	// workspaceDir is the stage workspace root; when non-empty a findings file
+	// dropped at .ao/pipeline-findings.jsonl is harvested. Empty disables it.
+	workspaceDir string
+	// timedOut reports that the stage's timeout fired and the process was killed.
+	timedOut bool
+	// timeoutMs is the configured timeout, surfaced in the timeout reason.
+	timeoutMs int64
+}
+
+// interpretExit maps a finished subprocess to a stage outcome. It has two modes:
 //
-//   - non-zero exit / signal / spawn error -> failed (the shim itself crashed;
-//     a partial stdout dump is worse than a clean failure label).
-//   - exit 0 with capped/empty/unparseable/invalid stdout -> failed.
-//   - exit 0 with outcome=failed -> failed (with the shim's reason).
-//   - otherwise -> completed, verdict from the result (or derived from outcome),
-//     with a self-skip observation for outcome=skipped.
-func interpretExit(stageName string, res CommandResult) Outcome {
+//   - Envelope mode (stdout is a JSON object carrying an "outcome" field): the
+//     historical JSON-over-stdout contract, unchanged.
+//   - Exit-code fallback (stdout is not that envelope): exit 0 -> completed/pass,
+//     nonzero -> failed with a reason built from the exit code plus a stderr
+//     tail. A fallback outcome carries a command_stage_exit_mode observation.
+//
+// In BOTH modes a completed stage harvests a .ao/pipeline-findings.jsonl drop
+// (same helper the agent executor uses); a malformed findings file fails the
+// stage. The combined stdout+stderr tail is captured on every terminal outcome.
+func interpretExit(ex commandExit) Outcome {
+	out := interpretExitStatus(ex)
+	out.Output = combinedOutputTail(ex.res.Stdout, ex.res.Stderr)
+	if out.Status != OutcomeCompleted {
+		return out
+	}
+	return harvestCommandFindings(ex, out)
+}
+
+// interpretExitStatus resolves the terminal status/verdict before findings
+// harvest, dispatching between envelope and exit-code-fallback modes.
+func interpretExitStatus(ex commandExit) Outcome {
+	stageName, res := ex.stageName, ex.res
 	if res.Err != nil {
 		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q spawn error: %v", stageName, res.Err)}
 	}
-	if res.Signal != "" || res.ExitCode != 0 {
-		label := fmt.Sprintf("code %d", res.ExitCode)
-		if res.Signal != "" {
-			label = "signal " + res.Signal
-		}
-		suffix := ""
-		if preview := strings.TrimSpace(res.Stderr); preview != "" {
-			if len(preview) > 500 {
-				preview = preview[:500]
-			}
-			suffix = "; stderr: " + preview
-		}
-		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q exited with %s%s", stageName, label, suffix)}
+	if ex.timedOut {
+		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q timed out after %dms%s", stageName, ex.timeoutMs, stderrSuffix(res.Stderr))}
 	}
-	if res.StdoutCapped {
-		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q stdout exceeded %d bytes", stageName, commandOutputCapBytes)}
+	if res.Signal != "" {
+		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q killed by signal %s%s", stageName, res.Signal, stderrSuffix(res.Stderr))}
 	}
 
 	trimmed := strings.TrimSpace(res.Stdout)
-	if trimmed == "" {
-		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q produced no JSON on stdout", stageName)}
+	if looksLikeEnvelope(trimmed) {
+		return interpretEnvelope(stageName, res, trimmed)
+	}
+
+	// Exit-code fallback: no JSON envelope, so the raw exit code is the verdict.
+	obs := Observation{Name: "command_stage_exit_mode", Data: map[string]any{
+		"stage":    stageName,
+		"mode":     "exit-code",
+		"exitCode": res.ExitCode,
+	}}
+	if res.ExitCode != 0 {
+		return Outcome{Status: OutcomeFailed, Observations: []Observation{obs},
+			ErrorMessage: fmt.Sprintf("command stage %q exited with code %d%s", stageName, res.ExitCode, stderrSuffix(res.Stderr))}
+	}
+	return Outcome{Status: OutcomeCompleted, Verdict: pipeline.VerdictPass, Observations: []Observation{obs}}
+}
+
+// interpretEnvelope applies the historical JSON-over-stdout contract to a stdout
+// already known to be an envelope. A nonzero exit still fails: the shim crashed.
+func interpretEnvelope(stageName string, res CommandResult, trimmed string) Outcome {
+	if res.ExitCode != 0 {
+		return Outcome{Status: OutcomeFailed, ErrorMessage: fmt.Sprintf("command stage %q exited with code %d%s", stageName, res.ExitCode, stderrSuffix(res.Stderr))}
 	}
 
 	var result commandTaskResult
@@ -342,6 +438,87 @@ func interpretExit(stageName string, res CommandResult) Outcome {
 		out.Observations = []Observation{{Name: "command_stage_self_skipped", Data: data}}
 	}
 	return out
+}
+
+// harvestCommandFindings merges a command stage's optional findings-file drop
+// into an already-completed outcome. A malformed file flips the stage to failed
+// (matching agent semantics); a truncated file adds a truncation observation.
+func harvestCommandFindings(ex commandExit, out Outcome) Outcome {
+	if ex.workspaceDir == "" {
+		return out
+	}
+	findingsPath := filepath.Join(ex.workspaceDir, stageFindingsRelativePath)
+	if !fileExists(findingsPath) {
+		return out
+	}
+
+	result, err := parseFindingsFile(findingsPath)
+	if err != nil {
+		return Outcome{Status: OutcomeFailed, Output: out.Output,
+			ErrorMessage: fmt.Sprintf("command stage %q produced unparseable findings at %s: %v", ex.stageName, findingsPath, err)}
+	}
+
+	out.Artifacts = append(out.Artifacts, result.artifacts...)
+	if result.truncated {
+		out.Observations = append(out.Observations, Observation{
+			Name: "pipeline.findings.truncated",
+			Data: map[string]any{
+				"stageName":    ex.stageName,
+				"findingsPath": findingsPath,
+				"capBytes":     findingsFileSizeCapBytes,
+				"bytesRead":    result.bytesRead,
+			},
+		})
+	}
+	return out
+}
+
+// looksLikeEnvelope reports whether trimmed stdout is a JSON object carrying an
+// "outcome" field, i.e. an attempt at the command-task envelope. Anything else
+// (plain text, a JSON array, an object without "outcome") routes to the
+// exit-code fallback.
+func looksLikeEnvelope(trimmed string) bool {
+	if trimmed == "" {
+		return false
+	}
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(trimmed), &probe); err != nil {
+		return false
+	}
+	_, ok := probe["outcome"]
+	return ok
+}
+
+// stderrSuffix returns a "; stderr: <tail>" snippet for a failure reason, or ""
+// when stderr is blank. The tail (last stderrTailCapBytes) is kept because the
+// end of a build log is usually where the error is.
+func stderrSuffix(stderr string) string {
+	preview := strings.TrimSpace(stderr)
+	if preview == "" {
+		return ""
+	}
+	if len(preview) > stderrTailCapBytes {
+		preview = preview[len(preview)-stderrTailCapBytes:]
+	}
+	return "; stderr: " + preview
+}
+
+// combinedOutputTail joins stdout and stderr and keeps the last
+// stageOutputTailCapBytes for the run detail. Captured on success and failure.
+func combinedOutputTail(stdout, stderr string) string {
+	var combined string
+	switch {
+	case stdout != "" && stderr != "":
+		combined = stdout + "\n" + stderr
+	case stdout != "":
+		combined = stdout
+	default:
+		combined = stderr
+	}
+	if len(combined) > stageOutputTailCapBytes {
+		combined = combined[len(combined)-stageOutputTailCapBytes:]
+	}
+	return combined
 }
 
 func defaultVerdictFor(outcome string) pipeline.Verdict {

--- a/backend/internal/pipeline/executors/command_fallback_test.go
+++ b/backend/internal/pipeline/executors/command_fallback_test.go
@@ -1,0 +1,163 @@
+package executors
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// writeStageFindings drops a .ao/pipeline-findings.jsonl into a fresh temp
+// workspace and returns the workspace root.
+func writeStageFindings(t *testing.T, lines string) string {
+	t.Helper()
+	ws := t.TempDir()
+	dir := filepath.Join(ws, ".ao")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, pipeline.FindingsFilename), []byte(lines), 0o644); err != nil {
+		t.Fatalf("write findings: %v", err)
+	}
+	return ws
+}
+
+const validFindingLine = `{"kind":"finding","filePath":"a.go","startLine":1,"endLine":2,"title":"t","description":"d","category":"lint","severity":"warning","confidence":0.5}`
+
+func TestInterpretExit_ExitCodeFallbackModeObservation(t *testing.T) {
+	// Fallback (non-envelope) stdout carries a mode observation; envelope does not.
+	fallback := interpretExit(commandExit{stageName: "lint", res: CommandResult{ExitCode: 0, Stdout: "ok"}})
+	if fallback.Status != OutcomeCompleted || fallback.Verdict != pipeline.VerdictPass {
+		t.Fatalf("fallback exit 0 should pass, got %s/%s", fallback.Status, fallback.Verdict)
+	}
+	if len(fallback.Observations) != 1 || fallback.Observations[0].Name != "command_stage_exit_mode" {
+		t.Fatalf("fallback should emit a mode observation, got %+v", fallback.Observations)
+	}
+	if fallback.Observations[0].Data["mode"] != "exit-code" {
+		t.Errorf("want mode=exit-code, got %v", fallback.Observations[0].Data["mode"])
+	}
+
+	env := interpretExit(commandExit{stageName: "lint", res: CommandResult{ExitCode: 0, Stdout: `{"outcome":"succeeded"}`}})
+	for _, o := range env.Observations {
+		if o.Name == "command_stage_exit_mode" {
+			t.Errorf("envelope mode must NOT emit a mode observation, got %+v", env.Observations)
+		}
+	}
+}
+
+func TestInterpretExit_OutputCapturedBothModes(t *testing.T) {
+	cases := []struct {
+		name string
+		res  CommandResult
+	}{
+		{"pass", CommandResult{ExitCode: 0, Stdout: "hello stdout", Stderr: "some stderr"}},
+		{"fail", CommandResult{ExitCode: 1, Stdout: "hello stdout", Stderr: "boom"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := interpretExit(commandExit{stageName: "s", res: tc.res})
+			if !strings.Contains(out.Output, "hello stdout") {
+				t.Errorf("output should include stdout, got %q", out.Output)
+			}
+			if !strings.Contains(out.Output, tc.res.Stderr) {
+				t.Errorf("output should include stderr, got %q", out.Output)
+			}
+		})
+	}
+}
+
+func TestInterpretExit_OutputTailCapped(t *testing.T) {
+	big := strings.Repeat("x", stageOutputTailCapBytes+4096)
+	out := interpretExit(commandExit{stageName: "s", res: CommandResult{ExitCode: 0, Stdout: big}})
+	if len(out.Output) != stageOutputTailCapBytes {
+		t.Fatalf("output should be capped to %d, got %d", stageOutputTailCapBytes, len(out.Output))
+	}
+}
+
+func TestInterpretExit_Timeout(t *testing.T) {
+	out := interpretExit(commandExit{
+		stageName: "test",
+		res:       CommandResult{Signal: "terminated", Stderr: "still running"},
+		timedOut:  true,
+		timeoutMs: 1500,
+	})
+	if out.Status != OutcomeFailed {
+		t.Fatalf("timeout should fail, got %s", out.Status)
+	}
+	if !strings.Contains(out.ErrorMessage, "timed out after 1500ms") {
+		t.Errorf("want timeout reason, got %q", out.ErrorMessage)
+	}
+}
+
+func TestInterpretExit_FindingsHarvest(t *testing.T) {
+	t.Run("envelope plus findings", func(t *testing.T) {
+		ws := writeStageFindings(t, validFindingLine+"\n")
+		out := interpretExit(commandExit{
+			stageName:    "review",
+			res:          CommandResult{ExitCode: 0, Stdout: `{"outcome":"succeeded"}`},
+			workspaceDir: ws,
+		})
+		if out.Status != OutcomeCompleted {
+			t.Fatalf("want completed, got %s (%s)", out.Status, out.ErrorMessage)
+		}
+		if len(out.Artifacts) != 1 || out.Artifacts[0].FilePath != "a.go" {
+			t.Fatalf("findings should be harvested, got %+v", out.Artifacts)
+		}
+	})
+
+	t.Run("fallback plus findings", func(t *testing.T) {
+		ws := writeStageFindings(t, validFindingLine+"\n")
+		out := interpretExit(commandExit{
+			stageName:    "review",
+			res:          CommandResult{ExitCode: 0, Stdout: "no envelope here"},
+			workspaceDir: ws,
+		})
+		if out.Status != OutcomeCompleted || out.Verdict != pipeline.VerdictPass {
+			t.Fatalf("want completed/pass, got %s/%s", out.Status, out.Verdict)
+		}
+		if len(out.Artifacts) != 1 {
+			t.Fatalf("findings should be harvested in fallback mode, got %+v", out.Artifacts)
+		}
+	})
+
+	t.Run("malformed findings fails", func(t *testing.T) {
+		ws := writeStageFindings(t, `{"kind":"finding","filePath":"a.go"}`+"\n")
+		out := interpretExit(commandExit{
+			stageName:    "review",
+			res:          CommandResult{ExitCode: 0, Stdout: "ok"},
+			workspaceDir: ws,
+		})
+		if out.Status != OutcomeFailed {
+			t.Fatalf("malformed findings should fail the stage, got %s", out.Status)
+		}
+		if !strings.Contains(out.ErrorMessage, "unparseable findings") {
+			t.Errorf("want unparseable-findings reason, got %q", out.ErrorMessage)
+		}
+	})
+
+	t.Run("no findings file is fine", func(t *testing.T) {
+		ws := t.TempDir()
+		out := interpretExit(commandExit{
+			stageName:    "review",
+			res:          CommandResult{ExitCode: 0, Stdout: "ok"},
+			workspaceDir: ws,
+		})
+		if out.Status != OutcomeCompleted || len(out.Artifacts) != 0 {
+			t.Fatalf("no findings file should pass with no artifacts, got %s/%+v", out.Status, out.Artifacts)
+		}
+	})
+
+	t.Run("findings not harvested when stage failed", func(t *testing.T) {
+		ws := writeStageFindings(t, validFindingLine+"\n")
+		out := interpretExit(commandExit{
+			stageName:    "review",
+			res:          CommandResult{ExitCode: 1, Stderr: "boom"},
+			workspaceDir: ws,
+		})
+		if out.Status != OutcomeFailed || len(out.Artifacts) != 0 {
+			t.Fatalf("failed stage should not harvest artifacts, got %s/%+v", out.Status, out.Artifacts)
+		}
+	})
+}

--- a/backend/internal/pipeline/executors/command_test.go
+++ b/backend/internal/pipeline/executors/command_test.go
@@ -196,9 +196,12 @@ func TestCommand_ExitCodeSemantics(t *testing.T) {
 	}{
 		{"nonzero exit fails", CommandResult{ExitCode: 1, Stderr: "tsc blew up"}, OutcomeFailed, "", "exited with code 1"},
 		{"signal fails", CommandResult{Signal: "killed"}, OutcomeFailed, "", "signal killed"},
-		{"empty stdout fails", CommandResult{ExitCode: 0, Stdout: "  "}, OutcomeFailed, "", "no JSON on stdout"},
-		{"bad json fails", CommandResult{ExitCode: 0, Stdout: "{not json"}, OutcomeFailed, "", "unparseable JSON"},
-		{"capped stdout fails", CommandResult{ExitCode: 0, Stdout: "{}", StdoutCapped: true}, OutcomeFailed, "", "exceeded"},
+		// Exit-code fallback: bare commands with no JSON envelope succeed on exit 0.
+		{"empty stdout + exit 0 -> pass", CommandResult{ExitCode: 0, Stdout: "  "}, OutcomeCompleted, pipeline.VerdictPass, ""},
+		{"non-envelope stdout + exit 0 -> pass", CommandResult{ExitCode: 0, Stdout: "All checks passed."}, OutcomeCompleted, pipeline.VerdictPass, ""},
+		{"broken json + exit 0 -> pass", CommandResult{ExitCode: 0, Stdout: "{not json"}, OutcomeCompleted, pipeline.VerdictPass, ""},
+		{"non-envelope object + exit 0 -> pass", CommandResult{ExitCode: 0, Stdout: "{}"}, OutcomeCompleted, pipeline.VerdictPass, ""},
+		{"non-envelope + exit 2 -> fail", CommandResult{ExitCode: 2, Stdout: "3 problems", Stderr: "lint failed"}, OutcomeFailed, "", "exited with code 2"},
 		{"bad outcome enum fails", CommandResult{ExitCode: 0, Stdout: `{"outcome":"weird"}`}, OutcomeFailed, "", "failed validation"},
 		{"outcome=failed fails with reason", CommandResult{ExitCode: 0, Stdout: `{"outcome":"failed","reason":"3 type errors"}`}, OutcomeFailed, "", "3 type errors"},
 		{"succeeded -> pass", CommandResult{ExitCode: 0, Stdout: `{"outcome":"succeeded"}`}, OutcomeCompleted, pipeline.VerdictPass, ""},

--- a/backend/internal/pipeline/executors/executor.go
+++ b/backend/internal/pipeline/executors/executor.go
@@ -50,6 +50,10 @@ type Outcome struct {
 	Artifacts    []pipeline.ArtifactInput
 	Observations []Observation
 	ErrorMessage string
+	// Output is a capped tail of the stage's combined stdout+stderr, surfaced in
+	// the run detail. Set by the command executor on both success and failure;
+	// empty for executor kinds that produce no subprocess output.
+	Output string
 }
 
 // Handle is an opaque running-stage token returned by Start and threaded back

--- a/backend/internal/pipeline/executors/runner.go
+++ b/backend/internal/pipeline/executors/runner.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"time"
 )
 
 // LogSink receives streamed subprocess output for logging. stream is "stdout"
@@ -57,6 +58,15 @@ func (r *osRunner) Start(ctx context.Context, spec CommandSpec) (CommandProcess,
 	cmd.Dir = spec.Dir
 	cmd.Env = mergeEnv(spec.Env)
 	configureProcAttr(cmd)
+	// On ctx expiry (a stage timeout) tear down the whole process group via the
+	// same SIGTERM->SIGKILL path Cancel uses, not just the direct child, so a
+	// shell's descendants die too. WaitDelay bounds the post-signal wait so a
+	// lingering grandchild holding a pipe cannot hang cmd.Wait forever.
+	cmd.Cancel = func() error {
+		killProcessTree(cmd)
+		return nil
+	}
+	cmd.WaitDelay = 5 * time.Second
 
 	capBytes := spec.OutputCap
 	if capBytes <= 0 {

--- a/backend/internal/pipeline/reducer.go
+++ b/backend/internal/pipeline/reducer.go
@@ -229,6 +229,7 @@ func reduceStageCompleted(state EngineState, event StageCompleted) (EngineState,
 	updatedStage.Status = StageStatusSucceeded
 	updatedStage.CompletedAt = &completed
 	updatedStage.Verdict = event.Verdict
+	updatedStage.Output = event.Output
 	updatedStage.Artifacts = append(append([]ArtifactID{}, stage.Artifacts...), newIDs...)
 
 	return finalizeStageCompletion(state, run, event.StageName, updatedStage, newArtifacts, now)
@@ -253,6 +254,7 @@ func reduceStageFailed(state EngineState, event StageFailed) (EngineState, []Eff
 	updatedStage.Status = StageStatusFailed
 	updatedStage.CompletedAt = &completed
 	updatedStage.ErrorMessage = event.ErrorMessage
+	updatedStage.Output = event.Output
 
 	return finalizeStageCompletion(state, run, event.StageName, updatedStage, nil, now)
 }

--- a/backend/internal/pipeline/types.go
+++ b/backend/internal/pipeline/types.go
@@ -578,6 +578,10 @@ type StageState struct {
 	CompletedAt *time.Time `json:"completedAt,omitempty"`
 
 	ErrorMessage string `json:"errorMessage,omitempty"`
+	// Output is a capped tail of the stage's combined stdout+stderr (command
+	// stages only), surfaced in the run detail. Empty for stages with no
+	// subprocess output.
+	Output string `json:"output,omitempty"`
 }
 
 // RunState is one pipeline run's full runtime state.

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1159,6 +1159,7 @@ export interface components {
             /** Format: date-time */
             completedAt?: null | string;
             errorMessage?: string;
+            output?: string;
             stageName: string;
             stageRunId: string;
             /** Format: date-time */

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -5,9 +5,12 @@ import { formatTimeCompact } from "../lib/format-time";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { loopStateTone, severityBadgeVariant, shortSha, stageStatusDotTone } from "../lib/pipeline-display";
 import { pipelineRunQueryKey, usePipelineRun, type PipelineArtifact } from "../hooks/usePipelineRuns";
+import type { components } from "../../api/schema";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { Switch } from "./ui/switch";
+
+type PipelineStageView = components["schemas"]["PipelineStageView"];
 
 // Read-only detail for one pipeline run: per-stage state, materialized findings,
 // and cancel/resume actions. No followup thread, no artifact editing — v1 detail
@@ -109,22 +112,7 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 				<h2 className="mb-2 text-micro font-semibold uppercase tracking-wide text-passive">Stages</h2>
 				<div className="flex flex-col gap-2">
 					{stages.map((stage) => (
-						<div
-							key={stage.stageRunId || stage.stageName}
-							data-stage={stage.stageName}
-							className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-card px-3 py-2"
-						>
-							<span className={cn("h-2 w-2 shrink-0 rounded-full", stageStatusDotTone(stage.status))} />
-							<span className="font-mono text-caption font-medium text-foreground">{stage.stageName}</span>
-							<span className="font-mono text-micro text-passive">{stage.status}</span>
-							{stage.verdict && <Badge variant="outline">{stage.verdict}</Badge>}
-							<span className="ml-auto font-mono text-micro text-passive">
-								attempt {stage.attempt}
-								{stage.artifactIds.length > 0 &&
-									` · ${stage.artifactIds.length} artifact${stage.artifactIds.length === 1 ? "" : "s"}`}
-							</span>
-							{stage.errorMessage && <p className="w-full font-mono text-micro text-error">{stage.errorMessage}</p>}
-						</div>
+						<StageRow key={stage.stageRunId || stage.stageName} stage={stage} />
 					))}
 					{stages.length === 0 && <p className="text-caption text-passive">No stages yet.</p>}
 				</div>
@@ -149,6 +137,46 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 					{findings.length === 0 && <p className="text-caption text-passive">No findings.</p>}
 				</div>
 			</section>
+		</div>
+	);
+}
+
+// One stage row: status/verdict summary plus a collapsible block for the
+// captured command output (last 64 KiB of combined stdout+stderr), when present.
+function StageRow({ stage }: { stage: PipelineStageView }) {
+	const [showOutput, setShowOutput] = useState(false);
+	return (
+		<div
+			data-stage={stage.stageName}
+			className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-card px-3 py-2"
+		>
+			<span className={cn("h-2 w-2 shrink-0 rounded-full", stageStatusDotTone(stage.status))} />
+			<span className="font-mono text-caption font-medium text-foreground">{stage.stageName}</span>
+			<span className="font-mono text-micro text-passive">{stage.status}</span>
+			{stage.verdict && <Badge variant="outline">{stage.verdict}</Badge>}
+			<span className="ml-auto flex items-center gap-2 font-mono text-micro text-passive">
+				{stage.output && (
+					<button
+						type="button"
+						onClick={() => setShowOutput((v) => !v)}
+						className="rounded px-1 text-passive underline-offset-2 hover:text-foreground hover:underline"
+						aria-expanded={showOutput}
+					>
+						{showOutput ? "Hide output" : "Output"}
+					</button>
+				)}
+				<span>
+					attempt {stage.attempt}
+					{stage.artifactIds.length > 0 &&
+						` · ${stage.artifactIds.length} artifact${stage.artifactIds.length === 1 ? "" : "s"}`}
+				</span>
+			</span>
+			{stage.errorMessage && <p className="w-full font-mono text-micro text-error">{stage.errorMessage}</p>}
+			{stage.output && showOutput && (
+				<pre className="max-h-80 w-full overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-background px-2 py-1.5 font-mono text-micro text-muted-foreground">
+					{stage.output}
+				</pre>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## What

Makes pipeline command stages practical. Before this, `interpretExit` required a JSON envelope `{outcome,...}` on stdout, so any exit-0 command whose stdout was not that JSON was forced to failed. Bare `pnpm lint` / `pnpm test` (including our own shipped templates and the `parallel-checks` / `merge-gate` samples) could never succeed.

### 1. Exit-code fallback
`interpretExit` now detects whether stdout is the envelope (a JSON object carrying an `outcome` field):
- Envelope stdout: today's behavior, unchanged.
- Otherwise: exit 0 maps to completed/pass, nonzero to failed with a reason built from the exit code plus a stderr tail. No new config knob. Fallback outcomes carry a `command_stage_exit_mode` observation noting the mode.

### 2. Shared findings harvest for commands
A completed command stage harvests `.ao/pipeline-findings.jsonl` from the stage workspace with the same `parseFindingsFile` helper `agent.go` uses, in both envelope and fallback modes. A malformed findings file fails the stage (agent semantics); a truncated file adds a `pipeline.findings.truncated` observation.

### 3. Timeout enforcement
`Stage.TimeoutMs` now wraps the command ctx with `context.WithTimeout`. On expiry the runner's `Cmd.Cancel` hook fires the existing `killProcessTree` (SIGTERM then SIGKILL) path and the stage fails with a timeout reason. `WaitDelay` bounds the post-signal wait.

### 4. Output capture
A capped (64 KiB) tail of combined stdout+stderr is captured on both success and failure, threaded `Outcome` -> `StageCompleted`/`StageFailed` -> reducer -> `StageState.Output` -> `PipelineStageView.output`, and rendered as a collapsible block per stage in `PipelineRunDetail`. OpenAPI spec and `frontend/src/api/schema.ts` regenerated.

Scope guards respected: no changes to loop keys, RunContext/env threading, `engine.go` startInput, `executors/agent.go` spawn fields, workspace modes, or blocksMerge.

## Tests
- `go build ./...`, `go test ./internal/pipeline/... ./internal/httpd/...` green (442 passed); `gofmt` clean on touched files.
- Table tests for `interpretExit`: valid envelope (pass/fail/artifacts/skip), non-JSON + exit 0, non-JSON + exit 2, empty stdout, broken JSON, envelope+findings, fallback+findings, malformed findings, no-findings, findings-skipped-on-failure, timeout expiry, output capture + cap, mode observation.
- Frontend: `tsc --noEmit` clean, renderer `vite build` succeeds, prettier clean on the touched component (`schema.ts` is prettier-ignored/generated).

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)