### PR TITLE
feat(pipelines): evaluate, persist, surface, and enforce blocksMerge

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -147,6 +147,10 @@ func Run() error {
 	if resolvePipelinesEnabled(ctx, cfg, store, log) {
 		pipelineStk = startPipelineEngine(ctx, store, sessionSvc, cdcPipe.Broadcaster, log)
 		pipelinesSvc = pipelinesvc.New(store, pipelinesvc.SupervisorEngines(pipelineStk.supervisor))
+		// Let the lifecycle merge-readiness path veto a ready-to-merge PR whose
+		// latest settled pipeline run blocks merge. Only wired when pipelines are
+		// enabled, so the gate stays a no-op otherwise.
+		lcStack.LCM.SetPipelineMergeGate(pipelinesSvc)
 	}
 
 	previewDone := preview.NewPoller(store, sessionSvc, "http://"+cfg.Addr(), preview.PollerConfig{Logger: log}).Start(ctx)

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -3054,6 +3054,8 @@ components:
       type: object
     PipelineRunDetail:
       properties:
+        blocksMerge:
+          type: boolean
         createdAt:
           format: date-time
           type: string
@@ -3105,6 +3107,7 @@ components:
       - stageCount
       - stageStatuses
       - hasOpenFindings
+      - blocksMerge
       - createdAt
       - updatedAt
       - stages
@@ -3119,6 +3122,8 @@ components:
       type: object
     PipelineRunSummary:
       properties:
+        blocksMerge:
+          type: boolean
         createdAt:
           format: date-time
           type: string
@@ -3162,6 +3167,7 @@ components:
       - stageCount
       - stageStatuses
       - hasOpenFindings
+      - blocksMerge
       - createdAt
       - updatedAt
       type: object

--- a/backend/internal/httpd/controllers/pipelines.go
+++ b/backend/internal/httpd/controllers/pipelines.go
@@ -122,6 +122,7 @@ type PipelineRunSummary struct {
 	StageCount        int               `json:"stageCount"`
 	StageStatuses     map[string]string `json:"stageStatuses"`
 	HasOpenFindings   bool              `json:"hasOpenFindings"`
+	BlocksMerge       bool              `json:"blocksMerge"`
 	CreatedAt         time.Time         `json:"createdAt"`
 	UpdatedAt         time.Time         `json:"updatedAt"`
 }
@@ -499,6 +500,7 @@ func runSummary(run pipeline.RunState) PipelineRunSummary {
 		StageCount:        len(run.Stages),
 		StageStatuses:     statuses,
 		HasOpenFindings:   hasOpenFindings(run),
+		BlocksMerge:       run.BlocksMerge,
 		CreatedAt:         run.CreatedAt,
 		UpdatedAt:         run.UpdatedAt,
 	}

--- a/backend/internal/httpd/controllers/pipelines_test.go
+++ b/backend/internal/httpd/controllers/pipelines_test.go
@@ -112,6 +112,10 @@ func (f *fakePipelineService) GetArtifact(context.Context, pipeline.ArtifactID) 
 	return f.artifact, nil
 }
 
