### PR TITLE
feat(pipelines): uniform fork gate, session click-through, stage policy UI, template + docs fixes

### DIFF
--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -3258,7 +3258,13 @@ components:
           - string
         errorMessage:
           type: string
+        notes:
+          items:
+            type: string
+          type: array
         output:
+          type: string
+        sessionId:
           type: string
         stageName:
           type: string

--- a/backend/internal/httpd/controllers/pipelines.go
+++ b/backend/internal/httpd/controllers/pipelines.go
@@ -146,7 +146,13 @@ type PipelineStageView struct {
 	ErrorMessage string     `json:"errorMessage,omitempty"`
 	// Output is a capped tail of the stage's combined stdout+stderr (command
 	// stages only), empty otherwise.
-	Output      string   `json:"output,omitempty"`
+	Output string `json:"output,omitempty"`
+	// SessionID is the AO session the stage ran in (agent stages only), so the UI
+	// can link straight to it. Empty for command and builtin stages.
+	SessionID string `json:"sessionId,omitempty"`
+	// Notes are human-relevant one-line annotations for the stage (fork skip,
+	// findings truncated, exit-mode fallback, unknown status fingerprint).
+	Notes       []string `json:"notes,omitempty"`
 	ArtifactIDs []string `json:"artifactIds"`
 }
 
@@ -560,6 +566,8 @@ func runDetail(run pipeline.RunState) PipelineRunDetail {
 			CompletedAt:  st.CompletedAt,
 			ErrorMessage: st.ErrorMessage,
 			Output:       st.Output,
+			SessionID:    st.SessionID,
+			Notes:        st.Notes,
 			ArtifactIDs:  ids,
 		})
 	}

--- a/backend/internal/pipeline/engine/engine.go
+++ b/backend/internal/pipeline/engine/engine.go
@@ -537,13 +537,14 @@ func (e *Engine) pollInflight() {
 			continue
 		}
 		delete(e.inflight, k)
+		notes := observationNotes(outcome.Observations)
 		if outcome.Status == executors.OutcomeCompleted {
 			// StatusChanges ride the event so the reducer applies them (to
 			// run.Findings and the store) before the exit decision, letting a
 			// last-stage resolve/reopen change whether the run is done.
-			e.reduceAndExecute(pipeline.StageCompleted{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), Verdict: outcome.Verdict, Artifacts: outcome.Artifacts, StatusChanges: outcome.StatusChanges, Output: outcome.Output})
+			e.reduceAndExecute(pipeline.StageCompleted{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), Verdict: outcome.Verdict, Artifacts: outcome.Artifacts, StatusChanges: outcome.StatusChanges, Output: outcome.Output, SessionID: outcome.SessionID, Notes: notes})
 		} else {
-			e.reduceAndExecute(pipeline.StageFailed{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), ErrorMessage: outcome.ErrorMessage, Output: outcome.Output})
+			e.reduceAndExecute(pipeline.StageFailed{Now: e.now(), RunID: h.RunID(), StageName: h.StageName(), ErrorMessage: outcome.ErrorMessage, Output: outcome.Output, SessionID: outcome.SessionID, Notes: notes})
 		}
 		e.routeObservations(outcome.Observations)
 	}
@@ -602,6 +603,20 @@ func (e *Engine) routeObservations(obs []executors.Observation) {
 	for _, o := range obs {
 		e.observe(o.Name, o.Data)
 	}
+}
+
+// observationNotes extracts the human-readable one-line notes an outcome's
+// observations carry, in order, so the reducer can persist them onto the stage
+// state for the run detail. Observations with no Note (telemetry-only) are
+// skipped; the reducer caps the total.
+func observationNotes(obs []executors.Observation) []string {
+	var notes []string
+	for _, o := range obs {
+		if o.Note != "" {
+			notes = append(notes, o.Note)
+		}
+	}
+	return notes
 }
 
 // observe forwards an observation to the sink, enriching it with the project id

