### PR TITLE
fix(scm): classify same-repo PR fork provenance on GraphQL poll path (#285)

### DIFF
--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -261,6 +261,7 @@ func scmPRFields() string {
 number url state isDraft merged closed title additions deletions changedFiles
 mergeable mergeStateStatus reviewDecision headRefName headRefOid baseRefName baseRefOid
 createdAt updatedAt mergedAt closedAt
+headRepository{ nameWithOwner }
 author{ login }
 mergeCommit{ oid }
 commits(last:1){ nodes{ commit{ oid statusCheckRollup{ state contexts(first:CONTEXT_LIMIT){ nodes{
@@ -369,6 +370,7 @@ func scmObservationFromGraphQL(ref ports.SCMPRRef, pr map[string]any) ports.SCMO
 			Merged:                   merged,
 			Closed:                   closed,
 			SourceBranch:             str(pr["headRefName"]),
+			HeadRepo:                 headRepositoryName(pr),
 			TargetBranch:             str(pr["baseRefName"]),
 			HeadSHA:                  firstNonEmpty(str(pr["headRefOid"]), latestCommitOID(pr)),
 			Title:                    str(pr["title"]),
@@ -707,6 +709,14 @@ func parseGitHubTime(s string) time.Time {
 func authorLogin(v any) string {
 	author, _ := v.(map[string]any)
 	return str(author["login"])
+}
+
+// headRepositoryName returns the PR head repository's owner/name, or "" when
+// GitHub omits it (e.g. the fork was deleted). The observer treats "" as unknown
+// provenance, so is_from_fork stays NULL rather than being guessed.
+func headRepositoryName(pr map[string]any) string {
+	headRepo, _ := pr["headRepository"].(map[string]any)
+	return str(headRepo["nameWithOwner"])
 }
 
 func mergeCommitOID(pr map[string]any) string {

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -1219,6 +1219,39 @@ func TestSCMObservationUsesRollupStateWhenContextsPaginated(t *testing.T) {
 	}
 }
 
+// TestSCMObservationCarriesHeadRepoFromGraphQL pins the poll-path fix for #285:
+// the GraphQL PR observation must carry the head repository so the observer can
+// classify pr.is_from_fork instead of leaving it NULL. A missing headRepository
+// (deleted fork) stays unknown ("") rather than being guessed.
+func TestSCMObservationCarriesHeadRepoFromGraphQL(t *testing.T) {
+	ref := ports.SCMPRRef{Repo: ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "octocat", Name: "hello", Repo: "octocat/hello"}, Number: 42}
+	cases := []struct {
+		name     string
+		headRepo any
+		want     string
+	}{
+		{"same repo", map[string]any{"nameWithOwner": "octocat/hello"}, "octocat/hello"},
+		{"fork repo", map[string]any{"nameWithOwner": "forker/hello"}, "forker/hello"},
+		{"missing head repository stays unknown", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := basePRFixture()
+			var pr map[string]any
+			fx.prData(func(m map[string]any) {
+				pr = m
+				if tc.headRepo != nil {
+					m["headRepository"] = tc.headRepo
+				}
+			})
+			obs := scmObservationFromGraphQL(ref, pr)
+			if obs.PR.HeadRepo != tc.want {
+				t.Fatalf("HeadRepo = %q, want %q", obs.PR.HeadRepo, tc.want)
+			}
+		})
+	}
+}
+
 func TestSCMMergeabilityBlocksReviewRequiredAndDraft(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/backend/internal/integration/scm_observer_test.go
+++ b/backend/internal/integration/scm_observer_test.go
@@ -394,6 +394,66 @@ func TestSCMObserverEndToEnd(t *testing.T) {
 		}
 	})
 
+	t.Run("Same-repo PR self-heals is_from_fork from NULL to false on refresh", func(t *testing.T) {
+		ctx := context.Background()
+		f := newSCMFixture(t, "feat/x")
+		const (
+			prURL   = "https://github.com/octocat/hello/pull/59"
+			headSHA = "beadfeed"
+		)
+		f.provider.detected["feat/x"] = ports.SCMPRObservation{
+			URL: prURL, Number: 59, SourceBranch: "feat/x", HeadRepo: scmTestRepo.Repo, TargetBranch: "main", HeadSHA: headSHA,
+		}
+		// forkFacts reads the provenance the command-executor fork gate consults
+		// (pr.is_from_fork projected onto PRFacts), not the display projection,
+		// which is where the fail-safe block reads from.
+		forkFacts := func(stage string) *bool {
+			facts, ok, err := f.store.GetPRFactsByURL(ctx, prURL)
+			if err != nil || !ok {
+				t.Fatalf("GetPRFactsByURL %s: ok=%v err=%v", stage, ok, err)
+			}
+			return facts.IsFromFork
+		}
+
+		// First poll simulates the pre-fix provider path: no head repo, so
+		// provenance is unknown and is_from_fork stays NULL (issue #285).
+		noHeadRepo := openSCMObservation(prURL, 59, headSHA, "feat/x", "main", domain.MergeMergeable)
+		f.provider.observations[59] = noHeadRepo
+		if err := f.observer.Poll(ctx); err != nil {
+			t.Fatalf("first Poll: %v", err)
+		}
+		if got := forkFacts("after first Poll"); got != nil {
+			t.Fatalf("is_from_fork = %v, want nil (unknown) before head repo is known", *got)
+		}
+
+		// Second poll carries the now-populated head repo (the fix). The same-repo
+		// PR must transition NULL -> false so existing rows self-heal.
+		withHeadRepo := noHeadRepo
+		withHeadRepo.PR.HeadRepo = scmTestRepo.Repo
+		f.provider.observations[59] = withHeadRepo
+		if err := f.observer.Poll(ctx); err != nil {
+			t.Fatalf("second Poll: %v", err)
+		}
+		got := forkFacts("after second Poll")
+		if got == nil {
+			t.Fatal("is_from_fork = nil, want false after same-repo head repo observed (self-heal)")
+		}
+		if *got {
+			t.Fatalf("is_from_fork = true, want false for a same-repo PR")
+		}
+
+		// A fork head repo on a later refresh flips the same row to true.
+		forkHeadRepo := withHeadRepo
+		forkHeadRepo.PR.HeadRepo = "forker/hello"
+		f.provider.observations[59] = forkHeadRepo
+		if err := f.observer.Poll(ctx); err != nil {
+			t.Fatalf("third Poll: %v", err)
+		}
+		if got := forkFacts("after third Poll"); got == nil || !*got {
+			t.Fatalf("is_from_fork = %v, want true for a fork head repo", got)
+		}
+	})
+
 	t.Run("Branch with no open PR writes nothing and sends no nudge", func(t *testing.T) {
 		ctx := context.Background()
 		f := newSCMFixture(t, "feat/quiet")


### PR DESCRIPTION
## Problem

Migration 0025 added the tri-state `pr.is_from_fork` (NULL = unknown), computed by the SCM observer via `forkFromRepos(obs.Repo, obs.PR.HeadRepo)`. But the GraphQL batch fetch (`scmObservationFromGraphQL`), which is the poll path that refreshes the `pr` row, never requested the PR's head repository and never set `HeadRepo`. So `obs.PR.HeadRepo` was empty on that path, `forkFromRepos` could not classify, and `pr.is_from_fork` stayed NULL forever.

Consequence: the pipelines fork gate treats unknown provenance as untrusted and self-skips every stage on a user's own same-repo PR ("SCM plugin could not determine fork status ...; blocking by default"), forcing users to set `allowForkPRs: true` on their own PRs, which defeats the gate.

(The REST list path `restListPullToSCM` already populated `HeadRepo`; only the GraphQL poll path was missing it.)

## Fix

- Request `headRepository{ nameWithOwner }` in the batch PR query.
- Map it onto `HeadRepo` in `scmObservationFromGraphQL` via a small `headRepositoryName` helper.

Because `HeadRepo` participates in `metadataSemanticHash`, existing NULL rows self-heal on the next observation. A missing `headRepository` (e.g. deleted fork) maps to `""`, so provenance stays unknown rather than guessed. No changes to the fork gate or pipeline code; the fail-safe semantics are intentionally left intact.

## Tests

- `scmObservationFromGraphQL` carries head repo: same-repo, fork, and missing-head-repository cases.
- End-to-end `Observer.Poll` self-heal against the real sqlite store: same-repo PR transitions NULL -> false on a refreshed observation, then a fork head repo flips it to true. Reads via the same PRFacts projection the command-executor fork gate consults.

## Verification

- `go build ./...`, gofmt clean.
- `go test ./...` from `backend/`: all passing except 4 pre-existing `cli` spawn tests that require a running daemon (reproduced on the base `pipelines` branch, unrelated to this change).

Closes #285