+func (f *fakePipelineService) PRBlocksMerge(context.Context, domain.ProjectID, string, string) (bool, error) {
+	return false, nil
+}
+
 func newPipelineTestServer(t *testing.T, svc pipelinesvc.Manager) *httptest.Server {
 	t.Helper()
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -130,6 +134,7 @@ func sampleRun() pipeline.RunState {
 		LoopState:    pipeline.LoopRunning,
 		LoopRounds:   1,
 		HeadSHA:      "sha1",
+		BlocksMerge:  true,
 		Stages: map[string]pipeline.StageState{
 			"review": {StageRunID: "sr-1", Status: pipeline.StageStatusRunning, Attempt: 1, Artifacts: []pipeline.ArtifactID{"a-1"}},
 		},
@@ -280,7 +285,7 @@ func TestPipelinesListRuns_HappyPassesFilter(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("status = %d body=%s", status, body)
 	}
-	if !contains(body, `"runs"`) || !contains(body, `"run-1"`) || !contains(body, `"hasOpenFindings":true`) {
+	if !contains(body, `"runs"`) || !contains(body, `"run-1"`) || !contains(body, `"hasOpenFindings":true`) || !contains(body, `"blocksMerge":true`) {
 		t.Fatalf("body missing run summary: %s", body)
 	}
 	if svc.lastFilter.PipelineName != "review" || svc.lastFilter.Status != pipeline.LoopRunning || svc.lastFilter.Limit != 5 {

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -36,6 +36,14 @@ type notificationSink interface {
 	Notify(ctx context.Context, intent ports.NotificationIntent) error
 }
 
+// pipelineMergeGate is the optional one-directional coupling to the pipelines
+// service: lifecycle asks the pipeline package whether a settled run blocks a
+// PR's merge; the pipeline package never imports lifecycle. Nil (pipelines off
+// or no manager) makes the merge-readiness gate a no-op.
+type pipelineMergeGate interface {
+	PRBlocksMerge(ctx context.Context, projectID domain.ProjectID, prURL, headSHA string) (bool, error)
+}
+
 // Option customizes a Manager.
 type Option func(*Manager)
 
@@ -58,6 +66,9 @@ type Manager struct {
 	// nudges become no-ops but the reducer still runs.
 	guard         *sessionguard.Guard
 	notifications notificationSink
+	// pipelineGate is set post-construction (SetPipelineMergeGate) only when the
+	// pipelines subsystem is enabled; nil otherwise. Guarded by mu.
+	pipelineGate pipelineMergeGate
 
 	mu        sync.Mutex
 	window    time.Duration
@@ -84,6 +95,16 @@ func New(store sessionStore, messenger ports.AgentMessenger, opts ...Option) *Ma
 		opt(m)
 	}
 	return m
+}
+
+// SetPipelineMergeGate wires the pipelines merge-readiness gate after
+// construction. The daemon calls it only when the pipelines subsystem is enabled
+// (the gate is the pipeline service); left unset, the readiness path never
+// consults pipelines. A nil gate resets to the no-op behavior.
+func (m *Manager) SetPipelineMergeGate(gate pipelineMergeGate) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pipelineGate = gate
 }
 
 func (m *Manager) mutate(ctx context.Context, id domain.SessionID, fn func(domain.SessionRecord, time.Time) (domain.SessionRecord, bool)) error {

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -1440,3 +1440,79 @@ func TestSCMObservation_ReadyToMergeSuppressedWhileWaitingInput(t *testing.T) {
 		t.Fatalf("waiting-input session emitted ready notification: %+v", sink.intents)
 	}
 }
+
+// fakeMergeGate records the merge-readiness gate call and returns a scripted
+// verdict, so the lifecycle test can assert both the suppression behavior and
+// the exact (project, prURL, headSHA) the gate is asked about.
+type fakeMergeGate struct {
+	blocked    bool
+	err        error
+	calls      int
+	gotProject domain.ProjectID
+	gotPR      string
+	gotSHA     string
+}
+
+func (f *fakeMergeGate) PRBlocksMerge(_ context.Context, p domain.ProjectID, prURL, headSHA string) (bool, error) {
+	f.calls++
+	f.gotProject, f.gotPR, f.gotSHA = p, prURL, headSHA
+	return f.blocked, f.err
+}
+
+func TestSCMObservation_PipelineMergeGate(t *testing.T) {
+	ready := ports.SCMObservation{
+		Fetched:      true,
+		PR:           ports.SCMPRObservation{URL: "https://github.com/o/r/pull/1", Number: 1, Title: "checkout", HeadSHA: "sha1"},
+		CI:           ports.SCMCIObservation{Summary: string(domain.CIPassing)},
+		Review:       ports.SCMReviewObservation{Decision: string(domain.ReviewApproved)},
+		Mergeability: ports.SCMMergeabilityObservation{State: string(domain.MergeMergeable)},
+	}
+
+	t.Run("blocking pipeline suppresses ready-to-merge", func(t *testing.T) {
+		st := newFakeStore()
+		sink := &fakeNotificationSink{}
+		m := New(st, nil, WithNotificationSink(sink))
+		gate := &fakeMergeGate{blocked: true}
+		m.SetPipelineMergeGate(gate)
+		st.sessions["mer-1"] = working("mer-1")
+
+		if err := m.ApplySCMObservation(ctx, "mer-1", ready); err != nil {
+			t.Fatal(err)
+		}
+		if len(sink.intents) != 0 {
+			t.Fatalf("blocking pipeline should suppress ready-to-merge, got %+v", sink.intents)
+		}
+		if gate.calls != 1 || gate.gotProject != "mer" || gate.gotPR != ready.PR.URL || gate.gotSHA != "sha1" {
+			t.Fatalf("gate call = %+v, want one call for (mer, %s, sha1)", gate, ready.PR.URL)
+		}
+	})
+
+	t.Run("non-blocking pipeline leaves ready-to-merge", func(t *testing.T) {
+		st := newFakeStore()
+		sink := &fakeNotificationSink{}
+		m := New(st, nil, WithNotificationSink(sink))
+		m.SetPipelineMergeGate(&fakeMergeGate{blocked: false})
+		st.sessions["mer-1"] = working("mer-1")
+
+		if err := m.ApplySCMObservation(ctx, "mer-1", ready); err != nil {
+			t.Fatal(err)
+		}
+		if len(sink.intents) != 1 || sink.intents[0].Type != domain.NotificationReadyToMerge {
+			t.Fatalf("non-blocking pipeline should keep ready-to-merge, got %+v", sink.intents)
+		}
+	})
+
+	t.Run("nil gate (pipelines off) leaves ready-to-merge", func(t *testing.T) {
+		st := newFakeStore()
+		sink := &fakeNotificationSink{}
+		m := New(st, nil, WithNotificationSink(sink))
+		st.sessions["mer-1"] = working("mer-1")
+
+		if err := m.ApplySCMObservation(ctx, "mer-1", ready); err != nil {
+			t.Fatal(err)
+		}
+		if len(sink.intents) != 1 || sink.intents[0].Type != domain.NotificationReadyToMerge {
+			t.Fatalf("nil gate should not veto ready-to-merge, got %+v", sink.intents)
+		}
+	})
+}

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -338,15 +338,35 @@ func (m *Manager) notificationIntentForCurrentSCM(ctx context.Context, id domain
 	// Serialize the session snapshot with activity transitions so ready-to-merge
 	// notifications do not race against a simultaneous waiting_input update.
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	rec, ok, err := m.store.GetSession(ctx, id)
 	if err != nil {
+		m.mu.Unlock()
 		return nil, err
 	}
 	if !ok {
+		m.mu.Unlock()
 		return nil, nil
 	}
-	return m.notificationIntentForSCM(rec, o), nil
+	intent := m.notificationIntentForSCM(rec, o)
+	gate := m.pipelineGate
+	m.mu.Unlock()
+
+	// A pipeline configured to block merge overrides an otherwise ready-to-merge
+	// PR. Consult the gate only for a ready-to-merge intent (the sole state a
+	// pipeline can veto) and outside the lock, since it does store I/O. No gate,
+	// no matching settled run, or a stale-SHA run means no opinion: the intent
+	// stands.
+	if intent != nil && intent.Type == domain.NotificationReadyToMerge && gate != nil {
+		headSHA := firstSCMNonEmpty(o.CI.HeadSHA, o.PR.HeadSHA)
+		blocked, err := gate.PRBlocksMerge(ctx, rec.ProjectID, intent.PRURL, headSHA)
+		if err != nil {
+			return nil, err
+		}
+		if blocked {
+			return nil, nil
+		}
+	}
+	return intent, nil
 }
 
 func (m *Manager) notificationIntentForSCM(rec domain.SessionRecord, o ports.SCMObservation) *ports.NotificationIntent {

--- a/backend/internal/pipeline/reducer_blocksmerge_test.go
+++ b/backend/internal/pipeline/reducer_blocksmerge_test.go
@@ -1,0 +1,101 @@
+package pipeline
+
+import "testing"
+
+func boolPtr(b bool) *bool { return &b }
+
+// blocksWhenOpenFindings is a blocksMerge predicate that fires when open findings
+// remain: not(no_open_findings). It is the natural "unresolved findings block the
+// merge" shape and is deterministic from the run's materialized findings.
+func blocksWhenOpenFindings() *ExitPredicates {
+	return &ExitPredicates{BlocksMerge: &Predicate{
+		Kind:      PredicateNot,
+		Predicate: &Predicate{Kind: PredicateNoOpenFindings},
+	}}
+}
+
+func stageWithBlockingPolicy(name string) Stage {
+	s := stageDef(name)
+	s.Policy = &StagePolicy{BlocksMerge: boolPtr(true)}
+	return s
+}
+
+func TestRunSetsBlocksMerge(t *testing.T) {
+	t.Run("blocksMerge predicate true sets BlocksMerge", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		p.ExitPredicates = blocksWhenOpenFindings()
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		// An open finding remains, so not(no_open_findings) is true.
+		state, effects := Reduce(engineWith(run), StageCompleted{
+			Now: testNow, RunID: "r1", StageName: "a", Verdict: VerdictPass,
+			Artifacts: []ArtifactInput{findingInput("x.go", "bug", "correctness", SeverityError)},
+		})
+		final := state.Runs["r1"]
+		if !final.BlocksMerge {
+			t.Fatalf("BlocksMerge = false, want true (blocksMerge predicate matched open finding)")
+		}
+		if got := observationsNamed(effects, "pipeline.run.blocks_merge"); len(got) != 1 {
+			t.Fatalf("blocks_merge observations = %d, want 1", len(got))
+		}
+	})
+
+	t.Run("blocksMerge predicate false leaves BlocksMerge unset", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		p.ExitPredicates = blocksWhenOpenFindings()
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		// No findings -> no_open_findings true -> not(...) false.
+		state, effects := Reduce(engineWith(run), StageCompleted{Now: testNow, RunID: "r1", StageName: "a"})
+		final := state.Runs["r1"]
+		if final.BlocksMerge {
+			t.Fatalf("BlocksMerge = true, want false (no open findings)")
+		}
+		if got := observationsNamed(effects, "pipeline.run.blocks_merge"); len(got) != 0 {
+			t.Fatalf("blocks_merge observations = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("finally-failed stage with blocking policy sets BlocksMerge without a predicate", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageWithBlockingPolicy("a"))
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		state, effects := Reduce(engineWith(run), StageFailed{Now: testNow, RunID: "r1", StageName: "a", ErrorMessage: "boom"})
+		final := state.Runs["r1"]
+		if final.LoopState != LoopStalled {
+			t.Fatalf("loopState = %v, want stalled", final.LoopState)
+		}
+		if !final.BlocksMerge {
+			t.Fatalf("BlocksMerge = false, want true (failed stage policy blocks merge)")
+		}
+		if got := observationsNamed(effects, "pipeline.run.blocks_merge"); len(got) != 1 {
+			t.Fatalf("blocks_merge observations = %d, want 1", len(got))
+		}
+	})
+
+	t.Run("blocking policy on a non-failed stage does not block", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageWithBlockingPolicy("a"))
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		// Stage succeeds; the policy only blocks on a finally-failed stage.
+		state, _ := Reduce(engineWith(run), StageCompleted{Now: testNow, RunID: "r1", StageName: "a", Verdict: VerdictPass})
+		if state.Runs["r1"].BlocksMerge {
+			t.Fatalf("BlocksMerge = true, want false (blocking policy stage succeeded)")
+		}
+	})
+}
+
+func TestRunBlocksMergeSupersededNeverBlocks(t *testing.T) {
+	// A run whose failed stage policy AND blocksMerge predicate would both block.
+	p := pipelineOf("p", 1, stageWithBlockingPolicy("a"))
+	p.ExitPredicates = blocksWhenOpenFindings()
+	run := runState("r1", p, map[string]StageStatus{"a": StageStatusFailed})
+	run.Findings = []Artifact{{ArtifactInput: ArtifactInput{Kind: ArtifactKindFinding}, Status: ArtifactStatusOpen, Fingerprint: "fp"}}
+
+	for _, reason := range []RunTerminationReason{TerminationOutdated, TerminationManualCancel, TerminationConfigChange} {
+		if runBlocksMerge(EmptyEngineState(), run, reason) {
+			t.Fatalf("reason %s must never block merge (run was superseded)", reason)
+		}
+	}
+	// Sanity: a genuine terminal reason with the same state does block, proving
+	// the superseded guard, not a wiring gap, is what suppresses the block.
+	if !runBlocksMerge(EmptyEngineState(), run, TerminationStageFailure) {
+		t.Fatal("stage_failure with a blocking policy stage should block merge")
+	}
+}

--- a/backend/internal/pipeline/reducer_helpers.go
+++ b/backend/internal/pipeline/reducer_helpers.go
@@ -184,6 +184,7 @@ func terminateRunFromState(state EngineState, run RunState, reason RunTerminatio
 	finalRun.Stages = terminatedStages
 	finalRun.LoopState = finalLoopState
 	finalRun.TerminationReason = reason
+	finalRun.BlocksMerge = runBlocksMerge(state, run, reason)
 	finalRun.UpdatedAt = now
 
 	key := LoopKeyFor(run.Context, run.SessionID, run.PipelineName, run.RunID)
@@ -221,7 +222,7 @@ func terminateRunFromState(state EngineState, run RunState, reason RunTerminatio
 		HistorySummaries: histories,
 	}
 
-	effects := make([]Effect, 0, len(preceding)+len(cancelEffects)+3)
+	effects := make([]Effect, 0, len(preceding)+len(cancelEffects)+4)
 	effects = append(effects, preceding...)
 	effects = append(effects, cancelEffects...)
 	effects = append(effects,
@@ -237,8 +238,52 @@ func terminateRunFromState(state EngineState, run RunState, reason RunTerminatio
 			},
 		},
 	)
+	if finalRun.BlocksMerge {
+		effects = append(effects, EmitObservation{
+			Name: "pipeline.run.blocks_merge",
+			Data: map[string]any{
+				"runId":        run.RunID,
+				"pipelineName": run.PipelineName,
+				"prUrl":        run.Context.PRURL,
+				"headSha":      run.HeadSHA,
+			},
+		})
+	}
 
 	return nextState, effects
+}
+
+// runBlocksMerge is the terminal-time merge-blocking decision for a run. Runs
+// superseded by a later run (outdated), cancelled by hand, or terminated by a
+// config change never block, since they were replaced rather than judged. For
+// every other termination, a finally-failed stage whose policy opts into
+// blocking blocks merge, and otherwise the exitPredicates.blocksMerge predicate
+// (when configured) is evaluated with the same PredicateCtx used for done and
+// stalled.
+func runBlocksMerge(state EngineState, run RunState, reason RunTerminationReason) bool {
+	switch reason {
+	case TerminationOutdated, TerminationManualCancel, TerminationConfigChange:
+		return false
+	}
+	for _, stage := range run.PipelineConfigSnapshot.Stages {
+		st, ok := run.Stages[stage.Name]
+		if !ok || st.Status != StageStatusFailed {
+			continue
+		}
+		if stage.Policy != nil && stage.Policy.BlocksMerge != nil && *stage.Policy.BlocksMerge {
+			return true
+		}
+	}
+	exits := run.PipelineConfigSnapshot.ExitPredicates
+	if exits == nil || exits.BlocksMerge == nil {
+		return false
+	}
+	ctx := PredicateCtx{
+		Run:      &run,
+		History:  state.HistorySummaries[LoopKeyFor(run.Context, run.SessionID, run.PipelineName, run.RunID)],
+		Findings: run.Findings,
+	}
+	return Evaluate(*exits.BlocksMerge, ctx)
 }
 
 // terminateRun is terminateRunFromState with no preceding effects.

