### PR TITLE
feat(pipelines): findings lifecycle (status records, upstream findings in prompts, dismiss API+UI)

### DIFF
--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2653,7 +2653,7 @@ components:
     ControllersUpdatePipelineArtifactStatusRequest:
       properties:
         status:
-          description: 'New artifact status: open | dismissed | sent_to_agent | resolved.'
+          description: 'New artifact status: open | resolved | dismissed.'
           type: string
       required:
       - status

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -933,6 +933,70 @@ paths:
       summary: Fetch one pipeline run artifact by id
       tags:
       - pipelines
+  /api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status:
+    post:
+      operationId: updatePipelineArtifactStatus
+      parameters:
+      - description: Pipeline run identifier.
+        in: path
+        name: runId
+        required: true
+        schema:
+          description: Pipeline run identifier.
+          type: string
+      - description: Artifact identifier.
+        in: path
+        name: artifactId
+        required: true
+        schema:
+          description: Artifact identifier.
+          type: string
+      - description: Project id the pipeline belongs to (required).
+        in: query
+        name: project
+        schema:
+          description: Project id the pipeline belongs to (required).
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ControllersUpdatePipelineArtifactStatusRequest'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PipelineArtifactResponse'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Bad Request
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Change a pipeline finding's lifecycle status (dismiss, reopen, resolve)
+      tags:
+      - pipelines
   /api/v1/pipelines/runs/{runId}/cancel:
     post:
       operationId: cancelPipelineRun
@@ -2585,6 +2649,14 @@ components:
       - updatedAt
       - status
       - prs