--- a/backend/internal/pipeline/engine/engine.go
+++ b/backend/internal/pipeline/engine/engine.go
@@ -610,7 +610,7 @@ func (e *Engine) routeObservations(obs []executors.Observation) {
 // state for the run detail. Observations with no Note (telemetry-only) are
 // skipped; the reducer caps the total.
 func observationNotes(obs []executors.Observation) []string {
-	var notes []string
+	notes := make([]string, 0, len(obs))
 	for _, o := range obs {
 		if o.Note != "" {
 			notes = append(notes, o.Note)

--- a/backend/internal/pipeline/events.go
+++ b/backend/internal/pipeline/events.go
@@ -91,6 +91,13 @@ type StageCompleted struct {
 	// Output is a capped tail of the stage's combined stdout+stderr, persisted
 	// onto the stage state for the run detail.
 	Output string
+	// SessionID is the AO session the stage ran in (agent stages only), persisted
+	// onto the stage state so the run detail can link to it.
+	SessionID string
+	// Notes are human-relevant one-line annotations (fork skip, findings
+	// truncated, exit-mode fallback) the driver collected from the outcome's
+	// observations, persisted onto the stage state.
+	Notes []string
 }
 
 // Type implements Event.
@@ -107,6 +114,12 @@ type StageFailed struct {
 	// Output is a capped tail of the stage's combined stdout+stderr, persisted
 	// onto the stage state for the run detail.
 	Output string
+	// SessionID is the AO session the stage ran in (agent stages only), persisted
+	// onto the stage state so the run detail can link to it even on failure.
+	SessionID string
+	// Notes are human-relevant one-line annotations the driver collected from the
+	// outcome's observations, persisted onto the stage state.
+	Notes []string
 }
 
 // Type implements Event.

--- a/backend/internal/pipeline/executors/agent.go
+++ b/backend/internal/pipeline/executors/agent.go
@@ -59,11 +59,14 @@ type SessionSpawner interface {
 	Kill(ctx context.Context, sessionID string) error
 }
 
-// agentHandle is the running-stage token for an agent stage.
+// agentHandle is the running-stage token for an agent stage. final is non-nil
+// when the stage short-circuited before spawn (the fork gate); Poll then returns
+// it immediately and no session was ever created.
 type agentHandle struct {
 	stageIdentity
 	sessionID     string
 	workspacePath string
+	final         *Outcome
 }
 
 // AgentExecutor bridges a pipeline stage to a real, visible AO session: spawn a
@@ -89,6 +92,17 @@ func (e *AgentExecutor) Start(ctx context.Context, in StartInput) (Handle, error
 		return nil, fmt.Errorf("agent executor cannot start stage %q with executor.kind=%s", in.Stage.Name, in.Stage.Executor.Kind)
 	}
 
+	id := stageIdentity{runID: in.RunID, stageRunID: in.StageRunID, stageName: in.Stage.Name}
+
+	// Fork-PR gate, BEFORE spawn, via the shared helper so agent stages honor the
+	// same trust boundary as command stages. Resolved from the run context's
+	// tri-state (a PR run always carries it; a manual/no-PR run resolves to
+	// ForkNo and flows normally). No session is spawned when the gate blocks.
+	fork, prNumber := forkFromContext(in.Context)
+	if skip, gated := forkGateDecision(fork, prNumber, in.Stage.Name, in.AllowForkPRs); gated {
+		return &agentHandle{stageIdentity: id, final: &skip}, nil
+	}
+
 	prompt := buildStagePrompt(in.PipelineName, in.Stage, in.LoopRound, in.Context, in.UpstreamFindings)
 	session, err := e.sessions.Spawn(ctx, SpawnRequest{
 		ProjectID:  in.ProjectID,
@@ -109,7 +123,7 @@ func (e *AgentExecutor) Start(ctx context.Context, in StartInput) (Handle, error
 	}
 
 	return &agentHandle{
-		stageIdentity: stageIdentity{runID: in.RunID, stageRunID: in.StageRunID, stageName: in.Stage.Name},
+		stageIdentity: id,
 		sessionID:     session.SessionID,
 		workspacePath: session.WorkspacePath,
 	}, nil
@@ -125,6 +139,10 @@ func (e *AgentExecutor) Poll(ctx context.Context, h Handle) (Outcome, error) {
 	if !ok {
 		return Outcome{}, fmt.Errorf("agent executor: unexpected handle type %T", h)
 	}
+	if handle.final != nil {
+		// Fork-gated (or otherwise pre-decided) stage: no session was spawned.
+		return *handle.final, nil
+	}
 
 	snap, exists, err := e.sessions.Get(ctx, handle.sessionID)
 	if err != nil {
@@ -135,12 +153,14 @@ func (e *AgentExecutor) Poll(ctx context.Context, h Handle) (Outcome, error) {
 		// waiting for an idle signal that will never come.
 		return Outcome{
 			Status:       OutcomeFailed,
+			SessionID:    handle.sessionID,
 			ErrorMessage: fmt.Sprintf("stage %q session %s no longer exists", handle.stageName, handle.sessionID),
 		}, nil
 	}
 	if snap.Terminated || snap.Activity == "exited" {
 		return Outcome{
 			Status:       OutcomeFailed,
+			SessionID:    handle.sessionID,
 			ErrorMessage: fmt.Sprintf("stage %q session %s terminated without findings (activity=%s)", handle.stageName, handle.sessionID, snap.Activity),
 		}, nil
 	}
@@ -155,13 +175,14 @@ func (e *AgentExecutor) Poll(ctx context.Context, h Handle) (Outcome, error) {
 		// Leave the session up so a human can inspect the bad findings file.
 		return Outcome{
 			Status:       OutcomeFailed,
+			SessionID:    handle.sessionID,
 			ErrorMessage: fmt.Sprintf("stage %q produced unparseable findings at %s: %v", handle.stageName, findingsPath, err),
 		}, nil
 	}
 
 	_ = e.sessions.Kill(ctx, handle.sessionID)
 
-	outcome := Outcome{Status: OutcomeCompleted, Artifacts: result.artifacts, StatusChanges: result.statusChanges}
+	outcome := Outcome{Status: OutcomeCompleted, SessionID: handle.sessionID, Artifacts: result.artifacts, StatusChanges: result.statusChanges}
 	if result.truncated {
 		outcome.Observations = []Observation{{
 			Name: "pipeline.findings.truncated",
@@ -173,6 +194,7 @@ func (e *AgentExecutor) Poll(ctx context.Context, h Handle) (Outcome, error) {
 				"capBytes":     findingsFileSizeCapBytes,
 				"bytesRead":    result.bytesRead,
 			},
+			Note: fmt.Sprintf("findings file exceeded %d bytes and was truncated; some findings may be missing", findingsFileSizeCapBytes),
 		}}
 	}
 	return outcome, nil
@@ -183,6 +205,10 @@ func (e *AgentExecutor) Cancel(ctx context.Context, h Handle) error {
 	handle, ok := h.(*agentHandle)
 	if !ok {
 		return fmt.Errorf("agent executor: unexpected handle type %T", h)
+	}
+	if handle.final != nil || handle.sessionID == "" {
+		// Fork-gated stage: no session was ever spawned, nothing to tear down.
+		return nil
 	}
 	if err := e.sessions.Kill(ctx, handle.sessionID); err != nil && !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("agent executor: kill session %s: %w", handle.sessionID, err)

--- a/backend/internal/pipeline/executors/agent_test.go
+++ b/backend/internal/pipeline/executors/agent_test.go
@@ -225,7 +225,8 @@ func TestAgent_SpawnSetsBranchFromPRContext(t *testing.T) {
 	m := &mockSpawner{workspace: t.TempDir(), activity: "active"}
 	exec := NewAgentExecutor(m)
 	in := agentStartInput(m.workspace)
-	in.Context = pipeline.RunContext{SourceBranch: "feature", PRNumber: 3}
+	sameRepo := false
+	in.Context = pipeline.RunContext{SourceBranch: "feature", PRNumber: 3, IsFromFork: &sameRepo}
 	if _, err := exec.Start(context.Background(), in); err != nil {
 		t.Fatalf("start: %v", err)
 	}

--- a/backend/internal/pipeline/executors/builtin.go
+++ b/backend/internal/pipeline/executors/builtin.go
@@ -59,6 +59,15 @@ func (e *BuiltinExecutor) Start(ctx context.Context, in StartInput) (Handle, err
 	}
 	id := stageIdentity{runID: in.RunID, stageRunID: in.StageRunID, stageName: in.Stage.Name}
 
+	// Fork-PR gate via the shared helper: the router delivers findings into a
+	// live worker session, so a builtin stage is fork-sensitive like a command
+	// stage. Resolved from the run context's tri-state (a manual/no-PR run
+	// resolves to ForkNo and flows normally).
+	fork, prNumber := forkFromContext(in.Context)
+	if skip, gated := forkGateDecision(fork, prNumber, in.Stage.Name, in.AllowForkPRs); gated {
+		return &builtinHandle{stageIdentity: id, final: skip}, nil
+	}
+
 	inputs, err := e.store.UpstreamArtifacts(ctx, in.RunID, in.Stage.DependsOn)
 	if err != nil {
 		return &builtinHandle{stageIdentity: id, final: Outcome{

--- a/backend/internal/pipeline/executors/command.go
+++ b/backend/internal/pipeline/executors/command.go
@@ -153,27 +153,16 @@ func (e *CommandExecutor) Start(ctx context.Context, in StartInput) (Handle, err
 			ErrorMessage: fmt.Sprintf("command stage %q references unknown session %s", in.Stage.Name, in.LinkedSessionID)}), nil
 	}
 
-	// Fork-PR gate, BEFORE spawn. ForkUnknown is fail-safe (blocks) so untrusted
-	// code we cannot classify never executes.
-	if session.Fork != ForkNo && !in.AllowForkPRs {
-		reason := fmt.Sprintf("PR #%d is from a fork and pipeline.allowForkPRs is not enabled", session.PRNumber)
-		if session.Fork == ForkUnknown {
-			reason = fmt.Sprintf("SCM plugin could not determine fork status for PR #%d; blocking by default", session.PRNumber)
-		}
-		return shortCircuit(id, Outcome{
-			Status:    OutcomeCompleted,
-			Verdict:   pipeline.VerdictNeutral,
-			Artifacts: nil,
-			Observations: []Observation{{
-				Name: "command_stage_skipped_fork_pr",
-				Data: map[string]any{
-					"stage":      in.Stage.Name,
-					"prNumber":   session.PRNumber,
-					"isFromFork": session.Fork == ForkYes,
-					"reason":     reason,
-				},
-			}},
-		}), nil
+	// Fork-PR gate, BEFORE spawn, via the shared helper so agent/command/builtin
+	// share one trust boundary. Prefer the run context's tri-state (#275); fall
+	// back to the live session lookup this path already resolved when the context
+	// carries no verdict (e.g. runs persisted before RunContext, manual runs).
+	fork, prNumber := session.Fork, session.PRNumber
+	if in.Context.IsFromFork != nil {
+		fork, prNumber = forkFromContext(in.Context)
+	}
+	if skip, gated := forkGateDecision(fork, prNumber, in.Stage.Name, in.AllowForkPRs); gated {
+		return shortCircuit(id, skip), nil
 	}
 
 	if session.WorkspacePath == "" {
@@ -395,7 +384,7 @@ func interpretExitStatus(ex commandExit) Outcome {
 		"stage":    stageName,
 		"mode":     "exit-code",
 		"exitCode": res.ExitCode,
-	}}
+	}, Note: fmt.Sprintf("no JSON result envelope on stdout; verdict taken from exit code %d", res.ExitCode)}
 	if res.ExitCode != 0 {
 		return Outcome{Status: OutcomeFailed, Observations: []Observation{obs},
 			ErrorMessage: fmt.Sprintf("command stage %q exited with code %d%s", stageName, res.ExitCode, stderrSuffix(res.Stderr))}
@@ -469,6 +458,7 @@ func harvestCommandFindings(ex commandExit, out Outcome) Outcome {
 				"capBytes":     findingsFileSizeCapBytes,
 				"bytesRead":    result.bytesRead,
 			},
+			Note: fmt.Sprintf("findings file exceeded %d bytes and was truncated; some findings may be missing", findingsFileSizeCapBytes),
 		})
 	}
 	return out

--- a/backend/internal/pipeline/executors/command_test.go
+++ b/backend/internal/pipeline/executors/command_test.go
@@ -104,7 +104,7 @@ func TestCommand_ForkGateSkipsWithoutSpawn(t *testing.T) {
 		if out.Status != OutcomeCompleted || out.Verdict != pipeline.VerdictNeutral {
 			t.Fatalf("fork=%v: want completed/neutral skip, got %s/%s", fork, out.Status, out.Verdict)
 		}
-		if len(out.Observations) != 1 || out.Observations[0].Name != "command_stage_skipped_fork_pr" {
+		if len(out.Observations) != 1 || out.Observations[0].Name != forkSkipObservation {
 			t.Fatalf("fork=%v: expected a fork-skip observation, got %+v", fork, out.Observations)
 		}
 	}

--- a/backend/internal/pipeline/executors/executor.go
+++ b/backend/internal/pipeline/executors/executor.go
@@ -38,6 +38,11 @@ const (
 type Observation struct {
 	Name string
 	Data map[string]any
+	// Note is an optional human-readable one-line summary of this observation. When
+	// set, the engine appends it to the stage's Notes so the run detail can explain
+	// an otherwise silent decision (fork skip, findings truncated, exit-mode
+	// fallback). Empty for observations that are telemetry-only.
+	Note string
 }
 
 // Outcome is the result of polling a running stage. Status is the only field
@@ -59,6 +64,11 @@ type Outcome struct {
 	// the run detail. Set by the command executor on both success and failure;
 	// empty for executor kinds that produce no subprocess output.
 	Output string
+	// SessionID is the AO session this stage ran in, so the run detail can link
+	// straight to what the stage did. The agent executor sets it (the session it
+	// spawned) on both completed and failed outcomes; empty for command/builtin
+	// stages, which do not own a session.
+	SessionID string
 }
 
 // Handle is an opaque running-stage token returned by Start and threaded back

--- a/backend/internal/pipeline/executors/forkgate.go
+++ b/backend/internal/pipeline/executors/forkgate.go
@@ -1,0 +1,68 @@
+package executors
+
+import (
+	"fmt"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// forkSkipObservation is the shared name every executor emits when the fork-PR
+// trust gate self-skips a stage. Uniform across agent, command, and builtin so
+// the run detail and telemetry treat the boundary identically.
+const forkSkipObservation = "pipeline.stage.skipped_fork_pr"
+
+// forkFromContext derives the fork verdict for a stage from the run context
+// alone (the #275 tri-state), mirroring the command path's session-lookup
+// semantics without needing a session read:
+//
+//   - IsFromFork known -> that verdict (true -> ForkYes, false -> ForkNo);
+//   - IsFromFork unknown but a PR exists -> ForkUnknown (fail-safe block);
+//   - IsFromFork unknown and no PR (manual/no-PR run) -> ForkNo (runs).
+//
+// This lets the agent and builtin executors gate without a fork-status seam of
+// their own: a PR run always carries IsFromFork from the trigger bridge, and a
+// manual run has no PR so it resolves to ForkNo and flows normally.
+func forkFromContext(c pipeline.RunContext) (ForkStatus, int) {
+	if c.IsFromFork != nil {
+		if *c.IsFromFork {
+			return ForkYes, c.PRNumber
+		}
+		return ForkNo, c.PRNumber
+	}
+	if c.PRNumber > 0 {
+		return ForkUnknown, c.PRNumber
+	}
+	return ForkNo, c.PRNumber
+}
+
+// forkGateDecision applies the fork-PR trust gate. It returns (skip, true) with
+// a completed/neutral self-skip outcome when the stage must not run untrusted
+// code, else (Outcome{}, false). ForkUnknown is fail-safe (blocked): provenance
+// we cannot classify never executes. allowForkPRs opens the gate for genuine
+// fork PRs. The outcome carries a uniform observation whose Note explains the
+// skip in the run detail.
+func forkGateDecision(fork ForkStatus, prNumber int, stageName string, allowForkPRs bool) (Outcome, bool) {
+	if fork == ForkNo || allowForkPRs {
+		return Outcome{}, false
+	}
+
+	reason := fmt.Sprintf("PR #%d is from a fork and pipeline.allowForkPRs is not enabled", prNumber)
+	if fork == ForkUnknown {
+		reason = fmt.Sprintf("SCM plugin could not determine fork status for PR #%d; blocking by default", prNumber)
+	}
+
+	return Outcome{
+		Status:  OutcomeCompleted,
+		Verdict: pipeline.VerdictNeutral,
+		Observations: []Observation{{
+			Name: forkSkipObservation,
+			Data: map[string]any{
+				"stage":      stageName,
+				"prNumber":   prNumber,
+				"isFromFork": fork == ForkYes,
+				"reason":     reason,
+			},
+			Note: "stage skipped: " + reason,
+		}},
+	}, true
+}

--- a/backend/internal/pipeline/executors/forkgate_test.go
+++ b/backend/internal/pipeline/executors/forkgate_test.go
@@ -1,0 +1,166 @@
+package executors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+func boolp(b bool) *bool { return &b }
+
+// TestForkFromContext pins the tri-state resolution the agent and builtin gates
+// rely on: a known verdict passes through, an unknown verdict with a PR is
+// fail-safe blocked, and an unknown verdict with no PR (manual run) runs.
+func TestForkFromContext(t *testing.T) {
+	cases := []struct {
+		name     string
+		ctx      pipeline.RunContext
+		wantFork ForkStatus
+		wantPR   int
+	}{
+		{"known fork", pipeline.RunContext{IsFromFork: boolp(true), PRNumber: 7}, ForkYes, 7},
+		{"known same-repo", pipeline.RunContext{IsFromFork: boolp(false), PRNumber: 7}, ForkNo, 7},
+		{"unknown with PR", pipeline.RunContext{PRNumber: 7}, ForkUnknown, 7},
+		{"unknown no PR (manual)", pipeline.RunContext{}, ForkNo, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fork, pr := forkFromContext(c.ctx)
+			if fork != c.wantFork || pr != c.wantPR {
+				t.Fatalf("got fork=%v pr=%d, want fork=%v pr=%d", fork, pr, c.wantFork, c.wantPR)
+			}
+		})
+	}
+}
+
+// TestAgent_ForkGate covers the fork/no-fork/unknown x allowForkPRs matrix: a
+// gated stage self-skips completed/neutral WITHOUT spawning, and carries the
+// uniform observation plus a human note; an allowed or non-fork PR spawns.
+func TestAgent_ForkGate(t *testing.T) {
+	cases := []struct {
+		name        string
+		ctx         pipeline.RunContext
+		allow       bool
+		wantSpawn   bool
+		wantVerdict pipeline.Verdict
+	}{
+		{"fork blocked", pipeline.RunContext{IsFromFork: boolp(true), PRNumber: 7}, false, false, pipeline.VerdictNeutral},
+		{"unknown blocked", pipeline.RunContext{PRNumber: 7}, false, false, pipeline.VerdictNeutral},
+		{"fork allowed", pipeline.RunContext{IsFromFork: boolp(true), PRNumber: 7}, true, true, ""},
+		{"same-repo runs", pipeline.RunContext{IsFromFork: boolp(false), PRNumber: 7}, false, true, ""},
+		{"manual runs", pipeline.RunContext{}, false, true, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &mockSpawner{workspace: t.TempDir(), activity: "active"}
+			exec := NewAgentExecutor(m)
+			in := agentStartInput(m.workspace)
+			in.Context = c.ctx
+			in.AllowForkPRs = c.allow
+
+			h, err := exec.Start(context.Background(), in)
+			if err != nil {
+				t.Fatalf("start: %v", err)
+			}
+			if c.wantSpawn {
+				if m.spawnCalls != 1 {
+					t.Fatalf("want a spawn, got %d spawn calls", m.spawnCalls)
+				}
+				return
+			}
+			if m.spawnCalls != 0 {
+				t.Fatalf("gated stage must NOT spawn, got %d spawn calls", m.spawnCalls)
+			}
+			out, err := exec.Poll(context.Background(), h)
+			if err != nil {
+				t.Fatalf("poll: %v", err)
+			}
+			if out.Status != OutcomeCompleted || out.Verdict != c.wantVerdict {
+				t.Fatalf("want completed/%s skip, got %s/%s", c.wantVerdict, out.Status, out.Verdict)
+			}
+			if len(out.Observations) != 1 || out.Observations[0].Name != forkSkipObservation {
+				t.Fatalf("expected a fork-skip observation, got %+v", out.Observations)
+			}
+			if out.Observations[0].Note == "" {
+				t.Fatal("fork-skip observation must carry a human note")
+			}
+		})
+	}
+}
+
+// TestBuiltin_ForkGate mirrors the agent matrix for the builtin router: a gated
+// stage self-skips WITHOUT any delivery, an allowed/non-fork/manual run delivers.
+func TestBuiltin_ForkGate(t *testing.T) {
+	cases := []struct {
+		name     string
+		ctx      pipeline.RunContext
+		allow    bool
+		wantSkip bool
+	}{
+		{"fork blocked", pipeline.RunContext{IsFromFork: boolp(true), PRNumber: 7}, false, true},
+		{"unknown blocked", pipeline.RunContext{PRNumber: 7}, false, true},
+		{"fork allowed", pipeline.RunContext{IsFromFork: boolp(true), PRNumber: 7}, true, false},
+		{"same-repo runs", pipeline.RunContext{IsFromFork: boolp(false), PRNumber: 7}, false, false},
+		{"manual runs", pipeline.RunContext{}, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			store := &fakeStore{arts: map[string][]pipeline.Artifact{
+				"review": {finding("review", "a.go", "bug A")},
+			}}
+			msg := &fakeMessenger{alive: true}
+			in := builtinInput(builtinStage(pipeline.BuiltinRouter, "review"))
+			in.Context = c.ctx
+			in.AllowForkPRs = c.allow
+
+			out := runBuiltin(t, store, msg, in)
+
+			if c.wantSkip {
+				if len(msg.sent) != 0 {
+					t.Fatalf("gated builtin must NOT deliver, got %d messages", len(msg.sent))
+				}
+				if out.Status != OutcomeCompleted || out.Verdict != pipeline.VerdictNeutral {
+					t.Fatalf("want completed/neutral skip, got %s/%s", out.Status, out.Verdict)
+				}
+				if len(out.Observations) != 1 || out.Observations[0].Name != forkSkipObservation {
+					t.Fatalf("expected a fork-skip observation, got %+v", out.Observations)
+				}
+				return
+			}
+			if len(msg.sent) != 1 {
+				t.Fatalf("ungated builtin must deliver once, got %d messages", len(msg.sent))
+			}
+		})
+	}
+}
+
+// TestAgent_SetsSessionIDOnOutcomes verifies the spawned session id rides both a
+// completed and a failed agent outcome so the run detail can link to it either way.
+func TestAgent_SetsSessionIDOnOutcomes(t *testing.T) {
+	// Failed path: session terminates without findings.
+	m := &mockSpawner{workspace: t.TempDir(), activity: "exited"}
+	exec := NewAgentExecutor(m)
+	h, err := exec.Start(context.Background(), agentStartInput(m.workspace))
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	out, _ := exec.Poll(context.Background(), h)
+	if out.Status != OutcomeFailed || out.SessionID != "sess-1" {
+		t.Fatalf("failed outcome must carry session id, got %s/%q", out.Status, out.SessionID)
+	}
+
+	// Completed path: idle with a findings file.
+	ws := t.TempDir()
+	m2 := &mockSpawner{workspace: ws, activity: "idle"}
+	exec2 := NewAgentExecutor(m2)
+	h2, err := exec2.Start(context.Background(), agentStartInput(ws))
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	writeFindingsAt(t, ws, findingLine(t, 0.9, "error"))
+	out2, _ := exec2.Poll(context.Background(), h2)
+	if out2.Status != OutcomeCompleted || out2.SessionID != "sess-1" {
+		t.Fatalf("completed outcome must carry session id, got %s/%q", out2.Status, out2.SessionID)
+	}
+}

--- a/backend/internal/pipeline/reducer.go
+++ b/backend/internal/pipeline/reducer.go
@@ -273,6 +273,10 @@ func reduceStageCompleted(state EngineState, event StageCompleted) (EngineState,
 	updatedStage.CompletedAt = &completed
 	updatedStage.Verdict = event.Verdict
 	updatedStage.Output = event.Output
+	if event.SessionID != "" {
+		updatedStage.SessionID = event.SessionID
+	}
+	updatedStage.Notes = capStageNotes(append(append([]string{}, stage.Notes...), event.Notes...))
 	updatedStage.Artifacts = append(append([]ArtifactID{}, stage.Artifacts...), newIDs...)
 
 	return finalizeStageCompletion(state, run, event.StageName, updatedStage, newArtifacts, event.StatusChanges, now)
@@ -292,7 +296,7 @@ func reduceStageFailed(state EngineState, event StageFailed) (EngineState, []Eff
 		return invalidTransition(state, "STAGE_FAILED requires running|pending; got "+string(stage.Status)+" for "+event.StageName)
 	}
 
-	return failStage(state, run, event.StageName, event.ErrorMessage, event.Output, now, false)
+	return failStage(state, run, event.StageName, event.ErrorMessage, event.Output, event.SessionID, event.Notes, now, false)
 }
 
 // failStage applies a stage failure with automatic retry. When the stage still
@@ -302,7 +306,7 @@ func reduceStageFailed(state EngineState, event StageFailed) (EngineState, []Eff
 // otherwise it finalizes the stage as failed. cancel emits a CANCEL_STAGE effect
 // first: the TICK timeout path fails a stage whose executor handle is still
 // live, so the engine must tear it down.
-func failStage(state EngineState, run RunState, stageName, errorMessage, output string, now time.Time, cancel bool) (EngineState, []Effect) {
+func failStage(state EngineState, run RunState, stageName, errorMessage, output, sessionID string, notes []string, now time.Time, cancel bool) (EngineState, []Effect) {
 	stage := run.Stages[stageName]
 
 	var preceding []Effect
@@ -324,6 +328,10 @@ func failStage(state EngineState, run RunState, stageName, errorMessage, output 
 	updatedStage.CompletedAt = &completed
 	updatedStage.ErrorMessage = errorMessage
 	updatedStage.Output = output
+	if sessionID != "" {
+		updatedStage.SessionID = sessionID
+	}
+	updatedStage.Notes = capStageNotes(append(append([]string{}, stage.Notes...), notes...))
 	updatedStage.Deadline = nil
 
 	return finalizeStageCompletion(state, run, stageName, updatedStage, nil, nil, now, preceding...)
@@ -397,7 +405,7 @@ func reduceTick(state EngineState, event Tick) (EngineState, []Effect) {
 		run := state.Runs[runID]
 		message := timeoutMessage(run.Stages[stageName])
 		var step []Effect
-		state, step = failStage(state, run, stageName, message, "", now, true)
+		state, step = failStage(state, run, stageName, message, "", "", nil, now, true)
 		effects = append(effects, step...)
 	}
 	return state, effects
@@ -548,8 +556,17 @@ func finalizeStageCompletion(state EngineState, run RunState, stageName string, 
 	// finding this same stage just emitted.
 	if len(statusChanges) > 0 {
 		var statusEffects []Effect
-		updatedRun, statusEffects = applyFindingStatusChanges(updatedRun, statusChanges)
+		var statusNotes []string
+		updatedRun, statusEffects, statusNotes = applyFindingStatusChanges(updatedRun, statusChanges)
 		effects = append(effects, statusEffects...)
+		// Surface unknown-fingerprint status records as stage notes: a verify stage
+		// referencing a fingerprint no finding in this run carries is otherwise a
+		// silent no-op. Append onto the stage the record belongs to.
+		if len(statusNotes) > 0 {
+			st := updatedRun.Stages[stageName]
+			st.Notes = capStageNotes(append(append([]string{}, st.Notes...), statusNotes...))
+			updatedRun = patchRun(updatedRun, map[string]StageState{stageName: st}, now)
+		}
 	}
 
 	effects = append(effects, EmitObservation{
@@ -599,9 +616,10 @@ func finalizeStageCompletion(state EngineState, run RunState, stageName string, 
 // fingerprint that matches no finding is tolerated: it yields a
 // pipeline.status.unknown_fingerprint observation, never a failure. Pure and
 // copy-on-write: run.Findings is not mutated in place.
-func applyFindingStatusChanges(run RunState, changes []FindingStatusChange) (RunState, []Effect) {
+func applyFindingStatusChanges(run RunState, changes []FindingStatusChange) (RunState, []Effect, []string) {
 	findings := append([]Artifact{}, run.Findings...)
 	var effects []Effect
+	var notes []string
 	for _, ch := range changes {
 		matched := false
 		for i := range findings {
@@ -625,10 +643,29 @@ func applyFindingStatusChanges(run RunState, changes []FindingStatusChange) (Run
 					"status":      ch.Status,
 				},
 			})
+			notes = append(notes, fmt.Sprintf("status record (%s) targeted fingerprint %s, which matches no finding in this run; ignored", ch.Status, shortFingerprint(ch.Fingerprint)))
 		}
 	}
 	run.Findings = findings
-	return run, effects
+	return run, effects, notes
+}
+
+// shortFingerprint trims a finding fingerprint to a readable prefix for a note.
+func shortFingerprint(fp string) string {
+	if len(fp) > 12 {
+		return fp[:12] + "..."
+	}
+	return fp
+}
+
+// capStageNotes bounds a stage's note list to MaxStageNotes, keeping the most
+// recent lines (drop oldest first) so a long-running loop's stage cannot grow it
+// without limit.
+func capStageNotes(notes []string) []string {
+	if len(notes) <= MaxStageNotes {
+		return notes
+	}
+	return notes[len(notes)-MaxStageNotes:]
 }
 
 func reduceNewSHADetected(state EngineState, event NewSHADetected) (EngineState, []Effect) {

--- a/backend/internal/pipeline/reducer_test.go
+++ b/backend/internal/pipeline/reducer_test.go
@@ -268,6 +268,40 @@ func TestReduceStageCompleted(t *testing.T) {
 		_, effects := Reduce(engineWith(run), StageCompleted{Now: testNow, RunID: "r1", StageName: "a"})
 		assertInvalid(t, effects)
 	})
+
+	t.Run("session id and notes land on the stage state", func(t *testing.T) {
+		p := pipelineOf("p", 1, stageDef("a"))
+		run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+		state, _ := Reduce(engineWith(run), StageCompleted{
+			Now: testNow, RunID: "r1", StageName: "a", Verdict: VerdictPass,
+			SessionID: "sess-9", Notes: []string{"stage skipped: fork PR"},
+		})
+		stage := state.Runs["r1"].Stages["a"]
+		if stage.SessionID != "sess-9" {
+			t.Fatalf("session id = %q, want sess-9", stage.SessionID)
+		}
+		if len(stage.Notes) != 1 || stage.Notes[0] != "stage skipped: fork PR" {
+			t.Fatalf("notes = %v, want one fork-skip line", stage.Notes)
+		}
+	})
+}
+
+func TestReduceStageNotesCapped(t *testing.T) {
+	p := pipelineOf("p", 1, stageDef("a"))
+	run := runState("r1", p, map[string]StageStatus{"a": StageStatusRunning})
+	notes := make([]string, MaxStageNotes+5)
+	for i := range notes {
+		notes[i] = "note"
+	}
+	state, _ := Reduce(engineWith(run), StageFailed{
+		Now: testNow, RunID: "r1", StageName: "a", ErrorMessage: "boom", SessionID: "sess-9", Notes: notes,
+	})
+	if got := len(state.Runs["r1"].Stages["a"].Notes); got != MaxStageNotes {
+		t.Fatalf("notes len = %d, want capped at %d", got, MaxStageNotes)
+	}
+	if state.Runs["r1"].Stages["a"].SessionID != "sess-9" {
+		t.Fatal("failed stage must still carry its session id")
+	}
 }
 
 func TestReduceStageFailed(t *testing.T) {

--- a/backend/internal/pipeline/types.go
+++ b/backend/internal/pipeline/types.go
@@ -544,10 +544,10 @@ type Pipeline struct {
 	// serial execution in that case.
 	MaxConcurrentStages *int `json:"maxConcurrentStages,omitempty" yaml:"maxConcurrentStages,omitempty"`
 
-	// AllowForkPRs opts in to running command-executor stages for pull
-	// requests opened from forks. Defaults to false: fork-PR command stages
-	// are skipped before any subprocess is spawned. Only applies to the
-	// command executor.
+	// AllowForkPRs opts in to running stages for pull requests opened from
+	// forks. Defaults to false: fork-PR stages self-skip before any work
+	// happens. Applies uniformly to every executor kind (agent, command, and
+	// builtin) via the shared fork gate.
 	AllowForkPRs *bool `json:"allowForkPRs,omitempty" yaml:"allowForkPRs,omitempty"`
 
 	// ExitPredicates optionally overrides the v0 hardcoded run-exit rules.

--- a/backend/internal/pipeline/types.go
+++ b/backend/internal/pipeline/types.go
@@ -583,6 +583,11 @@ type RunContext struct {
 	IsFromFork *bool `json:"isFromFork,omitempty"`
 }
 
+// MaxStageNotes bounds StageState.Notes so a pathological run cannot grow the
+// per-stage annotation list without limit. A handful of lines is plenty for the
+// run detail; excess is dropped oldest-first.
+const MaxStageNotes = 8
+
 // StageState is one stage's runtime state within a run.
 type StageState struct {
 	StageRunID StageRunID   `json:"stageRunId"`
@@ -604,6 +609,14 @@ type StageState struct {
 	// stages only), surfaced in the run detail. Empty for stages with no
 	// subprocess output.
 	Output string `json:"output,omitempty"`
+	// SessionID is the AO session this stage ran in, so the run detail can link
+	// straight to it. Set for agent stages (the session they spawned); empty for
+	// command and builtin stages, which own no session.
+	SessionID string `json:"sessionId,omitempty"`
+	// Notes are human-relevant one-line annotations for the stage (fork skip
+	// reason, findings truncated, exit-mode fallback, unknown status fingerprint),
+	// surfaced under the stage row in the run detail. Capped to MaxStageNotes.
+	Notes []string `json:"notes,omitempty"`
 }
 
 // RunState is one pipeline run's full runtime state.

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -181,6 +181,9 @@ type PipelineStageRun struct {
 	StartedAt    sql.NullTime
 	CompletedAt  sql.NullTime
 	ErrorMessage string
+	SessionID    string
+	Notes        string
+	Output       string
 }
 
 type Project struct {

--- a/backend/internal/storage/sqlite/gen/pipeline.sql.go
+++ b/backend/internal/storage/sqlite/gen/pipeline.sql.go
@@ -381,7 +381,7 @@ func (q *Queries) ListPipelineRuns(ctx context.Context, arg ListPipelineRunsPara
 
 const listPipelineStageRunsByRun = `-- name: ListPipelineStageRunsByRun :many
 SELECT run_id, project_id, stage_name, stage_run_id, status, attempt, verdict,
-       started_at, completed_at, error_message
+       started_at, completed_at, error_message, session_id, notes, output
 FROM pipeline_stage_runs WHERE run_id = ? ORDER BY stage_name ASC
 `
 
@@ -405,6 +405,9 @@ func (q *Queries) ListPipelineStageRunsByRun(ctx context.Context, runID string) 
 			&i.StartedAt,
 			&i.CompletedAt,
 			&i.ErrorMessage,
+			&i.SessionID,
+			&i.Notes,
+			&i.Output,
 		); err != nil {
 			return nil, err
 		}
@@ -530,8 +533,8 @@ const upsertPipelineStageRun = `-- name: UpsertPipelineStageRun :exec
 
 INSERT INTO pipeline_stage_runs (
     run_id, project_id, stage_name, stage_run_id, status, attempt, verdict,
-    started_at, completed_at, error_message
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    started_at, completed_at, error_message, session_id, notes, output
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (run_id, stage_name) DO UPDATE SET
     stage_run_id = excluded.stage_run_id,
     status = excluded.status,
@@ -539,7 +542,10 @@ ON CONFLICT (run_id, stage_name) DO UPDATE SET
     verdict = excluded.verdict,
     started_at = excluded.started_at,
     completed_at = excluded.completed_at,
-    error_message = excluded.error_message
+    error_message = excluded.error_message,
+    session_id = excluded.session_id,
+    notes = excluded.notes,
+    output = excluded.output
 `
 
 type UpsertPipelineStageRunParams struct {
@@ -553,6 +559,9 @@ type UpsertPipelineStageRunParams struct {
 	StartedAt    sql.NullTime
 	CompletedAt  sql.NullTime
 	ErrorMessage string
+	SessionID    string
+	Notes        string
+	Output       string
 }
 
 // Pipeline stage runs --------------------------------------------------------
@@ -568,6 +577,9 @@ func (q *Queries) UpsertPipelineStageRun(ctx context.Context, arg UpsertPipeline
 		arg.StartedAt,
 		arg.CompletedAt,
 		arg.ErrorMessage,
+		arg.SessionID,
+		arg.Notes,
+		arg.Output,
 	)
 	return err
 }

--- a/backend/internal/storage/sqlite/migrations/0030_pipeline_stage_run_session_notes.sql
+++ b/backend/internal/storage/sqlite/migrations/0030_pipeline_stage_run_session_notes.sql
@@ -1,0 +1,30 @@
+-- Persist per-stage session id, human notes, and captured output on
+-- pipeline_stage_runs. StageState.SessionID (the agent session a stage ran in,
+-- for run-detail click-through), StageState.Notes (fork-skip, findings-
+-- truncated, exit-mode, unknown-fingerprint annotations), and StageState.Output
+-- (command stdout+stderr tail) all round-trip through RunState but had no
+-- columns, so the run detail served from the store lost them. Store notes as a
+-- JSON array text; legacy rows default to empty, which renders as no session
+-- link and no notes.
+
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs ADD COLUMN session_id TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs ADD COLUMN notes TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs ADD COLUMN output TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs DROP COLUMN session_id;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs DROP COLUMN notes;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs DROP COLUMN output;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/pipeline.sql
+++ b/backend/internal/storage/sqlite/queries/pipeline.sql
@@ -82,8 +82,8 @@ LIMIT 1;
 -- name: UpsertPipelineStageRun :exec
 INSERT INTO pipeline_stage_runs (
     run_id, project_id, stage_name, stage_run_id, status, attempt, verdict,
-    started_at, completed_at, error_message
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    started_at, completed_at, error_message, session_id, notes, output
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (run_id, stage_name) DO UPDATE SET
     stage_run_id = excluded.stage_run_id,
     status = excluded.status,
@@ -91,11 +91,14 @@ ON CONFLICT (run_id, stage_name) DO UPDATE SET
     verdict = excluded.verdict,
     started_at = excluded.started_at,
     completed_at = excluded.completed_at,
-    error_message = excluded.error_message;
+    error_message = excluded.error_message,
+    session_id = excluded.session_id,
+    notes = excluded.notes,
+    output = excluded.output;
 
 -- name: ListPipelineStageRunsByRun :many
 SELECT run_id, project_id, stage_name, stage_run_id, status, attempt, verdict,
-       started_at, completed_at, error_message
+       started_at, completed_at, error_message, session_id, notes, output
 FROM pipeline_stage_runs WHERE run_id = ? ORDER BY stage_name ASC;
 
 -- Pipeline artifacts ---------------------------------------------------------

--- a/backend/internal/storage/sqlite/store/pipeline_store.go
+++ b/backend/internal/storage/sqlite/store/pipeline_store.go
@@ -426,6 +426,9 @@ func stageUpsertParams(projectID domain.ProjectID, runID, stageName string, st p
 		StartedAt:    nullTimeFromPtr(st.StartedAt),
 		CompletedAt:  nullTimeFromPtr(st.CompletedAt),
 		ErrorMessage: st.ErrorMessage,
+		SessionID:    st.SessionID,
+		Notes:        marshalStageNotes(st.Notes),
+		Output:       st.Output,
 	}
 }
 
@@ -438,7 +441,37 @@ func stageStateFromRow(r gen.PipelineStageRun) pipeline.StageState {
 		StartedAt:    ptrFromNullTime(r.StartedAt),
 		CompletedAt:  ptrFromNullTime(r.CompletedAt),
 		ErrorMessage: r.ErrorMessage,
+		SessionID:    r.SessionID,
+		Notes:        unmarshalStageNotes(r.Notes),
+		Output:       r.Output,
 	}
+}
+
+// marshalStageNotes encodes a stage's notes as a JSON array for the notes
+// column. An empty list stores "" (not "null") so a legacy default round-trips
+// to a nil slice.
+func marshalStageNotes(notes []string) string {
+	if len(notes) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(notes)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// unmarshalStageNotes decodes the notes column back into a slice. An empty or
+// malformed value yields nil so the run detail simply shows no notes.
+func unmarshalStageNotes(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var notes []string
+	if err := json.Unmarshal([]byte(s), &notes); err != nil {
+		return nil
+	}
+	return notes
 }
 
 func artifactInsertParams(projectID domain.ProjectID, a pipeline.Artifact) (gen.InsertPipelineArtifactParams, error) {

--- a/backend/internal/storage/sqlite/store/pipeline_store_test.go
+++ b/backend/internal/storage/sqlite/store/pipeline_store_test.go
@@ -120,7 +120,8 @@ func TestPipelineRunSaveLoadRoundTrip(t *testing.T) {
 		LoopState:  pipeline.LoopRunning,
 		LoopRounds: 2,
 		Stages: map[string]pipeline.StageState{
-			"lint": {StageRunID: "sr-1", Status: pipeline.StageStatusRunning, Attempt: 1, StartedAt: &started},
+			"lint": {StageRunID: "sr-1", Status: pipeline.StageStatusRunning, Attempt: 1, StartedAt: &started,
+				SessionID: "worker-9", Notes: []string{"ran in exit-code fallback mode", "findings truncated"}, Output: "build ok\n"},
 		},
 		Fingerprints: []string{"fp-b", "fp-a"},
 		CreatedAt:    now,
@@ -155,6 +156,12 @@ func TestPipelineRunSaveLoadRoundTrip(t *testing.T) {
 	}
 	if st.StartedAt == nil || !st.StartedAt.Equal(started) {
 		t.Fatalf("stage startedAt = %v, want %v", st.StartedAt, started)
+	}
+	if st.SessionID != "worker-9" || st.Output != "build ok\n" {
+		t.Fatalf("stage session/output not round-tripped: %+v", st)
+	}
+	if len(st.Notes) != 2 || st.Notes[0] != "ran in exit-code fallback mode" || st.Notes[1] != "findings truncated" {
+		t.Fatalf("stage notes not round-tripped: %v", st.Notes)
 	}
 
 	// Re-saving with a terminal transition updates in place.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -120,7 +120,8 @@ Key fields, by section:
   `args`/`env`/`cwd`), `builtin` (requires `name`, one of `router`/
   `compose`). Fields from another kind are rejected, not silently dropped.
 - **Pipeline-level**: `maxConcurrentStages` (defaults to 1, i.e. serial),
-  `allowForkPRs` (defaults to false; gates `command` stages on fork PRs),
+  `allowForkPRs` (defaults to false; gates every stage, agent, command, and
+  builtin alike, on fork PRs; see Fork-PR gate below),
   `exitPredicates.{done,stalled,blocksMerge}`.
 
 ### Predicates
@@ -236,12 +237,22 @@ ao pipeline resume run_01hz...
 
 ## Where findings land
 
-An agent stage's session is expected to write findings to
-`.ao/pipeline-findings.jsonl` inside the stage's workspace, one JSON object
-per line. The executor harvests this file after the session goes idle,
-streaming it up to a 5MB cap (a torn, unterminated final line is tolerated
-and dropped; a malformed complete line fails the harvest). Each line is
-either a `finding` or a free-form `json` artifact:
+A stage (agent or command) is expected to write findings to
+`.ao/pipeline-findings.jsonl` inside its workspace, one JSON object per
+line, using the write-to-temp-then-rename convention (`pipeline-findings.jsonl.tmp`
+renamed onto the final path) so the executor never observes a torn write.
+For an agent stage the executor polls until the session goes idle AND the
+file exists, then harvests it and kills the session; for a command stage
+the harvest runs once the process exits with a completed outcome (see
+Command result modes below). Harvesting streams the file up to a 5MB cap
+(`findingsFileSizeCapBytes`): a torn, unterminated final line is tolerated
+and dropped, a malformed complete line fails the whole harvest, and file
+existence (not contents) is the completion signal, so an empty renamed
+file means "no findings." Exceeding the cap does not fail the stage; it
+sets a `pipeline.findings.truncated` observation (stage name, path, cap,
+bytes read) and a matching stage note, and stops reading at the cap.
+
+Each JSONL line is one of three kinds:
 
 ```json
 {
@@ -257,14 +268,210 @@ either a `finding` or a free-form `json` artifact:
 }
 ```
 
-Finding fields: `filePath`, `startLine`, `endLine`, `title`, `description`,
-`category` (free-form, e.g. `security`/`correctness`/`style`/`general`),
-`severity` (`error`/`warning`/`info`), `confidence` (a float in `[0, 1]`),
-and an optional `anchorSignature` used to keep the finding's fingerprint
-stable across rounds. A `json`-kind artifact instead carries a `data`
-object. All finding fields except `anchorSignature` are required on a
-`finding`-kind line; a missing field or an out-of-range confidence fails
-that record.
+- **`{kind:"finding"}`**: `filePath`, `startLine`, `endLine`, `title`,
+  `description`, `category` (free-form, e.g.
+  `security`/`correctness`/`style`/`general`), `severity`
+  (`error`/`warning`/`info`), and `confidence` (a float in `[0, 1]`) are all
+  required; `anchorSignature` is optional and keeps the finding's
+  fingerprint stable across rounds. A missing required field or an
+  out-of-range confidence fails that record (and the harvest).
+- **`{kind:"status", fingerprint, status}`**: a stage's request to flip an
+  existing finding's lifecycle status by its stable fingerprint (e.g. a
+  verify stage resolving what an earlier review stage found). `status` must
+  be `open`, `resolved`, or `dismissed` (`sent_to_agent` is engine-internal
+  and never authored here). Both fields are required; a bad status fails
+  the harvest. A fingerprint that matches no finding in the run is
+  *tolerated*, not rejected: it emits a `pipeline.status.unknown_fingerprint`
+  observation and a stage note rather than failing the stage. Status
+  changes are applied before the run's exit decision, so a verify stage
+  resolving a finding can flip `no_open_findings` in the same round.
+- **`{kind:"json", data:{...}}`**: a free-form artifact carrying an object
+  `data`; used by `answer`-mode stages. Not mirrored into `run.findings`
+  (only `finding`-kind artifacts are).
+
+## Command stage result modes
+
+A `command` stage's exit is interpreted one of two ways, chosen by what the
+process wrote to stdout:
+
+- **Envelope mode.** If trimmed stdout parses as a JSON object with an
+  `outcome` field, it is treated as the historical command-task envelope:
+  `{"outcome": "succeeded"|"failed"|"neutral"|"skipped", "verdict"?:
+  "pass"|"fail"|"neutral", "artifacts"?: [...], "reason"?: "..."}`. A nonzero
+  exit code still fails the stage even in envelope mode (the shim crashed
+  before or after writing valid JSON). `outcome: "failed"` fails the stage,
+  using `reason` as the error message when present. Otherwise the stage
+  completes; `verdict` is used if set, else defaulted from `outcome`
+  (`succeeded` -> `pass`, `neutral`/`skipped` -> `neutral`). `outcome:
+  "skipped"` also adds a `command_stage_self_skipped` observation.
+- **Exit-code fallback.** If stdout is not that envelope (empty, plain text,
+  a JSON array, or an object without `outcome`), the raw process exit code
+  is the verdict: exit 0 completes with `verdict: pass`; nonzero fails with
+  a reason built from the exit code plus a stderr tail. Either way a
+  `command_stage_exit_mode` observation is attached (`mode: "exit-code"`,
+  the exit code), so the run detail always shows which mode decided the
+  outcome.
+
+In both modes: a stage timeout or a kill-by-signal fails the stage before
+either mode is even considered; the combined stdout+stderr tail (last 64
+KiB) is captured onto the stage's `output` field on every terminal outcome;
+and, when the process completed, a `.ao/pipeline-findings.jsonl` drop is
+harvested exactly as described above (a malformed file flips an otherwise
+completed outcome to failed).
+
+## Upstream findings in agent prompts
+
+An agent stage whose `dependsOn` names earlier stages receives their
+materialized findings as an "## Upstream findings" section injected into
+its spawn prompt (built by `buildStagePrompt`), one line per finding:
+severity, fingerprint, originating stage, `file:startLine-endLine`, title,
+and current status. The section is capped at 100 findings with an overflow
+count past the cap. This is how a `summarize`/`verify`-style downstream
+stage can reference a specific finding by fingerprint and emit a
+`{kind:"status"}` record to resolve or dismiss it. The prompt also always
+carries a "## Reporting Findings" block explaining the JSONL contract
+(write-to-temp, rename, the finding/status record shapes for the stage's
+mode) and, when the run has a PR, a "## Pull request" block (see below).
+
+## PR context available to stages
+
+When a run is backed by a PR, its identity flows to every stage:
+
+- **Agent stages** spawn on the PR's source branch (`Branch:
+  in.Context.SourceBranch` in the spawn request), so a review/code session
+  sees the PR diff and can push directly to it; a collision with an
+  already-checked-out branch falls back to a stage-run-id-suffixed branch
+  name. The prompt's "## Pull request" block renders whichever of these
+  fields the run context carries: `Number: #<n>`, `URL: <url>`, `Branch:
+  <source> -> <target>`, `Head SHA: <sha>`. A manual run with no PR omits
+  the block entirely.
+- **Command stages** get the same facts as environment variables
+  (`pipelineEnv`), always alongside `AO_PIPELINE_RUN_ID` and
+  `AO_PIPELINE_STAGE`:
+
+  | Variable | Set when |
+  |---|---|
+  | `AO_PIPELINE_RUN_ID` | always |
+  | `AO_PIPELINE_STAGE` | always |
+  | `AO_PR_NUMBER` | `PRNumber > 0` |
+  | `AO_PR_URL` | `PRURL` set |
+  | `AO_PR_BRANCH` | `SourceBranch` set |
+  | `AO_PR_BASE_BRANCH` | `TargetBranch` set |
+  | `AO_PR_HEAD_SHA` | `HeadSHA` set |
+
+  Unset PR fields are omitted entirely rather than passed as empty strings.
+  A stage's own `executor.env` is applied last and wins on any key
+  collision.
+
+This context (`RunContext`) is populated once at trigger time, from the CDC
+trigger bridge's `PRFacts` lookup for a PR-driven run, or from the session
+and head SHA a manual run supplies, and is persisted as part of the run so
+every stage attempt sees the same facts.
+
+## Per-PR loop identity and same-SHA dedup
+
+Each pipeline "loop" (the persistent per-session, per-pipeline run
+sequence) is keyed by `LoopKeyFor`, not just session+pipeline name:
+
+- a PR-backed run keys as `sessionID:pipelineName:prURL`, so sibling PRs
+  driven off the same session and pipeline never collide, a new SHA on
+  PR-B cannot cancel or continue PR-A's in-flight run;
+- a manual run scoped to a session keys as `sessionID:pipelineName` (the
+  pre-PR-context shape, which older persisted runs also degrade to);
+- a manual run with no session keys as `run:<runID>` so unscoped manual
+  runs never share a global key and no-op each other.
+
+Within one PR's loop, the reducer also dedups by exact head SHA: a
+non-manual trigger (`pr.opened`/`pr.updated`/`pr.merge_ready`/`pr.merged`)
+whose SHA already produced a *settled* run (`done` or `stalled`; not
+`outdated`/`cancelled`/`config_change`) is a no-op, emitting a
+`pipeline.run.trigger_deduped` observation instead of spawning a duplicate.
+This absorbs CI flapping and fact-only `pr.updated` churn on an unchanged
+SHA. A manual trigger always fires, even at an already-run SHA, since a
+human explicitly asked. Only settled runs count toward `loop_rounds_at_least`;
+a run cut short by outdated/cancel/config-change is not a round.
+
+## Deadlines, retries, honest exits
+
+- **Stage timeout.** `Stage.TimeoutMs` is a per-stage deadline; when unset
+  (or non-positive) the engine falls back to `DefaultStageTimeout`, which is
+  **30 minutes** (`pipeline.DefaultStageTimeout`, in `reducer.go`). The
+  deadline is stamped at `STAGE_STARTED` (`StartedAt + timeout`) and cleared
+  on retry/re-pend; a periodic `Tick` event fails any running stage whose
+  deadline has passed, so a wedged executor cannot leave a run running
+  forever.
+- **Retries.** `Stage.Retries` (default nil, meaning no automatic retry) is
+  a budget of *additional* attempts: `retries: 2` allows up to 3 attempts
+  total. A failed stage within budget is silently re-pended with a fresh
+  `stageRunId` and `attempt+1` and re-enters the scheduler; a
+  `pipeline.stage.retried` observation is emitted either way. Retries apply
+  uniformly to timeouts, non-zero exits, and executor errors.
+- **`maxLoopRounds`.** `Stage.MaxLoopRounds` caps how many *loop rounds* (not
+  attempts) a stage may run for across a PR's whole loop; once the run's
+  `loopRounds` exceeds the cap the stage is skipped instead of started, with
+  a `pipeline.stage.skipped_max_rounds` observation. It is per-stage, not
+  pipeline-global.
+- **Honest exits.** Once every stage in a run reaches a terminal status, the
+  run's exit is decided by `decideRunExit`: with no `exitPredicates`
+  configured, any failed stage means `stalled`/`stage_failure`, otherwise
+  `done`/`completed` (the v0 default). With `exitPredicates.done` configured,
+  the run is *never* reported `done`/`completed` unless that predicate is
+  actually true. If `done` is configured but evaluates false (and `stalled`,
+  if any, does not fire), the run terminates as `stalled` with the distinct
+  reason `done_predicate_unmet` (`pipeline.TerminationDonePredicateUnmet`) so
+  a stage that finished without satisfying its own success condition (e.g.
+  open findings remain) is never dishonestly reported as completed.
+  Stall-window convergence (`policy.stallWindow`, the same fingerprint set
+  repeating across the window) is checked before exit predicates and, when
+  it fires, terminates as `stalled`/`converged` instead.
+
+## Merge blocking and dismissing findings
+
+- **`blocksMerge` end to end.** At a run's terminal transition (any of
+  `done`, `stalled`, or `terminated` that isn't outdated/manually-cancelled/
+  config-changed), `runBlocksMerge` sets `RunState.BlocksMerge`: true when
+  any finally-failed stage's `policy.blocksMerge` is true, else when
+  `exitPredicates.blocksMerge` (if configured) evaluates true against the
+  run's findings/history. Runs superseded as `outdated`, cancelled by hand,
+  or ended by a config change never block, since they were replaced rather
+  than judged. A true result emits a `pipeline.run.blocks_merge` observation.
+  The lifecycle merge-readiness check (`Service.PRBlocksMerge`, backing the
+  SCM integration's merge gate) looks up the most recent *settled* run for
+  the PR's URL and only honors its `BlocksMerge` when that run's `HeadSHA`
+  still matches the PR's current head; a stale-SHA or absent run is treated
+  as no opinion (`false`), so pipelines never fabricate a stale block.
+- **Dismiss flow.** `POST /api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status`
+  (`?project=<id>` required) takes `{"status": "open"|"resolved"|"dismissed"}`
+  and drives the same lifecycle a `{kind:"status"}` JSONL record would,
+  dispatched as an `ArtifactStatusChanged` event with `actor: "user"`. The
+  reducer updates the finding's status in `run.Findings`, persists an
+  `UpdateArtifactStatus` effect, and emits a `pipeline.artifact.status_changed`
+  observation; the call is synchronous on the engine actor, so the response
+  reflects the new status immediately. `sent_to_agent` is not a settable
+  target from this route (or from a findings-file status record); it is
+  engine-internal.
+
+## Fork-PR trust gate and per-stage diagnostics
+
+`allowForkPRs` (pipeline-level, default false) gates **every** executor
+kind uniformly, agent, command, and builtin alike, through one shared
+helper (`forkGateDecision` / `forkFromContext` in
+`backend/internal/pipeline/executors/forkgate.go`). Fork status is resolved
+from `RunContext.IsFromFork` (the tri-state the trigger bridge populates
+from `PRFacts`): known-true blocks unless `allowForkPRs` is set,
+known-false always runs, and *unknown* (the SCM plugin could not classify
+it) is fail-safe: blocked by default, same as a known fork. A gated stage
+never starts a subprocess or spawns a session; it completes immediately as
+`neutral` with a `pipeline.stage.skipped_fork_pr` observation explaining
+why.
+
+Every stage's runtime state also now carries a `sessionId` (the AO session
+it ran in, for agent stages; empty for command/builtin, which own no
+session) and a capped list of human-readable `notes` (fork-PR skip reason,
+findings-file truncation, command exit-mode fallback, an unknown status
+fingerprint, and similar one-line annotations), both surfaced per stage in
+the run detail response so a human can see what happened without digging
+through raw observations.
 
 ## UI overview
 
@@ -283,4 +490,6 @@ feature) has two tabs:
   query invalidation, no separate SSE endpoint.
 
 A run detail view is read-only: pipeline, session, loop state, rounds, head
-SHA, per-stage status/verdict/attempt/artifacts, and the run's findings.
+SHA, whether the run blocks merge, per-stage status/verdict/attempt/output/
+session id/notes/artifacts, and the run's findings (each dismissible via the
+artifact-status route described in Merge blocking and dismissing findings).

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -281,7 +281,7 @@ Each JSONL line is one of three kinds:
   be `open`, `resolved`, or `dismissed` (`sent_to_agent` is engine-internal
   and never authored here). Both fields are required; a bad status fails
   the harvest. A fingerprint that matches no finding in the run is
-  *tolerated*, not rejected: it emits a `pipeline.status.unknown_fingerprint`
+  _tolerated_, not rejected: it emits a `pipeline.status.unknown_fingerprint`
   observation and a stage note rather than failing the stage. Status
   changes are applied before the run's exit decision, so a verify stage
   resolving a finding can flip `no_open_findings` in the same round.
@@ -297,13 +297,13 @@ process wrote to stdout:
 - **Envelope mode.** If trimmed stdout parses as a JSON object with an
   `outcome` field, it is treated as the historical command-task envelope:
   `{"outcome": "succeeded"|"failed"|"neutral"|"skipped", "verdict"?:
-  "pass"|"fail"|"neutral", "artifacts"?: [...], "reason"?: "..."}`. A nonzero
+"pass"|"fail"|"neutral", "artifacts"?: [...], "reason"?: "..."}`. A nonzero
   exit code still fails the stage even in envelope mode (the shim crashed
   before or after writing valid JSON). `outcome: "failed"` fails the stage,
   using `reason` as the error message when present. Otherwise the stage
   completes; `verdict` is used if set, else defaulted from `outcome`
   (`succeeded` -> `pass`, `neutral`/`skipped` -> `neutral`). `outcome:
-  "skipped"` also adds a `command_stage_self_skipped` observation.
+"skipped"` also adds a `command_stage_self_skipped` observation.
 - **Exit-code fallback.** If stdout is not that envelope (empty, plain text,
   a JSON array, or an object without `outcome`), the raw process exit code
   is the verdict: exit 0 completes with `verdict: pass`; nonzero fails with
@@ -338,26 +338,26 @@ mode) and, when the run has a PR, a "## Pull request" block (see below).
 When a run is backed by a PR, its identity flows to every stage:
 
 - **Agent stages** spawn on the PR's source branch (`Branch:
-  in.Context.SourceBranch` in the spawn request), so a review/code session
+in.Context.SourceBranch` in the spawn request), so a review/code session
   sees the PR diff and can push directly to it; a collision with an
   already-checked-out branch falls back to a stage-run-id-suffixed branch
   name. The prompt's "## Pull request" block renders whichever of these
   fields the run context carries: `Number: #<n>`, `URL: <url>`, `Branch:
-  <source> -> <target>`, `Head SHA: <sha>`. A manual run with no PR omits
+<source> -> <target>`, `Head SHA: <sha>`. A manual run with no PR omits
   the block entirely.
 - **Command stages** get the same facts as environment variables
   (`pipelineEnv`), always alongside `AO_PIPELINE_RUN_ID` and
   `AO_PIPELINE_STAGE`:
 
-  | Variable | Set when |
-  |---|---|
-  | `AO_PIPELINE_RUN_ID` | always |
-  | `AO_PIPELINE_STAGE` | always |
-  | `AO_PR_NUMBER` | `PRNumber > 0` |
-  | `AO_PR_URL` | `PRURL` set |
-  | `AO_PR_BRANCH` | `SourceBranch` set |
-  | `AO_PR_BASE_BRANCH` | `TargetBranch` set |
-  | `AO_PR_HEAD_SHA` | `HeadSHA` set |
+  | Variable             | Set when           |
+  | -------------------- | ------------------ |
+  | `AO_PIPELINE_RUN_ID` | always             |
+  | `AO_PIPELINE_STAGE`  | always             |
+  | `AO_PR_NUMBER`       | `PRNumber > 0`     |
+  | `AO_PR_URL`          | `PRURL` set        |
+  | `AO_PR_BRANCH`       | `SourceBranch` set |
+  | `AO_PR_BASE_BRANCH`  | `TargetBranch` set |
+  | `AO_PR_HEAD_SHA`     | `HeadSHA` set      |
 
   Unset PR fields are omitted entirely rather than passed as empty strings.
   A stage's own `executor.env` is applied last and wins on any key
@@ -383,7 +383,7 @@ sequence) is keyed by `LoopKeyFor`, not just session+pipeline name:
 
 Within one PR's loop, the reducer also dedups by exact head SHA: a
 non-manual trigger (`pr.opened`/`pr.updated`/`pr.merge_ready`/`pr.merged`)
-whose SHA already produced a *settled* run (`done` or `stalled`; not
+whose SHA already produced a _settled_ run (`done` or `stalled`; not
 `outdated`/`cancelled`/`config_change`) is a no-op, emitting a
 `pipeline.run.trigger_deduped` observation instead of spawning a duplicate.
 This absorbs CI flapping and fact-only `pr.updated` churn on an unchanged
@@ -401,12 +401,12 @@ a run cut short by outdated/cancel/config-change is not a round.
   deadline has passed, so a wedged executor cannot leave a run running
   forever.
 - **Retries.** `Stage.Retries` (default nil, meaning no automatic retry) is
-  a budget of *additional* attempts: `retries: 2` allows up to 3 attempts
+  a budget of _additional_ attempts: `retries: 2` allows up to 3 attempts
   total. A failed stage within budget is silently re-pended with a fresh
   `stageRunId` and `attempt+1` and re-enters the scheduler; a
   `pipeline.stage.retried` observation is emitted either way. Retries apply
   uniformly to timeouts, non-zero exits, and executor errors.
-- **`maxLoopRounds`.** `Stage.MaxLoopRounds` caps how many *loop rounds* (not
+- **`maxLoopRounds`.** `Stage.MaxLoopRounds` caps how many _loop rounds_ (not
   attempts) a stage may run for across a PR's whole loop; once the run's
   `loopRounds` exceeds the cap the stage is skipped instead of started, with
   a `pipeline.stage.skipped_max_rounds` observation. It is per-stage, not
@@ -415,7 +415,7 @@ a run cut short by outdated/cancel/config-change is not a round.
   run's exit is decided by `decideRunExit`: with no `exitPredicates`
   configured, any failed stage means `stalled`/`stage_failure`, otherwise
   `done`/`completed` (the v0 default). With `exitPredicates.done` configured,
-  the run is *never* reported `done`/`completed` unless that predicate is
+  the run is _never_ reported `done`/`completed` unless that predicate is
   actually true. If `done` is configured but evaluates false (and `stalled`,
   if any, does not fire), the run terminates as `stalled` with the distinct
   reason `done_predicate_unmet` (`pipeline.TerminationDonePredicateUnmet`) so
@@ -436,7 +436,7 @@ a run cut short by outdated/cancel/config-change is not a round.
   or ended by a config change never block, since they were replaced rather
   than judged. A true result emits a `pipeline.run.blocks_merge` observation.
   The lifecycle merge-readiness check (`Service.PRBlocksMerge`, backing the
-  SCM integration's merge gate) looks up the most recent *settled* run for
+  SCM integration's merge gate) looks up the most recent _settled_ run for
   the PR's URL and only honors its `BlocksMerge` when that run's `HeadSHA`
   still matches the PR's current head; a stale-SHA or absent run is treated
   as no opinion (`false`), so pipelines never fabricate a stale block.
@@ -459,7 +459,7 @@ helper (`forkGateDecision` / `forkFromContext` in
 `backend/internal/pipeline/executors/forkgate.go`). Fork status is resolved
 from `RunContext.IsFromFork` (the tri-state the trigger bridge populates
 from `PRFacts`): known-true blocks unless `allowForkPRs` is set,
-known-false always runs, and *unknown* (the SCM plugin could not classify
+known-false always runs, and _unknown_ (the SCM plugin could not classify
 it) is fail-safe: blocked by default, same as a known fork. A gated stage
 never starts a subprocess or spawns a session; it completes immediately as
 `neutral` with a `pipeline.stage.skipped_fork_pr` observation explaining

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1182,7 +1182,9 @@ export interface components {
             /** Format: date-time */
             completedAt?: null | string;
             errorMessage?: string;
+            notes?: string[];
             output?: string;
+            sessionId?: string;
             stageName: string;
             stageRunId: string;
             /** Format: date-time */

--- a/frontend/src/renderer/components/PipelineCanvas.test.tsx
+++ b/frontend/src/renderer/components/PipelineCanvas.test.tsx
@@ -193,6 +193,20 @@ describe("PipelineCanvas", () => {
 		expect(document.querySelector('[data-stage-name="fix"]')).not.toHaveAttribute("data-issue-count");
 	});
 
+	it("shows a blocks-merge badge for a stage whose policy.blocksMerge is true", () => {
+		const draft = draftOf(
+			stage("review", { policy: { blocksMerge: true } }),
+			stage("fix", { policy: { blocksMerge: false } }),
+			stage("triage"),
+		);
+		render(<PipelineCanvas draft={draft} />);
+
+		expect(screen.getAllByText("blocks merge")).toHaveLength(1);
+		expect(document.querySelector('[data-stage-name="review"] span.text-warning')).toHaveTextContent("blocks merge");
+		expect(document.querySelector('[data-stage-name="fix"]')).not.toHaveTextContent("blocks merge");
+		expect(document.querySelector('[data-stage-name="triage"]')).not.toHaveTextContent("blocks merge");
+	});
+
 	it("shows the zoom indicator and view controls", () => {
 		render(<PipelineCanvas draft={draftOf(stage("review"))} />);
 

--- a/frontend/src/renderer/components/PipelineCanvas.tsx
+++ b/frontend/src/renderer/components/PipelineCanvas.tsx
@@ -418,7 +418,16 @@ function StageNode({ data, selected }: NodeProps<StageNodeType>) {
 				</p>
 			)}
 			{inCycle && <p className="mt-1.5 text-micro text-error">in dependency cycle</p>}
-			{footer && <p className="mt-1.5 truncate text-micro text-passive">{footer}</p>}
+			{(footer || stage.policy?.blocksMerge) && (
+				<p className="mt-1.5 flex items-center gap-1.5">
+					{footer && <span className="truncate text-micro text-passive">{footer}</span>}
+					{stage.policy?.blocksMerge && (
+						<span className="shrink-0 rounded border border-warning/40 bg-warning/10 px-1.5 py-0.5 font-mono text-micro text-warning">
+							blocks merge
+						</span>
+					)}
+				</p>
+			)}
 			<Handle type="source" position={Position.Right} className="!size-2 !border-border-strong !bg-raised" />
 		</div>
 	);

--- a/frontend/src/renderer/components/PipelineRunDetail.test.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.test.tsx
@@ -5,9 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PipelineRunDetail } from "./PipelineRunDetail";
 import type { PipelineArtifact, PipelineRunDetail as RunDetail } from "../hooks/usePipelineRuns";
 
-const { usePipelineRunMock, postMock } = vi.hoisted(() => ({
+const { usePipelineRunMock, postMock, navigateMock } = vi.hoisted(() => ({
 	usePipelineRunMock: vi.fn(),
 	postMock: vi.fn(),
+	navigateMock: vi.fn(),
 }));
 
 vi.mock("../hooks/usePipelineRuns", () => ({
@@ -17,6 +18,9 @@ vi.mock("../hooks/usePipelineRuns", () => ({
 vi.mock("../lib/api-client", () => ({
 	apiClient: { POST: (...args: unknown[]) => postMock(...args) },
 	apiErrorMessage: (e: unknown) => (e instanceof Error ? e.message : "error"),
+}));
+vi.mock("@tanstack/react-router", () => ({
+	useNavigate: () => navigateMock,
 }));
 
 type StageView = RunDetail["stages"][number];
@@ -79,6 +83,7 @@ function renderDetail(project?: string) {
 beforeEach(() => {
 	usePipelineRunMock.mockReset();
 	postMock.mockReset().mockResolvedValue({ error: undefined });
+	navigateMock.mockReset();
 });
 
 afterEach(() => vi.restoreAllMocks());
@@ -181,5 +186,60 @@ describe("PipelineRunDetail", () => {
 
 		const row = screen.getByText("Open bug").closest("[data-finding]") as HTMLElement;
 		expect(within(row).getByRole("button", { name: "Dismiss" })).toBeDisabled();
+	});
+
+	it("links the run-level session id to the session page", async () => {
+		setRun(detail({ sessionId: "sess-42" }));
+		renderDetail("proj-1");
+
+		await userEvent.setup().click(screen.getByRole("button", { name: "sess-42" }));
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/sessions/$sessionId", params: { sessionId: "sess-42" } });
+	});
+
+	it("renders a dash instead of a link when the run has no session", () => {
+		setRun(detail({ sessionId: "" }));
+		renderDetail("proj-1");
+
+		expect(screen.getByText("—", { exact: false })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "sess-42" })).not.toBeInTheDocument();
+	});
+
+	it("links a stage's session id to the session page", async () => {
+		setRun(
+			detail({
+				stages: [stage({ stageName: "fix", sessionId: "sess-fix-1" })],
+			}),
+		);
+		renderDetail("proj-1");
+
+		const row = screen.getByText("fix").closest("[data-stage]") as HTMLElement;
+		await userEvent.setup().click(within(row).getByRole("button", { name: "sess-fix-1" }));
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/sessions/$sessionId", params: { sessionId: "sess-fix-1" } });
+	});
+
+	it("does not render a stage session link when the stage has no sessionId (command/builtin stages)", () => {
+		setRun(detail({ stages: [stage({ stageName: "lint" })] }));
+		renderDetail("proj-1");
+
+		const row = screen.getByText("lint").closest("[data-stage]") as HTMLElement;
+		expect(within(row).queryAllByRole("button")).toHaveLength(0);
+	});
+
+	it("renders stage notes as read-only annotations", () => {
+		setRun(
+			detail({
+				stages: [
+					stage({
+						stageName: "triage",
+						notes: ["fork PR: findings skipped", "exit mode fell back to timeout"],
+					}),
+				],
+			}),
+		);
+		renderDetail("proj-1");
+
+		const row = screen.getByText("triage").closest("[data-stage]") as HTMLElement;
+		expect(within(row).getByText("fork PR: findings skipped")).toBeInTheDocument();
+		expect(within(row).getByText("exit mode fell back to timeout")).toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import { cn } from "../lib/utils";
 import { formatTimeCompact } from "../lib/format-time";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
@@ -78,7 +79,8 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 						{run.blocksMerge && <Badge variant="error">Blocks merge</Badge>}
 					</div>
 					<p className="mt-0.5 truncate font-mono text-micro text-passive">
-						{run.runId} · session {run.sessionId || "—"} · {shortSha(run.headSha)} · {run.loopRounds} round
+						{run.runId} · session {run.sessionId ? <SessionLink sessionId={run.sessionId} /> : "—"} ·{" "}
+						{shortSha(run.headSha)} · {run.loopRounds} round
 						{run.loopRounds === 1 ? "" : "s"} · updated {formatTimeCompact(run.updatedAt)}
 					</p>
 				</div>
@@ -160,6 +162,11 @@ function StageRow({ stage }: { stage: PipelineStageView }) {
 			<span className={cn("h-2 w-2 shrink-0 rounded-full", stageStatusDotTone(stage.status))} />
 			<span className="font-mono text-caption font-medium text-foreground">{stage.stageName}</span>
 			<span className="font-mono text-micro text-passive">{stage.status}</span>
+			{stage.sessionId && (
+				<span className="font-mono text-micro text-passive">
+					· session <SessionLink sessionId={stage.sessionId} />
+				</span>
+			)}
 			{stage.verdict && <Badge variant="outline">{stage.verdict}</Badge>}
 			<span className="ml-auto flex items-center gap-2 font-mono text-micro text-passive">
 				{stage.output && (
@@ -179,12 +186,33 @@ function StageRow({ stage }: { stage: PipelineStageView }) {
 				</span>
 			</span>
 			{stage.errorMessage && <p className="w-full font-mono text-micro text-error">{stage.errorMessage}</p>}
+			{stage.notes?.map((note, i) => (
+				<p key={i} className="w-full font-mono text-micro text-warning">
+					{note}
+				</p>
+			))}
 			{stage.output && showOutput && (
 				<pre className="max-h-80 w-full overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-background px-2 py-1.5 font-mono text-micro text-muted-foreground">
 					{stage.output}
 				</pre>
 			)}
 		</div>
+	);
+}
+
+// SessionLink navigates to a session's page (from the routes shell), reused for
+// both the run-level session and any stage that ran an agent (command/builtin
+// stages leave stage.sessionId empty and stay plain text).
+function SessionLink({ sessionId }: { sessionId: string }) {
+	const navigate = useNavigate();
+	return (
+		<button
+			type="button"
+			onClick={() => void navigate({ to: "/sessions/$sessionId", params: { sessionId } })}
+			className="rounded px-0.5 text-passive underline-offset-2 hover:text-foreground hover:underline"
+		>
+			{sessionId}
+		</button>
 	);
 }
 

--- a/frontend/src/renderer/components/StageInspector.test.tsx
+++ b/frontend/src/renderer/components/StageInspector.test.tsx
@@ -226,4 +226,32 @@ describe("StageInspector", () => {
 		renderInspector(agentStage());
 		expect(screen.queryByRole("button", { name: "Delete stage" })).not.toBeInTheDocument();
 	});
+
+	it("toggles policy.blocksMerge", async () => {
+		const { last } = renderInspector(agentStage());
+		const toggle = screen.getByRole("switch", { name: "Blocks merge" });
+		expect(toggle).not.toBeChecked();
+
+		await userEvent.click(toggle);
+		expect(last().policy).toEqual({ blocksMerge: true });
+
+		await userEvent.click(toggle);
+		expect(last().policy).toBeUndefined();
+	});
+
+	it("binds policy.stallWindow and drops the policy object once it is minimal again", async () => {
+		const { last } = renderInspector(agentStage());
+		await userEvent.type(screen.getByRole("spinbutton", { name: "Stall window (rounds)" }), "3");
+		expect(last().policy).toEqual({ stallWindow: 3 });
+
+		await userEvent.clear(screen.getByRole("spinbutton", { name: "Stall window (rounds)" }));
+		expect(last().policy).toBeUndefined();
+	});
+
+	it("keeps both policy fields together when both are set", async () => {
+		const { last } = renderInspector(agentStage());
+		await userEvent.click(screen.getByRole("switch", { name: "Blocks merge" }));
+		await userEvent.type(screen.getByRole("spinbutton", { name: "Stall window (rounds)" }), "2");
+		expect(last().policy).toEqual({ blocksMerge: true, stallWindow: 2 });
+	});
 });

--- a/frontend/src/renderer/components/StageInspector.tsx
+++ b/frontend/src/renderer/components/StageInspector.tsx
@@ -8,6 +8,7 @@ import {
 	type BuiltinName,
 	type ExecutorKind,
 	type StageDraft,
+	type StagePolicyDraft,
 	type StageTriggerEvent,
 	type TaskDraft,
 	type TaskMode,
@@ -17,6 +18,7 @@ import { summarizePredicate } from "../lib/predicate-summary";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+import { Switch } from "./ui/switch";
 
 // The stage inspector (mockup 1a, right panel): a form two-way bound to the
 // selected StageDraft. Every edit calls onChange with the next stage; the
@@ -75,6 +77,12 @@ export function StageInspector({
 		const budget = { ...stage.budget, ...patch };
 		const empty = budget.maxUsd === undefined && budget.maxDurationMs === undefined;
 		update({ budget: empty ? undefined : budget });
+	};
+
+	const updatePolicy = (patch: Partial<StagePolicyDraft>) => {
+		const policy = { ...stage.policy, ...patch };
+		const empty = !policy.blocksMerge && policy.stallWindow === undefined;
+		update({ policy: empty ? undefined : policy });
 	};
 
 	// Swapping executor kind rewrites the sub-object from scratch so no other
@@ -261,6 +269,28 @@ export function StageInspector({
 						value={stage.workspace ?? "default"}
 						onChange={(value) => update({ workspace: value === "default" ? undefined : value })}
 					/>
+				</Section>
+
+				<Section label="Policy">
+					<div className="flex flex-col gap-2.5">
+						<div className="flex items-center justify-between gap-2">
+							<span className="text-caption text-muted-foreground">Blocks merge</span>
+							<Switch
+								aria-label="Blocks merge"
+								checked={!!stage.policy?.blocksMerge}
+								onCheckedChange={(blocksMerge) => updatePolicy({ blocksMerge })}
+							/>
+						</div>
+						<NumberField
+							label="Stall window (rounds)"
+							value={stage.policy?.stallWindow}
+							onCommit={(stallWindow) => updatePolicy({ stallWindow })}
+						/>
+						<p className="text-caption text-passive">
+							Number of consecutive loop rounds with the same finding fingerprint set before the run is treated as
+							converged (stalled).
+						</p>
+					</div>
 				</Section>
 
 				<Section label="Advanced knobs">

--- a/frontend/src/renderer/lib/pipeline-templates.test.ts
+++ b/frontend/src/renderer/lib/pipeline-templates.test.ts
@@ -171,6 +171,19 @@ describe("PIPELINE_TEMPLATES", () => {
 		expect(PIPELINE_TEMPLATES.map((t) => t.name)).toEqual(Object.keys(EXPECTED_STAGE_COUNTS));
 	});
 
+	it("pr-review-loop gates its fix stage on real findings, not a findingless builtin", () => {
+		const draft = PIPELINE_TEMPLATES.find((t) => t.id === "pr-review-loop")!.draft();
+		const fix = draft.stages.find((s) => s.name === "fix")!;
+		const when = fix.routes?.when;
+		// not(no_open_findings) with no stage scope: scoping it to the compose
+		// builtin (which emits a JSON artifact, never findings) made the predicate
+		// vacuously true, so fix was skipped every run.
+		expect(when?.kind).toBe("not");
+		const inner = when && when.kind === "not" ? when.predicate : undefined;
+		expect(inner?.kind).toBe("no_open_findings");
+		expect((inner as { stage?: string } | undefined)?.stage).toBeUndefined();
+	});
+
 	for (const template of PIPELINE_TEMPLATES) {
 		describe(template.name, () => {
 			it("has the advertised stage count", () => {

--- a/frontend/src/renderer/lib/pipeline-templates.ts
+++ b/frontend/src/renderer/lib/pipeline-templates.ts
@@ -59,7 +59,11 @@ function prReviewLoop(): PipelineDraft {
 				executor: { kind: "agent", plugin: "claude-code", mode: "code" },
 				task: { prompt: "Fix the open findings, smallest correct change first. Push the fixes to the PR branch." },
 				dependsOn: ["triage"],
-				routes: { when: { kind: "not", predicate: { kind: "no_open_findings", stage: "compose-findings" } } },
+				// Run the fix stage whenever the run has any open findings. Scoping this
+				// to "compose-findings" was vacuously true (that builtin emits a JSON
+				// artifact, never findings), so fix was skipped every run. Unscoped
+				// matches the run's done predicate below.
+				routes: { when: { kind: "not", predicate: { kind: "no_open_findings" } } },
 				workspace: "isolated-rw",
 				maxLoopRounds: 3,
 			},


### PR DESCRIPTION
Closes #274.

Batch 4a: closes out the pipelines trust + UX gaps. Base branch: `pipelines`.

## What's in here

**1. Uniform fork gate (backend).** The fork-PR trust gate was command-executor only; the agent and builtin executors ran unconditionally, so on a fork PR an agent `security` stage would run while a command `lint` stage was correctly blocked, an inconsistent trust boundary inside one pipeline. Extracted the decision into a shared helper (`executors/forkgate.go`) applied in `AgentExecutor.Start` and `BuiltinExecutor.Start`. Fork provenance is resolved from the run context tri-state (`Context.IsFromFork`, #275), using `PRNumber` to disambiguate the unknown case (PR present + unknown = fail-safe block; no PR = manual run, flows normally), mirroring the command path's session-lookup semantics without a new session seam (so `adapters.go`, owned by #277/#282, is untouched). Gated stages self-skip completed/neutral with a uniform observation, identical to the command path, so pipelines keep flowing.

**2. Session click-through (backend + frontend).** Threaded the spawned agent session id through `Outcome.SessionID` (set on both completed and failed outcomes) -> `StageState.SessionID` -> DTO. The run detail renders the run-level and per-stage session ids as links to the session (command/builtin stages leave it empty and stay plain text).

**3. Observations on stages.** Added `StageState.Notes` (capped at 8): the engine collects human-relevant one-line notes from executor observations (fork skip reason, findings truncated, exit-mode fallback) plus the reducer's unknown-status-fingerprint note, rendered as warning lines under the stage row.

**4. Policy UI (frontend).** `StageInspector` gets a Policy section (blocksMerge switch, stallWindow number input) bound through the existing draft codec; `PipelineCanvas` shows a compact "blocks merge" chip on nodes whose `policy.blocksMerge` is true.

**5. Persistence.** `StageState.Output`/`SessionID`/`Notes` had no columns (Output round-tripped through `RunState` but was dropped by the store), so the run detail served from the store lost them. Migration `0030` adds `session_id`, `notes`, `output` columns; sqlc + store mapping updated.

**6. pr-review-loop template fix.** Its fix stage gated on `not(no_open_findings, stage: "compose-findings")`, but compose emits a JSON artifact and never findings, so the predicate was vacuously true and fix was **skipped every run**. Re-scoped to unscoped `not(no_open_findings)`, matching the run's done predicate.

**7. Docs.** Rewrote `docs/pipelines.md`: command result modes, findings contract incl. status records and fingerprints, upstream findings injection, PR context (branch, prompt block, `AO_*` env), per-PR loop identity and same-SHA dedup, deadlines/retries/maxLoopRounds (30 min default) and honest exits, blocksMerge end to end, dismiss flow, and the uniform fork gate + per-stage session id and notes.

## Verification
- `go build ./...`, `go test ./...` green (fork-gate matrix for agent + builtin, session id on completed/failed outcomes, reducer notes cap, store round-trip). Regenerated sqlc, OpenAPI, `schema.ts`.
- Frontend: `tsc --noEmit` clean, full vitest suite green (922 tests), prettier clean.
- Pre-existing base-branch failures in `internal/cli` spawn tests (identical on untouched `origin/pipelines`) are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