--- a/backend/internal/pipeline/types.go
+++ b/backend/internal/pipeline/types.go
@@ -616,6 +616,15 @@ type RunState struct {
 	TerminationReason RunTerminationReason `json:"terminationReason,omitempty"`
 	LoopRounds        int                  `json:"loopRounds"`
 
+	// BlocksMerge is the terminal-time decision of whether this run blocks the
+	// PR from merging. It is evaluated once, when the run reaches a terminal
+	// loop state (see terminateRunFromState): true when a finally-failed stage's
+	// policy opts into blocking, or the exitPredicates.blocksMerge predicate is
+	// true. Runs superseded by an outdated/cancel/config-change termination never
+	// block. The lifecycle merge-readiness path consults this on the most recent
+	// settled run matching the PR (by URL + head SHA).
+	BlocksMerge bool `json:"blocksMerge,omitempty"`
+
 	// Stages is keyed by stage name. v1 has at most one entry per stage.
 	Stages map[string]StageState `json:"stages"`
 

--- a/backend/internal/service/pipeline/pipeline.go
+++ b/backend/internal/service/pipeline/pipeline.go
@@ -39,6 +39,7 @@ type Store interface {
 
 	ListPipelineRuns(ctx context.Context, projectID domain.ProjectID, filter pipeline.RunFilter) ([]pipeline.RunState, error)
 	GetPipelineRun(ctx context.Context, id pipeline.RunID) (pipeline.RunState, bool, error)
+	LatestSettledPipelineRunByPR(ctx context.Context, projectID domain.ProjectID, prURL string) (pipeline.RunState, bool, error)
 	GetPipelineArtifact(ctx context.Context, id pipeline.ArtifactID) (pipeline.Artifact, bool, error)
 }
 
@@ -99,6 +100,13 @@ type Manager interface {
 	ResumeRun(ctx context.Context, projectID domain.ProjectID, id pipeline.RunID) (pipeline.RunState, error)
 	TriggerRun(ctx context.Context, projectID domain.ProjectID, in TriggerInput) (pipeline.RunID, error)
 	GetArtifact(ctx context.Context, id pipeline.ArtifactID) (pipeline.Artifact, error)
+
+	// PRBlocksMerge reports whether the most recent settled pipeline run for a
+	// PR blocks it from merging. It is the read side of the lifecycle
+	// merge-readiness gate. It returns false (no opinion) when the PR has no
+	// settled run, the latest settled run's head SHA is stale relative to the
+	// PR's current head, or either argument is empty.
+	PRBlocksMerge(ctx context.Context, projectID domain.ProjectID, prURL, headSHA string) (bool, error)
 }
 
 // Service is the concrete Manager over a Store + Engines.
@@ -392,6 +400,25 @@ func (s *Service) resolveDefinition(ctx context.Context, projectID domain.Projec
 	}
 	return pipeline.Definition{}, apierr.NotFound("PIPELINE_NOT_FOUND",
 		fmt.Sprintf("no pipeline definition %q in this project", ref))
+}
+
+// PRBlocksMerge implements the merge-readiness gate. It looks up the most recent
+// settled run for the PR and blocks only when that run is fresh (its head SHA
+// equals the PR's current head) and its terminal decision was BlocksMerge. Any
+// other case, no settled run, a stale-SHA run, or empty arguments, is treated as
+// no opinion (false) so pipelines never fabricate a block.
+func (s *Service) PRBlocksMerge(ctx context.Context, projectID domain.ProjectID, prURL, headSHA string) (bool, error) {
+	if prURL == "" || headSHA == "" {
+		return false, nil
+	}
+	run, ok, err := s.store.LatestSettledPipelineRunByPR(ctx, projectID, prURL)
+	if err != nil || !ok {
+		return false, err
+	}
+	if run.HeadSHA != headSHA {
+		return false, nil
+	}
+	return run.BlocksMerge, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/service/pipeline/pipeline_test.go
+++ b/backend/internal/service/pipeline/pipeline_test.go
@@ -349,3 +349,55 @@ func TestTriggerUnknownRefNotFound(t *testing.T) {
 		t.Fatalf("err = %v, want not-found apierr", err)
 	}
 }
