### PR TITLE
fix(pipelines): fall back to derived branch when PR source branch is checked out elsewhere

### DIFF
--- a/backend/internal/daemon/pipeline_wiring.go
+++ b/backend/internal/daemon/pipeline_wiring.go
@@ -26,7 +26,7 @@ type pipelineStack struct {
 // start failure is logged, never fatal: an unhealthy pipeline subsystem must not
 // block daemon boot, and idle engines (no definitions, no triggers) are harmless.
 func startPipelineEngine(ctx context.Context, store *sqlite.Store, sessions pipelineengine.SessionCommander, bcast *cdc.Broadcaster, log *slog.Logger) *pipelineStack {
-	execs := pipelineengine.BuildExecutorSet(sessions, store)
+	execs := pipelineengine.BuildExecutorSet(sessions, store, log)
 	sup := pipelineengine.NewSupervisor(pipelineengine.SupervisorConfig{
 		Store:     store,
 		Executors: execs,

--- a/backend/internal/pipeline/engine/adapters.go
+++ b/backend/internal/pipeline/engine/adapters.go
@@ -2,8 +2,13 @@ package engine
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -35,8 +40,11 @@ type SessionReader interface {
 // BuildExecutorSet assembles the three kind executors over the real session
 // service + store and returns the routing facade the engine drives. This is the
 // single place the executors are wired to infra.
-func BuildExecutorSet(cmd SessionCommander, reader SessionReader) *executors.Set {
-	agent := executors.NewAgentExecutor(&sessionSpawnerAdapter{cmd: cmd, reader: reader})
+func BuildExecutorSet(cmd SessionCommander, reader SessionReader, log *slog.Logger) *executors.Set {
+	if log == nil {
+		log = slog.Default()
+	}
+	agent := executors.NewAgentExecutor(&sessionSpawnerAdapter{cmd: cmd, reader: reader, log: log})
 	// nil LogSink: the subprocess output is still captured (capped) for the
 	// JSON-over-stdout contract; streaming it to an activity log is a phase-2
 	// nicety, not needed for correctness.
@@ -54,6 +62,7 @@ func BuildExecutorSet(cmd SessionCommander, reader SessionReader) *executors.Set
 type sessionSpawnerAdapter struct {
 	cmd    SessionCommander
 	reader SessionReader
+	log    *slog.Logger
 }
 
 var _ executors.SessionSpawner = (*sessionSpawnerAdapter)(nil)
@@ -68,12 +77,101 @@ func (a *sessionSpawnerAdapter) Spawn(ctx context.Context, req executors.SpawnRe
 		Prompt:    req.Prompt,
 	})
 	if err != nil {
+		// The PR's owning worker session usually has the PR source branch checked
+		// out while alive, so a pr.updated-triggered stage spawn onto that branch
+		// is refused (ErrWorkspaceBranchCheckedOutElsewhere, surfaced as a 409).
+		// Fall back once to a run-unique derived branch based at the PR head so the
+		// stage still runs; the agent pushes with `git push origin HEAD:<branch>`.
+		if req.Branch == "" || !isBranchCheckedOutElsewhere(err) {
+			return executors.SpawnedSession{}, err
+		}
+		return a.spawnOnFallbackBranch(ctx, req, err)
+	}
+	return executors.SpawnedSession{
+		SessionID:     string(sess.ID),
+		WorkspacePath: sess.Metadata.WorkspacePath,
+	}, nil
+}
+
+// spawnOnFallbackBranch retries a spawn that was refused because req.Branch is
+// checked out elsewhere. It creates a fresh derived branch based at the original
+// branch's head (BaseBranch), notes the substitution in the prompt, and logs it.
+func (a *sessionSpawnerAdapter) spawnOnFallbackBranch(ctx context.Context, req executors.SpawnRequest, cause error) (executors.SpawnedSession, error) {
+	fallback := fallbackBranchName(req.StageRunID)
+	a.log.Warn("pipeline spawn: source branch checked out elsewhere, using fallback branch",
+		"sourceBranch", req.Branch,
+		"fallbackBranch", fallback,
+		"stageRunId", req.StageRunID,
+		"cause", cause.Error(),
+	)
+	sess, err := a.cmd.Spawn(ctx, ports.SpawnConfig{
+		ProjectID:  domain.ProjectID(req.ProjectID),
+		IssueID:    domain.IssueID(req.IssueID),
+		Kind:       domain.KindWorker,
+		Harness:    domain.AgentHarness(req.Harness),
+		Branch:     fallback,
+		BaseBranch: req.Branch,
+		Prompt:     appendFallbackBranchNote(req.Prompt, fallback, req.Branch),
+	})
+	if err != nil {
 		return executors.SpawnedSession{}, err
 	}
 	return executors.SpawnedSession{
 		SessionID:     string(sess.ID),
 		WorkspacePath: sess.Metadata.WorkspacePath,
 	}, nil
+}
+
+// isBranchCheckedOutElsewhere reports whether err is the branch-conflict refusal.
+// The session service maps the workspace sentinel to a typed API error whose
+// Unwrap chain does not carry the sentinel, so both forms are checked: the
+// wrapped sentinel (direct session-manager wiring) and the API error code (the
+// production path through session.Service).
+func isBranchCheckedOutElsewhere(err error) bool {
+	if errors.Is(err, ports.ErrWorkspaceBranchCheckedOutElsewhere) {
+		return true
+	}
+	var apiErr *apierr.Error
+	return errors.As(err, &apiErr) && apiErr.Code == "BRANCH_CHECKED_OUT_ELSEWHERE"
+}
+
+// fallbackBranchName mints a collision-free branch under pipeline/ from the
+// stage run id (itself run-unique, e.g. sr-<uuid> or sr-<uuid>#2 on retry). A
+// missing id falls back to a fixed leaf; the caller only reaches this when a
+// real stage spawn conflicts, where StageRunID is always set.
+func fallbackBranchName(stageRunID string) string {
+	leaf := sanitizeBranchSegment(stageRunID)
+	if leaf == "" {
+		leaf = "stage"
+	}
+	return "pipeline/" + leaf
+}
+
+// sanitizeBranchSegment collapses characters git refnames forbid into '-' so an
+// id like "sr-abc#2" becomes a valid branch leaf "sr-abc-2".
+func sanitizeBranchSegment(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return strings.Trim(b.String(), "-.")
+}
+
+// appendFallbackBranchNote tells the agent it is on a derived branch and how to
+// push back to the real PR source branch. The stage prompt already names the PR
+// branch; this only clarifies the substitution.
+func appendFallbackBranchNote(prompt, fallback, sourceBranch string) string {
+	note := fmt.Sprintf("Note: this session is on fallback branch `%s` because `%s` was already checked out in another worktree. Push your work with `git push origin HEAD:%s`.",
+		fallback, sourceBranch, sourceBranch)
+	if strings.TrimSpace(prompt) == "" {
+		return note
+	}
+	return prompt + "\n\n" + note
 }
 
 func (a *sessionSpawnerAdapter) Get(ctx context.Context, sessionID string) (executors.SessionSnapshot, bool, error) {

--- a/backend/internal/pipeline/engine/adapters_test.go
+++ b/backend/internal/pipeline/engine/adapters_test.go
@@ -3,26 +3,39 @@ package engine
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-// fakeCommander records spawn/kill/send calls for the adapter tests.
+// fakeCommander records spawn/kill/send calls for the adapter tests. When
+// spawnErrOnce is set it is returned by the first Spawn and then cleared, so the
+// fallback-retry path can be exercised (the second Spawn succeeds).
 type fakeCommander struct {
-	spawned  ports.SpawnConfig
-	spawnOut domain.Session
-	spawnErr error
-	killErr  error
-	killed   []domain.SessionID
-	sent     map[domain.SessionID]string
+	spawned      ports.SpawnConfig
+	spawnConfigs []ports.SpawnConfig
+	spawnOut     domain.Session
+	spawnErr     error
+	spawnErrOnce error
+	killErr      error
+	killed       []domain.SessionID
+	sent         map[domain.SessionID]string
 }
 
 func (f *fakeCommander) Spawn(_ context.Context, cfg ports.SpawnConfig) (domain.Session, error) {
 	f.spawned = cfg
+	f.spawnConfigs = append(f.spawnConfigs, cfg)
+	if f.spawnErrOnce != nil {
+		err := f.spawnErrOnce
+		f.spawnErrOnce = nil
+		return domain.Session{}, err
+	}
 	return f.spawnOut, f.spawnErr
 }
 
@@ -86,6 +99,97 @@ func TestSessionSpawnerAdapterSpawnMapsConfig(t *testing.T) {
 		cmd.spawned.Prompt != "review this" || cmd.spawned.Harness != "codex" ||
 		cmd.spawned.Kind != domain.KindWorker {
 		t.Fatalf("spawn config mismapped: %+v", cmd.spawned)
+	}
+}
+
+// checkedOutElsewhereAPIErr mirrors what session.Service returns in production:
+// the workspace sentinel mapped by toAPIError into a typed 409 whose Unwrap chain
+// no longer carries the sentinel, only the stable code.
+func checkedOutElsewhereAPIErr() error {
+	return apierr.Conflict("BRANCH_CHECKED_OUT_ELSEWHERE", "workspace: branch is already checked out in another worktree", nil)
+}
+
+func TestSessionSpawnerAdapterFallbackOnBranchConflict(t *testing.T) {
+	cmd := &fakeCommander{
+		spawnErrOnce: checkedOutElsewhereAPIErr(),
+		spawnOut: domain.Session{SessionRecord: domain.SessionRecord{
+			ID: "mer-9", Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-9"},
+		}},
+	}
+	a := &sessionSpawnerAdapter{cmd: cmd, reader: &fakeReader{}, log: slog.Default()}
+
+	got, err := a.Spawn(context.Background(), executors.SpawnRequest{
+		ProjectID: "mer", Prompt: "review this", Harness: "codex",
+		Branch: "feature/x", StageRunID: "sr-abc#2",
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if got.SessionID != "mer-9" {
+		t.Fatalf("fallback spawn session = %+v", got)
+	}
+	if len(cmd.spawnConfigs) != 2 {
+		t.Fatalf("want 2 spawn attempts, got %d", len(cmd.spawnConfigs))
+	}
+	// First attempt: the real PR source branch, no base override.
+	if cmd.spawnConfigs[0].Branch != "feature/x" || cmd.spawnConfigs[0].BaseBranch != "" {
+		t.Fatalf("first attempt = %+v, want Branch=feature/x BaseBranch=empty", cmd.spawnConfigs[0])
+	}
+	// Retry: a derived pipeline/ branch based at the PR source branch head.
+	retry := cmd.spawnConfigs[1]
+	if retry.Branch != "pipeline/sr-abc-2" {
+		t.Fatalf("fallback branch = %q, want pipeline/sr-abc-2", retry.Branch)
+	}
+	if retry.BaseBranch != "feature/x" {
+		t.Fatalf("fallback base = %q, want feature/x", retry.BaseBranch)
+	}
+	if !strings.Contains(retry.Prompt, "review this") || !strings.Contains(retry.Prompt, "git push origin HEAD:feature/x") {
+		t.Fatalf("fallback prompt missing note or original: %q", retry.Prompt)
+	}
+}
+
+func TestSessionSpawnerAdapterNoRetryOnOtherError(t *testing.T) {
+	cmd := &fakeCommander{spawnErr: errors.New("boom")}
+	a := &sessionSpawnerAdapter{cmd: cmd, reader: &fakeReader{}, log: slog.Default()}
+
+	if _, err := a.Spawn(context.Background(), executors.SpawnRequest{
+		ProjectID: "mer", Branch: "feature/x", StageRunID: "sr-1",
+	}); err == nil {
+		t.Fatal("want error for non-conflict failure")
+	}
+	if len(cmd.spawnConfigs) != 1 {
+		t.Fatalf("non-conflict error must not retry, got %d attempts", len(cmd.spawnConfigs))
+	}
+}
+
+func TestSessionSpawnerAdapterEmptyBranchNeverRetries(t *testing.T) {
+	cmd := &fakeCommander{spawnErr: checkedOutElsewhereAPIErr()}
+	a := &sessionSpawnerAdapter{cmd: cmd, reader: &fakeReader{}, log: slog.Default()}
+
+	if _, err := a.Spawn(context.Background(), executors.SpawnRequest{
+		ProjectID: "mer", Branch: "", StageRunID: "sr-1",
+	}); err == nil {
+		t.Fatal("want error propagated for empty-branch spawn")
+	}
+	if len(cmd.spawnConfigs) != 1 {
+		t.Fatalf("empty-branch spawn must not retry, got %d attempts", len(cmd.spawnConfigs))
+	}
+}
+
+func TestFallbackBranchNamesUniquePerStage(t *testing.T) {
+	// Two stages of the same run carry distinct StageRunIDs, so their derived
+	// fallback branches never collide.
+	one := fallbackBranchName("sr-" + "aaaa-1111")
+	two := fallbackBranchName("sr-" + "bbbb-2222")
+	if one == two {
+		t.Fatalf("derived names collide: %q", one)
+	}
+	if one != "pipeline/sr-aaaa-1111" {
+		t.Fatalf("unexpected derived name %q", one)
+	}
+	// A retry attempt (#N suffix) sanitizes to a valid, distinct leaf.
+	if got := fallbackBranchName("sr-aaaa-1111#3"); got != "pipeline/sr-aaaa-1111-3" {
+		t.Fatalf("retry derived name = %q, want pipeline/sr-aaaa-1111-3", got)
 	}
 }
 

--- a/backend/internal/pipeline/executors/agent.go
+++ b/backend/internal/pipeline/executors/agent.go
@@ -24,6 +24,10 @@ type SpawnRequest struct {
 	// review sessions see the PR diff and can push to it. Empty spawns a fresh
 	// worktree off the project default branch.
 	Branch string
+	// StageRunID is the run-unique id of the stage attempt. The spawn adapter uses
+	// it to mint a collision-free fallback branch name when Branch is already
+	// checked out in another worktree.
+	StageRunID string
 }
 
 // SpawnedSession is what the session manager returns for a fresh spawn.
@@ -87,11 +91,12 @@ func (e *AgentExecutor) Start(ctx context.Context, in StartInput) (Handle, error
 
 	prompt := buildStagePrompt(in.PipelineName, in.Stage, in.LoopRound, in.Context, in.UpstreamFindings)
 	session, err := e.sessions.Spawn(ctx, SpawnRequest{
-		ProjectID: in.ProjectID,
-		IssueID:   in.IssueID,
-		Prompt:    prompt,
-		Harness:   in.Stage.Executor.Plugin,
-		Branch:    in.Context.SourceBranch,
+		ProjectID:  in.ProjectID,
+		IssueID:    in.IssueID,
+		Prompt:     prompt,
+		Harness:    in.Stage.Executor.Plugin,
+		Branch:     in.Context.SourceBranch,
+		StageRunID: string(in.StageRunID),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("agent executor: spawn session for stage %q: %w", in.Stage.Name, err)

--- a/backend/internal/ports/session.go
+++ b/backend/internal/ports/session.go
@@ -20,7 +20,12 @@ type SpawnConfig struct {
 	Kind         domain.SessionKind
 	Harness      domain.AgentHarness
 	Branch       string
-	Prompt       string
+	// BaseBranch overrides the base the new session branch is created from. Empty
+	// falls back to the project's default branch. The pipeline spawn path sets it
+	// to a PR source branch so a fallback derived branch starts at the PR head when
+	// the source branch is already checked out in another worktree.
+	BaseBranch string
+	Prompt     string
 
 	// DisplayName is the user-facing sidebar label. Empty falls back to the
 	// session id in the read model (e.g. orchestrator sessions).

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -407,7 +407,7 @@ func (m *Manager) createSessionWorkspace(ctx context.Context, project domain.Pro
 			Kind:          cfg.Kind,
 			SessionPrefix: sessionPrefix(project),
 			Branch:        branch,
-			BaseBranch:    project.Config.WithDefaults().DefaultBranch,
+			BaseBranch:    firstNonEmptyString(cfg.BaseBranch, project.Config.WithDefaults().DefaultBranch),
 		})
 		return ws, nil, err
 	}
@@ -434,7 +434,7 @@ func (m *Manager) createSessionWorkspace(ctx context.Context, project domain.Pro
 		SessionPrefix: sessionPrefix(project),
 		Branch:        branch,
 		RootRepoPath:  project.Path,
-		BaseBranch:    project.Config.WithDefaults().DefaultBranch,
+		BaseBranch:    firstNonEmptyString(cfg.BaseBranch, project.Config.WithDefaults().DefaultBranch),
 		Repos:         childRepos,
 	})
 	if err != nil {


### PR DESCRIPTION
## Problem

Since #275, agent stages spawn with `SpawnConfig.Branch` set to the PR source branch so the review session sees the PR diff. The gitworktree layer refuses a worktree for a branch already checked out in another worktree (`ErrWorkspaceBranchCheckedOutElsewhere`, surfaced as a 409). The PR's owning worker session usually holds exactly that branch while it is alive, so a `pr.updated`-triggered review stage fails to spawn in the common dogfood case, and the stage fails (now burning auto-retries since #279).

## Fix

The pipeline spawn adapter (`sessionSpawnerAdapter.Spawn`) retries **once** on that specific conflict:

- Derives a run-unique branch `pipeline/<stage-run-id>` (sanitized to a valid refname, unique across stages of a run and across retries).
- Bases it at the original PR source branch head via `SpawnConfig.BaseBranch` (resolves `origin/<sourceBranch>` in `addWorktree`), so the derived branch starts at the PR head.
- Logs the substitution (structured `slog.Warn` via a logger threaded into `BuildExecutorSet`).
- Appends a short prompt note so the agent pushes back with `git push origin HEAD:<sourceBranch>`.

Non-conflict errors and empty-`Branch` spawns never retry. One fallback attempt, then fail as before.

### Detection note
`session.Service.Spawn` maps the workspace sentinel through `toAPIError` into a typed 409 (`apierr.Conflict("BRANCH_CHECKED_OUT_ELSEWHERE", ...)`) whose `Unwrap` chain no longer carries the sentinel. Detection therefore matches **both** the wrapped `ports.ErrWorkspaceBranchCheckedOutElsewhere` (direct session-manager wiring) and the API error `Code` (the production path). `apierr` documents that any layer may depend on it without a cycle.

## Scope

Confined to the spawn path per the task brief: `engine/adapters.go`, `executors/agent.go` (adds `StageRunID` to `SpawnRequest`), `ports/session.go` (`SpawnConfig.BaseBranch`), `session_manager/manager.go` (honor `BaseBranch`), and `daemon/pipeline_wiring.go` (thread logger). No changes to `stageprompt.go`, `builtin.go`, `command.go`, or any frontend file.

## Tests

`internal/pipeline/engine/adapters_test.go`:
- first Spawn returns the branch-conflict (as the real mapped `apierr` 409), retry succeeds on a derived branch based at the source branch;
- non-conflict errors do not retry;
- empty-`Branch` spawns never retry;
- derived names are unique across two stages of the same run and sanitize the `#N` retry suffix.

`go build ./...`, `go test ./...` green (pre-existing CLI daemon-404 failures reproduce on base `pipelines`, unrelated). gofmt clean.

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)