### PR TITLE
fix(pipelines): per-PR loop keys, same-SHA trigger dedup, settled-only loopRounds

### DIFF
--- a/backend/internal/integration/pipeline_e2e_test.go
+++ b/backend/internal/integration/pipeline_e2e_test.go
@@ -236,7 +236,9 @@ func TestPipelineEndToEndFlagOn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hydrate: %v", err)
 	}
-	key := pipeline.LoopKey(string(sessionID), "review")
+	// The run is PR-backed, so it keys per PR (session:pipeline:prURL), not by the
+	// bare session+pipeline key. Derive the key from the run's persisted Context.
+	key := pipeline.LoopKeyFor(run.Context, run.SessionID, "review", run.RunID)
 	if _, live := hydrated.CurrentRunByLoop[key]; live {
 		t.Fatalf("terminal run must not hold a live loop pointer")
 	}

--- a/backend/internal/pipeline/events.go
+++ b/backend/internal/pipeline/events.go
@@ -116,6 +116,10 @@ type NewSHADetected struct {
 	SessionID    string
 	PipelineName string
 	SHA          string
+	// PRURL scopes the SHA change to a single PR's run so a sibling PR's run on
+	// the same session+pipeline is never terminated as outdated. Empty for a
+	// non-PR loop (degrades to the session+pipeline key).
+	PRURL string
 }
 
 // Type implements Event.

--- a/backend/internal/pipeline/reducer.go
+++ b/backend/internal/pipeline/reducer.go
@@ -1,6 +1,9 @@
 package pipeline
 
-import "time"
+import (
+	"sort"
+	"time"
+)
 
 // Pure pipeline reducer.
 //