+
+// TestPRBlocksMerge covers the merge-readiness gate: it blocks only when the
+// latest settled run for the PR is fresh (its head SHA matches the PR head) and
+// its terminal decision was BlocksMerge; a stale-SHA run, no settled run, a
+// newer clearing run, or empty inputs are all no opinion.
+func TestPRBlocksMerge(t *testing.T) {
+	ctx := context.Background()
+	svc, _, store, _ := newHarness(t)
+	const prURL = "https://github.com/o/r/pull/9"
+	base := time.Now().UTC().Truncate(time.Second)
+
+	save := func(id string, state pipeline.LoopStateName, headSHA string, blocks bool, at time.Time) {
+		run := pipeline.RunState{
+			RunID: pipeline.RunID(id), PipelineID: "pl-review", PipelineName: "review", SessionID: "mer-1",
+			HeadSHA: headSHA, Context: pipeline.RunContext{PRURL: prURL, HeadSHA: headSHA},
+			LoopState: state, BlocksMerge: blocks, Stages: map[string]pipeline.StageState{},
+			CreatedAt: at, UpdatedAt: at,
+		}
+		if err := store.SavePipelineRun(ctx, "mer", run); err != nil {
+			t.Fatalf("save %s: %v", id, err)
+		}
+	}
+	check := func(headSHA string, want bool) {
+		t.Helper()
+		got, err := svc.PRBlocksMerge(ctx, "mer", prURL, headSHA)
+		if err != nil {
+			t.Fatalf("PRBlocksMerge: %v", err)
+		}
+		if got != want {
+			t.Fatalf("PRBlocksMerge(sha=%s) = %v, want %v", headSHA, got, want)
+		}
+	}
+
+	// No settled run yet: no opinion.
+	check("sha1", false)
+
+	// Latest settled run blocks on sha1.
+	save("r1", pipeline.LoopStalled, "sha1", true, base)
+	check("sha1", true)
+	// Same blocking run, but the PR has advanced to sha2: stale decision, no opinion.
+	check("sha2", false)
+
+	// A newer settled run on sha2 that does not block clears the veto.
+	save("r2", pipeline.LoopDone, "sha2", false, base.Add(time.Minute))
+	check("sha2", false)
+
+	// Empty inputs are always no opinion.
+	check("", false)
+	if got, _ := svc.PRBlocksMerge(ctx, "mer", "", "sha1"); got {
+		t.Fatal("empty prURL should be no opinion")
+	}
+}

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -167,6 +167,7 @@ type PipelineRun struct {
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
 	ContextJson       string
+	BlocksMerge       int64
 }
 
 type PipelineStageRun struct {

--- a/backend/internal/storage/sqlite/gen/pipeline.sql.go
+++ b/backend/internal/storage/sqlite/gen/pipeline.sql.go
@@ -55,6 +55,50 @@ func (q *Queries) DeletePipelineDefinition(ctx context.Context, id string) (int6
 	return result.RowsAffected()
 }
 
+const getLatestSettledPipelineRunByPR = `-- name: GetLatestSettledPipelineRunByPR :one
+SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
+       loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
+       created_at, updated_at, context_json, blocks_merge
+FROM pipeline_runs
+WHERE project_id = ?
+  AND json_extract(context_json, '$.prUrl') = ?2
+  AND loop_state IN ('done', 'stalled')
+ORDER BY created_at DESC, id DESC
+LIMIT 1
+`
+
+type GetLatestSettledPipelineRunByPRParams struct {
+	ProjectID domain.ProjectID
+	PRURL     string
+}
+
+// Latest settled (done or stalled) run for a PR, matched by the RunContext PR
+// URL stored in context_json. The lifecycle merge-readiness path compares the
+// returned run's head SHA against the PR's current head to decide whether the
+// decision is fresh; a stale-SHA run is treated as no opinion by the caller.
+func (q *Queries) GetLatestSettledPipelineRunByPR(ctx context.Context, arg GetLatestSettledPipelineRunByPRParams) (PipelineRun, error) {
+	row := q.db.QueryRowContext(ctx, getLatestSettledPipelineRunByPR, arg.ProjectID, arg.PRURL)
+	var i PipelineRun
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.PipelineID,
+		&i.PipelineName,
+		&i.SessionID,
+		&i.HeadSha,
+		&i.LoopState,
+		&i.TerminationReason,
+		&i.LoopRounds,
+		&i.ConfigSnapshot,
+		&i.Fingerprints,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ContextJson,
+		&i.BlocksMerge,
+	)
+	return i, err
+}
+
 const getPipelineArtifact = `-- name: GetPipelineArtifact :one
 SELECT id, pipeline_run_id, project_id, stage_run_id, stage_name, kind,
        fingerprint, status, sent_to_agent_at, payload, created_at
@@ -128,7 +172,7 @@ func (q *Queries) GetPipelineDefinitionByName(ctx context.Context, arg GetPipeli
 const getPipelineRun = `-- name: GetPipelineRun :one
 SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
        loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at, context_json