+      type: object
+    ControllersUpdatePipelineArtifactStatusRequest:
+      properties:
+        status:
+          description: 'New artifact status: open | dismissed | sent_to_agent | resolved.'
+          type: string
+      required:
+      - status
       type: object
     DegradedProject:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -490,6 +490,19 @@ func pipelineOperations() []operation {
 			},
 		},
 		{
+			method: http.MethodPost, path: "/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status", id: "updatePipelineArtifactStatus", tag: "pipelines",
+			summary:    "Change a pipeline finding's lifecycle status (dismiss, reopen, resolve)",
+			pathParams: []any{controllers.PipelineArtifactIDParam{}, controllers.PipelineProjectQuery{}},
+			reqBody:    controllers.UpdatePipelineArtifactStatusRequest{},
+			resps: []respUnit{
+				{http.StatusOK, controllers.PipelineArtifactResponse{}},
+				{http.StatusBadRequest, envelope.APIError{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+		{
 			method: http.MethodPut, path: "/api/v1/pipelines/{id}", id: "updatePipelineDefinition", tag: "pipelines",
 			summary:    "Update a pipeline definition's YAML",
 			pathParams: []any{controllers.PipelineIDParam{}},

--- a/backend/internal/httpd/controllers/pipelines.go
+++ b/backend/internal/httpd/controllers/pipelines.go
@@ -186,7 +186,7 @@ type PipelineArtifactResponse struct {
 // the new lifecycle status for one finding (e.g. "dismissed" to hide a false
 // positive, "open" to reopen it).
 type UpdatePipelineArtifactStatusRequest struct {
-	Status string `json:"status" description:"New artifact status: open | dismissed | sent_to_agent | resolved."`
+	Status string `json:"status" description:"New artifact status: open | resolved | dismissed."`
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/httpd/controllers/pipelines.go
+++ b/backend/internal/httpd/controllers/pipelines.go
@@ -176,9 +176,17 @@ type TriggerPipelineRunResponse struct {
 	RunID string `json:"runId"`
 }
 
-// PipelineArtifactResponse is the body of the artifact-fetch route.
+// PipelineArtifactResponse is the body of the artifact-fetch and
+// artifact-status routes.
 type PipelineArtifactResponse struct {
 	Artifact pipeline.Artifact `json:"artifact"`
+}
+
+// UpdatePipelineArtifactStatusRequest is the body of the artifact-status route:
+// the new lifecycle status for one finding (e.g. "dismissed" to hide a false
+// positive, "open" to reopen it).
+type UpdatePipelineArtifactStatusRequest struct {
+	Status string `json:"status" description:"New artifact status: open | dismissed | sent_to_agent | resolved."`
 }
 
 // ---------------------------------------------------------------------------
@@ -205,6 +213,7 @@ func (c *PipelinesController) Register(r chi.Router) {
 	r.Post("/pipelines/runs/{runId}/cancel", c.cancelRun)
 	r.Post("/pipelines/runs/{runId}/resume", c.resumeRun)
 	r.Get("/pipelines/runs/{runId}/artifacts/{artifactId}", c.getArtifact)
+	r.Post("/pipelines/runs/{runId}/artifacts/{artifactId}/status", c.updateArtifactStatus)
 
 	r.Put("/pipelines/{id}", c.updateDefinition)
 	r.Delete("/pipelines/{id}", c.deleteDefinition)
@@ -432,6 +441,34 @@ func (c *PipelinesController) getArtifact(w http.ResponseWriter, r *http.Request
 		return
 	}
 	art, err := c.Svc.GetArtifact(r.Context(), pipeline.ArtifactID(chi.URLParam(r, "artifactId")))
+	if err != nil {
+		writePipelineError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, PipelineArtifactResponse{Artifact: art})
+}
+
+// updateArtifactStatus changes one finding's lifecycle status (dismiss / reopen /
+// resolve) on a run. Project-scoped like the other lifecycle routes so the
+// service can reach the project engine. A nil Svc returns 501.
+func (c *PipelinesController) updateArtifactStatus(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "POST", "/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status")
+		return
+	}
+	projectID, ok := requireProject(w, r)
+	if !ok {
+		return
+	}
+	var in UpdatePipelineArtifactStatusRequest
+	if err := decodeJSONStrict(r, &in); err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
+		return
+	}
+	art, err := c.Svc.UpdateArtifactStatus(r.Context(), projectID,
+		pipeline.RunID(chi.URLParam(r, "runId")),
+		pipeline.ArtifactID(chi.URLParam(r, "artifactId")),
+		pipeline.ArtifactStatus(in.Status))
 	if err != nil {
 		writePipelineError(w, r, err)
 		return

--- a/backend/internal/httpd/controllers/pipelines_test.go
+++ b/backend/internal/httpd/controllers/pipelines_test.go
@@ -38,9 +38,11 @@ type fakePipelineService struct {
 	getRunErr, cancelErr, resumeErr error
 	triggerErr, artifactErr         error
 	validateErr                     error
+	statusErr                       error
 
-	lastTrigger pipelinesvc.TriggerInput
-	lastFilter  pipeline.RunFilter
+	lastTrigger      pipelinesvc.TriggerInput
+	lastFilter       pipeline.RunFilter
+	lastStatusChange pipeline.ArtifactStatus
 }
 
 func (f *fakePipelineService) ListDefinitions(context.Context, domain.ProjectID) ([]pipeline.Definition, error) {
@@ -114,6 +116,14 @@ func (f *fakePipelineService) GetArtifact(context.Context, pipeline.ArtifactID) 
 
 func (f *fakePipelineService) PRBlocksMerge(context.Context, domain.ProjectID, string, string) (bool, error) {
 	return false, nil
+}
+
+func (f *fakePipelineService) UpdateArtifactStatus(_ context.Context, _ domain.ProjectID, _ pipeline.RunID, _ pipeline.ArtifactID, status pipeline.ArtifactStatus) (pipeline.Artifact, error) {
+	f.lastStatusChange = status
+	if f.statusErr != nil {
+		return pipeline.Artifact{}, f.statusErr
+	}
+	return f.artifact, nil
 }
 
 func newPipelineTestServer(t *testing.T, svc pipelinesvc.Manager) *httptest.Server {
@@ -368,6 +378,47 @@ func TestPipelinesGetArtifact_HappyAndNotFound(t *testing.T) {
 	assertErrorCode(t, body, status, http.StatusNotFound, "PIPELINE_ARTIFACT_NOT_FOUND")
 }
 
+func TestPipelinesUpdateArtifactStatus_HappyBadAndUnknown(t *testing.T) {
+	art := pipeline.Artifact{
+		ArtifactInput: pipeline.ArtifactInput{Kind: pipeline.ArtifactKindFinding, Title: "leak"},
+		ArtifactID:    "a-7", Status: pipeline.ArtifactStatusDismissed,
+	}
+	fake := &fakePipelineService{artifact: art}
+	srv := newPipelineTestServer(t, fake)
+
+	// Happy path: the new status is passed to the service and the artifact returned.
+	body, status, headers := doRequest(t, srv, "POST", "/api/v1/pipelines/runs/run-1/artifacts/a-7/status?project=mer", `{"status":"dismissed"}`)
+	assertJSON(t, headers)
+	if status != http.StatusOK || !contains(body, `"artifact"`) || !contains(body, `"a-7"`) {
+		t.Fatalf("status happy: status=%d body=%s", status, body)
+	}
+	if fake.lastStatusChange != pipeline.ArtifactStatusDismissed {
+		t.Fatalf("service saw status %q, want dismissed", fake.lastStatusChange)
+	}
+
+	// Missing project is a 400.
+	_, status, _ = doRequest(t, srv, "POST", "/api/v1/pipelines/runs/run-1/artifacts/a-7/status", `{"status":"dismissed"}`)
+	if status != http.StatusBadRequest {
+		t.Fatalf("missing project = %d, want 400", status)
+	}
+
+	// Malformed body is a 400.
+	_, status, _ = doRequest(t, srv, "POST", "/api/v1/pipelines/runs/run-1/artifacts/a-7/status?project=mer", `{`)
+	if status != http.StatusBadRequest {
+		t.Fatalf("bad json = %d, want 400", status)
+	}
+
+	// A bad status value surfaces the service's validation error.
+	badSrv := newPipelineTestServer(t, &fakePipelineService{statusErr: apierr.Invalid("PIPELINE_ARTIFACT_STATUS_INVALID", "bad", nil)})
+	body, status, _ = doRequest(t, badSrv, "POST", "/api/v1/pipelines/runs/run-1/artifacts/a-7/status?project=mer", `{"status":"nonsense"}`)
+	assertErrorCode(t, body, status, http.StatusBadRequest, "PIPELINE_ARTIFACT_STATUS_INVALID")
+
+	// An unknown artifact is a 404.
+	nfSrv := newPipelineTestServer(t, &fakePipelineService{statusErr: apierr.NotFound("PIPELINE_ARTIFACT_NOT_FOUND", "gone")})
+	body, status, _ = doRequest(t, nfSrv, "POST", "/api/v1/pipelines/runs/run-1/artifacts/a-x/status?project=mer", `{"status":"open"}`)
+	assertErrorCode(t, body, status, http.StatusNotFound, "PIPELINE_ARTIFACT_NOT_FOUND")
+}
+
 // TestPipelinesFlagOffReturns501 is the AO_PIPELINES=off contract (T11): the
 // daemon passes a nil Pipelines Manager when the flag is off, and every route
 // stays registered but returns 501 Not Implemented, across all method kinds.
@@ -388,6 +439,7 @@ func TestPipelinesFlagOffReturns501(t *testing.T) {
 		{"POST", "/api/v1/pipelines/runs/run-1/cancel", ""},
 		{"POST", "/api/v1/pipelines/runs/run-1/resume", ""},
 		{"GET", "/api/v1/pipelines/runs/run-1/artifacts/a-1", ""},
+		{"POST", "/api/v1/pipelines/runs/run-1/artifacts/a-1/status?project=mer", `{"status":"dismissed"}`},
 	}
 	for _, tc := range cases {
 		_, status, _ := doRequest(t, srv, tc.method, tc.path, tc.body)

--- a/backend/internal/pipeline/engine/engine.go
+++ b/backend/internal/pipeline/engine/engine.go
@@ -479,49 +479,6 @@ func upstreamFindings(run pipeline.RunState, dependsOn []string) []pipeline.Arti
 	return out
 }
 
-// applyStatusChanges resolves each stage-reported StatusChange (a {kind:"status"}
-// findings record) against the run's materialized findings and dispatches one
-// ARTIFACT_STATUS_CHANGED per matching finding. An unresolvable fingerprint is
-// tolerated: it emits a pipeline.status.unknown_fingerprint observation rather
-// than failing the stage. Runs on the actor goroutine, after the STAGE_COMPLETED
-// reduce has materialized this stage's own findings.
-func (e *Engine) applyStatusChanges(runID pipeline.RunID, changes []executors.StatusChange) {
-	if len(changes) == 0 {
-		return
-	}
-	run, ok := e.state.Runs[runID]
-	if !ok {
-		return
-	}
-	// Snapshot the findings before dispatching: reduceArtifactStatusChanged is
-	// copy-on-write on run.Findings, so this slice stays valid across dispatches,
-	// and fingerprint/id/stageRunId never change.
-	findings := run.Findings
-	for _, ch := range changes {
-		matched := false
-		for _, f := range findings {
-			if f.Fingerprint != "" && f.Fingerprint == ch.Fingerprint {
-				matched = true
-				e.reduceAndExecute(pipeline.ArtifactStatusChanged{
-					Now:        e.now(),
-					RunID:      runID,
-					StageRunID: f.StageRunID,
-					ArtifactID: f.ArtifactID,
-					Status:     ch.Status,
-					Actor:      "stage",
-				})
-			}
-		}
-		if !matched {
-			e.observe("pipeline.status.unknown_fingerprint", map[string]any{
-				"runId":       string(runID),
-				"fingerprint": ch.Fingerprint,
-				"status":      string(ch.Status),
-			})
-		}
-	}
-}
-
 func (e *Engine) cancelStage(eff pipeline.CancelStage) {
 	h, ok := e.inflight[eff.StageRunID]
 	if !ok {
@@ -581,11 +538,10 @@ func (e *Engine) pollInflight() {
 		}
 		delete(e.inflight, k)
 		if outcome.Status == executors.OutcomeCompleted {
-			e.reduceAndExecute(pipeline.StageCompleted{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), Verdict: outcome.Verdict, Artifacts: outcome.Artifacts, Output: outcome.Output})
-			// Apply status records only after STAGE_COMPLETED has materialized this
-			// stage's own findings, so a stage may reference a fingerprint it just
-			// emitted as well as any upstream one.
-			e.applyStatusChanges(h.RunID(), outcome.StatusChanges)
+			// StatusChanges ride the event so the reducer applies them (to
+			// run.Findings and the store) before the exit decision, letting a
+			// last-stage resolve/reopen change whether the run is done.
+			e.reduceAndExecute(pipeline.StageCompleted{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), Verdict: outcome.Verdict, Artifacts: outcome.Artifacts, StatusChanges: outcome.StatusChanges, Output: outcome.Output})
 		} else {
 			e.reduceAndExecute(pipeline.StageFailed{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), ErrorMessage: outcome.ErrorMessage, Output: outcome.Output})
 		}

--- a/backend/internal/pipeline/engine/engine.go
+++ b/backend/internal/pipeline/engine/engine.go
@@ -431,16 +431,94 @@ func (e *Engine) startInput(run pipeline.RunState, eff pipeline.StartStage) exec
 	loopRound := run.LoopRounds
 	allowFork := run.PipelineConfigSnapshot.AllowForkPRs != nil && *run.PipelineConfigSnapshot.AllowForkPRs
 	return executors.StartInput{
-		PipelineName:    run.PipelineName,
-		ProjectID:       string(e.projectID),
-		RunID:           eff.RunID,
-		StageRunID:      eff.StageRunID,
-		Stage:           eff.Stage,
-		IssueID:         run.Context.IssueID,
-		LoopRound:       &loopRound,
-		LinkedSessionID: run.SessionID,
-		AllowForkPRs:    allowFork,
-		Context:         run.Context,
+		PipelineName:     run.PipelineName,
+		ProjectID:        string(e.projectID),
+		RunID:            eff.RunID,
+		StageRunID:       eff.StageRunID,
+		Stage:            eff.Stage,
+		IssueID:          run.Context.IssueID,
+		LoopRound:        &loopRound,
+		LinkedSessionID:  run.SessionID,
+		AllowForkPRs:     allowFork,
+		Context:          run.Context,
+		UpstreamFindings: upstreamFindings(run, eff.Stage.DependsOn),
+	}
+}
+
+// upstreamFindings resolves the finding artifacts produced by a stage's
+// dependsOn stages, read from the run's in-memory materialized findings (the
+// same set the builtin dispatcher fetches from the store, but already
+// denormalized: finding artifacts are mirrored onto run.Findings by
+// finalizeStageCompletion, so no store round-trip is needed here).
+// The result is a flat slice sorted by stage name then fingerprint so the agent
+// prompt is deterministic. Returns nil when the stage has no dependsOn or no
+// upstream findings exist yet.
+func upstreamFindings(run pipeline.RunState, dependsOn []string) []pipeline.Artifact {
+	if len(dependsOn) == 0 || len(run.Findings) == 0 {
+		return nil
+	}
+	deps := make(map[string]bool, len(dependsOn))
+	for _, d := range dependsOn {
+		deps[d] = true
+	}
+	var out []pipeline.Artifact
+	for _, f := range run.Findings {
+		if f.Kind == pipeline.ArtifactKindFinding && deps[f.StageName] {
+			out = append(out, f)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].StageName != out[j].StageName {
+			return out[i].StageName < out[j].StageName
+		}
+		return out[i].Fingerprint < out[j].Fingerprint
+	})
+	return out
+}
+
+// applyStatusChanges resolves each stage-reported StatusChange (a {kind:"status"}
+// findings record) against the run's materialized findings and dispatches one
+// ARTIFACT_STATUS_CHANGED per matching finding. An unresolvable fingerprint is
+// tolerated: it emits a pipeline.status.unknown_fingerprint observation rather
+// than failing the stage. Runs on the actor goroutine, after the STAGE_COMPLETED
+// reduce has materialized this stage's own findings.
+func (e *Engine) applyStatusChanges(runID pipeline.RunID, changes []executors.StatusChange) {
+	if len(changes) == 0 {
+		return
+	}
+	run, ok := e.state.Runs[runID]
+	if !ok {
+		return
+	}
+	// Snapshot the findings before dispatching: reduceArtifactStatusChanged is
+	// copy-on-write on run.Findings, so this slice stays valid across dispatches,
+	// and fingerprint/id/stageRunId never change.
+	findings := run.Findings
+	for _, ch := range changes {
+		matched := false
+		for _, f := range findings {
+			if f.Fingerprint != "" && f.Fingerprint == ch.Fingerprint {
+				matched = true
+				e.reduceAndExecute(pipeline.ArtifactStatusChanged{
+					Now:        e.now(),
+					RunID:      runID,
+					StageRunID: f.StageRunID,
+					ArtifactID: f.ArtifactID,
+					Status:     ch.Status,
+					Actor:      "stage",
+				})
+			}
+		}
+		if !matched {
+			e.observe("pipeline.status.unknown_fingerprint", map[string]any{
+				"runId":       string(runID),
+				"fingerprint": ch.Fingerprint,
+				"status":      string(ch.Status),
+			})
+		}
 	}
 }
 
@@ -504,6 +582,10 @@ func (e *Engine) pollInflight() {
 		delete(e.inflight, k)
 		if outcome.Status == executors.OutcomeCompleted {
 			e.reduceAndExecute(pipeline.StageCompleted{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), Verdict: outcome.Verdict, Artifacts: outcome.Artifacts, Output: outcome.Output})
+			// Apply status records only after STAGE_COMPLETED has materialized this
+			// stage's own findings, so a stage may reference a fingerprint it just
+			// emitted as well as any upstream one.
+			e.applyStatusChanges(h.RunID(), outcome.StatusChanges)
 		} else {
 			e.reduceAndExecute(pipeline.StageFailed{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), ErrorMessage: outcome.ErrorMessage, Output: outcome.Output})
 		}

--- a/backend/internal/pipeline/engine/engine_test.go
+++ b/backend/internal/pipeline/engine/engine_test.go
@@ -66,7 +66,7 @@ func (f *fakeExecutor) Start(_ context.Context, in executors.StartInput) (execut
 
 // completeStatus scripts a stage to complete emitting only {kind:"status"} status
 // changes (no artifacts): a verify/summarize stage acting on upstream findings.
-func (f *fakeExecutor) completeStatus(stage string, changes ...executors.StatusChange) {
+func (f *fakeExecutor) completeStatus(stage string, changes ...pipeline.FindingStatusChange) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.outcome[stage] = executors.Outcome{Status: executors.OutcomeCompleted, Verdict: pipeline.VerdictNeutral, StatusChanges: changes}
@@ -651,7 +651,7 @@ func TestStatusRecordFlipsFindingStatus(t *testing.T) {
 	}
 
 	// verify dismisses scan's finding by fingerprint.
-	fake.completeStatus("verify", executors.StatusChange{Fingerprint: fp, Status: pipeline.ArtifactStatusDismissed})
+	fake.completeStatus("verify", pipeline.FindingStatusChange{Fingerprint: fp, Status: pipeline.ArtifactStatusDismissed})
 	e.Tick() // verify completes, status change applied, run terminates
 
 	run := e.State().Runs[runID]
@@ -686,7 +686,7 @@ func TestStatusRecordUnknownFingerprintTolerated(t *testing.T) {
 	fake.complete("scan", pipeline.VerdictPass, finding("bug"))
 	e.Tick()
 
-	fake.completeStatus("verify", executors.StatusChange{Fingerprint: "does-not-exist", Status: pipeline.ArtifactStatusResolved})
+	fake.completeStatus("verify", pipeline.FindingStatusChange{Fingerprint: "does-not-exist", Status: pipeline.ArtifactStatusResolved})
 	e.Tick()
 
 	if n := sink.count("pipeline.status.unknown_fingerprint"); n != 1 {
@@ -699,5 +699,74 @@ func TestStatusRecordUnknownFingerprintTolerated(t *testing.T) {
 	// scan's finding stays open (nothing matched).
 	if run.Findings[0].Status != pipeline.ArtifactStatusOpen {
 		t.Fatalf("finding status = %s, want open (untouched)", run.Findings[0].Status)
+	}
+}
+
+// TestLastStageResolveMakesDoneFire proves the exit decision sees post-flip
+// finding statuses: a verify stage resolving the only open finding must make a
+// no_open_findings `done` predicate fire (LoopDone), not stall. This only holds
+// because status records are applied in the reducer BEFORE decideRunExit.
+func TestLastStageResolveMakesDoneFire(t *testing.T) {
+	store := newTestStore(t, "mer")
+	fake := newFakeExecutor()
+	e := newTestEngine(t, "mer", store, fake, nil)
+
+	p := pipelineOf("verify-loop", 1, agentStage("scan"), agentStage("verify", "scan"))
+	p.ExitPredicates = &pipeline.ExitPredicates{Done: &pipeline.Predicate{Kind: pipeline.PredicateNoOpenFindings}}
+	runID, err := e.TriggerRun(TriggerRequest{Pipeline: p, SessionID: "mer-1", HeadSHA: "sha1"})
+	if err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+
+	fake.complete("scan", pipeline.VerdictPass, finding("bug"))
+	e.Tick() // scan done (finding open), verify starts
+
+	fp := e.State().Runs[runID].Findings[0].Fingerprint
+	fake.completeStatus("verify", pipeline.FindingStatusChange{Fingerprint: fp, Status: pipeline.ArtifactStatusResolved})
+	e.Tick() // verify done; resolve applied before the exit decision
+
+	run := e.State().Runs[runID]
+	if run.LoopState != pipeline.LoopDone {
+		t.Fatalf("loop state = %s/%s, want done (resolved finding must satisfy no_open_findings)", run.LoopState, run.TerminationReason)
+	}
+	if run.Findings[0].Status != pipeline.ArtifactStatusResolved {
+		t.Fatalf("finding status = %s, want resolved", run.Findings[0].Status)
+	}
+}
+
+// TestLastStageReopenPreventsDone is the mirror: a finding resolved by an earlier
+// stage but reopened by the last stage must leave a no_open_findings `done`
+// predicate unmet, so the run stalls instead of reporting done.
+func TestLastStageReopenPreventsDone(t *testing.T) {
+	store := newTestStore(t, "mer")
+	fake := newFakeExecutor()
+	e := newTestEngine(t, "mer", store, fake, nil)
+
+	p := pipelineOf("verify-loop", 1,
+		agentStage("scan"),
+		agentStage("triage", "scan"),
+		agentStage("verify", "triage"))
+	p.ExitPredicates = &pipeline.ExitPredicates{Done: &pipeline.Predicate{Kind: pipeline.PredicateNoOpenFindings}}
+	runID, err := e.TriggerRun(TriggerRequest{Pipeline: p, SessionID: "mer-1", HeadSHA: "sha1"})
+	if err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+
+	fake.complete("scan", pipeline.VerdictPass, finding("bug"))
+	e.Tick() // scan done, triage starts
+	fp := e.State().Runs[runID].Findings[0].Fingerprint
+
+	fake.completeStatus("triage", pipeline.FindingStatusChange{Fingerprint: fp, Status: pipeline.ArtifactStatusResolved})
+	e.Tick() // triage done (finding resolved), verify starts
+
+	fake.completeStatus("verify", pipeline.FindingStatusChange{Fingerprint: fp, Status: pipeline.ArtifactStatusOpen})
+	e.Tick() // verify done; reopen applied before the exit decision
+
+	run := e.State().Runs[runID]
+	if run.LoopState != pipeline.LoopStalled || run.TerminationReason != pipeline.TerminationDonePredicateUnmet {
+		t.Fatalf("loop state = %s/%s, want stalled/done_predicate_unmet (reopened finding blocks done)", run.LoopState, run.TerminationReason)
+	}
+	if run.Findings[0].Status != pipeline.ArtifactStatusOpen {
+		t.Fatalf("finding status = %s, want open (reopened)", run.Findings[0].Status)
 	}
 }

--- a/backend/internal/pipeline/engine/engine_test.go
+++ b/backend/internal/pipeline/engine/engine_test.go
@@ -39,6 +39,7 @@ type fakeExecutor struct {
 	ready     map[string]bool
 	started   map[string]int
 	cancelled map[string]int
+	lastInput map[string]executors.StartInput
 }
 
 func newFakeExecutor() *fakeExecutor {
@@ -48,6 +49,7 @@ func newFakeExecutor() *fakeExecutor {
 		ready:     map[string]bool{},
 		started:   map[string]int{},
 		cancelled: map[string]int{},
+		lastInput: map[string]executors.StartInput{},
 	}
 }
 
@@ -58,7 +60,25 @@ func (f *fakeExecutor) Start(_ context.Context, in executors.StartInput) (execut
 		return nil, err
 	}
 	f.started[in.Stage.Name]++
+	f.lastInput[in.Stage.Name] = in
 	return fakeHandle{runID: in.RunID, stageRunID: in.StageRunID, stageName: in.Stage.Name}, nil
+}
+
+// completeStatus scripts a stage to complete emitting only {kind:"status"} status
+// changes (no artifacts): a verify/summarize stage acting on upstream findings.
+func (f *fakeExecutor) completeStatus(stage string, changes ...executors.StatusChange) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.outcome[stage] = executors.Outcome{Status: executors.OutcomeCompleted, Verdict: pipeline.VerdictNeutral, StatusChanges: changes}
+	f.ready[stage] = true
+}
+
+// upstreamInput returns the StartInput the stage was last started with, for
+// asserting resolved upstream findings.
+func (f *fakeExecutor) upstreamInput(stage string) executors.StartInput {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastInput[stage]
 }
 
 func (f *fakeExecutor) Poll(_ context.Context, h executors.Handle) (executors.Outcome, error) {
@@ -566,5 +586,118 @@ func TestStageAutoRetryViaEngine(t *testing.T) {
 	}
 	if got := final.Stages["review"]; got.Status != pipeline.StageStatusFailed || got.Attempt != 2 {
 		t.Fatalf("review stage = %+v, want failed attempt=2", got)
+	}
+}
+
+// TestUpstreamFindingsThreadedToDownstreamStage drives scan -> verify (dependsOn
+// scan) and asserts the engine resolves scan's finding onto verify's StartInput,
+// while scan itself (no dependsOn) receives none.
+func TestUpstreamFindingsThreadedToDownstreamStage(t *testing.T) {
+	store := newTestStore(t, "mer")
+	fake := newFakeExecutor()
+	e := newTestEngine(t, "mer", store, fake, nil)
+
+	p := pipelineOf("verify-loop", 1, agentStage("scan"), agentStage("verify", "scan"))
+	runID, err := e.TriggerRun(TriggerRequest{Pipeline: p, SessionID: "mer-1", HeadSHA: "sha1"})
+	if err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+
+	// scan gets no upstream (no dependsOn).
+	if up := fake.upstreamInput("scan").UpstreamFindings; len(up) != 0 {
+		t.Fatalf("scan should have no upstream findings, got %d", len(up))
+	}
+
+	// Complete scan with a finding; the tick starts verify with that finding
+	// resolved onto its input.
+	fake.complete("scan", pipeline.VerdictPass, finding("bug"))
+	e.Tick()
+
+	if fake.startCount("verify") != 1 {
+		t.Fatalf("verify started %d times, want 1", fake.startCount("verify"))
+	}
+	up := fake.upstreamInput("verify").UpstreamFindings
+	if len(up) != 1 {
+		t.Fatalf("verify upstream findings = %d, want 1", len(up))
+	}
+	if up[0].StageName != "scan" || up[0].Title != "bug" || up[0].Fingerprint == "" {
+		t.Fatalf("verify upstream finding = %+v, want scan's fingerprinted bug", up[0])
+	}
+	_ = runID
+}
+
+// TestStatusRecordFlipsFindingStatus drives scan -> verify where verify emits a
+// {kind:"status"} record dismissing scan's finding, then asserts the finding's
+// status flips both in engine state and in the persisted store.
+func TestStatusRecordFlipsFindingStatus(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t, "mer")
+	fake := newFakeExecutor()
+	e := newTestEngine(t, "mer", store, fake, nil)
+
+	p := pipelineOf("verify-loop", 1, agentStage("scan"), agentStage("verify", "scan"))
+	runID, err := e.TriggerRun(TriggerRequest{Pipeline: p, SessionID: "mer-1", HeadSHA: "sha1"})
+	if err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+
+	fake.complete("scan", pipeline.VerdictPass, finding("bug"))
+	e.Tick() // scan completes, verify starts
+
+	fp := e.State().Runs[runID].Findings[0].Fingerprint
+	artifactID := e.State().Runs[runID].Findings[0].ArtifactID
+	if fp == "" {
+		t.Fatal("scan finding has no fingerprint")
+	}
+
+	// verify dismisses scan's finding by fingerprint.
+	fake.completeStatus("verify", executors.StatusChange{Fingerprint: fp, Status: pipeline.ArtifactStatusDismissed})
+	e.Tick() // verify completes, status change applied, run terminates
+
+	run := e.State().Runs[runID]
+	if run.Findings[0].Status != pipeline.ArtifactStatusDismissed {
+		t.Fatalf("in-memory finding status = %s, want dismissed", run.Findings[0].Status)
+	}
+
+	art, ok, err := store.GetPipelineArtifact(ctx, artifactID)
+	if err != nil || !ok {
+		t.Fatalf("get persisted artifact: ok=%v err=%v", ok, err)
+	}
+	if art.Status != pipeline.ArtifactStatusDismissed {
+		t.Fatalf("persisted artifact status = %s, want dismissed", art.Status)
+	}
+}
+
+// TestStatusRecordUnknownFingerprintTolerated asserts a status record naming a
+// fingerprint that matches no finding emits an observation and does NOT fail the
+// stage or run.
+func TestStatusRecordUnknownFingerprintTolerated(t *testing.T) {
+	store := newTestStore(t, "mer")
+	fake := newFakeExecutor()
+	sink := &captureSink{}
+	e := newTestEngine(t, "mer", store, fake, sink)
+
+	p := pipelineOf("verify-loop", 1, agentStage("scan"), agentStage("verify", "scan"))
+	runID, err := e.TriggerRun(TriggerRequest{Pipeline: p, SessionID: "mer-1", HeadSHA: "sha1"})
+	if err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+
+	fake.complete("scan", pipeline.VerdictPass, finding("bug"))
+	e.Tick()
+
+	fake.completeStatus("verify", executors.StatusChange{Fingerprint: "does-not-exist", Status: pipeline.ArtifactStatusResolved})
+	e.Tick()
+
+	if n := sink.count("pipeline.status.unknown_fingerprint"); n != 1 {
+		t.Fatalf("unknown_fingerprint observation count = %d, want 1", n)
+	}
+	run := e.State().Runs[runID]
+	if run.Stages["verify"].Status != pipeline.StageStatusSucceeded {
+		t.Fatalf("verify stage = %s, want succeeded (unknown fp must not fail it)", run.Stages["verify"].Status)
+	}
+	// scan's finding stays open (nothing matched).
+	if run.Findings[0].Status != pipeline.ArtifactStatusOpen {
+		t.Fatalf("finding status = %s, want open (untouched)", run.Findings[0].Status)
 	}
 }

--- a/backend/internal/pipeline/events.go
+++ b/backend/internal/pipeline/events.go
@@ -83,6 +83,11 @@ type StageCompleted struct {
 	StageName string
 	Verdict   Verdict
 	Artifacts []ArtifactInput
+	// StatusChanges are {kind:"status"} records the stage emitted to flip existing
+	// findings' status by fingerprint. The reducer applies them (to run.Findings
+	// and the store) after materializing this stage's own artifacts and before the
+	// exit decision, so a last-stage resolve/reopen changes whether the run is done.
+	StatusChanges []FindingStatusChange
 	// Output is a capped tail of the stage's combined stdout+stderr, persisted
 	// onto the stage state for the run detail.
 	Output string

--- a/backend/internal/pipeline/executors/agent.go
+++ b/backend/internal/pipeline/executors/agent.go
@@ -85,7 +85,7 @@ func (e *AgentExecutor) Start(ctx context.Context, in StartInput) (Handle, error
 		return nil, fmt.Errorf("agent executor cannot start stage %q with executor.kind=%s", in.Stage.Name, in.Stage.Executor.Kind)
 	}
 
-	prompt := buildStagePrompt(in.PipelineName, in.Stage, in.LoopRound, in.Context)
+	prompt := buildStagePrompt(in.PipelineName, in.Stage, in.LoopRound, in.Context, in.UpstreamFindings)
 	session, err := e.sessions.Spawn(ctx, SpawnRequest{
 		ProjectID: in.ProjectID,
 		IssueID:   in.IssueID,
@@ -156,7 +156,7 @@ func (e *AgentExecutor) Poll(ctx context.Context, h Handle) (Outcome, error) {
 
 	_ = e.sessions.Kill(ctx, handle.sessionID)
 
-	outcome := Outcome{Status: OutcomeCompleted, Artifacts: result.artifacts}
+	outcome := Outcome{Status: OutcomeCompleted, Artifacts: result.artifacts, StatusChanges: result.statusChanges}
 	if result.truncated {
 		outcome.Observations = []Observation{{
 			Name: "pipeline.findings.truncated",

--- a/backend/internal/pipeline/executors/command.go
+++ b/backend/internal/pipeline/executors/command.go
@@ -459,6 +459,7 @@ func harvestCommandFindings(ex commandExit, out Outcome) Outcome {
 	}
 
 	out.Artifacts = append(out.Artifacts, result.artifacts...)
+	out.StatusChanges = append(out.StatusChanges, result.statusChanges...)
 	if result.truncated {
 		out.Observations = append(out.Observations, Observation{
 			Name: "pipeline.findings.truncated",

--- a/backend/internal/pipeline/executors/executor.go
+++ b/backend/internal/pipeline/executors/executor.go
@@ -49,10 +49,10 @@ type Outcome struct {
 	Verdict   pipeline.Verdict
 	Artifacts []pipeline.ArtifactInput
 	// StatusChanges are {kind:"status"} records the stage emitted to flip
-	// existing findings' lifecycle status by fingerprint. The engine resolves
-	// each fingerprint against the run's findings and dispatches
-	// ARTIFACT_STATUS_CHANGED. Meaningful on OutcomeCompleted.
-	StatusChanges []StatusChange
+	// existing findings' lifecycle status by fingerprint. They ride the
+	// STAGE_COMPLETED event so the reducer applies them before the exit decision.
+	// Meaningful on OutcomeCompleted.
+	StatusChanges []pipeline.FindingStatusChange
 	Observations  []Observation
 	ErrorMessage  string
 	// Output is a capped tail of the stage's combined stdout+stderr, surfaced in

--- a/backend/internal/pipeline/executors/executor.go
+++ b/backend/internal/pipeline/executors/executor.go
@@ -45,11 +45,16 @@ type Observation struct {
 // ErrorMessage on OutcomeFailed. Observations may accompany any terminal
 // status.
 type Outcome struct {
-	Status       OutcomeStatus
-	Verdict      pipeline.Verdict
-	Artifacts    []pipeline.ArtifactInput
-	Observations []Observation
-	ErrorMessage string
+	Status    OutcomeStatus
+	Verdict   pipeline.Verdict
+	Artifacts []pipeline.ArtifactInput
+	// StatusChanges are {kind:"status"} records the stage emitted to flip
+	// existing findings' lifecycle status by fingerprint. The engine resolves
+	// each fingerprint against the run's findings and dispatches
+	// ARTIFACT_STATUS_CHANGED. Meaningful on OutcomeCompleted.
+	StatusChanges []StatusChange
+	Observations  []Observation
+	ErrorMessage  string
 	// Output is a capped tail of the stage's combined stdout+stderr, surfaced in
 	// the run detail. Set by the command executor on both success and failure;
 	// empty for executor kinds that produce no subprocess output.
@@ -95,6 +100,13 @@ type StartInput struct {
 	// SourceBranch to spawn on the PR branch and render a PR block in the
 	// prompt; command stages surface it as AO_PR_* env vars.
 	Context pipeline.RunContext
+	// UpstreamFindings are the finding artifacts produced by this stage's
+	// dependsOn stages earlier in the run, resolved by the engine from the run's
+	// materialized findings. The agent executor renders them into an "## Upstream
+	// findings" prompt section so a summarize/verify stage can act on them and
+	// emit {kind:"status"} records referencing their fingerprints. Empty when the
+	// stage has no dependsOn or no upstream findings exist.
+	UpstreamFindings []pipeline.Artifact
 }
 
 // StageExecutor is the contract the engine drives. Start begins the work and

--- a/backend/internal/pipeline/executors/findings.go
+++ b/backend/internal/pipeline/executors/findings.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
 )
@@ -26,10 +27,35 @@ var stageFindingsRelativePath = filepath.Join(".ao", pipeline.FindingsFilename)
 // parseResult is the outcome of harvesting a findings file.
 type parseResult struct {
 	artifacts []pipeline.ArtifactInput
+	// statusChanges are {kind:"status"} records: a stage asking to flip an
+	// existing finding's lifecycle status by fingerprint. Unknown fingerprints
+	// are resolved (and tolerated) by the engine, not here.
+	statusChanges []StatusChange
 	// truncated is true when the cap fired and trailing lines were dropped.
 	truncated bool
 	// bytesRead is how many bytes were consumed before stopping.
 	bytesRead int64
+}
+
+// StatusChange is a stage-reported request to flip an existing finding's
+// lifecycle status, addressed by its stable fingerprint. Threaded through the
+// executor Outcome; the engine resolves the fingerprint to an artifact id
+// against the run's findings and dispatches ARTIFACT_STATUS_CHANGED.
+type StatusChange struct {
+	Fingerprint string
+	Status      pipeline.ArtifactStatus
+}
+
+// statusRecordKind is the JSONL "kind" value marking a status record.
+const statusRecordKind = "status"
+
+// validRecordStatuses are the statuses a {kind:"status"} record may set. It is
+// the human/agent-settable subset of the artifact status enum: sent_to_agent is
+// engine-internal and never authored in a findings file.
+var validRecordStatuses = map[pipeline.ArtifactStatus]bool{
+	pipeline.ArtifactStatusOpen:      true,
+	pipeline.ArtifactStatusResolved:  true,
+	pipeline.ArtifactStatusDismissed: true,
 }
 
 // validSeverities are the finding severities the coercion accepts.
@@ -63,6 +89,7 @@ func parseFindingsFile(path string) (parseResult, error) {
 
 	reader := bufio.NewReader(f)
 	var out []pipeline.ArtifactInput
+	var statusChanges []StatusChange
 	var bytesRead int64
 	lineNo := 0
 	truncated := false
@@ -84,7 +111,7 @@ func parseFindingsFile(path string) (parseResult, error) {
 		trimmed := trimLine(line)
 		if trimmed != "" {
 			lineNo++
-			artifact, perr := coerceArtifactInput([]byte(trimmed))
+			artifact, status, perr := parseRecord([]byte(trimmed))
 			if perr != nil {
 				if torn {
 					// Tolerate a torn final line: drop it rather than failing an
@@ -93,7 +120,11 @@ func parseFindingsFile(path string) (parseResult, error) {
 				}
 				return parseResult{}, fmt.Errorf("line %d: %w", lineNo, perr)
 			}
-			out = append(out, artifact)
+			if status != nil {
+				statusChanges = append(statusChanges, *status)
+			} else {
+				out = append(out, artifact)
+			}
 		}
 
 		if readErr != nil {
@@ -106,7 +137,55 @@ func parseFindingsFile(path string) (parseResult, error) {
 		}
 	}
 
-	return parseResult{artifacts: out, truncated: truncated, bytesRead: bytesRead}, nil
+	return parseResult{artifacts: out, statusChanges: statusChanges, truncated: truncated, bytesRead: bytesRead}, nil
+}
+
+// parseRecord classifies one JSONL record. A {kind:"status"} record yields a
+// non-nil StatusChange (and a zero ArtifactInput); every other kind is coerced
+// into an ArtifactInput. Exactly one of the two returns is meaningful.
+func parseRecord(raw []byte) (pipeline.ArtifactInput, *StatusChange, error) {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return pipeline.ArtifactInput{}, nil, err
+	}
+	var kind string
+	if k, ok := probe["kind"]; ok {
+		_ = json.Unmarshal(k, &kind)
+	}
+	if kind == statusRecordKind {
+		sc, err := coerceStatusChange(probe, raw)
+		if err != nil {
+			return pipeline.ArtifactInput{}, nil, err
+		}
+		return pipeline.ArtifactInput{}, &sc, nil
+	}
+	art, err := coerceArtifactInput(raw)
+	return art, nil, err
+}
+
+// coerceStatusChange validates one {kind:"status"} record: it needs a non-empty
+// fingerprint and a status in the settable subset (open|resolved|dismissed). A
+// bad status or missing field fails the harvest so a human inspects a genuinely
+// malformed file; an unknown fingerprint is NOT rejected here (the parser cannot
+// know the run's fingerprints; the engine tolerates it with an observation).
+func coerceStatusChange(probe map[string]json.RawMessage, raw []byte) (StatusChange, error) {
+	if err := requireFields(probe, "fingerprint", "status"); err != nil {
+		return StatusChange{}, err
+	}
+	var rec struct {
+		Fingerprint string                  `json:"fingerprint"`
+		Status      pipeline.ArtifactStatus `json:"status"`
+	}
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		return StatusChange{}, err
+	}
+	if strings.TrimSpace(rec.Fingerprint) == "" {
+		return StatusChange{}, errors.New(`"status" record requires a non-empty "fingerprint"`)
+	}
+	if !validRecordStatuses[rec.Status] {
+		return StatusChange{}, fmt.Errorf(`field "status" must be one of "open", "resolved", "dismissed", got %q`, rec.Status)
+	}
+	return StatusChange{Fingerprint: rec.Fingerprint, Status: rec.Status}, nil
 }
 
 // coerceArtifactInput validates one JSONL record into an ArtifactInput,

--- a/backend/internal/pipeline/executors/findings.go
+++ b/backend/internal/pipeline/executors/findings.go
@@ -29,21 +29,12 @@ type parseResult struct {
 	artifacts []pipeline.ArtifactInput
 	// statusChanges are {kind:"status"} records: a stage asking to flip an
 	// existing finding's lifecycle status by fingerprint. Unknown fingerprints
-	// are resolved (and tolerated) by the engine, not here.
-	statusChanges []StatusChange
+	// are resolved (and tolerated) by the reducer, not here.
+	statusChanges []pipeline.FindingStatusChange
 	// truncated is true when the cap fired and trailing lines were dropped.
 	truncated bool
 	// bytesRead is how many bytes were consumed before stopping.
 	bytesRead int64
-}
-
-// StatusChange is a stage-reported request to flip an existing finding's
-// lifecycle status, addressed by its stable fingerprint. Threaded through the
-// executor Outcome; the engine resolves the fingerprint to an artifact id
-// against the run's findings and dispatches ARTIFACT_STATUS_CHANGED.
-type StatusChange struct {
-	Fingerprint string
-	Status      pipeline.ArtifactStatus
 }
 
 // statusRecordKind is the JSONL "kind" value marking a status record.
@@ -89,7 +80,7 @@ func parseFindingsFile(path string) (parseResult, error) {
 
 	reader := bufio.NewReader(f)
 	var out []pipeline.ArtifactInput
-	var statusChanges []StatusChange
+	var statusChanges []pipeline.FindingStatusChange
 	var bytesRead int64
 	lineNo := 0
 	truncated := false
@@ -141,9 +132,9 @@ func parseFindingsFile(path string) (parseResult, error) {
 }
 
 // parseRecord classifies one JSONL record. A {kind:"status"} record yields a
-// non-nil StatusChange (and a zero ArtifactInput); every other kind is coerced
-// into an ArtifactInput. Exactly one of the two returns is meaningful.
-func parseRecord(raw []byte) (pipeline.ArtifactInput, *StatusChange, error) {
+// non-nil FindingStatusChange (and a zero ArtifactInput); every other kind is
+// coerced into an ArtifactInput. Exactly one of the two returns is meaningful.
+func parseRecord(raw []byte) (pipeline.ArtifactInput, *pipeline.FindingStatusChange, error) {
 	var probe map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &probe); err != nil {
 		return pipeline.ArtifactInput{}, nil, err
@@ -168,24 +159,24 @@ func parseRecord(raw []byte) (pipeline.ArtifactInput, *StatusChange, error) {
 // bad status or missing field fails the harvest so a human inspects a genuinely
 // malformed file; an unknown fingerprint is NOT rejected here (the parser cannot
 // know the run's fingerprints; the engine tolerates it with an observation).
-func coerceStatusChange(probe map[string]json.RawMessage, raw []byte) (StatusChange, error) {
+func coerceStatusChange(probe map[string]json.RawMessage, raw []byte) (pipeline.FindingStatusChange, error) {
 	if err := requireFields(probe, "fingerprint", "status"); err != nil {
-		return StatusChange{}, err
+		return pipeline.FindingStatusChange{}, err
 	}
 	var rec struct {
 		Fingerprint string                  `json:"fingerprint"`
 		Status      pipeline.ArtifactStatus `json:"status"`
 	}
 	if err := json.Unmarshal(raw, &rec); err != nil {
-		return StatusChange{}, err
+		return pipeline.FindingStatusChange{}, err
 	}
 	if strings.TrimSpace(rec.Fingerprint) == "" {
-		return StatusChange{}, errors.New(`"status" record requires a non-empty "fingerprint"`)
+		return pipeline.FindingStatusChange{}, errors.New(`"status" record requires a non-empty "fingerprint"`)
 	}
 	if !validRecordStatuses[rec.Status] {
-		return StatusChange{}, fmt.Errorf(`field "status" must be one of "open", "resolved", "dismissed", got %q`, rec.Status)
+		return pipeline.FindingStatusChange{}, fmt.Errorf(`field "status" must be one of "open", "resolved", "dismissed", got %q`, rec.Status)
 	}
-	return StatusChange{Fingerprint: rec.Fingerprint, Status: rec.Status}, nil
+	return pipeline.FindingStatusChange{Fingerprint: rec.Fingerprint, Status: rec.Status}, nil
 }
 
 // coerceArtifactInput validates one JSONL record into an ArtifactInput,

--- a/backend/internal/pipeline/executors/findings_test.go
+++ b/backend/internal/pipeline/executors/findings_test.go
@@ -188,7 +188,7 @@ func TestParseFindings_StatusRecords(t *testing.T) {
 	if len(res.statusChanges) != 3 {
 		t.Fatalf("want 3 status changes, got %d", len(res.statusChanges))
 	}
-	want := []StatusChange{
+	want := []pipeline.FindingStatusChange{
 		{Fingerprint: "abc123", Status: pipeline.ArtifactStatusResolved},
 		{Fingerprint: "def456", Status: pipeline.ArtifactStatusDismissed},
 		{Fingerprint: "ghi789", Status: pipeline.ArtifactStatusOpen},

--- a/backend/internal/pipeline/executors/findings_test.go
+++ b/backend/internal/pipeline/executors/findings_test.go
@@ -171,6 +171,53 @@ func TestParseFindings_CapTriggersTruncation(t *testing.T) {
 	}
 }
 
+func TestParseFindings_StatusRecords(t *testing.T) {
+	path := writeFindings(t,
+		findingLine(t, 0.9, "error"),
+		`{"kind":"status","fingerprint":"abc123","status":"resolved"}`,
+		`{"kind":"status","fingerprint":"def456","status":"dismissed"}`,
+		`{"kind":"status","fingerprint":"ghi789","status":"open"}`,
+	)
+	res, err := parseFindingsFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.artifacts) != 1 {
+		t.Fatalf("want 1 artifact (status records are not artifacts), got %d", len(res.artifacts))
+	}
+	if len(res.statusChanges) != 3 {
+		t.Fatalf("want 3 status changes, got %d", len(res.statusChanges))
+	}
+	want := []StatusChange{
+		{Fingerprint: "abc123", Status: pipeline.ArtifactStatusResolved},
+		{Fingerprint: "def456", Status: pipeline.ArtifactStatusDismissed},
+		{Fingerprint: "ghi789", Status: pipeline.ArtifactStatusOpen},
+	}
+	for i, w := range want {
+		if res.statusChanges[i] != w {
+			t.Errorf("statusChanges[%d] = %+v, want %+v", i, res.statusChanges[i], w)
+		}
+	}
+}
+
+func TestParseFindings_StatusRecordBadShapeFails(t *testing.T) {
+	cases := map[string]string{
+		"bad status value":     `{"kind":"status","fingerprint":"abc","status":"nonsense"}`,
+		"sent_to_agent barred": `{"kind":"status","fingerprint":"abc","status":"sent_to_agent"}`,
+		"missing fingerprint":  `{"kind":"status","status":"resolved"}`,
+		"empty fingerprint":    `{"kind":"status","fingerprint":"   ","status":"resolved"}`,
+		"missing status":       `{"kind":"status","fingerprint":"abc"}`,
+	}
+	for name, line := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writeFindings(t, line)
+			if _, err := parseFindingsFile(path); err == nil {
+				t.Fatalf("%s: expected a hard parse error", name)
+			}
+		})
+	}
+}
+
 func TestParseFindings_MissingFile(t *testing.T) {
 	_, err := parseFindingsFile(filepath.Join(t.TempDir(), "nope.jsonl"))
 	if err == nil {

--- a/backend/internal/pipeline/executors/stageprompt.go
+++ b/backend/internal/pipeline/executors/stageprompt.go
@@ -2,6 +2,7 @@ package executors
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -15,7 +16,7 @@ import (
 //
 // The findings path is documented relative to the workspace root so the agent
 // does not need the absolute path.
-func buildStagePrompt(pipelineName string, stage pipeline.Stage, loopRound *int, prCtx pipeline.RunContext) string {
+func buildStagePrompt(pipelineName string, stage pipeline.Stage, loopRound *int, prCtx pipeline.RunContext, upstream []pipeline.Artifact) string {
 	var mode pipeline.TaskMode
 	if stage.Executor.Kind == pipeline.ExecutorAgent {
 		mode = stage.Executor.Mode
@@ -34,6 +35,7 @@ func buildStagePrompt(pipelineName string, stage pipeline.Stage, loopRound *int,
 	}
 
 	lines = append(lines, prBlock(prCtx)...)
+	lines = append(lines, upstreamFindingsBlock(upstream)...)
 
 	if stage.Task.Prompt != "" {
 		lines = append(lines, "", "## Task", stage.Task.Prompt)
@@ -72,6 +74,43 @@ func prBlock(prCtx pipeline.RunContext) []string {
 	return lines
 }
 
+// upstreamFindingsCap bounds how many upstream findings are rendered into the
+// prompt so a run with thousands of open findings does not blow the context
+// window. Beyond the cap the overflow count is noted.
+const upstreamFindingsCap = 100
+
+// upstreamFindingsBlock renders an "## Upstream findings" section: one line per
+// finding carrying its fingerprint, severity, stage of origin, file:line, title,
+// and current status, so a summarize/verify stage can reference them by
+// fingerprint in {kind:"status"} records. Returns nil when there are none,
+// leaving the prompt unchanged. The section is capped at upstreamFindingsCap with
+// an overflow note.
+func upstreamFindingsBlock(upstream []pipeline.Artifact) []string {
+	if len(upstream) == 0 {
+		return nil
+	}
+	lines := []string{"", "## Upstream findings",
+		"Findings from earlier stages this stage depends on. Reference a fingerprint below in a status record to resolve or dismiss it (see Reporting Findings)."}
+	shown := upstream
+	overflow := 0
+	if len(shown) > upstreamFindingsCap {
+		overflow = len(shown) - upstreamFindingsCap
+		shown = shown[:upstreamFindingsCap]
+	}
+	for _, a := range shown {
+		status := a.Status
+		if status == "" {
+			status = pipeline.ArtifactStatusOpen
+		}
+		lines = append(lines, fmt.Sprintf("- [%s] fp=%s (%s) %s:%d-%d %s — status: %s",
+			a.Severity, a.Fingerprint, a.StageName, a.FilePath, a.StartLine, a.EndLine, a.Title, status))
+	}
+	if overflow > 0 {
+		lines = append(lines, fmt.Sprintf("... and %d more findings not shown (cap %d).", overflow, upstreamFindingsCap))
+	}
+	return lines
+}
+
 // formatFindingsInstructions mirrors the old JSONL write-then-rename contract:
 // the executor polls for the final file and parses it on first sight, so the
 // agent must write a temp file and rename it into place to avoid the executor
@@ -95,7 +134,9 @@ func formatFindingsInstructions(mode pipeline.TaskMode) string {
 		blocks = append(blocks, `Each line must be either a "finding" or a "json" record (see ArtifactInput in the orchestrator types).`)
 	}
 
-	blocks = append(blocks, "If there are no findings, rename an empty file. The file's existence, not its contents, is the completion signal.")
+	blocks = append(blocks,
+		`To update an existing upstream finding (listed above under Upstream findings), emit a status record: { kind: "status", fingerprint: "<fp>", status: "open" | "resolved" | "dismissed" }, using a fingerprint from that list. Use "resolved" for a finding you fixed, "dismissed" for a false positive, "open" to reopen one still broken.`,
+		"If there are no findings, rename an empty file. The file's existence, not its contents, is the completion signal.")
 
 	return strings.Join(blocks, " ")
 }

--- a/backend/internal/pipeline/executors/stageprompt.go
+++ b/backend/internal/pipeline/executors/stageprompt.go
@@ -102,7 +102,7 @@ func upstreamFindingsBlock(upstream []pipeline.Artifact) []string {
 		if status == "" {
 			status = pipeline.ArtifactStatusOpen
 		}
-		lines = append(lines, fmt.Sprintf("- [%s] fp=%s (%s) %s:%d-%d %s — status: %s",
+		lines = append(lines, fmt.Sprintf("- [%s] fp=%s (%s) %s:%d-%d %s; status: %s",
 			a.Severity, a.Fingerprint, a.StageName, a.FilePath, a.StartLine, a.EndLine, a.Title, status))
 	}
 	if overflow > 0 {
@@ -122,7 +122,7 @@ func formatFindingsInstructions(mode pipeline.TaskMode) string {
 	blocks := []string{
 		"When this stage is complete, write your findings to `" + path + "` (one JSON object per line, JSONL).",
 		"Write the JSONL to `" + tmpPath + "` first, then rename it to `" + path + "` so the orchestrator never observes a partial file (e.g. `mv " + tmpPath + " " + path + "`).",
-		"The orchestrator harvests this file once you go idle — without it the stage cannot complete.",
+		"The orchestrator harvests this file once you go idle; without it the stage cannot complete.",
 	}
 
 	switch mode {

--- a/backend/internal/pipeline/executors/stageprompt_test.go
+++ b/backend/internal/pipeline/executors/stageprompt_test.go
@@ -15,9 +15,65 @@ func agentStage(mode pipeline.TaskMode) pipeline.Stage {
 	}
 }
 
+func upstreamFinding(stage, fp, sev, file, title string, status pipeline.ArtifactStatus) pipeline.Artifact {
+	return pipeline.Artifact{
+		ArtifactInput: pipeline.ArtifactInput{
+			Kind: pipeline.ArtifactKindFinding, FilePath: file, StartLine: 10, EndLine: 12,
+			Title: title, Severity: pipeline.Severity(sev),
+		},
+		StageName: stage, Fingerprint: fp, Status: status,
+	}
+}
+
+func TestBuildStagePrompt_UpstreamFindingsSection(t *testing.T) {
+	upstream := []pipeline.Artifact{
+		upstreamFinding("scan", "fp-open", "error", "src/a.go", "leak", pipeline.ArtifactStatusOpen),
+		upstreamFinding("scan", "fp-dismissed", "warning", "src/b.go", "nit", pipeline.ArtifactStatusDismissed),
+	}
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil, pipeline.RunContext{}, upstream)
+
+	for _, want := range []string{
+		"## Upstream findings",
+		"fp=fp-open",
+		"(scan)",
+		"src/a.go:10-12",
+		"leak",
+		"status: open",
+		"fp=fp-dismissed",
+		"status: dismissed",
+		// the reporting contract must teach the status-record vocabulary
+		`{ kind: "status", fingerprint:`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prompt missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
+func TestBuildStagePrompt_NoUpstreamNoSection(t *testing.T) {
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil, pipeline.RunContext{}, nil)
+	if strings.Contains(got, "## Upstream findings") {
+		t.Errorf("no dependsOn artifacts must not render an Upstream findings section\n%s", got)
+	}
+}
+
+func TestBuildStagePrompt_UpstreamFindingsCap(t *testing.T) {
+	var upstream []pipeline.Artifact
+	for i := 0; i < upstreamFindingsCap+25; i++ {
+		upstream = append(upstream, upstreamFinding("scan", "fp", "info", "src/x.go", "t", pipeline.ArtifactStatusOpen))
+	}
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil, pipeline.RunContext{}, upstream)
+	if !strings.Contains(got, "and 25 more findings not shown") {
+		t.Errorf("expected overflow note for cap %d\n%s", upstreamFindingsCap, got)
+	}
+	if n := strings.Count(got, "- [info] fp=fp"); n != upstreamFindingsCap {
+		t.Errorf("want %d rendered finding lines, got %d", upstreamFindingsCap, n)
+	}
+}
+
 func TestBuildStagePrompt_CoreShape(t *testing.T) {
 	round := 3
-	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), &round, pipeline.RunContext{})
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), &round, pipeline.RunContext{}, nil)
 
 	for _, want := range []string{
 		"## Pipeline Stage",
@@ -38,7 +94,7 @@ func TestBuildStagePrompt_CoreShape(t *testing.T) {
 }
 
 func TestBuildStagePrompt_ReviewModeFindingSchema(t *testing.T) {
-	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil, pipeline.RunContext{})
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil, pipeline.RunContext{}, nil)
 	if !strings.Contains(got, `"finding"`) || !strings.Contains(got, "severity") {
 		t.Errorf("review mode must document the finding record schema\n%s", got)
 	}
@@ -48,7 +104,7 @@ func TestBuildStagePrompt_ReviewModeFindingSchema(t *testing.T) {
 }
 
 func TestBuildStagePrompt_AnswerModeJSONSchema(t *testing.T) {
-	got := buildStagePrompt("ci", agentStage(pipeline.ModeAnswer), nil, pipeline.RunContext{})
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeAnswer), nil, pipeline.RunContext{}, nil)
 	if !strings.Contains(got, `"json"`) || !strings.Contains(got, "outputSchema") {
 		t.Errorf("answer mode must document the json record schema\n%s", got)
 	}
@@ -58,7 +114,7 @@ func TestBuildStagePrompt_BlocksMergeNotice(t *testing.T) {
 	stage := agentStage(pipeline.ModeReview)
 	blocks := true
 	stage.Policy = &pipeline.StagePolicy{BlocksMerge: &blocks}
-	got := buildStagePrompt("ci", stage, nil, pipeline.RunContext{})
+	got := buildStagePrompt("ci", stage, nil, pipeline.RunContext{}, nil)
 	if !strings.Contains(got, "block merge") {
 		t.Errorf("blocksMerge stage must warn about blocking merge\n%s", got)
 	}
@@ -67,7 +123,7 @@ func TestBuildStagePrompt_BlocksMergeNotice(t *testing.T) {
 func TestBuildStagePrompt_InputsRendered(t *testing.T) {
 	stage := agentStage(pipeline.ModeReview)
 	stage.Task.Inputs = map[string]any{"threshold": 5}
-	got := buildStagePrompt("ci", stage, nil, pipeline.RunContext{})
+	got := buildStagePrompt("ci", stage, nil, pipeline.RunContext{}, nil)
 	if !strings.Contains(got, "## Inputs") || !strings.Contains(got, "threshold") {
 		t.Errorf("inputs must be rendered as a JSON block\n%s", got)
 	}
@@ -81,7 +137,7 @@ func TestBuildStagePrompt_PRBlockRendered(t *testing.T) {
 		TargetBranch: "main",
 		HeadSHA:      "abc123",
 	}
-	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil, prCtx)
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil, prCtx, nil)
 	for _, want := range []string{
 		"## Pull request",
 		"Number: #42",
@@ -96,7 +152,7 @@ func TestBuildStagePrompt_PRBlockRendered(t *testing.T) {
 }
 
 func TestBuildStagePrompt_NoPRContextOmitsBlock(t *testing.T) {
-	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil, pipeline.RunContext{})
+	got := buildStagePrompt("ci", agentStage(pipeline.ModeReview), nil, pipeline.RunContext{}, nil)
 	if strings.Contains(got, "## Pull request") {
 		t.Errorf("empty PR context must not render a PR block\n%s", got)
 	}
@@ -107,7 +163,7 @@ func TestBuildStagePrompt_NonAgentStageOmitsMode(t *testing.T) {
 		Name:     "typecheck",
 		Executor: pipeline.StageExecutor{Kind: pipeline.ExecutorCommand, Command: "tsc"},
 	}
-	got := buildStagePrompt("ci", stage, nil, pipeline.RunContext{})
+	got := buildStagePrompt("ci", stage, nil, pipeline.RunContext{}, nil)
 	if strings.Contains(got, "Mode:") {
 		t.Errorf("command stage has no agent mode line\n%s", got)
 	}

--- a/backend/internal/pipeline/reducer.go
+++ b/backend/internal/pipeline/reducer.go
@@ -275,7 +275,7 @@ func reduceStageCompleted(state EngineState, event StageCompleted) (EngineState,
 	updatedStage.Output = event.Output
 	updatedStage.Artifacts = append(append([]ArtifactID{}, stage.Artifacts...), newIDs...)
 
-	return finalizeStageCompletion(state, run, event.StageName, updatedStage, newArtifacts, now)
+	return finalizeStageCompletion(state, run, event.StageName, updatedStage, newArtifacts, event.StatusChanges, now)
 }
 
 func reduceStageFailed(state EngineState, event StageFailed) (EngineState, []Effect) {
@@ -326,7 +326,7 @@ func failStage(state EngineState, run RunState, stageName, errorMessage, output 
 	updatedStage.Output = output
 	updatedStage.Deadline = nil
 
-	return finalizeStageCompletion(state, run, stageName, updatedStage, nil, now, preceding...)
+	return finalizeStageCompletion(state, run, stageName, updatedStage, nil, nil, now, preceding...)
 }
 
 // retryStage re-pends a failed stage for another attempt (fresh stageRunId,
@@ -505,7 +505,7 @@ func roundCappedObservations(runID RunID, skippedNames []string, run RunState) [
 // and terminates the run (checking convergence then exit predicates) once every
 // stage is terminal. Shared by STAGE_COMPLETED and STAGE_FAILED. preceding
 // effects (e.g. a CANCEL_STAGE for a timed-out stage) are emitted first.
-func finalizeStageCompletion(state EngineState, run RunState, stageName string, updatedStage StageState, newArtifacts []Artifact, now time.Time, preceding ...Effect) (EngineState, []Effect) {
+func finalizeStageCompletion(state EngineState, run RunState, stageName string, updatedStage StageState, newArtifacts []Artifact, statusChanges []FindingStatusChange, now time.Time, preceding ...Effect) (EngineState, []Effect) {
 	// Accumulate finding fingerprints onto the run so summarizeRun can return
 	// them at termination. Append rather than recompute so the reducer never
 	// re-reads stored artifacts.
@@ -539,6 +539,17 @@ func finalizeStageCompletion(state EngineState, run RunState, stageName string, 
 			StageRunID: updatedStage.StageRunID,
 			Artifacts:  newArtifacts,
 		})
+	}
+
+	// Apply this stage's {kind:"status"} records BEFORE scheduling and the exit
+	// decision, so a verify stage resolving (or reopening) a finding actually
+	// changes whether no_open_findings holds. Runs after the AppendArtifacts effect
+	// so the UPDATE lands on an already-persisted row when the record targets a
+	// finding this same stage just emitted.
+	if len(statusChanges) > 0 {
+		var statusEffects []Effect
+		updatedRun, statusEffects = applyFindingStatusChanges(updatedRun, statusChanges)
+		effects = append(effects, statusEffects...)
 	}
 
 	effects = append(effects, EmitObservation{
@@ -580,6 +591,44 @@ func finalizeStageCompletion(state EngineState, run RunState, stageName string, 
 	out = append(out, sched.startEffects...)
 
 	return replaceRun(state, sched.run), out
+}
+
+// applyFindingStatusChanges flips the status of every finding in run.Findings
+// whose fingerprint matches a status change, returning the updated run plus one
+// UpdateArtifactStatus effect per applied flip (so the store stays in sync). A
+// fingerprint that matches no finding is tolerated: it yields a
+// pipeline.status.unknown_fingerprint observation, never a failure. Pure and
+// copy-on-write: run.Findings is not mutated in place.
+func applyFindingStatusChanges(run RunState, changes []FindingStatusChange) (RunState, []Effect) {
+	findings := append([]Artifact{}, run.Findings...)
+	var effects []Effect
+	for _, ch := range changes {
+		matched := false
+		for i := range findings {
+			if findings[i].Fingerprint != "" && findings[i].Fingerprint == ch.Fingerprint {
+				matched = true
+				findings[i].Status = ch.Status
+				effects = append(effects, UpdateArtifactStatus{
+					RunID:      run.RunID,
+					StageRunID: findings[i].StageRunID,
+					ArtifactID: findings[i].ArtifactID,
+					Status:     ch.Status,
+				})
+			}
+		}
+		if !matched {
+			effects = append(effects, EmitObservation{
+				Name: "pipeline.status.unknown_fingerprint",
+				Data: map[string]any{
+					"runId":       run.RunID,
+					"fingerprint": ch.Fingerprint,
+					"status":      ch.Status,
+				},
+			})
+		}
+	}
+	run.Findings = findings
+	return run, effects
 }
 
 func reduceNewSHADetected(state EngineState, event NewSHADetected) (EngineState, []Effect) {

--- a/backend/internal/pipeline/types.go
+++ b/backend/internal/pipeline/types.go
@@ -333,6 +333,17 @@ func (s ArtifactStatus) IsKnown() bool {
 	return false
 }
 
+// FindingStatusChange is a stage-reported request to flip an existing finding's
+// lifecycle status, addressed by its stable fingerprint. It is produced by
+// harvesting {kind:"status"} records from a stage's findings file and carried on
+// the StageCompleted event so the reducer can apply the flip (to run.Findings and
+// the store) BEFORE the run's exit decision, letting a verify stage's resolve or
+// reopen actually decide whether the run is done.
+type FindingStatusChange struct {
+	Fingerprint string         `json:"fingerprint"`
+	Status      ArtifactStatus `json:"status"`
+}
+
 // ArtifactKind distinguishes a finding artifact from a free-form JSON
 // artifact.
 type ArtifactKind string

--- a/backend/internal/service/pipeline/pipeline.go
+++ b/backend/internal/service/pipeline/pipeline.go
@@ -449,9 +449,13 @@ func (s *Service) GetArtifact(ctx context.Context, id pipeline.ArtifactID) (pipe
 // direct store write) keeps run state owned by the actor loop and mirrors the
 // status onto the in-memory run's findings.
 func (s *Service) UpdateArtifactStatus(ctx context.Context, projectID domain.ProjectID, runID pipeline.RunID, artifactID pipeline.ArtifactID, status pipeline.ArtifactStatus) (pipeline.Artifact, error) {
-	if !status.IsKnown() {
+	// Restrict the human path to the same subset the findings-file status records
+	// allow: sent_to_agent is engine-internal and never set from the outside.
+	switch status {
+	case pipeline.ArtifactStatusOpen, pipeline.ArtifactStatusResolved, pipeline.ArtifactStatusDismissed:
+	default:
 		return pipeline.Artifact{}, apierr.Invalid("PIPELINE_ARTIFACT_STATUS_INVALID",
-			fmt.Sprintf("status must be one of open|dismissed|sent_to_agent|resolved, got %q", status), nil)
+			fmt.Sprintf("status must be one of open|resolved|dismissed, got %q", status), nil)
 	}
 	art, ok, err := s.store.GetPipelineArtifact(ctx, artifactID)
 	if err != nil {

--- a/backend/internal/service/pipeline/pipeline.go
+++ b/backend/internal/service/pipeline/pipeline.go
@@ -49,6 +49,7 @@ type Engine interface {
 	TriggerRun(req engine.TriggerRequest) (pipeline.RunID, error)
 	Cancel(runID pipeline.RunID, reason pipeline.RunTerminationReason)
 	Resume(runID pipeline.RunID)
+	ChangeArtifactStatus(req engine.ArtifactStatusRequest)
 	Dispatch(event pipeline.Event)
 	State() pipeline.EngineState
 }
@@ -107,6 +108,8 @@ type Manager interface {
 	// settled run, the latest settled run's head SHA is stale relative to the
 	// PR's current head, or either argument is empty.
 	PRBlocksMerge(ctx context.Context, projectID domain.ProjectID, prURL, headSHA string) (bool, error)
+
+	UpdateArtifactStatus(ctx context.Context, projectID domain.ProjectID, runID pipeline.RunID, artifactID pipeline.ArtifactID, status pipeline.ArtifactStatus) (pipeline.Artifact, error)
 }
 
 // Service is the concrete Manager over a Store + Engines.
@@ -436,6 +439,43 @@ func (s *Service) GetArtifact(ctx context.Context, id pipeline.ArtifactID) (pipe
 			fmt.Sprintf("no artifact %q", id))
 	}
 	return art, nil
+}
+
+// UpdateArtifactStatus changes one finding's lifecycle status (e.g. a human
+// dismissing a false positive, or reopening a dismissed finding) through the
+// project engine, then returns the artifact read back from the store. The status
+// is validated against the artifact status enum; an unknown artifact, or one that
+// does not belong to the named run, is a 404. Routing through the engine (not a
+// direct store write) keeps run state owned by the actor loop and mirrors the
+// status onto the in-memory run's findings.
+func (s *Service) UpdateArtifactStatus(ctx context.Context, projectID domain.ProjectID, runID pipeline.RunID, artifactID pipeline.ArtifactID, status pipeline.ArtifactStatus) (pipeline.Artifact, error) {
+	if !status.IsKnown() {
+		return pipeline.Artifact{}, apierr.Invalid("PIPELINE_ARTIFACT_STATUS_INVALID",
+			fmt.Sprintf("status must be one of open|dismissed|sent_to_agent|resolved, got %q", status), nil)
+	}
+	art, ok, err := s.store.GetPipelineArtifact(ctx, artifactID)
+	if err != nil {
+		return pipeline.Artifact{}, err
+	}
+	if !ok || art.PipelineRunID != runID {
+		return pipeline.Artifact{}, apierr.NotFound("PIPELINE_ARTIFACT_NOT_FOUND",
+			fmt.Sprintf("no artifact %q on run %q", artifactID, runID))
+	}
+
+	eng, err := s.engines.For(ctx, projectID)
+	if err != nil {
+		return pipeline.Artifact{}, err
+	}
+	eng.ChangeArtifactStatus(engine.ArtifactStatusRequest{
+		RunID:      runID,
+		StageRunID: art.StageRunID,
+		ArtifactID: artifactID,
+		Status:     status,
+		Actor:      "user",
+	})
+	// ChangeArtifactStatus is synchronous on the engine actor (the UPDATE effect
+	// runs before it returns), so the read-back reflects the new status.
+	return s.GetArtifact(ctx, artifactID)
 }
 
 // parse validates raw YAML, passing a *pipeline.ValidationError (the full issue

--- a/backend/internal/service/pipeline/pipeline_test.go
+++ b/backend/internal/service/pipeline/pipeline_test.go
@@ -65,6 +65,13 @@ func (f *fakeExecutor) fail(stage, msg string) {
 	f.ready[stage] = true
 }
 
+func (f *fakeExecutor) complete(stage string, arts ...pipeline.ArtifactInput) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.outcome[stage] = executors.Outcome{Status: executors.OutcomeCompleted, Verdict: pipeline.VerdictPass, Artifacts: arts}
+	f.ready[stage] = true
+}
+
 // staticEngines hands the same engine back for any project.
 type staticEngines struct{ eng Engine }
 
@@ -399,5 +406,72 @@ func TestPRBlocksMerge(t *testing.T) {
 	check("", false)
 	if got, _ := svc.PRBlocksMerge(ctx, "mer", "", "sha1"); got {
 		t.Fatal("empty prURL should be no opinion")
+	}
+}
+
+// TestUpdateArtifactStatusDismissAndReopen drives a run that emits a finding,
+// then dismisses it through the service and reopens it, asserting the status
+// flips durably each time and that bad inputs are rejected.
+func TestUpdateArtifactStatusDismissAndReopen(t *testing.T) {
+	ctx := context.Background()
+	svc, eng, store, fake := newHarness(t)
+	if _, err := svc.CreateDefinition(ctx, "mer", reviewYAML); err != nil {
+		t.Fatalf("create definition: %v", err)
+	}
+	runID, err := svc.TriggerRun(ctx, "mer", TriggerInput{Ref: "review", SessionID: "mer-1"})
+	if err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+
+	fake.complete("review", pipeline.ArtifactInput{
+		Kind: pipeline.ArtifactKindFinding, FilePath: "main.go", StartLine: 1, EndLine: 2,
+		Title: "bug", Category: "correctness", Severity: pipeline.SeverityError,
+	})
+	eng.Tick()
+
+	run, err := svc.GetRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if len(run.Findings) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(run.Findings))
+	}
+	artID := run.Findings[0].ArtifactID
+
+	// Dismiss.
+	got, err := svc.UpdateArtifactStatus(ctx, "mer", runID, artID, pipeline.ArtifactStatusDismissed)
+	if err != nil {
+		t.Fatalf("dismiss: %v", err)
+	}
+	if got.Status != pipeline.ArtifactStatusDismissed {
+		t.Fatalf("returned status = %s, want dismissed", got.Status)
+	}
+	persisted, _, _ := store.GetPipelineArtifact(ctx, artID)
+	if persisted.Status != pipeline.ArtifactStatusDismissed {
+		t.Fatalf("persisted status = %s, want dismissed", persisted.Status)
+	}
+
+	// Reopen.
+	got, err = svc.UpdateArtifactStatus(ctx, "mer", runID, artID, pipeline.ArtifactStatusOpen)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if got.Status != pipeline.ArtifactStatusOpen {
+		t.Fatalf("returned status = %s, want open", got.Status)
+	}
+
+	// Bad status is rejected before touching the engine.
+	if _, err := svc.UpdateArtifactStatus(ctx, "mer", runID, artID, pipeline.ArtifactStatus("nonsense")); err == nil {
+		t.Fatal("bad status must error")
+	}
+
+	// Unknown artifact is a 404-style error.
+	if _, err := svc.UpdateArtifactStatus(ctx, "mer", runID, "no-such-artifact", pipeline.ArtifactStatusDismissed); err == nil {
+		t.Fatal("unknown artifact must error")
+	}
+
+	// An artifact that belongs to a different run is not found on this run.
+	if _, err := svc.UpdateArtifactStatus(ctx, "mer", "run-other", artID, pipeline.ArtifactStatusDismissed); err == nil {
+		t.Fatal("artifact on a mismatched run must error")
 	}
 }

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -946,7 +946,7 @@ export interface components {
             updatedAt: string;
         };
         ControllersUpdatePipelineArtifactStatusRequest: {
-            /** @description New artifact status: open | dismissed | sent_to_agent | resolved. */
+            /** @description New artifact status: open | resolved | dismissed. */
             status: string;
         };
         DegradedProject: {

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -349,6 +349,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Change a pipeline finding's lifecycle status (dismiss, reopen, resolve) */
+        post: operations["updatePipelineArtifactStatus"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/pipelines/runs/{runId}/cancel": {
         parameters: {
             query?: never;
@@ -927,6 +944,10 @@ export interface components {
             terminalHandleId?: string;
             /** Format: date-time */
             updatedAt: string;
+        };
+        ControllersUpdatePipelineArtifactStatusRequest: {
+            /** @description New artifact status: open | dismissed | sent_to_agent | resolved. */
+            status: string;
         };
         DegradedProject: {
             id: string;
@@ -2707,6 +2728,74 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PipelineArtifactResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    updatePipelineArtifactStatus: {
+        parameters: {
+            query?: {
+                /** @description Project id the pipeline belongs to (required). */
+                project?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Pipeline run identifier. */
+                runId: string;
+                /** @description Artifact identifier. */
+                artifactId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllersUpdatePipelineArtifactStatusRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PipelineArtifactResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
                 };
             };
             /** @description Not Found */

--- a/frontend/src/renderer/components/PipelineRunDetail.test.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.test.tsx
@@ -144,4 +144,42 @@ describe("PipelineRunDetail", () => {
 
 		expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
 	});
+
+	it("dismisses an open finding via the artifact-status endpoint", async () => {
+		setRun(detail({ findings: [finding({ artifactId: "f1", title: "Open bug" })] }));
+		renderDetail("proj-9");
+
+		const row = screen.getByText("Open bug").closest("[data-finding]") as HTMLElement;
+		await userEvent.setup().click(within(row).getByRole("button", { name: "Dismiss" }));
+
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+		expect(postMock).toHaveBeenCalledWith("/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status", {
+			params: { path: { runId: "run-1", artifactId: "f1" }, query: { project: "proj-9" } },
+			body: { status: "dismissed" },
+		});
+	});
+
+	it("reopens a dismissed finding with status open", async () => {
+		setRun(detail({ findings: [finding({ artifactId: "f2", title: "Nit", status: "dismissed" })] }));
+		renderDetail("proj-9");
+
+		// Reveal the dismissed row first.
+		await userEvent.setup().click(screen.getByRole("switch"));
+		const row = screen.getByText("Nit").closest("[data-finding]") as HTMLElement;
+		await userEvent.setup().click(within(row).getByRole("button", { name: "Undo" }));
+
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+		expect(postMock).toHaveBeenCalledWith("/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status", {
+			params: { path: { runId: "run-1", artifactId: "f2" }, query: { project: "proj-9" } },
+			body: { status: "open" },
+		});
+	});
+
+	it("disables the dismiss button when the run's project is unknown", () => {
+		setRun(detail({ findings: [finding({ artifactId: "f1", title: "Open bug" })] }));
+		renderDetail(undefined);
+
+		const row = screen.getByText("Open bug").closest("[data-finding]") as HTMLElement;
+		expect(within(row).getByRole("button", { name: "Dismiss" })).toBeDisabled();
+	});
 });

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -133,7 +133,13 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 				</div>
 				<div className="flex flex-col gap-2">
 					{findings.map((finding) => (
-						<FindingRow key={finding.artifactId} finding={finding} />
+						<FindingRow
+							key={finding.artifactId}
+							finding={finding}
+							runId={runId}
+							project={project}
+							onChanged={refresh}
+						/>
 					))}
 					{findings.length === 0 && <p className="text-caption text-passive">No findings.</p>}
 				</div>
@@ -182,17 +188,45 @@ function StageRow({ stage }: { stage: PipelineStageView }) {
 	);
 }
 
-function FindingRow({ finding }: { finding: PipelineArtifact }) {
+function FindingRow({
+	finding,
+	runId,
+	project,
+	onChanged,
+}: {
+	finding: PipelineArtifact;
+	runId: string;
+	project?: string;
+	onChanged: () => void;
+}) {
+	const [error, setError] = useState<string | null>(null);
 	const location = finding.filePath
 		? `${finding.filePath}${finding.startLine ? `:${finding.startLine}` : ""}`
 		: undefined;
+	const isDismissed = finding.status === "dismissed";
+
+	// Dismiss hides a false-positive finding so it stops blocking no_open_findings
+	// gates; Undo reopens it. Both POST the new status, then invalidate on success.
+	const setStatus = useMutation({
+		mutationFn: async (status: "open" | "dismissed") => {
+			if (!project) throw new Error("Project is unknown for this run");
+			const { error: apiError } = await apiClient.POST("/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status", {
+				params: { path: { runId, artifactId: finding.artifactId }, query: { project } },
+				body: { status },
+			});
+			if (apiError) throw new Error(apiErrorMessage(apiError));
+		},
+		onSuccess: () => {
+			setError(null);
+			onChanged();
+		},
+		onError: (e: unknown) => setError(e instanceof Error ? e.message : "Action failed"),
+	});
+
 	return (
 		<div
 			data-finding={finding.artifactId}
-			className={cn(
-				"rounded-md border border-border bg-card px-3 py-2",
-				finding.status === "dismissed" && "opacity-60",
-			)}
+			className={cn("rounded-md border border-border bg-card px-3 py-2", isDismissed && "opacity-60")}
 		>
 			<div className="flex flex-wrap items-center gap-2">
 				<span className="truncate text-caption font-medium text-foreground">{finding.title || "(untitled)"}</span>
@@ -202,9 +236,22 @@ function FindingRow({ finding }: { finding: PipelineArtifact }) {
 					<span className="font-mono text-micro text-passive">· {Math.round(finding.confidence * 100)}%</span>
 				)}
 				<span className="ml-auto font-mono text-micro text-passive">{finding.stageName}</span>
+				{finding.kind === "finding" && (
+					<Button
+						size="sm"
+						variant="ghost"
+						className="h-6 px-2 text-micro"
+						disabled={setStatus.isPending || !project}
+						title={project ? undefined : "Open this run from the board to change findings"}
+						onClick={() => setStatus.mutate(isDismissed ? "open" : "dismissed")}
+					>
+						{setStatus.isPending ? "…" : isDismissed ? "Undo" : "Dismiss"}
+					</Button>
+				)}
 			</div>
 			{location && <p className="mt-0.5 font-mono text-micro text-passive">{location}</p>}
 			{finding.description && <p className="mt-1 text-micro text-muted-foreground">{finding.description}</p>}
+			{error && <p className="mt-1 font-mono text-micro text-error">{error}</p>}
 		</div>
 	);
 }


### PR DESCRIPTION
Closes #272.

Gives pipeline findings a real lifecycle. Base branch: `pipelines` (fork-only, `pipelines-v1`). Builds on #275/#276/#278/#279.

## What changed

### 1. Status records in the findings file
- Extended the findings JSONL contract with `{kind: "status", fingerprint, status: "open"|"resolved"|"dismissed"}` (`executors/findings.go`). Bad status / missing fields fail the harvest; malformed lines still fail; an unknown fingerprint is tolerated (resolved at apply time, not parse time).
- Threaded through the executor `Outcome.StatusChanges` for BOTH agent and command executors (shared harvest helper).
- After `STAGE_COMPLETED`, the engine resolves each fingerprint against the run's materialized findings and dispatches one `ARTIFACT_STATUS_CHANGED` per match (`engine.applyStatusChanges`). An unresolvable fingerprint emits a `pipeline.status.unknown_fingerprint` observation instead of failing the stage. The reducer stays pure (matching happens in the engine).

### 2. Upstream findings to agent prompts
- `engine.startInput` resolves the stage's `dependsOn` findings from the run's in-memory materialized findings and puts them on `StartInput.UpstreamFindings` (no store round-trip; findings are already denormalized onto `RunState.Findings`). Builtin executor keeps its own store fetch, untouched.
- `buildStagePrompt` renders an `## Upstream findings` section: one line per finding with fingerprint, severity, stage of origin, file:line, title, and current status, capped at 100 with an overflow note.
- The findings-contract text now teaches review/code/answer modes how to emit `{kind: "status"}` records referencing those fingerprints.

### 3. Human dismiss path
- `Manager.UpdateArtifactStatus(project, runID, artifactID, status)` validates the status enum, checks the artifact belongs to the run, and routes through `engine.ChangeArtifactStatus` (so run state stays owned by the actor loop).
- `POST /api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status` `{status}`, gated like every pipelines route. OpenAPI + `schema.ts` regenerated.
- `FindingRow` gets a Dismiss button for open findings and Undo for dismissed ones, optimistic via the existing query invalidation. Change confined to `FindingRow`.

### Scope guard
Did not touch `decideRunExit`, the scheduler, loop keys, or `blocksMerge` (owned by #273). UI change confined to `FindingRow`; DTO change confined to the artifact-status route.

## Tests
- `findings_test`: status-record parse (valid, bad status, sent_to_agent barred, missing/empty fingerprint, missing status).
- `stageprompt_test`: upstream section content, cap + overflow, absent with no deps, status-record vocabulary present.
- `engine_test`: upstream findings threaded to downstream `StartInput`; status record flips finding status in state + store; unknown fingerprint tolerated (stage still succeeds, finding untouched).
- `pipeline_test` (service): dismiss + reopen durable, bad status rejected, unknown artifact and run-mismatch 404.
- `pipelines_test` (controller): happy path, missing project 400, bad JSON 400, bad status, unknown artifact 404, flag-off 501.
- `PipelineRunDetail.test.tsx`: dismiss and reopen call the endpoint with the right body; disabled when project unknown.

## Verification
- `go build ./...`, `go test ./...` (the 4 pre-existing `internal/cli` spawn failures reproduce on `pipelines` base, unrelated), gofmt clean, golangci-lint clean on touched packages.
- Frontend `tsc --noEmit` clean, `vitest` 912 passed, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)