@@ -46,7 +49,7 @@ func Reduce(state EngineState, event Event) (EngineState, []Effect) {
 
 func reduceTriggerFired(state EngineState, event TriggerFired) (EngineState, []Effect) {
 	now := event.Now
-	key := LoopKey(event.SessionID, event.Pipeline.Name)
+	key := LoopKeyFor(event.Context, event.SessionID, event.Pipeline.Name, event.RunID)
 
 	if runID, ok := state.CurrentRunByLoop[key]; ok {
 		if _, running := state.Runs[runID]; running {
@@ -57,12 +60,41 @@ func reduceTriggerFired(state EngineState, event TriggerFired) (EngineState, []E
 		}
 	}
 
+	// Same-SHA dedup: a non-manual trigger that already ran this exact SHA to a
+	// settled outcome (completed or stalled) must not spawn an identical run.
+	// This absorbs CI flapping (pass -> fail -> pass on one SHA re-firing
+	// merge_ready) and fact-only pr.updated churn. Manual triggers always fire:
+	// a human explicitly asked, even at an already-run SHA.
+	if event.Trigger != TriggerManual && event.HeadSHA != "" {
+		for _, s := range state.HistorySummaries[key] {
+			if s.HeadSHA == event.HeadSHA && isSettledRun(s) {
+				return state, []Effect{EmitObservation{
+					Name: "pipeline.run.trigger_deduped",
+					Data: map[string]any{
+						"pipelineName": event.Pipeline.Name,
+						"sessionId":    event.SessionID,
+						"trigger":      event.Trigger,
+						"headSha":      event.HeadSHA,
+						"priorRunId":   s.RunID,
+					},
+				}}
+			}
+		}
+	}
+
 	stages, ok := buildInitialStageStates(event.Pipeline, event.StageRunIDs)
 	if !ok {
 		return invalidTransition(state, "TRIGGER_FIRED missing stageRunIds for one or more stages")
 	}
 
-	priorRound := len(state.HistorySummaries[key])
+	// Only settled runs (completed or stalled) count as loop rounds; runs cut
+	// short (outdated, cancelled, config change) must not trip loop_rounds_at_least.
+	priorRound := 0
+	for _, s := range state.HistorySummaries[key] {
+		if isSettledRun(s) {
+			priorRound++
+		}
+	}
 	isContinuation := event.Trigger == TriggerPRUpdated || event.Trigger == TriggerManual
 	loopRounds := priorRound
 	if isContinuation {
@@ -340,13 +372,21 @@ func finalizeStageCompletion(state EngineState, run RunState, stageName string, 
 }
 
 func reduceNewSHADetected(state EngineState, event NewSHADetected) (EngineState, []Effect) {
-	key := LoopKey(event.SessionID, event.PipelineName)
+	// Look up by the PR-scoped loop key so a SHA change on one PR only reaches
+	// that PR's run, never a sibling PR's run on the same session+pipeline.
+	key := LoopKeyFor(RunContext{PRURL: event.PRURL}, event.SessionID, event.PipelineName, "")
 	runID, ok := state.CurrentRunByLoop[key]
 	if !ok {
 		return state, nil
 	}
 	run, ok := state.Runs[runID]
 	if !ok || run.HeadSHA == event.SHA {
+		return state, nil
+	}
+	// Defensive guard: never terminate a run whose PR does not match the one
+	// whose SHA changed. The key already encodes the PR, so this only bites if a
+	// key ever aliased.
+	if event.PRURL != "" && run.Context.PRURL != event.PRURL {
 		return state, nil
 	}
 	// Run becomes outdated; the loop key is freed so the driver can spawn a new
@@ -370,16 +410,33 @@ func reduceRunCancelled(state EngineState, event RunCancelled) (EngineState, []E
 }
 
 func reduceConfigChanged(state EngineState, event ConfigChanged) (EngineState, []Effect) {
-	key := LoopKey(event.SessionID, event.PipelineName)
-	runID, ok := state.CurrentRunByLoop[key]
-	if !ok {
+	// The config changed for a whole session+pipeline, but per-PR loop keys mean
+	// several runs (one per PR, plus any manual) may be in flight for it. Every
+	// run is pinned to the now-stale config snapshot, so terminate them all.
+	// Collect matching non-terminal runs and terminate in RunID order for
+	// deterministic effects.
+	runIDs := make([]RunID, 0, len(state.Runs))
+	for id, run := range state.Runs {
+		if run.SessionID == event.SessionID && run.PipelineName == event.PipelineName && !run.LoopState.IsTerminal() {
+			runIDs = append(runIDs, id)
+		}
+	}
+	if len(runIDs) == 0 {
 		return state, nil
 	}
-	run, ok := state.Runs[runID]
-	if !ok {
-		return state, nil
+	sort.Slice(runIDs, func(i, j int) bool { return runIDs[i] < runIDs[j] })
+
+	var effects []Effect
+	for _, id := range runIDs {
+		run, ok := state.Runs[id]
+		if !ok || run.LoopState.IsTerminal() {
+			continue
+		}
+		var eff []Effect
+		state, eff = terminateRun(state, run, TerminationConfigChange, event.Now, LoopTerminated)
+		effects = append(effects, eff...)
 	}
-	return terminateRun(state, run, TerminationConfigChange, event.Now, LoopTerminated)
+	return state, effects
 }
 
 func reduceArtifactStatusChanged(state EngineState, event ArtifactStatusChanged) (EngineState, []Effect) {
@@ -467,7 +524,7 @@ func decideRunExit(run RunState, state EngineState) exitDecision {
 	exits := run.PipelineConfigSnapshot.ExitPredicates
 	ctx := PredicateCtx{
 		Run:      &run,
-		History:  state.HistorySummaries[LoopKey(run.SessionID, run.PipelineName)],
+		History:  state.HistorySummaries[LoopKeyFor(run.Context, run.SessionID, run.PipelineName, run.RunID)],
 		Findings: run.Findings,
 	}
 
@@ -506,7 +563,7 @@ func isConverged(state EngineState, run RunState) bool {
 		return false
 	}
 
-	history := state.HistorySummaries[LoopKey(run.SessionID, run.PipelineName)]
+	history := state.HistorySummaries[LoopKeyFor(run.Context, run.SessionID, run.PipelineName, run.RunID)]
 	if len(history) < window-1 {
 		return false
 	}

--- a/backend/internal/pipeline/reducer_helpers.go
+++ b/backend/internal/pipeline/reducer_helpers.go
@@ -75,6 +75,14 @@ func summarizeRun(run RunState) RunSummary {
 	}
 }
 
+// isSettledRun reports whether a run summary reached a real conclusion (loop
+// state done or stalled) rather than being cut short (outdated, cancelled, or
+// config change, all of which land in loop state terminated). Only settled runs
+// count toward the loop round counter and toward same-SHA trigger dedup.
+func isSettledRun(s RunSummary) bool {
+	return s.LoopState == LoopDone || s.LoopState == LoopStalled
+}
+
 // sortedUnique returns the deduped, ascending-sorted copy of in. It always
 // returns a non-nil slice so JSON round-trips as [] rather than null, matching
 // the old TypeScript summaries.
@@ -178,7 +186,7 @@ func terminateRunFromState(state EngineState, run RunState, reason RunTerminatio
 	finalRun.TerminationReason = reason
 	finalRun.UpdatedAt = now
 
-	key := LoopKey(run.SessionID, run.PipelineName)
+	key := LoopKeyFor(run.Context, run.SessionID, run.PipelineName, run.RunID)
 
 	// Append this run's summary to the loop's history (copy-on-write).
 	prior := state.HistorySummaries[key]

--- a/backend/internal/pipeline/reducer_loopkeys_test.go
+++ b/backend/internal/pipeline/reducer_loopkeys_test.go
@@ -1,0 +1,179 @@
+package pipeline
+
+import "testing"
+
+// triggerForPR builds a PR-backed TRIGGER_FIRED with a per-PR RunContext.
+func triggerForPR(p Pipeline, trigger StageTriggerEvent, runID RunID, prURL, headSHA string) TriggerFired {
+	ev := TriggerFired{
+		Now:         testNow,
+		Trigger:     trigger,
+		SessionID:   "sess-1",
+		Pipeline:    p,
+		HeadSHA:     headSHA,
+		RunID:       runID,
+		StageRunIDs: stageRunIDsFor(p),
+		Context: RunContext{
+			PRURL: prURL, HeadSHA: headSHA, SessionID: "sess-1",
+		},
+	}
+	return ev
+}
+
+// runToDone drives a single-stage run from a live trigger to a completed run.
+func runToDone(t *testing.T, state EngineState, runID RunID, stage string) EngineState {
+	t.Helper()
+	state, _ = Reduce(state, StageStarted{Now: testNow, RunID: runID, StageName: stage})
+	state, _ = Reduce(state, StageCompleted{Now: testNow, RunID: runID, StageName: stage})
+	if state.Runs[runID].LoopState != LoopDone {
+		t.Fatalf("run %s should be done, got %v", runID, state.Runs[runID].LoopState)
+	}
+	return state
+}
+
+func TestPerPRLoopKeys(t *testing.T) {
+	t.Run("two PRs on one session run the same pipeline concurrently", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		state, _ := Reduce(EmptyEngineState(), triggerForPR(p, TriggerPROpened, "rA", "https://x/pull/A", "sha-a"))
+		state, _ = Reduce(state, triggerForPR(p, TriggerPROpened, "rB", "https://x/pull/B", "sha-b"))
+
+		if state.Runs["rA"].LoopState != LoopRunning || state.Runs["rB"].LoopState != LoopRunning {
+			t.Fatalf("both runs should be live, got rA=%v rB=%v", state.Runs["rA"].LoopState, state.Runs["rB"].LoopState)
+		}
+		keyA := LoopKeyFor(RunContext{PRURL: "https://x/pull/A"}, "sess-1", "p", "")
+		keyB := LoopKeyFor(RunContext{PRURL: "https://x/pull/B"}, "sess-1", "p", "")
+		if state.CurrentRunByLoop[keyA] != "rA" || state.CurrentRunByLoop[keyB] != "rB" {
+			t.Fatalf("per-PR keys not isolated: %+v", state.CurrentRunByLoop)
+		}
+	})
+
+	t.Run("NEW_SHA for PR-B terminates only PR-B's run", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		state, _ := Reduce(EmptyEngineState(), triggerForPR(p, TriggerPROpened, "rA", "https://x/pull/A", "sha-a"))
+		state, _ = Reduce(state, triggerForPR(p, TriggerPROpened, "rB", "https://x/pull/B", "sha-b"))
+
+		state, _ = Reduce(state, NewSHADetected{Now: testNow, SessionID: "sess-1", PipelineName: "p", SHA: "sha-b2", PRURL: "https://x/pull/B"})
+
+		if state.Runs["rA"].LoopState != LoopRunning {
+			t.Fatalf("PR-A run must survive a PR-B SHA change, got %v", state.Runs["rA"].LoopState)
+		}
+		if state.Runs["rB"].LoopState != LoopTerminated || state.Runs["rB"].TerminationReason != TerminationOutdated {
+			t.Fatalf("PR-B run should be outdated, got %v/%v", state.Runs["rB"].LoopState, state.Runs["rB"].TerminationReason)
+		}
+		keyA := LoopKeyFor(RunContext{PRURL: "https://x/pull/A"}, "sess-1", "p", "")
+		keyB := LoopKeyFor(RunContext{PRURL: "https://x/pull/B"}, "sess-1", "p", "")
+		if state.CurrentRunByLoop[keyA] != "rA" {
+			t.Fatal("PR-A loop key must still point at rA")
+		}
+		if _, live := state.CurrentRunByLoop[keyB]; live {
+			t.Fatal("PR-B loop key should be freed for the new SHA")
+		}
+	})
+
+	t.Run("NEW_SHA for an unknown PR is a no-op", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		state, _ := Reduce(EmptyEngineState(), triggerForPR(p, TriggerPROpened, "rA", "https://x/pull/A", "sha-a"))
+		_, effects := Reduce(state, NewSHADetected{Now: testNow, SessionID: "sess-1", PipelineName: "p", SHA: "sha-z", PRURL: "https://x/pull/Z"})
+		if len(effects) != 0 {
+			t.Fatalf("SHA change on an untracked PR should be a no-op, got %v", effects)
+		}
+	})
+}
+
+func TestSameSHATriggerDedup(t *testing.T) {
+	p := pipelineOf("p", 1, stageDef("a"))
+
+	t.Run("merge_ready flap at the same SHA does not create a second run", func(t *testing.T) {
+		state, _ := Reduce(EmptyEngineState(), triggerForPR(p, TriggerPRMergeReady, "r1", "https://x/pull/A", "sha-a"))
+		state = runToDone(t, state, "r1", "a")
+
+		// CI flaps pass -> fail -> pass on the same SHA, re-firing the merge_ready
+		// transition. The reducer must dedup it.
+		state2, effects := Reduce(state, triggerForPR(p, TriggerPRMergeReady, "r2", "https://x/pull/A", "sha-a"))
+		if _, exists := state2.Runs["r2"]; exists {
+			t.Fatal("a second run must not be created at an already-settled SHA")
+		}
+		if len(effects) != 1 {
+			t.Fatalf("want a single dedup observation, got %d effects", len(effects))
+		}
+		if obs, ok := effects[0].(EmitObservation); !ok || obs.Name != "pipeline.run.trigger_deduped" {
+			t.Fatalf("want trigger_deduped observation, got %v", effects[0])
+		}
+	})
+
+	t.Run("a different SHA is not deduped", func(t *testing.T) {
+		state, _ := Reduce(EmptyEngineState(), triggerForPR(p, TriggerPRMergeReady, "r1", "https://x/pull/A", "sha-a"))
+		state = runToDone(t, state, "r1", "a")
+
+		state2, _ := Reduce(state, triggerForPR(p, TriggerPRMergeReady, "r2", "https://x/pull/A", "sha-b"))
+		if _, exists := state2.Runs["r2"]; !exists {
+			t.Fatal("a new SHA must start a fresh run")
+		}
+	})
+
+	t.Run("an outdated prior run at the SHA does not dedup a re-trigger", func(t *testing.T) {
+		// Prior run at sha-a was cut short (outdated), so the SHA was never run to
+		// a conclusion; a re-trigger must be allowed.
+		st := EmptyEngineState()
+		key := LoopKeyFor(RunContext{PRURL: "https://x/pull/A"}, "sess-1", "p", "")
+		st.HistorySummaries[key] = []RunSummary{
+			{RunID: "old", HeadSHA: "sha-a", LoopState: LoopTerminated, TerminationReason: TerminationOutdated},
+		}
+		state, _ := Reduce(st, triggerForPR(p, TriggerPRMergeReady, "r2", "https://x/pull/A", "sha-a"))
+		if _, exists := state.Runs["r2"]; !exists {
+			t.Fatal("a re-trigger after an outdated run at this SHA must fire")
+		}
+	})
+
+	t.Run("manual trigger always fires even at an already-run SHA", func(t *testing.T) {
+		st := EmptyEngineState()
+		// Manual-with-session key; a settled prior run sits at sha-a.
+		key := LoopKeyFor(RunContext{SessionID: "sess-1"}, "sess-1", "p", "")
+		st.HistorySummaries[key] = []RunSummary{
+			{RunID: "old", HeadSHA: "sha-a", LoopState: LoopDone},
+		}
+		ev := triggerFor(p, TriggerManual, "r1")
+		ev.HeadSHA = "sha-a"
+		ev.Context = RunContext{SessionID: "sess-1", HeadSHA: "sha-a"}
+		state, _ := Reduce(st, ev)
+		if _, exists := state.Runs["r1"]; !exists {
+			t.Fatal("a manual trigger must fire even at an already-settled SHA")
+		}
+	})
+}
+
+func TestUnscopedManualRunsCoexist(t *testing.T) {
+	p := pipelineOf("p", 1, stageDef("a"))
+	mk := func(runID RunID) TriggerFired {
+		return TriggerFired{
+			Now: testNow, Trigger: TriggerManual, SessionID: "", Pipeline: p,
+			HeadSHA: "", RunID: runID, StageRunIDs: stageRunIDsFor(p),
+			Context: RunContext{},
+		}
+	}
+	state, _ := Reduce(EmptyEngineState(), mk("m1"))
+	state, _ = Reduce(state, mk("m2"))
+
+	if state.Runs["m1"].LoopState != LoopRunning || state.Runs["m2"].LoopState != LoopRunning {
+		t.Fatalf("both unscoped manual runs should be live, got m1=%v m2=%v", state.Runs["m1"].LoopState, state.Runs["m2"].LoopState)
+	}
+	if state.CurrentRunByLoop["run:m1"] != "m1" || state.CurrentRunByLoop["run:m2"] != "m2" {
+		t.Fatalf("unscoped manual runs must not collide: %+v", state.CurrentRunByLoop)
+	}
+}
+
+func TestConfigChangedTerminatesAllPRRuns(t *testing.T) {
+	p := pipelineOf("p", 1, stageDef("a"))
+	state, _ := Reduce(EmptyEngineState(), triggerForPR(p, TriggerPROpened, "rA", "https://x/pull/A", "sha-a"))
+	state, _ = Reduce(state, triggerForPR(p, TriggerPROpened, "rB", "https://x/pull/B", "sha-b"))
+
+	state, _ = Reduce(state, ConfigChanged{Now: testNow, SessionID: "sess-1", PipelineName: "p"})
+
+	for _, id := range []RunID{"rA", "rB"} {
+		if state.Runs[id].LoopState != LoopTerminated || state.Runs[id].TerminationReason != TerminationConfigChange {
+			t.Fatalf("run %s should be config-change terminated, got %v/%v", id, state.Runs[id].LoopState, state.Runs[id].TerminationReason)
+		}
+	}
+	if len(state.CurrentRunByLoop) != 0 {
+		t.Fatalf("all loop keys should be freed, got %+v", state.CurrentRunByLoop)
+	}
+}

--- a/backend/internal/pipeline/reducer_resume.go
+++ b/backend/internal/pipeline/reducer_resume.go
@@ -31,7 +31,7 @@ func reduceRunResumed(state EngineState, event RunResumed) (EngineState, []Effec
 	// Refuse to resume when another run already owns the loop key: resuming an
 	// old stalled run after a fresh trigger claimed the loop would silently
 	// dispossess the active run of its loop pointer.
-	key := LoopKey(run.SessionID, run.PipelineName)
+	key := LoopKeyFor(run.Context, run.SessionID, run.PipelineName, run.RunID)
 	if activeRunID, present := state.CurrentRunByLoop[key]; present && activeRunID != event.RunID {
 		return invalidTransition(state, "RUN_RESUMED for "+string(event.RunID)+" but loop \""+key+"\" is already owned by active run "+string(activeRunID)+"; cancel that run before resuming the older one")
 	}

--- a/backend/internal/pipeline/reducer_test.go
+++ b/backend/internal/pipeline/reducer_test.go
@@ -113,25 +113,48 @@ func TestReduceTriggerFired(t *testing.T) {
 		}
 	})
 
-	t.Run("pr.opened after history keeps loopRounds at max(prior,1)", func(t *testing.T) {
+	t.Run("pr.opened after history keeps loopRounds at max(settled prior,1)", func(t *testing.T) {
 		p := pipelineOf("p", 1, stageDef("a"))
 		st := EmptyEngineState()
 		key := LoopKey("sess-1", "p")
-		st.HistorySummaries[key] = []RunSummary{{RunID: "old1"}, {RunID: "old2"}}
+		st.HistorySummaries[key] = []RunSummary{
+			{RunID: "old1", LoopState: LoopDone}, {RunID: "old2", LoopState: LoopStalled},
+		}
 		state, _ := Reduce(st, triggerFor(p, TriggerPROpened, "r1"))
 		if state.Runs["r1"].LoopRounds != 2 {
 			t.Fatalf("loopRounds = %d, want 2", state.Runs["r1"].LoopRounds)
 		}
 	})
 
-	t.Run("manual continuation increments loopRounds past history", func(t *testing.T) {
+	t.Run("manual continuation increments loopRounds past settled history", func(t *testing.T) {
 		p := pipelineOf("p", 1, stageDef("a"))
 		st := EmptyEngineState()
 		key := LoopKey("sess-1", "p")
-		st.HistorySummaries[key] = []RunSummary{{RunID: "old1"}, {RunID: "old2"}}
+		st.HistorySummaries[key] = []RunSummary{
+			{RunID: "old1", LoopState: LoopDone}, {RunID: "old2", LoopState: LoopStalled},
+		}
 		state, _ := Reduce(st, triggerFor(p, TriggerManual, "r1"))
 		if state.Runs["r1"].LoopRounds != 3 {
 			t.Fatalf("loopRounds = %d, want 3", state.Runs["r1"].LoopRounds)
+		}
+	})
+
+	t.Run("loopRounds ignores outdated/cancelled history", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		st := EmptyEngineState()
+		key := LoopKey("sess-1", "p")
+		// Two settled rounds plus three runs cut short (terminated); only the
+		// settled two count toward the round number.
+		st.HistorySummaries[key] = []RunSummary{
+			{RunID: "done1", LoopState: LoopDone},
+			{RunID: "outdated", LoopState: LoopTerminated, TerminationReason: TerminationOutdated},
+			{RunID: "cancelled", LoopState: LoopTerminated, TerminationReason: TerminationManualCancel},
+			{RunID: "stalled1", LoopState: LoopStalled},
+			{RunID: "cfg", LoopState: LoopTerminated, TerminationReason: TerminationConfigChange},
+		}
+		state, _ := Reduce(st, triggerFor(p, TriggerManual, "r1"))
+		if state.Runs["r1"].LoopRounds != 3 {
+			t.Fatalf("loopRounds = %d, want 3 (2 settled prior + 1 continuation)", state.Runs["r1"].LoopRounds)
 		}
 	})
 

--- a/backend/internal/pipeline/triggers/bridge.go
+++ b/backend/internal/pipeline/triggers/bridge.go
@@ -252,7 +252,7 @@ func (b *Bridge) process(ctx context.Context, e cdc.Event) {
 		// new SHA. Scoped to pr.updated subscribers because the rearm is the
 		// pr.updated trigger; the reducer no-ops when no run is in flight.
 		if fireUpdated && shaChanged && subsUpdated {
-			eng.Dispatch(pipeline.NewSHADetected{Now: b.now(), SessionID: session, PipelineName: cfg.Name, SHA: cur.headSHA})
+			eng.Dispatch(pipeline.NewSHADetected{Now: b.now(), SessionID: session, PipelineName: cfg.Name, SHA: cur.headSHA, PRURL: runCtx.PRURL})
 		}
 
 		b.fireIf(eng, fireOpened && defSubscribes(cfg, pipeline.TriggerPROpened), cfg, runCtx, pipeline.TriggerPROpened)

--- a/backend/internal/pipeline/types.go
+++ b/backend/internal/pipeline/types.go
@@ -661,10 +661,35 @@ type EngineState struct {
 	HistorySummaries map[string][]RunSummary `json:"historySummaries"`
 }
 
-// LoopKey returns the key used to index a session+pipeline loop in
-// EngineState.CurrentRunByLoop and EngineState.HistorySummaries.
+// LoopKey returns the session+pipeline key. It is used only to deduplicate
+// per-session+pipeline dispatches (e.g. CONFIG_CHANGED fan-out); the per-run
+// loop-identity index uses LoopKeyFor, which isolates runs by PR.
 func LoopKey(sessionID, pipelineName string) string {
 	return sessionID + ":" + pipelineName
+}
+
+// LoopKeyFor composes the per-run loop-identity key that indexes
+// EngineState.CurrentRunByLoop and EngineState.HistorySummaries. The key is
+// derived from what the run actually is, so runs stay isolated per PR:
+//
+//   - a run backed by a PR (ctx.PRURL set) keys per PR as
+//     "sessionID:pipelineName:prURL", so sibling PRs on one session+pipeline
+//     never collide (a NEW_SHA on PR-B cannot terminate PR-A's run);
+//   - a manual run scoped to a session keys "sessionID:pipelineName";
+//   - a manual run with no session keys "run:runID", so unscoped manual runs
+//     never share the global ":pipelineName" key and no-op each other.
+//
+// Runs persisted before RunContext existed have an empty ctx but a non-empty
+// sessionID, so they degrade to the historical "sessionID:pipelineName" shape,
+// which is acceptable.
+func LoopKeyFor(ctx RunContext, sessionID, pipelineName string, runID RunID) string {
+	if ctx.PRURL != "" {
+		return sessionID + ":" + pipelineName + ":" + ctx.PRURL
+	}
+	if sessionID != "" {
+		return sessionID + ":" + pipelineName
+	}
+	return "run:" + string(runID)
 }
 
 // EmptyEngineState returns a zero-value EngineState with initialized maps.

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -166,6 +166,7 @@ type PipelineRun struct {
 	Fingerprints      string
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
+	ContextJson       string
 }
 
 type PipelineStageRun struct {

--- a/backend/internal/storage/sqlite/gen/pipeline.sql.go
+++ b/backend/internal/storage/sqlite/gen/pipeline.sql.go
@@ -128,7 +128,7 @@ func (q *Queries) GetPipelineDefinitionByName(ctx context.Context, arg GetPipeli
 const getPipelineRun = `-- name: GetPipelineRun :one
 SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
        loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at
+       created_at, updated_at, context_json
 FROM pipeline_runs WHERE id = ?
 `
 
@@ -149,6 +149,7 @@ func (q *Queries) GetPipelineRun(ctx context.Context, id string) (PipelineRun, e
 		&i.Fingerprints,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ContextJson,
 	)
 	return i, err
 }
@@ -273,7 +274,7 @@ func (q *Queries) ListPipelineDefinitions(ctx context.Context, projectID domain.
 const listPipelineRuns = `-- name: ListPipelineRuns :many
 SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
        loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at
+       created_at, updated_at, context_json
 FROM pipeline_runs
 WHERE project_id = ?
   AND (?2 IS NULL OR pipeline_name = ?2)
@@ -317,6 +318,7 @@ func (q *Queries) ListPipelineRuns(ctx context.Context, arg ListPipelineRunsPara
 			&i.Fingerprints,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.ContextJson,
 		); err != nil {
 			return nil, err
 		}
@@ -422,8 +424,8 @@ const upsertPipelineRun = `-- name: UpsertPipelineRun :exec
 INSERT INTO pipeline_runs (
     id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
     loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-    created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    created_at, updated_at, context_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (id) DO UPDATE SET
     pipeline_name = excluded.pipeline_name,
     session_id = excluded.session_id,
@@ -433,6 +435,7 @@ ON CONFLICT (id) DO UPDATE SET
     loop_rounds = excluded.loop_rounds,
     config_snapshot = excluded.config_snapshot,
     fingerprints = excluded.fingerprints,
+    context_json = excluded.context_json,
     updated_at = excluded.updated_at
 `
 
@@ -450,6 +453,7 @@ type UpsertPipelineRunParams struct {
 	Fingerprints      string
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
+	ContextJson       string
 }
 
 // Pipeline runs --------------------------------------------------------------
@@ -468,6 +472,7 @@ func (q *Queries) UpsertPipelineRun(ctx context.Context, arg UpsertPipelineRunPa
 		arg.Fingerprints,
 		arg.CreatedAt,
 		arg.UpdatedAt,
+		arg.ContextJson,
 	)
 	return err
 }

--- a/backend/internal/storage/sqlite/migrations/0028_pipeline_run_context.sql
+++ b/backend/internal/storage/sqlite/migrations/0028_pipeline_run_context.sql
@@ -1,0 +1,17 @@
+-- Persist a pipeline run's RunContext (PR identity, issue id, session facts).
+-- PR #275 added RunContext to the in-memory RunState and threaded it to stage
+-- executors, but never persisted it, so a daemon restart rehydrated every run
+-- with an empty context. Per-PR loop keys (issue #270) derive from Context.PRURL,
+-- so without this column a restart collapses sibling PR runs back onto the shared
+-- session+pipeline key. Store the context as JSON; legacy rows default to '{}',
+-- which hydrates to the zero RunContext and degrades to the old key shape.
+
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE pipeline_runs ADD COLUMN context_json TEXT NOT NULL DEFAULT '{}';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE pipeline_runs DROP COLUMN context_json;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/pipeline.sql
+++ b/backend/internal/storage/sqlite/queries/pipeline.sql
@@ -30,8 +30,8 @@ DELETE FROM pipeline_definitions WHERE id = ?;
 INSERT INTO pipeline_runs (
     id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
     loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-    created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    created_at, updated_at, context_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (id) DO UPDATE SET
     pipeline_name = excluded.pipeline_name,
     session_id = excluded.session_id,
@@ -41,18 +41,19 @@ ON CONFLICT (id) DO UPDATE SET
     loop_rounds = excluded.loop_rounds,
     config_snapshot = excluded.config_snapshot,
     fingerprints = excluded.fingerprints,
+    context_json = excluded.context_json,
     updated_at = excluded.updated_at;
 
 -- name: GetPipelineRun :one
 SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
        loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at
+       created_at, updated_at, context_json
 FROM pipeline_runs WHERE id = ?;
 
 -- name: ListPipelineRuns :many
 SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
        loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at
+       created_at, updated_at, context_json
 FROM pipeline_runs
 WHERE project_id = ?
   AND (sqlc.narg('pipeline_name') IS NULL OR pipeline_name = sqlc.narg('pipeline_name'))

--- a/backend/internal/storage/sqlite/store/pipeline_hydrate.go
+++ b/backend/internal/storage/sqlite/store/pipeline_hydrate.go
@@ -30,7 +30,7 @@ func (s *Store) HydratePipelineEngineState(ctx context.Context, projectID domain
 			return pipeline.EmptyEngineState(), err
 		}
 		state.Runs[run.RunID] = run
-		key := pipeline.LoopKey(run.SessionID, run.PipelineName)
+		key := pipeline.LoopKeyFor(run.Context, run.SessionID, run.PipelineName, run.RunID)
 		if run.LoopState.IsTerminal() {
 			state.HistorySummaries[key] = append(state.HistorySummaries[key], summarizeRun(run))
 		} else {

--- a/backend/internal/storage/sqlite/store/pipeline_store.go
+++ b/backend/internal/storage/sqlite/store/pipeline_store.go
@@ -270,6 +270,14 @@ func hydrateRun(ctx context.Context, q *gen.Queries, row gen.PipelineRun) (pipel
 	if err := json.Unmarshal([]byte(row.Fingerprints), &fingerprints); err != nil {
 		return pipeline.RunState{}, fmt.Errorf("unmarshal fingerprints for run %s: %w", row.ID, err)
 	}
+	var runCtx pipeline.RunContext
+	// Legacy rows predate the column and default to '{}', which unmarshals to the
+	// zero RunContext (empty PRURL), degrading to the old session+pipeline key.
+	if row.ContextJson != "" {
+		if err := json.Unmarshal([]byte(row.ContextJson), &runCtx); err != nil {
+			return pipeline.RunState{}, fmt.Errorf("unmarshal context for run %s: %w", row.ID, err)
+		}
+	}
 
 	artRows, err := q.ListPipelineArtifactsByRun(ctx, row.ID)
 	if err != nil {
@@ -306,6 +314,7 @@ func hydrateRun(ctx context.Context, q *gen.Queries, row gen.PipelineRun) (pipel
 		SessionID:              row.SessionID,
 		PipelineConfigSnapshot: cfg,
 		HeadSHA:                row.HeadSha,
+		Context:                runCtx,
 		LoopState:              pipeline.LoopStateName(row.LoopState),
 		TerminationReason:      pipeline.RunTerminationReason(row.TerminationReason),
 		LoopRounds:             int(row.LoopRounds),
@@ -350,6 +359,10 @@ func runUpsertParams(projectID domain.ProjectID, run pipeline.RunState) (gen.Ups
 	if err != nil {
 		return gen.UpsertPipelineRunParams{}, fmt.Errorf("marshal fingerprints for run %s: %w", run.RunID, err)
 	}
+	ctxJSON, err := json.Marshal(run.Context)
+	if err != nil {
+		return gen.UpsertPipelineRunParams{}, fmt.Errorf("marshal context for run %s: %w", run.RunID, err)
+	}
 	return gen.UpsertPipelineRunParams{
 		ID:                string(run.RunID),
 		ProjectID:         projectID,
@@ -362,6 +375,7 @@ func runUpsertParams(projectID domain.ProjectID, run pipeline.RunState) (gen.Ups
 		LoopRounds:        int64(run.LoopRounds),
 		ConfigSnapshot:    string(cfg),
 		Fingerprints:      string(fpJSON),
+		ContextJson:       string(ctxJSON),
 		CreatedAt:         run.CreatedAt,
 		UpdatedAt:         run.UpdatedAt,
 	}, nil

--- a/backend/internal/storage/sqlite/store/pipeline_store_test.go
+++ b/backend/internal/storage/sqlite/store/pipeline_store_test.go
@@ -113,8 +113,12 @@ func TestPipelineRunSaveLoadRoundTrip(t *testing.T) {
 		SessionID:              "mer-1",
 		PipelineConfigSnapshot: samplePipeline("review"),
 		HeadSHA:                "abc123",
-		LoopState:              pipeline.LoopRunning,
-		LoopRounds:             2,
+		Context: pipeline.RunContext{
+			PRNumber: 42, PRURL: "https://github.com/o/r/pull/42", SourceBranch: "feat",
+			TargetBranch: "main", HeadSHA: "abc123", SessionID: "mer-1", IssueID: "iss-7",
+		},
+		LoopState:  pipeline.LoopRunning,
+		LoopRounds: 2,
 		Stages: map[string]pipeline.StageState{
 			"lint": {StageRunID: "sr-1", Status: pipeline.StageStatusRunning, Attempt: 1, StartedAt: &started},
 		},
@@ -136,6 +140,10 @@ func TestPipelineRunSaveLoadRoundTrip(t *testing.T) {
 	}
 	if got.PipelineConfigSnapshot.Stages[0].Executor.Command != "golangci-lint" {
 		t.Fatalf("config snapshot not round-tripped: %+v", got.PipelineConfigSnapshot)
+	}
+	if got.Context.PRURL != "https://github.com/o/r/pull/42" || got.Context.PRNumber != 42 ||
+		got.Context.IssueID != "iss-7" || got.Context.SourceBranch != "feat" {
+		t.Fatalf("run context not round-tripped: %+v", got.Context)
 	}
 	// Fingerprints keep insertion order (dedup+sort only happens in summaries).
 	if len(got.Fingerprints) != 2 || got.Fingerprints[0] != "fp-b" || got.Fingerprints[1] != "fp-a" {
@@ -295,6 +303,51 @@ func TestPipelineHydrateEngineState(t *testing.T) {
 	// The live run must not appear in history.
 	if _, ok := state.HistorySummaries[pipeline.LoopKey("mer-2", "review")]; ok {
 		t.Fatalf("live-only loop should have no history: %+v", state.HistorySummaries)
+	}
+}
+
+func TestPipelineHydrateRebuildsPerPRKeys(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	base := time.Now().UTC().Truncate(time.Second)
+
+	// Two live runs of one pipeline on one session, one per PR. Persisted Context
+	// carries the PR url; hydrate must key them separately so they don't collapse
+	// onto the shared session+pipeline key and clobber each other.
+	saveRun := func(id, prURL string, createdAt time.Time) {
+		run := pipeline.RunState{
+			RunID: pipeline.RunID(id), PipelineID: "pl-review", PipelineName: "review", SessionID: "mer-1",
+			PipelineConfigSnapshot: samplePipeline("review"), LoopState: pipeline.LoopRunning,
+			Context:   pipeline.RunContext{PRURL: prURL, SessionID: "mer-1"},
+			Stages:    map[string]pipeline.StageState{"lint": {StageRunID: pipeline.StageRunID("sr-" + id), Status: pipeline.StageStatusRunning}},
+			CreatedAt: createdAt,
+			UpdatedAt: createdAt,
+		}
+		if err := s.SavePipelineRun(ctx, "mer", run); err != nil {
+			t.Fatalf("save %s: %v", id, err)
+		}
+	}
+	saveRun("run-prA", "https://x/pull/1", base)
+	saveRun("run-prB", "https://x/pull/2", base.Add(time.Minute))
+
+	state, err := s.HydratePipelineEngineState(ctx, "mer")
+	if err != nil {
+		t.Fatalf("hydrate: %v", err)
+	}
+	keyA := pipeline.LoopKeyFor(pipeline.RunContext{PRURL: "https://x/pull/1"}, "mer-1", "review", "")
+	keyB := pipeline.LoopKeyFor(pipeline.RunContext{PRURL: "https://x/pull/2"}, "mer-1", "review", "")
+	if keyA == keyB {
+		t.Fatal("per-PR keys must differ")
+	}
+	if state.CurrentRunByLoop[keyA] != "run-prA" {
+		t.Fatalf("current run for PR-A = %q, want run-prA", state.CurrentRunByLoop[keyA])
+	}
+	if state.CurrentRunByLoop[keyB] != "run-prB" {
+		t.Fatalf("current run for PR-B = %q, want run-prB", state.CurrentRunByLoop[keyB])
+	}
+	if len(state.CurrentRunByLoop) != 2 {
+		t.Fatalf("want 2 distinct loop keys, got %d: %+v", len(state.CurrentRunByLoop), state.CurrentRunByLoop)
 	}
 }
 


### PR DESCRIPTION
## What

Fixes pipeline run identity so runs are isolated per PR and triggers do not
spawn duplicate or spuriously-terminated runs. Builds on #275's `RunContext`.

### Per-PR loop keys
`LoopKeyFor(ctx, sessionID, pipelineName, runID)` composes the engine loop key
from what a run actually is:
- **PR-backed** (`ctx.PRURL` set): `sessionID:pipelineName:prURL`, so sibling
  PRs on one session+pipeline run concurrently and never cancel each other.
- **manual with a session**: `sessionID:pipelineName` (unchanged).
- **manual with no session**: `run:runID`, so two unscoped manual runs of one
  pipeline no longer collide on the global `:pipelineName` key.

Used at every call site: trigger, new-SHA, config-change, exit, convergence,
resume, and hydrate. Old persisted runs without a Context degrade to the old
`sessionID:pipelineName` shape.

### NEW_SHA matching by PR
`NewSHADetected` now carries `PRURL`; the reducer looks up the PR-scoped key and
only terminates the run whose `Context.PRURL` matches (and whose HeadSHA
differs), never a sibling PR's run.

### Same-SHA trigger dedup
A non-manual trigger whose HeadSHA was already run to a **settled** outcome
(completed or stalled) is deduped, emitting a `pipeline.run.trigger_deduped`
observation. This absorbs CI flapping (pass -> fail -> pass on one SHA
re-firing `merge_ready`) and fact-only `pr.updated` churn. Manual triggers
always fire.

### Honest loopRounds
`priorRound` counts only settled history summaries. Outdated, cancelled, and
config-change terminations no longer increment the round counter, so unrelated
cancellations can't trip `loop_rounds_at_least` early.

### CONFIG_CHANGED fan-out
With per-PR keys a session+pipeline may have several in-flight runs, so
`CONFIG_CHANGED` now terminates all of them (deterministically, in RunID order).

### RunContext persistence
#275 added `RunContext` in memory but never persisted it, so a daemon restart
rehydrated every run with an empty context and collapsed per-PR keys. Added a
`context_json` column (migration `0028`) and marshal/unmarshal in the store, so
hydrate rebuilds per-PR keys after a restart. Legacy rows default to `{}`.

## Tests
New tests: two PRs run one pipeline concurrently without cancelling each other;
NEW_SHA for PR-B terminates only PR-B; merge_ready same-SHA flap creates no
second run; a different SHA still re-runs; an outdated prior run at the SHA does
not dedup; manual always fires at a deduped SHA; two unscoped manual runs
coexist; CONFIG_CHANGED terminates all PR runs; loopRounds ignores
outdated/cancelled history; RunContext round-trips through the store; hydrate
rebuilds per-PR keys from persisted Context.

`go build ./...`, `go test ./...` (pipeline + storage + integration green;
gofmt clean; `go vet` clean). The 4 `internal/cli` spawn failures (HTTP 404)
are pre-existing on `pipelines` and unrelated to this change.

Closes #270