+       created_at, updated_at, context_json, blocks_merge
 FROM pipeline_runs WHERE id = ?
 `
 
@@ -150,6 +194,7 @@ func (q *Queries) GetPipelineRun(ctx context.Context, id string) (PipelineRun, e
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.ContextJson,
+		&i.BlocksMerge,
 	)
 	return i, err
 }
@@ -274,7 +319,7 @@ func (q *Queries) ListPipelineDefinitions(ctx context.Context, projectID domain.
 const listPipelineRuns = `-- name: ListPipelineRuns :many
 SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
        loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at, context_json
+       created_at, updated_at, context_json, blocks_merge
 FROM pipeline_runs
 WHERE project_id = ?
   AND (?2 IS NULL OR pipeline_name = ?2)
@@ -319,6 +364,7 @@ func (q *Queries) ListPipelineRuns(ctx context.Context, arg ListPipelineRunsPara
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.ContextJson,
+			&i.BlocksMerge,
 		); err != nil {
 			return nil, err
 		}
@@ -424,8 +470,8 @@ const upsertPipelineRun = `-- name: UpsertPipelineRun :exec
 INSERT INTO pipeline_runs (
     id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
     loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-    created_at, updated_at, context_json
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    created_at, updated_at, context_json, blocks_merge
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (id) DO UPDATE SET
     pipeline_name = excluded.pipeline_name,
     session_id = excluded.session_id,
@@ -436,6 +482,7 @@ ON CONFLICT (id) DO UPDATE SET
     config_snapshot = excluded.config_snapshot,
     fingerprints = excluded.fingerprints,
     context_json = excluded.context_json,
+    blocks_merge = excluded.blocks_merge,
     updated_at = excluded.updated_at
 `
 
