### PR TITLE
feat(session): SpawnConfig.Env passthrough into session runtime env

### DIFF
--- a/backend/internal/ports/session.go
+++ b/backend/internal/ports/session.go
@@ -30,4 +30,11 @@ type SpawnConfig struct {
 	// DisplayName is the user-facing sidebar label. Empty falls back to the
 	// session id in the read model (e.g. orchestrator sessions).
 	DisplayName string
+
+	// Env is extra environment for the spawned session, merged over the
+	// project's env vars (an entry here wins on collision, so a caller's
+	// ambient identity cannot be masked by project config). AO-internal vars
+	// (AO_SESSION_ID and friends) still win over everything. Nil means no
+	// extra env.
+	Env map[string]string
 }

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -331,7 +331,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: no agent adapter for harness %q", id, cfg.Harness)
 	}
 	agentConfig := effectiveAgentConfig(cfg.Kind, project.Config)
-	env := m.runtimeEnv(id, cfg.ProjectID, cfg.IssueID, project.Config.Env)
+	env := m.runtimeEnv(id, cfg.ProjectID, cfg.IssueID, project.Config.Env, cfg.Env)
 	m.augmentAgentRuntimeEnv(agent, env)
 	if err := m.prepareWorkspace(ctx, agent, id, ws.Path, systemPrompt, systemPromptFile, agentConfig, env); err != nil {
 		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
@@ -866,7 +866,7 @@ func (m *Manager) relaunchRestoredSession(ctx context.Context, rec domain.Sessio
 	// Restore re-applies the project's resolved agent config so a configured
 	// model/permissions carry across a restore, matching fresh spawn.
 	agentConfig := effectiveAgentConfig(rec.Kind, project.Config)
-	env := m.runtimeEnv(rec.ID, rec.ProjectID, rec.IssueID, project.Config.Env)
+	env := m.runtimeEnv(rec.ID, rec.ProjectID, rec.IssueID, project.Config.Env, nil)
 	m.augmentAgentRuntimeEnv(agent, env)
 	if err := m.prepareWorkspace(ctx, agent, rec.ID, ws.Path, systemPrompt, systemPromptFile, agentConfig, env); err != nil {
 		return RestoreResult{}, fmt.Errorf("restore %s: %w", rec.ID, err)
@@ -2137,11 +2137,16 @@ func workspaceRepoList(repos []domain.WorkspaceRepoRecord) string {
 }
 
 // spawnEnv builds the runtime environment: the per-project env vars first, then
-// the AO-internal vars last so they always win (a project cannot override
-// AO_SESSION_ID and friends).
-func spawnEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueID, dataDir string, projectEnv map[string]string) map[string]string {
-	env := make(map[string]string, len(projectEnv)+4)
+// the spawn config's extra env (a spawn-config entry wins on collision, so a
+// caller's ambient identity cannot be masked by project config), then the
+// AO-internal vars last so they always win (neither a project nor a spawn
+// config can override AO_SESSION_ID and friends).
+func spawnEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueID, dataDir string, projectEnv, extraEnv map[string]string) map[string]string {
+	env := make(map[string]string, len(projectEnv)+len(extraEnv)+4)
 	for k, v := range projectEnv {
+		env[k] = v
+	}
+	for k, v := range extraEnv {
 		env[k] = v
 	}
 	env[EnvSessionID] = string(id)
@@ -2158,9 +2163,11 @@ func spawnEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueI
 // command, which fails every callback and silently kills activity tracking).
 // When the pin cannot be applied the inherited PATH is kept and a warning is
 // logged so the degradation isn't silent.
-func (m *Manager) runtimeEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueID, projectEnv map[string]string) map[string]string {
-	env := spawnEnv(id, project, issue, m.dataDir, projectEnv)
-	path, err := HookPATH(m.executable, os.Getenv, projectEnv)
+func (m *Manager) runtimeEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueID, projectEnv, extraEnv map[string]string) map[string]string {
+	env := spawnEnv(id, project, issue, m.dataDir, projectEnv, extraEnv)
+	// The PATH pin is applied over the merged env, so a PATH set by the spawn
+	// config is the base the daemon dir is prepended to, same as a project PATH.
+	path, err := HookPATH(m.executable, os.Getenv, env)
 	if err != nil {
 		m.logger.Warn("session PATH not pinned to the daemon binary; `ao hooks` callbacks may resolve to a different ao and activity tracking will stall",
 			"session", id, "error", err)
@@ -2171,13 +2178,13 @@ func (m *Manager) runtimeEnv(id domain.SessionID, project domain.ProjectID, issu
 }
 
 // HookPATH builds the PATH value pinned into a spawned session: the daemon
-// executable's directory prepended to the base PATH (the project's PATH
-// override when set, else the daemon's inherited PATH — matching what the
+// executable's directory prepended to the base PATH (the PATH override from
+// baseEnv when set, else the daemon's inherited PATH, matching what the
 // runtime would have exported anyway). An error means the pin cannot be
 // applied: the executable is unresolvable, or is not named "ao", in which case
 // prepending its directory would not change what `ao` resolves to. Exported so
 // the reviewer launcher can pin its pane's PATH the same way.
-func HookPATH(executable func() (string, error), getenv func(string) string, projectEnv map[string]string) (string, error) {
+func HookPATH(executable func() (string, error), getenv func(string) string, baseEnv map[string]string) (string, error) {
 	exe, err := executable()
 	if err != nil {
 		return "", fmt.Errorf("resolve daemon executable: %w", err)
@@ -2189,7 +2196,7 @@ func HookPATH(executable func() (string, error), getenv func(string) string, pro
 	if name != hookBinaryName {
 		return "", fmt.Errorf("daemon executable %s is not named %q", exe, hookBinaryName)
 	}
-	base := projectEnv["PATH"]
+	base := baseEnv["PATH"]
 	if base == "" {
 		base = getenv("PATH")
 	}
@@ -2364,9 +2371,9 @@ func (m *Manager) cleanupAgentWorkspace(ctx context.Context, rec domain.SessionR
 	if !ok {
 		return
 	}
-	env := spawnEnv(rec.ID, rec.ProjectID, rec.IssueID, m.dataDir, nil)
+	env := spawnEnv(rec.ID, rec.ProjectID, rec.IssueID, m.dataDir, nil, nil)
 	if project, err := m.loadProject(ctx, rec.ProjectID); err == nil {
-		env = m.runtimeEnv(rec.ID, rec.ProjectID, rec.IssueID, project.Config.Env)
+		env = m.runtimeEnv(rec.ID, rec.ProjectID, rec.IssueID, project.Config.Env, nil)
 	} else {
 		m.logger.Warn("workspace cleanup: project env unavailable; agent cleanup using AO env only",
 			"sessionID", rec.ID, "projectID", rec.ProjectID, "error", err)

--- a/backend/internal/session_manager/provision_test.go
+++ b/backend/internal/session_manager/provision_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 func TestSpawnEnvProjectVarsCannotOverrideInternal(t *testing.T) {
@@ -15,7 +16,7 @@ func TestSpawnEnvProjectVarsCannotOverrideInternal(t *testing.T) {
 		"FOO":        "bar",
 		EnvSessionID: "hacked", // a project must not override AO-internal vars
 		EnvProjectID: "hacked",
-	})
+	}, nil)
 	if env["FOO"] != "bar" {
 		t.Fatalf("FOO = %q, want bar", env["FOO"])
 	}
@@ -24,6 +25,75 @@ func TestSpawnEnvProjectVarsCannotOverrideInternal(t *testing.T) {
 	}
 	if env[EnvProjectID] != "mer" {
 		t.Fatalf("AO_PROJECT_ID = %q, want mer (internal wins)", env[EnvProjectID])
+	}
+}
+
+func TestSpawnEnvSpawnConfigWinsOverProject(t *testing.T) {
+	env := spawnEnv("mer-1", "mer", "issue-9", "/data", map[string]string{
+		"FOO":        "project",
+		"BAR":        "project-only",
+		"AO_RUN_ID":  "project-hijack",
+		EnvSessionID: "hacked",
+	}, map[string]string{
+		"FOO":        "spawn",
+		"AO_RUN_ID":  "r1",
+		EnvSessionID: "hacked-by-spawn", // AO-internal vars still win over everything
+	})
+	if env["FOO"] != "spawn" {
+		t.Fatalf("FOO = %q, want spawn (spawn config wins over project env)", env["FOO"])
+	}
+	if env["AO_RUN_ID"] != "r1" {
+		t.Fatalf("AO_RUN_ID = %q, want r1", env["AO_RUN_ID"])
+	}
+	if env["BAR"] != "project-only" {
+		t.Fatalf("BAR = %q, want project-only", env["BAR"])
+	}
+	if env[EnvSessionID] != "mer-1" {
+		t.Fatalf("AO_SESSION_ID = %q, want mer-1 (internal wins)", env[EnvSessionID])
+	}
+}
+
+func TestSpawnEnvNilExtraChangesNothing(t *testing.T) {
+	projectEnv := map[string]string{"FOO": "bar"}
+	base := spawnEnv("mer-1", "mer", "issue-9", "/data", projectEnv, nil)
+	empty := spawnEnv("mer-1", "mer", "issue-9", "/data", projectEnv, map[string]string{})
+	if len(base) != len(empty) {
+		t.Fatalf("nil vs empty extra env differ: %v vs %v", base, empty)
+	}
+	for k, v := range base {
+		if empty[k] != v {
+			t.Fatalf("env[%q] = %q, want %q", k, empty[k], v)
+		}
+	}
+	if base["FOO"] != "bar" || base[EnvSessionID] != "mer-1" || base[EnvProjectID] != "mer" || base[EnvDataDir] != "/data" {
+		t.Fatalf("nil extra env changed the base env: %v", base)
+	}
+}
+
+func TestSpawn_ConfigEnvReachesRuntime(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: domain.ProjectConfig{
+		Env: map[string]string{"FOO": "project", "BAR": "project-only"},
+	}}
+	rt := &fakeRuntime{}
+	m := New(Deps{Runtime: rt, Agents: singleAgent{agent: &recordingAgent{}}, Workspace: &fakeWorkspace{}, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st}, LookPath: func(string) (string, error) { return "/bin/true", nil }})
+
+	if _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, Harness: domain.HarnessClaudeCode,
+		Env: map[string]string{"AO_RUN_ID": "r1", "FOO": "spawn"}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := rt.lastCfg.Env["AO_RUN_ID"]; got != "r1" {
+		t.Fatalf("runtime env AO_RUN_ID = %q, want r1", got)
+	}
+	if got := rt.lastCfg.Env["FOO"]; got != "spawn" {
+		t.Fatalf("runtime env FOO = %q, want spawn (spawn config wins over project env)", got)
+	}
+	if got := rt.lastCfg.Env["BAR"]; got != "project-only" {
+		t.Fatalf("runtime env BAR = %q, want project-only", got)
+	}
+	if rt.lastCfg.Env[EnvSessionID] == "" {
+		t.Fatal("runtime env missing AO_SESSION_ID")
 	}
 }
 


### PR DESCRIPTION
Pipelines v2 Task 9. Platform change only, no pipeline code touched.

## What

`ports.SpawnConfig` gains `Env map[string]string`, merged into the runtime env of spawned sessions.

Merge order in `spawnEnv`: project env, then `SpawnConfig.Env`, then the AO-internal vars.

- Spawn-config entries win over project env on collision, so a caller's ambient identity (e.g. `AO_RUN_ID`, `AO_STAGE`) cannot be masked by project config.
- AO-internal vars (`AO_SESSION_ID`, `AO_PROJECT_ID`, `AO_ISSUE_ID`, `AO_DATA_DIR`) still win over everything, unchanged.
- Nil or empty `Env` behaves exactly as before.
- The hook PATH pin now takes the merged env as its base, so a spawn-config `PATH` is honored the same way a project `PATH` is. Identical behavior when `Env` is nil.
- Restore and cleanup paths pass `nil`, so their behavior is unchanged.

## Tests

`backend/internal/session_manager/provision_test.go`:

- `TestSpawnEnvSpawnConfigWinsOverProject`: spawn config beats project env, AO-internal vars beat both.
- `TestSpawnEnvNilExtraChangesNothing`: nil and empty extra env produce the pre-existing env.
- `TestSpawn_ConfigEnvReachesRuntime`: end to end through `Manager.Spawn`, `Env: {"AO_RUN_ID": "r1"}` lands in the runtime launch env and the collision resolves to the spawn-config value.

Verified: `go build ./...`, `go test ./...` (102 packages green), `gofmt -l .` empty.

## Risks

Low. Every existing caller passes `nil` for the new parameter, so behavior is unchanged unless a spawn explicitly sets `Env`.

Closes #288