@@ -454,6 +501,7 @@ type UpsertPipelineRunParams struct {
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
 	ContextJson       string
+	BlocksMerge       int64
 }
 
 // Pipeline runs --------------------------------------------------------------
@@ -473,6 +521,7 @@ func (q *Queries) UpsertPipelineRun(ctx context.Context, arg UpsertPipelineRunPa
 		arg.CreatedAt,
 		arg.UpdatedAt,
 		arg.ContextJson,
+		arg.BlocksMerge,
 	)
 	return err
 }

--- a/backend/internal/storage/sqlite/migrations/0029_pipeline_run_blocks_merge.sql
+++ b/backend/internal/storage/sqlite/migrations/0029_pipeline_run_blocks_merge.sql
@@ -1,0 +1,16 @@
+-- Persist a pipeline run's terminal merge-blocking decision. ExitPredicates
+-- .BlocksMerge and StagePolicy.BlocksMerge were parsed and editable but never
+-- evaluated, stored, or consumed. The reducer now sets RunState.BlocksMerge when
+-- a run reaches a terminal loop state, and the lifecycle merge-readiness path
+-- consults the most recent settled run for a PR. Store it as an integer bool;
+-- legacy rows default to 0 (does not block), which is the safe no-opinion value.
+
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE pipeline_runs ADD COLUMN blocks_merge INTEGER NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE pipeline_runs DROP COLUMN blocks_merge;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/pipeline.sql
+++ b/backend/internal/storage/sqlite/queries/pipeline.sql
@@ -30,8 +30,8 @@ DELETE FROM pipeline_definitions WHERE id = ?;
 INSERT INTO pipeline_runs (
     id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
     loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-    created_at, updated_at, context_json
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    created_at, updated_at, context_json, blocks_merge
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (id) DO UPDATE SET
     pipeline_name = excluded.pipeline_name,
     session_id = excluded.session_id,
@@ -42,24 +42,40 @@ ON CONFLICT (id) DO UPDATE SET
     config_snapshot = excluded.config_snapshot,
     fingerprints = excluded.fingerprints,
     context_json = excluded.context_json,
+    blocks_merge = excluded.blocks_merge,
     updated_at = excluded.updated_at;
 
 -- name: GetPipelineRun :one
 SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
        loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at, context_json
+       created_at, updated_at, context_json, blocks_merge
 FROM pipeline_runs WHERE id = ?;
 
 -- name: ListPipelineRuns :many
 SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
        loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at, context_json
+       created_at, updated_at, context_json, blocks_merge
 FROM pipeline_runs
 WHERE project_id = ?
   AND (sqlc.narg('pipeline_name') IS NULL OR pipeline_name = sqlc.narg('pipeline_name'))
   AND (sqlc.narg('loop_state') IS NULL OR loop_state = sqlc.narg('loop_state'))
 ORDER BY created_at DESC, id DESC
 LIMIT sqlc.arg('lim');
+
+-- name: GetLatestSettledPipelineRunByPR :one
+-- Latest settled (done or stalled) run for a PR, matched by the RunContext PR
+-- URL stored in context_json. The lifecycle merge-readiness path compares the
+-- returned run's head SHA against the PR's current head to decide whether the
+-- decision is fresh; a stale-SHA run is treated as no opinion by the caller.
+SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
+       loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
+       created_at, updated_at, context_json, blocks_merge
+FROM pipeline_runs
+WHERE project_id = ?
+  AND json_extract(context_json, '$.prUrl') = sqlc.arg('pr_url')
+  AND loop_state IN ('done', 'stalled')
+ORDER BY created_at DESC, id DESC
+LIMIT 1;
 
 -- Pipeline stage runs --------------------------------------------------------
 

--- a/backend/internal/storage/sqlite/store/pipeline_store.go
+++ b/backend/internal/storage/sqlite/store/pipeline_store.go
@@ -193,6 +193,29 @@ func (s *Store) ListPipelineRuns(ctx context.Context, projectID domain.ProjectID
 	return out, nil
 }
 
+// LatestSettledPipelineRunByPR returns the most recent settled (done or stalled)
+// run for a PR, matched by the RunContext PR URL. The run is fully reconstructed.
+// It is the read side of the lifecycle merge-readiness gate: the caller compares
+// the run's head SHA against the PR's current head and consults BlocksMerge. No
+// settled run for the PR returns (zero, false, nil).
+func (s *Store) LatestSettledPipelineRunByPR(ctx context.Context, projectID domain.ProjectID, prURL string) (pipeline.RunState, bool, error) {
+	if prURL == "" {
+		return pipeline.RunState{}, false, nil
+	}
+	row, err := s.qr.GetLatestSettledPipelineRunByPR(ctx, gen.GetLatestSettledPipelineRunByPRParams{ProjectID: projectID, PRURL: prURL})
+	if errors.Is(err, sql.ErrNoRows) {
+		return pipeline.RunState{}, false, nil
+	}
+	if err != nil {
+		return pipeline.RunState{}, false, fmt.Errorf("latest settled pipeline run for %s: %w", prURL, err)
+	}
+	run, err := hydrateRun(ctx, s.qr, row)
+	if err != nil {
+		return pipeline.RunState{}, false, err
+	}
+	return run, true, nil
+}
+
 // ---------------------------------------------------------------------------
 // Artifacts
 // ---------------------------------------------------------------------------
@@ -318,6 +341,7 @@ func hydrateRun(ctx context.Context, q *gen.Queries, row gen.PipelineRun) (pipel
 		LoopState:              pipeline.LoopStateName(row.LoopState),
 		TerminationReason:      pipeline.RunTerminationReason(row.TerminationReason),
 		LoopRounds:             int(row.LoopRounds),
+		BlocksMerge:            row.BlocksMerge != 0,
 		Stages:                 stages,
 		Findings:               findings,
 		Fingerprints:           fingerprints,
@@ -376,9 +400,18 @@ func runUpsertParams(projectID domain.ProjectID, run pipeline.RunState) (gen.Ups
 		ConfigSnapshot:    string(cfg),
 		Fingerprints:      string(fpJSON),
 		ContextJson:       string(ctxJSON),
+		BlocksMerge:       boolToInt64(run.BlocksMerge),
 		CreatedAt:         run.CreatedAt,
 		UpdatedAt:         run.UpdatedAt,
 	}, nil
+}
+
+// boolToInt64 maps a Go bool onto the SQLite integer-bool column convention.
+func boolToInt64(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 func stageUpsertParams(projectID domain.ProjectID, runID, stageName string, st pipeline.StageState) gen.UpsertPipelineStageRunParams {

--- a/backend/internal/storage/sqlite/store/pipeline_store_test.go
+++ b/backend/internal/storage/sqlite/store/pipeline_store_test.go
@@ -390,6 +390,64 @@ func TestPipelineRunListFilterAndOrder(t *testing.T) {
 	}
 }
 
+// TestPipelineRunBlocksMergePersistAndQuery covers the BlocksMerge persist +
+// hydrate round-trip and the LatestSettledPipelineRunByPR readiness query: it
+// returns the newest SETTLED run for a PR (ignoring running runs and other PRs),
+// so a newer settled run clears an older block.
+func TestPipelineRunBlocksMergePersistAndQuery(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	base := time.Now().UTC().Truncate(time.Second)
+	const prURL = "https://github.com/o/r/pull/7"
+
+	mk := func(id string, state pipeline.LoopStateName, prURLVal, headSHA string, blocks bool, createdAt time.Time) {
+		run := pipeline.RunState{
+			RunID: pipeline.RunID(id), PipelineID: "pl-review", PipelineName: "review", SessionID: "mer-1",
+			PipelineConfigSnapshot: samplePipeline("review"),
+			HeadSHA:                headSHA,
+			Context:                pipeline.RunContext{PRURL: prURLVal, HeadSHA: headSHA},
+			LoopState:              state,
+			BlocksMerge:            blocks,
+			Stages:                 map[string]pipeline.StageState{},
+			CreatedAt:              createdAt, UpdatedAt: createdAt,
+		}
+		if err := s.SavePipelineRun(ctx, "mer", run); err != nil {
+			t.Fatalf("save %s: %v", id, err)
+		}
+	}
+
+	// Oldest settled run for the PR blocks merge on sha1.
+	mk("r1", pipeline.LoopStalled, prURL, "sha1", true, base)
+	// Round-trip the BlocksMerge bit through the store.
+	if got, ok, err := s.GetPipelineRun(ctx, "r1"); err != nil || !ok || !got.BlocksMerge {
+		t.Fatalf("BlocksMerge round-trip: ok=%v err=%v blocks=%v", ok, err, got.BlocksMerge)
+	}
+
+	latest, ok, err := s.LatestSettledPipelineRunByPR(ctx, "mer", prURL)
+	if err != nil || !ok || latest.RunID != "r1" || !latest.BlocksMerge {
+		t.Fatalf("latest settled = %s ok=%v err=%v blocks=%v, want r1/true", latest.RunID, ok, err, latest.BlocksMerge)
+	}
+
+	// A running run on a newer SHA is not settled and must be ignored.
+	mk("r2", pipeline.LoopRunning, prURL, "sha2", false, base.Add(time.Minute))
+	if latest, _, _ := s.LatestSettledPipelineRunByPR(ctx, "mer", prURL); latest.RunID != "r1" {
+		t.Fatalf("running run leaked into settled query: got %s", latest.RunID)
+	}
+
+	// A newer SETTLED run that does not block clears the block.
+	mk("r3", pipeline.LoopDone, prURL, "sha2", false, base.Add(2*time.Minute))
+	latest, ok, err = s.LatestSettledPipelineRunByPR(ctx, "mer", prURL)
+	if err != nil || !ok || latest.RunID != "r3" || latest.BlocksMerge {
+		t.Fatalf("newest settled = %s blocks=%v, want r3/false", latest.RunID, latest.BlocksMerge)
+	}
+
+	// A different PR with no settled run returns no opinion.
+	if _, ok, _ := s.LatestSettledPipelineRunByPR(ctx, "mer", "https://github.com/o/r/pull/999"); ok {
+		t.Fatal("unknown PR should have no settled run")
+	}
+}
+
 func runIDs(runs []pipeline.RunState) []pipeline.RunID {
 	out := make([]pipeline.RunID, 0, len(runs))
 	for _, r := range runs {

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1111,6 +1111,7 @@ export interface components {
             yamlSource: string;
         };
         PipelineRunDetail: {
+            blocksMerge: boolean;
             /** Format: date-time */
             createdAt: string;
             findings: components["schemas"]["PipelineArtifact"][];
@@ -1135,6 +1136,7 @@ export interface components {
             run: components["schemas"]["PipelineRunDetail"];
         };
         PipelineRunSummary: {
+            blocksMerge: boolean;
             /** Format: date-time */
             createdAt: string;
             hasOpenFindings: boolean;

--- a/frontend/src/renderer/components/PipelineRunCard.tsx
+++ b/frontend/src/renderer/components/PipelineRunCard.tsx
@@ -2,6 +2,7 @@ import { cn } from "../lib/utils";
 import { formatTimeCompact } from "../lib/format-time";
 import { loopStateTone, shortSha, stageStatusDotTone } from "../lib/pipeline-display";
 import type { PipelineRunSummary } from "../hooks/usePipelineRuns";
+import { Badge } from "./ui/badge";
 
 // Card view of a single pipeline run in a Kanban column: pipeline name, run id,
 // session, loop rounds, per-stage status dots, artifact/findings hint, and a
@@ -20,6 +21,11 @@ export function PipelineRunCard({ run, onOpen }: { run: PipelineRunSummary; onOp
 		>
 			<div className="flex items-baseline gap-2">
 				<span className="truncate font-mono text-caption font-semibold text-foreground">{run.pipelineName}</span>
+				{run.blocksMerge && (
+					<Badge variant="error" className="shrink-0">
+						Blocks merge
+					</Badge>
+				)}
 				<span className={cn("ml-auto text-micro font-medium", loopStateTone(run.loopState))}>
 					rounds {run.loopRounds}
 				</span>

--- a/frontend/src/renderer/components/PipelineRunDetail.test.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.test.tsx
@@ -55,6 +55,7 @@ function detail(overrides: Partial<RunDetail>): RunDetail {
 		stageCount: 1,
 		stageStatuses: { review: "running" },
 		hasOpenFindings: false,
+		blocksMerge: false,
 		findings: [],
 		stages: [],
 		createdAt: "2026-07-15T00:00:00Z",

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -75,6 +75,7 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 						<h1 className="truncate text-subtitle font-bold tracking-tight text-foreground">{run.pipelineName}</h1>
 						<span className={cn("text-caption font-semibold", loopStateTone(run.loopState))}>{run.loopState}</span>
 						{run.terminationReason && <span className="text-caption text-passive">· {run.terminationReason}</span>}
+						{run.blocksMerge && <Badge variant="error">Blocks merge</Badge>}
 					</div>
 					<p className="mt-0.5 truncate font-mono text-micro text-passive">
 						{run.runId} · session {run.sessionId || "—"} · {shortSha(run.headSha)} · {run.loopRounds} round

--- a/frontend/src/renderer/components/PipelineWorkbench.test.tsx
+++ b/frontend/src/renderer/components/PipelineWorkbench.test.tsx
@@ -23,6 +23,7 @@ function run(overrides: Partial<PipelineRunSummary> & { runId: string }): Pipeli
 		stageCount: 2,
 		stageStatuses: { lint: "succeeded", test: "running" },
 		hasOpenFindings: false,
+		blocksMerge: false,
 		createdAt: "2026-07-15T00:00:00Z",
 		updatedAt: "2026-07-15T00:00:00Z",
 		projectId: "proj-1",


### PR DESCRIPTION
## What

Makes `blocksMerge` a real merge gate. Previously `ExitPredicates.BlocksMerge` and `StagePolicy.BlocksMerge` were parsed, validated, and editable but never evaluated, stored, or consumed, so the published merge-gate sample gated nothing.

Closes #273

## Changes

1. **Evaluate at termination** (`reducer_helpers.go`): `terminateRunFromState` sets `RunState.BlocksMerge`. A finally-failed stage whose `Policy.BlocksMerge == true` blocks regardless of the predicate; otherwise `exitPredicates.blocksMerge` is evaluated with the same `PredicateCtx` used for done/stalled. Runs superseded by `outdated`, `manual_cancel`, or `config_change` never block. A `pipeline.run.blocks_merge` observation is emitted when a run blocks.
2. **Persist + expose**: migration `0029` adds `pipeline_runs.blocks_merge`, sqlc regen, store upsert/hydrate, and `blocksMerge` on the run summary/detail DTOs. OpenAPI + `schema.ts` regenerated.
3. **Surface**: a destructive-variant "Blocks merge" badge on the kanban run card and in run detail (those two components only).
4. **Enforce** (`lifecycle/reactions.go`): before declaring a PR ready-to-merge, lifecycle asks the pipeline service for the most recent settled (done/stalled) run matching the PR by `Context.PRURL` and current head SHA. If that run `BlocksMerge`, the ready-to-merge notification is suppressed. No matching run, no settled run, a stale-SHA run, disabled pipelines, or a nil gate all mean no opinion. Coupling is one-directional (a `LatestSettledPipelineRunByPR` store query + a `PRBlocksMerge` service method behind an interface); the pipeline package does not import lifecycle. The gate is wired only when `AO_PIPELINES` is on.

## Tests

- Reducer: predicate-true sets `BlocksMerge`; predicate-false does not; policy-failed-stage sets it without a predicate; superseded terminations never block; observation emitted.
- Store: persist + hydrate round-trip; `LatestSettledPipelineRunByPR` returns newest settled run per PR, ignoring running runs and other PRs.
- Service: blocks on fresh same-SHA settled run; no opinion on stale SHA / no run / empty inputs.
- Lifecycle: ready-to-merge suppressed when the gate blocks; stands when it does not; stands with a nil gate.
- Controller: DTO exposes `blocksMerge`.

## Verification

`go build ./...`, `go test ./...` (backend, minus pre-existing-flaky `internal/cli` spawn tests that fail identically on base), gofmt clean, golangci-lint clean. Frontend typecheck clean, prettier clean, component vitest green.