### PR TITLE
feat(pipelines): v2 definition schema, validation, outcomes, subject, run state, plan-at-start

### DIFF
--- a/backend/internal/pipeline/definition.go
+++ b/backend/internal/pipeline/definition.go
@@ -1,0 +1,411 @@
+package pipeline
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultStageDeadline bounds any stage that declares no deadline and belongs
+// to a pipeline whose defaults declare none either. Every stage has a
+// deadline: an agent that hangs must eventually settle as timed_out, or the
+// run board grows entries nobody ever closes (spec section 13.1).
+const DefaultStageDeadline = 30 * time.Minute
+
+// ExecutorKind names how a stage does its work. There is no agent taxonomy:
+// "review agent" versus "answer agent" is a property of the stage's contract
+// (`produces:`), not of the executor (spec section 6.2).
+type ExecutorKind string
+
+// Every executor kind.
+const (
+	ExecutorAgent   ExecutorKind = "agent"
+	ExecutorCommand ExecutorKind = "command"
+)
+
+// AllExecutorKinds lists every executor kind.
+var AllExecutorKinds = []ExecutorKind{ExecutorAgent, ExecutorCommand}
+
+// IsKnown reports whether k is a defined executor kind.
+func (k ExecutorKind) IsKnown() bool {
+	for _, known := range AllExecutorKinds {
+		if k == known {
+			return true
+		}
+	}
+	return false
+}
+
+// WorkspaceKind names the tree a stage runs in (spec section 5.1). The key
+// always means what it says; only which value is the default varies by entry
+// edge, so there are no hidden semantics to discover.
+type WorkspaceKind string
+
+// Every workspace kind. The zero value means the author declared nothing, in
+// which case the entry edge picks the default: auto on a success entry,
+// inherit on a failure entry (spec section 5.4).
+const (
+	WorkspaceUnset    WorkspaceKind = ""
+	WorkspaceAuto     WorkspaceKind = "auto"
+	WorkspaceInherit  WorkspaceKind = "inherit"
+	WorkspaceSession  WorkspaceKind = "session"
+	WorkspaceRun      WorkspaceKind = "run"
+	WorkspaceStage    WorkspaceKind = "stage"
+	WorkspaceCheckout WorkspaceKind = "checkout"
+)
+
+// AllWorkspaceKinds lists every workspace value an author can write. The unset
+// zero value is deliberately absent: it is not something anyone types.
+var AllWorkspaceKinds = []WorkspaceKind{
+	WorkspaceAuto, WorkspaceInherit, WorkspaceSession, WorkspaceRun, WorkspaceStage, WorkspaceCheckout,
+}
+
+// IsKnown reports whether k is a workspace value an author can write.
+func (k WorkspaceKind) IsKnown() bool {
+	for _, known := range AllWorkspaceKinds {
+		if k == known {
+			return true
+		}
+	}
+	return false
+}
+
+// PREvent names a pull-request event a pipeline reacts to. The subject is the
+// PR, which may or may not have a local session tracking it.
+type PREvent string
+
+// Every PR trigger event.
+const (
+	PREventCreated    PREvent = "created"
+	PREventUpdated    PREvent = "updated"
+	PREventMergeReady PREvent = "merge-ready"
+	PREventMerged     PREvent = "merged"
+)
+
+// AllPREvents lists every PR trigger event.
+var AllPREvents = []PREvent{PREventCreated, PREventUpdated, PREventMergeReady, PREventMerged}
+
+// IsKnown reports whether e is a defined PR trigger event.
+func (e PREvent) IsKnown() bool {
+	for _, known := range AllPREvents {
+		if e == known {
+			return true
+		}
+	}
+	return false
+}
+
+// SessionEvent names a session lifecycle event a pipeline reacts to. The
+// subject is that session, which always exists.
+type SessionEvent string
+
+// Every session trigger event.
+const (
+	SessionEventIdle    SessionEvent = "idle"
+	SessionEventExited  SessionEvent = "exited"
+	SessionEventBlocked SessionEvent = "blocked"
+)
+
+// AllSessionEvents lists every session trigger event.
+var AllSessionEvents = []SessionEvent{SessionEventIdle, SessionEventExited, SessionEventBlocked}
+
+// IsKnown reports whether e is a defined session trigger event.
+func (e SessionEvent) IsKnown() bool {
+	for _, known := range AllSessionEvents {
+		if e == known {
+			return true
+		}
+	}
+	return false
+}
+
+// ConcurrencyScope decides which runs collide (spec section 10). It is paired
+// with a literal group name, which decides which pipelines share a bucket; the
+// effective concurrency key is (resolved scope identity, group).
+type ConcurrencyScope string
+
+// Every concurrency scope. The zero value means "the subject's natural
+// scope", resolved by Subject.DefaultScope.
+const (
+	ConcurrencyScopeUnset   ConcurrencyScope = ""
+	ConcurrencyScopePR      ConcurrencyScope = "pr"
+	ConcurrencyScopeSession ConcurrencyScope = "session"
+	ConcurrencyScopeProject ConcurrencyScope = "project"
+)
+
+// AllConcurrencyScopes lists every scope an author can write.
+var AllConcurrencyScopes = []ConcurrencyScope{ConcurrencyScopePR, ConcurrencyScopeSession, ConcurrencyScopeProject}
+
+// IsKnown reports whether s is a scope an author can write.
+func (s ConcurrencyScope) IsKnown() bool {
+	for _, known := range AllConcurrencyScopes {
+		if s == known {
+			return true
+		}
+	}
+	return false
+}
+
+// Pipeline is one pipeline definition document. One pipeline per YAML
+// document, authored in the definitions editor and stored in SQLite; the ID is
+// assigned by the store, never part of the document.
+type Pipeline struct {
+	Name        string          `yaml:"name" json:"name"`
+	On          TriggerSpec     `yaml:"on" json:"on"`
+	Concurrency ConcurrencySpec `yaml:"concurrency" json:"concurrency"`
+	Defaults    DefaultsSpec    `yaml:"defaults" json:"defaults"`
+	Stages      []Stage         `yaml:"stages" json:"stages"`
+}
+
+// TriggerSpec names the events that start a run. Declaring neither family is
+// legal and means a manual-only pipeline.
+type TriggerSpec struct {
+	PR      []PREvent      `yaml:"pr" json:"pr,omitempty"`
+	Session []SessionEvent `yaml:"session" json:"session,omitempty"`
+}
+
+// ConcurrencySpec serializes runs that share an effective key. Queue depth is
+// 1: a third arrival evicts the queued run rather than stacking.
+type ConcurrencySpec struct {
+	Scope            ConcurrencyScope `yaml:"scope" json:"scope,omitempty"`
+	Group            string           `yaml:"group" json:"group,omitempty"`
+	CancelInProgress bool             `yaml:"cancel-in-progress" json:"cancelInProgress,omitempty"`
+}
+
+// DefaultsSpec holds the pipeline-wide fallbacks. Deadline decodes from a Go
+// duration string ("45m"), which yaml.v3 handles natively for time.Duration
+// fields. OnFailure names the stage every unrouted failure lands on, so that
+// silence on failure is never the accidental outcome (spec section 9.4).
+type DefaultsSpec struct {
+	Deadline  time.Duration `yaml:"deadline" json:"deadline,omitempty"`
+	OnFailure string        `yaml:"on_failure" json:"onFailure,omitempty"`
+}
+
+// SessionSpec configures what happens to an agent stage's session once the
+// stage settles.
+type SessionSpec struct {
+	// KillOn lists the outcomes that kill the session. A nil slice (no
+	// kill-on key) means the default pair {succeeded, failed}; an explicit
+	// empty list means never kill, which is correct for any stage running in
+	// a user's live session.
+	KillOn []Outcome `yaml:"kill-on" json:"killOn,omitempty"`
+}
+
+// Stage is one node of the state machine. Each stage names its successors, so
+// the graph is a state machine rather than a DAG, which is why cycles have to
+// be rejected at validation time.
+type Stage struct {
+	ID       string       `yaml:"id" json:"id"`
+	Executor ExecutorKind `yaml:"executor" json:"executor"`
+
+	// Agent-stage keys.
+	Agent    string       `yaml:"agent" json:"agent,omitempty"`
+	Prompt   string       `yaml:"prompt" json:"prompt,omitempty"`
+	Produces string       `yaml:"produces" json:"produces,omitempty"`
+	Session  *SessionSpec `yaml:"session" json:"session,omitempty"`
+
+	// Command-stage keys.
+	Run         string   `yaml:"run" json:"run,omitempty"`
+	Credentials []string `yaml:"credentials" json:"credentials,omitempty"`
+
+	// Common keys.
+	Workspace WorkspaceKind `yaml:"workspace" json:"workspace,omitempty"`
+	Deadline  time.Duration `yaml:"deadline" json:"deadline,omitempty"`
+	OnSuccess StageList     `yaml:"on_success" json:"onSuccess,omitempty"`
+	OnFailure string        `yaml:"on_failure" json:"onFailure,omitempty"`
+	Needs     []string      `yaml:"needs" json:"needs,omitempty"`
+}
+
+// StageList is a list of stage ids that YAML may write as a bare scalar
+// ("on_success: build") or as a sequence ("on_success: [a, b]"). A list fans
+// out; the targets start concurrently. This is the only fan-out mechanism.
+type StageList []string
+
+// UnmarshalYAML accepts either a scalar or a sequence of scalars.
+func (l *StageList) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		var one string
+		if err := value.Decode(&one); err != nil {
+			return err
+		}
+		*l = StageList{one}
+		return nil
+	}
+	var many []string
+	if err := value.Decode(&many); err != nil {
+		return err
+	}
+	*l = many
+	return nil
+}
+
+// ParseDefinition decodes a single-document YAML pipeline definition and
+// validates it, returning the normalized *Pipeline.
+//
+// Unknown keys are rejected (strict decoding), and every validation rule
+// failure is collected into a single *ValidationError rather than stopping at
+// the first one, so an author sees every problem in one pass. Warnings are
+// dropped here; callers that want to surface them (the editor) call Validate
+// directly.
+func ParseDefinition(src []byte) (*Pipeline, error) {
+	var p Pipeline
+	if err := decodeStrict(src, &p); err != nil {
+		return nil, err
+	}
+	if _, err := Validate(&p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// decodeStrict runs one strict yaml.v3 decode into out. An empty document is
+// not an error here: it decodes to the zero value and falls through to
+// validation, which reports the missing name and stages together with
+// everything else rather than as a bare parse failure.
+func decodeStrict(src []byte, out any) error {
+	dec := yaml.NewDecoder(bytes.NewReader(src))
+	dec.KnownFields(true)
+	if err := dec.Decode(out); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return fmt.Errorf("parse pipeline definition: %w", err)
+	}
+	return nil
+}
+
+// StageByID returns the stage with the given id, or nil. The returned pointer
+// aliases the pipeline's own slice, so callers must not retain it across a
+// mutation of Stages.
+func (p *Pipeline) StageByID(id string) *Stage {
+	for i := range p.Stages {
+		if p.Stages[i].ID == id {
+			return &p.Stages[i]
+		}
+	}
+	return nil
+}
+
+// EntryStage returns the stage a run starts from: the first in document order.
+// It returns nil for a pipeline with no stages.
+func (p *Pipeline) EntryStage() *Stage {
+	if len(p.Stages) == 0 {
+		return nil
+	}
+	return &p.Stages[0]
+}
+
+// stageIDs lists every stage id in document order.
+func (p *Pipeline) stageIDs() []string {
+	ids := make([]string, 0, len(p.Stages))
+	for i := range p.Stages {
+		ids = append(ids, p.Stages[i].ID)
+	}
+	return ids
+}
+
+// successEdges maps each stage id to its on_success targets, in declaration
+// order. Targets naming an unknown stage are kept: the unknown-stage-id rule
+// owns that error, and the cycle detector tolerates dangling nodes.
+func (p *Pipeline) successEdges() map[string][]string {
+	edges := make(map[string][]string, len(p.Stages))
+	for i := range p.Stages {
+		s := &p.Stages[i]
+		if len(s.OnSuccess) > 0 {
+			edges[s.ID] = append(edges[s.ID], s.OnSuccess...)
+		}
+	}
+	return edges
+}
+
+// failureEdges maps each stage id to its single failure target: the explicit
+// on_failure when present, otherwise defaults.on_failure.
+//
+// The one carve-out (spec section 9.4): the stage named by defaults.on_failure
+// does not inherit the default, because routing to itself would be a self-edge
+// rejected as a cycle. Its own failure ends the branch.
+func (p *Pipeline) failureEdges() map[string][]string {
+	edges := make(map[string][]string, len(p.Stages))
+	for i := range p.Stages {
+		s := &p.Stages[i]
+		switch {
+		case s.OnFailure != "":
+			edges[s.ID] = []string{s.OnFailure}
+		case p.Defaults.OnFailure != "" && s.ID != p.Defaults.OnFailure:
+			edges[s.ID] = []string{p.Defaults.OnFailure}
+		}
+	}
+	return edges
+}
+
+// routingEdges is the union of successEdges and failureEdges: every edge a run
+// can actually traverse. Success targets come first so traversal order matches
+// document intent.
+func (p *Pipeline) routingEdges() map[string][]string {
+	success := p.successEdges()
+	failure := p.failureEdges()
+	edges := make(map[string][]string, len(p.Stages))
+	for i := range p.Stages {
+		id := p.Stages[i].ID
+		combined := make([]string, 0, len(success[id])+len(failure[id]))
+		combined = append(combined, success[id]...)
+		combined = append(combined, failure[id]...)
+		if len(combined) > 0 {
+			edges[id] = combined
+		}
+	}
+	return edges
+}
+
+// inboundSuccess maps each stage id to the set of stages that name it in their
+// on_success. Failure edges are never counted: they never join and never
+// require a needs key (spec section 9.2). A stage listed twice by the same
+// source counts once.
+func (p *Pipeline) inboundSuccess() map[string][]string {
+	inbound := make(map[string][]string, len(p.Stages))
+	for i := range p.Stages {
+		s := &p.Stages[i]
+		seen := make(map[string]bool, len(s.OnSuccess))
+		for _, target := range s.OnSuccess {
+			if seen[target] {
+				continue
+			}
+			seen[target] = true
+			inbound[target] = append(inbound[target], s.ID)
+		}
+	}
+	return inbound
+}
+
+// EffectiveDeadline resolves the stage's deadline: its own, else the
+// pipeline defaults, else DefaultStageDeadline. The canvas editor surfaces
+// this on every stage, which was the actual goal behind bounding stages
+// (spec section 13.1).
+func (s *Stage) EffectiveDeadline(d DefaultsSpec) time.Duration {
+	if s.Deadline > 0 {
+		return s.Deadline
+	}
+	if d.Deadline > 0 {
+		return d.Deadline
+	}
+	return DefaultStageDeadline
+}
+
+// EffectiveKillOn returns the outcomes that kill this stage's session. An
+// absent session block, or a session block with no kill-on key, means the
+// default {succeeded, failed}: no_output, no_signal and timed_out keep the
+// session alive, because those are precisely the cases where a human needs to
+// see what the agent was doing (spec section 7.2). An explicit empty list
+// means never.
+func (s *Stage) EffectiveKillOn() []Outcome {
+	if s.Session == nil || s.Session.KillOn == nil {
+		return []Outcome{OutcomeSucceeded, OutcomeFailed}
+	}
+	out := make([]Outcome, len(s.Session.KillOn))
+	copy(out, s.Session.KillOn)
+	return out
+}

--- a/backend/internal/pipeline/definition_test.go
+++ b/backend/internal/pipeline/definition_test.go
@@ -1,0 +1,287 @@
+package pipeline
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// releaseYAML is the spec section 11 worked example, embedded verbatim as
+// testdata/release.yaml. It is the canonical fixture for this package: fan-out,
+// two joins, signing credentials, a diagnostic agent on the failure path.
+//
+// One character differs from the spec as written: notify-partial's last run
+// line sits at column 0 there, below its block scalar's indent, so the spec's
+// document does not parse as YAML at all. It is indented to the block indent
+// here, which yields exactly the shell text the example intends (the content
+// is still at relative column 0). The spec itself is left alone deliberately:
+// correcting it drags the whole file through prettier, which would reformat
+// 45 unrelated lines and conflict with every other v2 worker reading it.
+func releaseYAML(t *testing.T) []byte {
+	t.Helper()
+	src, err := os.ReadFile("testdata/release.yaml")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	return src
+}
+
+func mustParse(t *testing.T, src []byte) *Pipeline {
+	t.Helper()
+	p, err := ParseDefinition(src)
+	if err != nil {
+		t.Fatalf("ParseDefinition: %v", err)
+	}
+	return p
+}
+
+// The implementation plan says "12 stages"; the spec's own YAML declares 14
+// (the plan appears to have counted the ASCII diagram, which omits
+// notify-failure and notify-partial). The spec is the canonical fixture, so
+// the fixture wins.
+const releaseStageCount = 14
+
+func TestParseDefinition_ReleaseExample(t *testing.T) {
+	p := mustParse(t, releaseYAML(t))
+
+	if p.Name != "release" {
+		t.Errorf("name = %q, want %q", p.Name, "release")
+	}
+	if got, want := p.On.PR, []PREvent{PREventMerged}; !reflect.DeepEqual(got, want) {
+		t.Errorf("on.pr = %v, want %v", got, want)
+	}
+	if len(p.On.Session) != 0 {
+		t.Errorf("on.session = %v, want empty", p.On.Session)
+	}
+	if p.Concurrency.Scope != ConcurrencyScopeProject {
+		t.Errorf("concurrency.scope = %q, want %q", p.Concurrency.Scope, ConcurrencyScopeProject)
+	}
+	if p.Concurrency.Group != "release" {
+		t.Errorf("concurrency.group = %q, want %q", p.Concurrency.Group, "release")
+	}
+	if p.Concurrency.CancelInProgress {
+		t.Error("concurrency.cancel-in-progress = true, want false")
+	}
+	if p.Defaults.OnFailure != "notify-failure" {
+		t.Errorf("defaults.on_failure = %q, want %q", p.Defaults.OnFailure, "notify-failure")
+	}
+	if p.Defaults.Deadline != 0 {
+		t.Errorf("defaults.deadline = %v, want unset", p.Defaults.Deadline)
+	}
+
+	if len(p.Stages) != releaseStageCount {
+		t.Fatalf("stage count = %d, want %d", len(p.Stages), releaseStageCount)
+	}
+
+	prepare := p.StageByID("prepare")
+	if prepare == nil {
+		t.Fatal("StageByID(prepare) = nil")
+	}
+	wantFanOut := StageList{"build-macos", "build-windows", "build-linux", "release-notes"}
+	if !reflect.DeepEqual(prepare.OnSuccess, wantFanOut) {
+		t.Errorf("prepare.on_success = %v, want %v", prepare.OnSuccess, wantFanOut)
+	}
+	if prepare.Workspace != WorkspaceRun {
+		t.Errorf("prepare.workspace = %q, want %q", prepare.Workspace, WorkspaceRun)
+	}
+	if prepare.Executor != ExecutorCommand {
+		t.Errorf("prepare.executor = %q, want %q", prepare.Executor, ExecutorCommand)
+	}
+
+	verify := p.StageByID("verify-digests")
+	if verify == nil {
+		t.Fatal("StageByID(verify-digests) = nil")
+	}
+	wantNeeds := []string{"build-macos", "build-windows", "build-linux"}
+	if !reflect.DeepEqual(verify.Needs, wantNeeds) {
+		t.Errorf("verify-digests.needs = %v, want %v", verify.Needs, wantNeeds)
+	}
+
+	sign := p.StageByID("sign-macos")
+	if sign == nil {
+		t.Fatal("StageByID(sign-macos) = nil")
+	}
+	if got, want := sign.Credentials, []string{"apple-signing"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("sign-macos.credentials = %v, want %v", got, want)
+	}
+	if sign.Deadline != 45*time.Minute {
+		t.Errorf("sign-macos.deadline = %v, want 45m", sign.Deadline)
+	}
+
+	notes := p.StageByID("release-notes")
+	if notes == nil {
+		t.Fatal("StageByID(release-notes) = nil")
+	}
+	if notes.Executor != ExecutorAgent {
+		t.Errorf("release-notes.executor = %q, want %q", notes.Executor, ExecutorAgent)
+	}
+	if notes.Agent != "claude-code" {
+		t.Errorf("release-notes.agent = %q, want %q", notes.Agent, "claude-code")
+	}
+	if notes.Produces != "release-notes.md" {
+		t.Errorf("release-notes.produces = %q, want %q", notes.Produces, "release-notes.md")
+	}
+	if !strings.Contains(notes.Prompt, "ao pipeline done") {
+		t.Errorf("release-notes.prompt does not mention the signal verb: %q", notes.Prompt)
+	}
+}
+
+func TestPipeline_EntryStageAndStageByID(t *testing.T) {
+	p := mustParse(t, releaseYAML(t))
+
+	entry := p.EntryStage()
+	if entry == nil || entry.ID != "prepare" {
+		t.Fatalf("EntryStage() = %v, want prepare", entry)
+	}
+	if got := p.StageByID("nope"); got != nil {
+		t.Errorf("StageByID(nope) = %v, want nil", got)
+	}
+	var empty Pipeline
+	if got := empty.EntryStage(); got != nil {
+		t.Errorf("EntryStage() on empty pipeline = %v, want nil", got)
+	}
+}
+
+func TestStageList_ScalarOrSequence(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want StageList
+	}{
+		{
+			name: "scalar",
+			yaml: "on_success: verify-digests\n",
+			want: StageList{"verify-digests"},
+		},
+		{
+			name: "flow sequence",
+			yaml: "on_success: [a, b]\n",
+			want: StageList{"a", "b"},
+		},
+		{
+			name: "block sequence",
+			yaml: "on_success:\n  - a\n  - b\n",
+			want: StageList{"a", "b"},
+		},
+		{
+			name: "absent",
+			yaml: "id: x\n",
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var s Stage
+			if err := decodeStrict([]byte(tc.yaml), &s); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if !reflect.DeepEqual(s.OnSuccess, tc.want) {
+				t.Errorf("on_success = %#v, want %#v", s.OnSuccess, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseDefinition_Durations(t *testing.T) {
+	p := mustParse(t, []byte(`
+name: p
+defaults:
+  deadline: 45m
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    deadline: 90s
+  - id: b
+    executor: command
+    run: "true"
+`))
+	if p.Defaults.Deadline != 45*time.Minute {
+		t.Errorf("defaults.deadline = %v, want 45m", p.Defaults.Deadline)
+	}
+	if got := p.StageByID("a").Deadline; got != 90*time.Second {
+		t.Errorf("a.deadline = %v, want 90s", got)
+	}
+	if got := p.StageByID("b").Deadline; got != 0 {
+		t.Errorf("b.deadline = %v, want unset", got)
+	}
+}
+
+func TestParseDefinition_RejectsUnknownKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{"top level", "name: p\nnope: 1\nstages: []\n"},
+		{"stage level", "name: p\nstages:\n  - id: a\n    executor: command\n    run: \"true\"\n    retries: 3\n"},
+		{"defaults", "name: p\ndefaults:\n  timeout: 1m\nstages: []\n"},
+		{"session", "name: p\nstages:\n  - id: a\n    executor: agent\n    agent: x\n    prompt: y\n    session:\n      keep: true\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseDefinition([]byte(tc.yaml)); err == nil {
+				t.Fatal("expected a strict-decode error, got nil")
+			} else if !strings.Contains(err.Error(), "field") {
+				t.Errorf("expected an unknown-field error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestParseDefinition_EmptyDocument(t *testing.T) {
+	_, err := ParseDefinition(nil)
+	var verr *ValidationError
+	if !asValidationError(err, &verr) {
+		t.Fatalf("expected *ValidationError, got %v", err)
+	}
+	if !hasIssue(verr, "stages") {
+		t.Errorf("expected a stages issue, got %v", verr.Issues)
+	}
+}
+
+func TestStage_EffectiveDeadline(t *testing.T) {
+	tests := []struct {
+		name     string
+		stage    Stage
+		defaults DefaultsSpec
+		want     time.Duration
+	}{
+		{"stage wins", Stage{Deadline: 40 * time.Minute}, DefaultsSpec{Deadline: 45 * time.Minute}, 40 * time.Minute},
+		{"defaults next", Stage{}, DefaultsSpec{Deadline: 45 * time.Minute}, 45 * time.Minute},
+		{"builtin default", Stage{}, DefaultsSpec{}, DefaultStageDeadline},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.stage.EffectiveDeadline(tc.defaults); got != tc.want {
+				t.Errorf("EffectiveDeadline() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+	if DefaultStageDeadline != 30*time.Minute {
+		t.Errorf("DefaultStageDeadline = %v, want 30m", DefaultStageDeadline)
+	}
+}
+
+func TestStage_EffectiveKillOn(t *testing.T) {
+	p := mustParse(t, releaseYAML(t))
+
+	// Explicit list.
+	if got, want := p.StageByID("release-notes").EffectiveKillOn(), []Outcome{OutcomeSucceeded, OutcomeFailed}; !reflect.DeepEqual(got, want) {
+		t.Errorf("release-notes kill-on = %v, want %v", got, want)
+	}
+	// Explicit empty list means never kill, and must not fall back to the default.
+	if got := p.StageByID("diagnose-build").EffectiveKillOn(); len(got) != 0 {
+		t.Errorf("diagnose-build kill-on = %v, want empty", got)
+	}
+	// No session block at all falls back to the default pair.
+	if got, want := p.StageByID("prepare").EffectiveKillOn(), []Outcome{OutcomeSucceeded, OutcomeFailed}; !reflect.DeepEqual(got, want) {
+		t.Errorf("prepare kill-on = %v, want %v", got, want)
+	}
+	// A session block with no kill-on key also falls back.
+	s := Stage{Session: &SessionSpec{}}
+	if got, want := s.EffectiveKillOn(), []Outcome{OutcomeSucceeded, OutcomeFailed}; !reflect.DeepEqual(got, want) {
+		t.Errorf("empty session block kill-on = %v, want %v", got, want)
+	}
+}

--- a/backend/internal/pipeline/outcome.go
+++ b/backend/internal/pipeline/outcome.go
@@ -1,0 +1,119 @@
+package pipeline
+
+// Outcome is the settled (or in-flight) state of a single stage run. The
+// taxonomy is spec section 7: eight settled outcomes plus the two in-flight
+// ones. It is deliberately wider than a success/failure boolean because the
+// session disposition rules (kill-on) and the run board both need to tell
+// "the agent said it failed" apart from "the agent never said anything".
+type Outcome string
+
+// Every stage outcome. pending and running are in-flight; the rest are
+// settled.
+const (
+	// OutcomePending means the stage is reachable and seeded but not started.
+	OutcomePending Outcome = "pending"
+	// OutcomeRunning means the executor has been launched and has not settled.
+	OutcomeRunning Outcome = "running"
+	// OutcomeSucceeded means signalled done (or exit 0) with the declared
+	// artifact present and non-empty.
+	OutcomeSucceeded Outcome = "succeeded"
+	// OutcomeSucceededUnverified means signalled done with no produces
+	// declared, so there was nothing for the engine to verify.
+	OutcomeSucceededUnverified Outcome = "succeeded_unverified"
+	// OutcomeFailed means an explicit `ao pipeline fail`, or a non-zero exit.
+	OutcomeFailed Outcome = "failed"
+	// OutcomeNoOutput means signalled done, but the declared artifact is
+	// missing or empty.
+	OutcomeNoOutput Outcome = "no_output"
+	// OutcomeNoSignal means the session exited or went idle without
+	// signalling.
+	OutcomeNoSignal Outcome = "no_signal"
+	// OutcomeTimedOut means the stage deadline was hit.
+	OutcomeTimedOut Outcome = "timed_out"
+	// OutcomeCancelled means the run was torn down (superseded by concurrency,
+	// or killed).
+	OutcomeCancelled Outcome = "cancelled"
+	// OutcomeSkipped means a predecessor did not succeed. Skipped is not
+	// failed, and it cascades.
+	OutcomeSkipped Outcome = "skipped"
+)
+
+// AllOutcomes lists every outcome, in taxonomy order. Validation of
+// `session.kill-on` and the schema enum-coverage test are both driven off this
+// table, so adding an outcome is a one-line change here plus the schema.
+var AllOutcomes = []Outcome{
+	OutcomePending,
+	OutcomeRunning,
+	OutcomeSucceeded,
+	OutcomeSucceededUnverified,
+	OutcomeFailed,
+	OutcomeNoOutput,
+	OutcomeNoSignal,
+	OutcomeTimedOut,
+	OutcomeCancelled,
+	OutcomeSkipped,
+}
+
+// IsKnown reports whether o is one of the defined outcomes.
+func (o Outcome) IsKnown() bool {
+	for _, k := range AllOutcomes {
+		if o == k {
+			return true
+		}
+	}
+	return false
+}
+
+// IsSettled reports whether the stage has reached a terminal outcome, i.e.
+// anything other than pending or running.
+func (o Outcome) IsSettled() bool {
+	return o != OutcomePending && o != OutcomeRunning
+}
+
+// IsSuccess reports whether the outcome counts as a success for the purposes
+// of taking an on_success edge. `succeeded (unverified)` counts: the stage
+// declared no artifact contract, so the signal was the whole contract.
+func (o Outcome) IsSuccess() bool {
+	return o == OutcomeSucceeded || o == OutcomeSucceededUnverified
+}
+
+// RoutesToFailure reports whether the outcome takes the stage's on_failure
+// edge. Notably cancelled and skipped do not: a cancelled run is being torn
+// down rather than routed (spec section 13.2), and a skipped stage cascades
+// its skip instead.
+func (o Outcome) RoutesToFailure() bool {
+	switch o {
+	case OutcomeFailed, OutcomeNoOutput, OutcomeNoSignal, OutcomeTimedOut:
+		return true
+	default:
+		return false
+	}
+}
+
+// RunStatus is the run-level rollup shown as a column on the Kanban board.
+// The mapping from the eight stage outcomes is owned by the reducer: cancelled
+// if the run was cancelled, else failed if any stage settled in
+// {failed, no_output, no_signal, timed_out}, else succeeded.
+type RunStatus string
+
+// Every run status.
+const (
+	RunPending   RunStatus = "pending"
+	RunRunning   RunStatus = "running"
+	RunSucceeded RunStatus = "succeeded"
+	RunFailed    RunStatus = "failed"
+	RunCancelled RunStatus = "cancelled"
+)
+
+// AllRunStatuses lists every run status, in board-column order.
+var AllRunStatuses = []RunStatus{RunPending, RunRunning, RunSucceeded, RunFailed, RunCancelled}
+
+// IsKnown reports whether s is one of the defined run statuses.
+func (s RunStatus) IsKnown() bool {
+	for _, k := range AllRunStatuses {
+		if s == k {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/pipeline/outcome_test.go
+++ b/backend/internal/pipeline/outcome_test.go
@@ -1,0 +1,72 @@
+package pipeline
+
+import "testing"
+
+func TestOutcome_Predicates(t *testing.T) {
+	tests := []struct {
+		outcome         Outcome
+		settled         bool
+		success         bool
+		routesToFailure bool
+	}{
+		{OutcomePending, false, false, false},
+		{OutcomeRunning, false, false, false},
+		{OutcomeSucceeded, true, true, false},
+		{OutcomeSucceededUnverified, true, true, false},
+		{OutcomeFailed, true, false, true},
+		{OutcomeNoOutput, true, false, true},
+		{OutcomeNoSignal, true, false, true},
+		{OutcomeTimedOut, true, false, true},
+		{OutcomeCancelled, true, false, false},
+		{OutcomeSkipped, true, false, false},
+	}
+	if len(tests) != len(AllOutcomes) {
+		t.Fatalf("table covers %d outcomes, AllOutcomes has %d", len(tests), len(AllOutcomes))
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.outcome), func(t *testing.T) {
+			if !tc.outcome.IsKnown() {
+				t.Error("IsKnown() = false, want true")
+			}
+			if got := tc.outcome.IsSettled(); got != tc.settled {
+				t.Errorf("IsSettled() = %v, want %v", got, tc.settled)
+			}
+			if got := tc.outcome.IsSuccess(); got != tc.success {
+				t.Errorf("IsSuccess() = %v, want %v", got, tc.success)
+			}
+			if got := tc.outcome.RoutesToFailure(); got != tc.routesToFailure {
+				t.Errorf("RoutesToFailure() = %v, want %v", got, tc.routesToFailure)
+			}
+		})
+	}
+}
+
+// A cancelled run is torn down, not routed, and a skipped stage cascades its
+// skip. Neither takes a failure edge (spec section 13.2, section 9.2).
+func TestOutcome_CancelledAndSkippedDoNotRoute(t *testing.T) {
+	for _, o := range []Outcome{OutcomeCancelled, OutcomeSkipped} {
+		if o.RoutesToFailure() {
+			t.Errorf("%q routes to failure, want it not to", o)
+		}
+	}
+}
+
+func TestOutcome_UnknownIsNotKnown(t *testing.T) {
+	if Outcome("exploded").IsKnown() {
+		t.Error("IsKnown() = true for an undefined outcome")
+	}
+	if Outcome("exploded").IsSuccess() || Outcome("exploded").RoutesToFailure() {
+		t.Error("an undefined outcome must not count as success or route to failure")
+	}
+}
+
+func TestRunStatus_IsKnown(t *testing.T) {
+	for _, s := range AllRunStatuses {
+		if !s.IsKnown() {
+			t.Errorf("%q IsKnown() = false", s)
+		}
+	}
+	if RunStatus("stuck").IsKnown() {
+		t.Error("IsKnown() = true for an undefined run status")
+	}
+}

--- a/backend/internal/pipeline/plan.go
+++ b/backend/internal/pipeline/plan.go
@@ -1,0 +1,137 @@
+package pipeline
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Plan is everything a run can know before its first stage starts: which
+// stages it could reach, how long each is allowed, and which tree each will
+// run in.
+//
+// It exists so the one impossible combination (workspace: session with no
+// session) fails the run before any stage runs, with the reason stated,
+// rather than half way through (spec section 5.3).
+type Plan struct {
+	// Reachable lists every stage the run could enter, in document order.
+	Reachable []string `json:"reachable"`
+	// Deadlines is the effective deadline per reachable stage.
+	Deadlines map[string]time.Duration `json:"deadlines"`
+	// Workspaces is the resolved tree kind per reachable stage. A stage
+	// entered only via failure edges and declaring no workspace stays
+	// symbolic as "inherit": the tree it gets is whichever stage routed into
+	// it, known only at runtime.
+	Workspaces map[string]WorkspaceKind `json:"workspaces"`
+}
+
+// ComputePlan walks the routing graph from the entry stage and resolves the
+// plan for this subject.
+//
+// It returns an error when a reachable stage requires a session workspace the
+// subject cannot supply. Fail the run; never silently fall back.
+func ComputePlan(def *Pipeline, subject Subject) (*Plan, error) {
+	entry := def.EntryStage()
+	if entry == nil {
+		return nil, errors.New("pipeline declares no stages")
+	}
+
+	reached, viaSuccess := walk(def, entry.ID)
+
+	plan := &Plan{
+		Reachable:  make([]string, 0, len(reached)),
+		Deadlines:  make(map[string]time.Duration, len(reached)),
+		Workspaces: make(map[string]WorkspaceKind, len(reached)),
+	}
+
+	for i := range def.Stages {
+		s := &def.Stages[i]
+		if !reached[s.ID] {
+			continue
+		}
+		plan.Reachable = append(plan.Reachable, s.ID)
+		plan.Deadlines[s.ID] = s.EffectiveDeadline(def.Defaults)
+
+		kind := resolveWorkspace(s.Workspace, viaSuccess[s.ID], subject)
+		if kind == WorkspaceSession && !subject.HasSession() {
+			return nil, fmt.Errorf("stage '%s' requires workspace 'session'; %s has no local session", s.ID, subject.describe())
+		}
+		plan.Workspaces[s.ID] = kind
+	}
+
+	return plan, nil
+}
+
+// walk enumerates the stages reachable from the entry stage over
+// on_success union on_failure union defaults.on_failure, and records which of
+// them can be entered via a success edge.
+//
+// The success flag can only ever turn on, so iterating to a fixpoint settles
+// in at most one pass per stage. Stage counts are small enough that the
+// simple loop beats maintaining a worklist.
+func walk(def *Pipeline, entryID string) (reached, viaSuccess map[string]bool) {
+	success := def.successEdges()
+	failure := def.failureEdges()
+	order := def.stageIDs()
+
+	reached = map[string]bool{entryID: true}
+	// The entry stage is entered by the trigger, which for workspace
+	// defaulting behaves like a success entry: auto, not inherit.
+	viaSuccess = map[string]bool{entryID: true}
+
+	for changed := true; changed; {
+		changed = false
+		for _, id := range order {
+			if !reached[id] {
+				continue
+			}
+			for _, target := range success[id] {
+				if def.StageByID(target) == nil {
+					continue // unknown id; the validator owns that error
+				}
+				if !reached[target] {
+					reached[target] = true
+					changed = true
+				}
+				if !viaSuccess[target] {
+					viaSuccess[target] = true
+					changed = true
+				}
+			}
+			for _, target := range failure[id] {
+				if def.StageByID(target) == nil {
+					continue
+				}
+				if !reached[target] {
+					reached[target] = true
+					changed = true
+				}
+			}
+		}
+	}
+	return reached, viaSuccess
+}
+
+// resolveWorkspace applies the entry-edge default and then resolves auto.
+//
+// The key always means what it says; only which value is the default varies
+// by entry edge (spec section 5.4). A stage reachable both ways defaults by
+// its success entry, because it will be entered with a resolvable tree at
+// least once and inherit would be wrong there.
+func resolveWorkspace(declared WorkspaceKind, enteredViaSuccess bool, subject Subject) WorkspaceKind {
+	kind := declared
+	if kind == WorkspaceUnset {
+		if enteredViaSuccess {
+			kind = WorkspaceAuto
+		} else {
+			kind = WorkspaceInherit
+		}
+	}
+	if kind == WorkspaceAuto {
+		if subject.HasSession() {
+			return WorkspaceSession
+		}
+		return WorkspaceRun
+	}
+	return kind
+}

--- a/backend/internal/pipeline/plan_test.go
+++ b/backend/internal/pipeline/plan_test.go
@@ -1,0 +1,298 @@
+package pipeline
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func prSubject(number int) Subject {
+	return Subject{
+		Kind:      SubjectPR,
+		ProjectID: "proj",
+		PR:        &PRRef{Number: number, Repo: "acme/app", URL: "https://example.test/pr", HeadBranch: "feat"},
+	}
+}
+
+func TestComputePlan_ReleaseExampleReachesEveryStage(t *testing.T) {
+	def := mustParse(t, releaseYAML(t))
+
+	plan, err := ComputePlan(def, prSubject(412))
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if len(plan.Reachable) != releaseStageCount {
+		t.Fatalf("reachable = %d stages (%v), want %d", len(plan.Reachable), plan.Reachable, releaseStageCount)
+	}
+	// Document order, so the entry stage comes first and the failure-path
+	// stages come last.
+	if plan.Reachable[0] != "prepare" {
+		t.Errorf("reachable[0] = %q, want prepare", plan.Reachable[0])
+	}
+	if got, want := plan.Reachable, def.stageIDs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("reachable = %v, want document order %v", got, want)
+	}
+}
+
+func TestComputePlan_EffectiveDeadlines(t *testing.T) {
+	def := mustParse(t, releaseYAML(t))
+
+	plan, err := ComputePlan(def, prSubject(412))
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	// prepare declares no deadline and the pipeline declares no
+	// defaults.deadline, so it inherits the 30m constant.
+	if got := plan.Deadlines["prepare"]; got != DefaultStageDeadline {
+		t.Errorf("prepare deadline = %v, want %v", got, DefaultStageDeadline)
+	}
+	if got := plan.Deadlines["build-macos"]; got != 40*time.Minute {
+		t.Errorf("build-macos deadline = %v, want 40m", got)
+	}
+	if got := plan.Deadlines["sign-macos"]; got != 45*time.Minute {
+		t.Errorf("sign-macos deadline = %v, want 45m", got)
+	}
+	if len(plan.Deadlines) != releaseStageCount {
+		t.Errorf("deadlines cover %d stages, want %d", len(plan.Deadlines), releaseStageCount)
+	}
+}
+
+func TestComputePlan_DefaultsDeadlineSitsBetween(t *testing.T) {
+	def := mustParse(t, []byte(`
+name: p
+defaults:
+  deadline: 45m
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_success: b
+  - id: b
+    executor: command
+    run: "true"
+    deadline: 5m
+`))
+	plan, err := ComputePlan(def, Subject{Kind: SubjectProject, ProjectID: "proj"})
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if got := plan.Deadlines["a"]; got != 45*time.Minute {
+		t.Errorf("a deadline = %v, want the pipeline default 45m", got)
+	}
+	if got := plan.Deadlines["b"]; got != 5*time.Minute {
+		t.Errorf("b deadline = %v, want the stage's own 5m", got)
+	}
+}
+
+func TestComputePlan_ReleaseExampleWorkspaces(t *testing.T) {
+	def := mustParse(t, releaseYAML(t))
+
+	plan, err := ComputePlan(def, prSubject(412))
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	want := map[string]WorkspaceKind{
+		"prepare":        WorkspaceRun,
+		"build-macos":    WorkspaceStage,
+		"build-windows":  WorkspaceStage,
+		"build-linux":    WorkspaceStage,
+		"release-notes":  WorkspaceStage,
+		"verify-digests": WorkspaceRun,
+		"sign-macos":     WorkspaceRun,
+		"publish-github": WorkspaceRun,
+		"update-tap":     WorkspaceRun,
+		"update-feed":    WorkspaceRun,
+		"announce":       WorkspaceRun,
+		"notify-failure": WorkspaceRun,
+		"notify-partial": WorkspaceRun,
+		// diagnose-build declares no workspace and is only ever entered via
+		// a failure edge, so it stays symbolic: the tree it gets is the tree
+		// of whichever build routed into it (spec section 5.4).
+		"diagnose-build": WorkspaceInherit,
+	}
+	if !reflect.DeepEqual(plan.Workspaces, want) {
+		t.Errorf("workspaces = %v,\nwant %v", plan.Workspaces, want)
+	}
+}
+
+func TestComputePlan_AutoResolvesPerSubject(t *testing.T) {
+	def := mustParse(t, []byte(`
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_success: b
+  - id: b
+    executor: command
+    run: "true"
+    workspace: auto
+`))
+
+	t.Run("subject with a session", func(t *testing.T) {
+		plan, err := ComputePlan(def, Subject{Kind: SubjectSession, ProjectID: "proj", SessionID: "sess-1"})
+		if err != nil {
+			t.Fatalf("ComputePlan: %v", err)
+		}
+		// Unset on a success entry defaults to auto, then resolves the same way.
+		for _, id := range []string{"a", "b"} {
+			if got := plan.Workspaces[id]; got != WorkspaceSession {
+				t.Errorf("%s workspace = %q, want %q", id, got, WorkspaceSession)
+			}
+		}
+	})
+
+	t.Run("subject without a session", func(t *testing.T) {
+		plan, err := ComputePlan(def, prSubject(412))
+		if err != nil {
+			t.Fatalf("ComputePlan: %v", err)
+		}
+		for _, id := range []string{"a", "b"} {
+			if got := plan.Workspaces[id]; got != WorkspaceRun {
+				t.Errorf("%s workspace = %q, want %q", id, got, WorkspaceRun)
+			}
+		}
+	})
+}
+
+// The one impossible combination, and the exact reason the spec section 5.3
+// requires the run to state.
+func TestComputePlan_SessionWorkspaceWithoutASession(t *testing.T) {
+	def := mustParse(t, []byte(`
+name: p
+stages:
+  - id: review
+    executor: agent
+    agent: claude-code
+    prompt: hi
+    workspace: session
+`))
+	_, err := ComputePlan(def, prSubject(412))
+	if err == nil {
+		t.Fatal("expected ComputePlan to fail, got nil")
+	}
+	const want = "stage 'review' requires workspace 'session'; PR #412 has no local session"
+	if err.Error() != want {
+		t.Errorf("error = %q,\nwant %q", err.Error(), want)
+	}
+}
+
+func TestComputePlan_SessionWorkspaceWithASessionIsFine(t *testing.T) {
+	def := mustParse(t, []byte(`
+name: p
+stages:
+  - id: review
+    executor: agent
+    agent: claude-code
+    prompt: hi
+    workspace: session
+`))
+	subject := prSubject(412)
+	subject.SessionID = "sess-1"
+	plan, err := ComputePlan(def, subject)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if got := plan.Workspaces["review"]; got != WorkspaceSession {
+		t.Errorf("review workspace = %q, want %q", got, WorkspaceSession)
+	}
+}
+
+// An unreachable stage cannot fail the plan, because it never runs.
+func TestComputePlan_UnreachableStagesAreExcluded(t *testing.T) {
+	def := mustParse(t, []byte(`
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+  - id: orphan
+    executor: command
+    run: "true"
+    workspace: session
+`))
+	plan, err := ComputePlan(def, prSubject(412))
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if got, want := plan.Reachable, []string{"a"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("reachable = %v, want %v", got, want)
+	}
+	if _, ok := plan.Workspaces["orphan"]; ok {
+		t.Error("unreachable stage appears in the plan")
+	}
+}
+
+func TestComputePlan_NoStages(t *testing.T) {
+	_, err := ComputePlan(&Pipeline{Name: "p"}, prSubject(1))
+	if err == nil || !strings.Contains(err.Error(), "no stages") {
+		t.Fatalf("error = %v, want a no-stages error", err)
+	}
+}
+
+// A stage reachable both ways defaults by its success entry: it will be
+// entered with a resolvable tree at least once, and inherit would be wrong
+// there.
+func TestComputePlan_SuccessEntryWinsOverFailureEntry(t *testing.T) {
+	def := mustParse(t, []byte(`
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_success: cleanup
+    on_failure: cleanup
+  - id: cleanup
+    executor: command
+    run: "true"
+`))
+	plan, err := ComputePlan(def, prSubject(412))
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if got := plan.Workspaces["cleanup"]; got != WorkspaceRun {
+		t.Errorf("cleanup workspace = %q, want %q (auto resolved for a sessionless subject)", got, WorkspaceRun)
+	}
+}
+
+func TestSubject_DefaultScopeAndIdentity(t *testing.T) {
+	pr := prSubject(412)
+	session := Subject{Kind: SubjectSession, ProjectID: "proj", SessionID: "sess-1"}
+	project := Subject{Kind: SubjectProject, ProjectID: "proj"}
+
+	tests := []struct {
+		name         string
+		subject      Subject
+		wantScope    ConcurrencyScope
+		scope        ConcurrencyScope
+		wantIdentity string
+	}{
+		{"pr default", pr, ConcurrencyScopePR, ConcurrencyScopeUnset, "acme/app#412"},
+		{"pr explicit", pr, ConcurrencyScopePR, ConcurrencyScopePR, "acme/app#412"},
+		{"pr under project scope", pr, ConcurrencyScopePR, ConcurrencyScopeProject, "proj"},
+		{"session default", session, ConcurrencyScopeSession, ConcurrencyScopeUnset, "sess-1"},
+		{"session under project scope", session, ConcurrencyScopeSession, ConcurrencyScopeProject, "proj"},
+		{"project default", project, ConcurrencyScopeProject, ConcurrencyScopeUnset, "proj"},
+		{"project under pr scope has no identity", project, ConcurrencyScopeProject, ConcurrencyScopePR, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.subject.DefaultScope(); got != tc.wantScope {
+				t.Errorf("DefaultScope() = %q, want %q", got, tc.wantScope)
+			}
+			if got := tc.subject.ScopeIdentity(tc.scope); got != tc.wantIdentity {
+				t.Errorf("ScopeIdentity(%q) = %q, want %q", tc.scope, got, tc.wantIdentity)
+			}
+		})
+	}
+}
+
+func TestSubject_HasSession(t *testing.T) {
+	if (Subject{Kind: SubjectPR}).HasSession() {
+		t.Error("HasSession() = true for a sessionless PR subject")
+	}
+	if !(Subject{Kind: SubjectPR, SessionID: "s"}).HasSession() {
+		t.Error("HasSession() = false for a PR subject with a tracking session")
+	}
+}

--- a/backend/internal/pipeline/schema.json
+++ b/backend/internal/pipeline/schema.json
@@ -2,272 +2,185 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://agent-orchestrator.dev/schema/pipeline-definition.json",
   "title": "Pipeline definition",
-  "description": "A single pipeline definition document (v1: one pipeline per YAML document, authored in the definitions editor and stored in SQLite). Mirrors backend/internal/pipeline/types.go; kept in sync by hand.",
+  "description": "A single pipeline definition document (one pipeline per YAML document, authored in the definitions editor and stored in SQLite). Mirrors backend/internal/pipeline/definition.go and the rules in validate.go; kept in sync by hand. This schema covers shape only. The graph rules (unknown stage ids, cycles, needs matching the inbound success edge set, credentials on agent stages) are cross-field and live in validate.go.",
   "type": "object",
   "properties": {
     "name": {
       "type": "string",
       "minLength": 1,
-      "description": "Human-readable pipeline name. Required; there is no map key to default it from."
+      "description": "Human-readable pipeline name."
     },
-    "scope": {
-      "type": "string",
-      "enum": ["worker"],
-      "description": "Pipeline-v3 scope. Only \"worker\" is accepted in v1; \"orchestrator\" and \"workstream\" are deferred to phase 2."
-    },
+    "on": { "$ref": "#/$defs/triggerSpec" },
+    "concurrency": { "$ref": "#/$defs/concurrencySpec" },
+    "defaults": { "$ref": "#/$defs/defaultsSpec" },
     "stages": {
       "type": "array",
       "minItems": 1,
+      "description": "The stages, in document order. The first is the entry stage.",
       "items": { "$ref": "#/$defs/stage" }
-    },
-    "maxConcurrentStages": {
-      "type": "integer",
-      "minimum": 1,
-      "description": "Defaults to 1 (serial execution) when unset."
-    },
-    "allowForkPRs": {
-      "type": "boolean",
-      "description": "Opt in to running command-executor stages for fork PRs. Defaults to false."
-    },
-    "exitPredicates": { "$ref": "#/$defs/exitPredicates" }
+    }
   },
   "required": ["name", "stages"],
   "additionalProperties": false,
 
   "$defs": {
-    "stage": {
+    "triggerSpec": {
       "type": "object",
+      "description": "Events that start a run. Declaring neither family is legal and means a manual-only pipeline.",
       "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "trigger": { "$ref": "#/$defs/stageTrigger" },
-        "executor": { "$ref": "#/$defs/stageExecutor" },
-        "task": { "$ref": "#/$defs/taskSpec" },
-        "policy": { "$ref": "#/$defs/stagePolicy" },
-        "budget": { "$ref": "#/$defs/stageBudget" },
-        "timeoutMs": { "type": "integer", "minimum": 0 },
-        "retries": { "type": "integer", "minimum": 0 },
-        "maxLoopRounds": { "type": "integer", "minimum": 1 },
-        "dependsOn": {
+        "pr": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
-        },
-        "routes": { "$ref": "#/$defs/stageRoutes" },
-        "workspace": {
-          "type": "string",
-          "enum": ["shared-ro", "isolated-rw"]
-        }
-      },
-      "required": ["name", "trigger", "executor"],
-      "additionalProperties": false
-    },
-
-    "stageTrigger": {
-      "type": "object",
-      "properties": {
-        "on": {
-          "type": "array",
+          "description": "Pull-request events. The subject is the PR, which may or may not have a local session tracking it.",
           "items": {
             "type": "string",
-            "enum": ["pr.opened", "pr.updated", "pr.merge_ready", "pr.merged", "manual"]
+            "enum": ["created", "updated", "merge-ready", "merged"]
+          }
+        },
+        "session": {
+          "type": "array",
+          "description": "Session lifecycle events. The subject is that session, which always exists.",
+          "items": {
+            "type": "string",
+            "enum": ["idle", "exited", "blocked"]
           }
         }
       },
-      "required": ["on"],
       "additionalProperties": false
     },
 
-    "stageExecutor": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "agent" },
-            "plugin": { "type": "string", "minLength": 1 },
-            "mode": { "type": "string", "enum": ["review", "code", "answer"] },
-            "config": { "type": "object" }
-          },
-          "required": ["kind", "plugin", "mode"],
-          "additionalProperties": false
+    "concurrencySpec": {
+      "type": "object",
+      "description": "Runs sharing an effective key (resolved scope identity, group) serialize. Queue depth is 1: a third arrival evicts the queued run rather than stacking.",
+      "properties": {
+        "scope": {
+          "type": "string",
+          "enum": ["pr", "session", "project"],
+          "description": "Which runs collide. Defaults to the subject's natural scope: pr triggers default to pr, session triggers to session."
         },
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "command" },
-            "command": { "type": "string", "minLength": 1 },
-            "args": { "type": "array", "items": { "type": "string" } },
-            "env": { "type": "object", "additionalProperties": { "type": "string" } },
-            "cwd": { "type": "string" }
-          },
-          "required": ["kind", "command"],
-          "additionalProperties": false
+        "group": {
+          "type": "string",
+          "description": "Which pipelines share a bucket. A literal, never interpolated. Defaults to the pipeline name."
         },
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "builtin" },
-            "name": { "type": "string", "enum": ["router", "compose"] },
-            "config": { "type": "object" }
-          },
-          "required": ["kind", "name"],
-          "additionalProperties": false
+        "cancel-in-progress": {
+          "type": "boolean",
+          "description": "A new run cancels the in-flight one. Recommended for pr.updated, wrong for release-shaped pipelines."
         }
-      ]
-    },
-
-    "taskSpec": {
-      "type": "object",
-      "properties": {
-        "prompt": { "type": "string" },
-        "outputSchema": { "type": "object" },
-        "inputs": { "type": "object" }
       },
       "additionalProperties": false
     },
 
-    "stagePolicy": {
+    "defaultsSpec": {
       "type": "object",
       "properties": {
-        "blocksMerge": { "type": "boolean" },
-        "stallWindow": { "type": "integer", "minimum": 0 }
-      },
-      "additionalProperties": false
-    },
-
-    "stageBudget": {
-      "type": "object",
-      "properties": {
-        "maxUsd": { "type": "number", "minimum": 0 },
-        "maxDurationMs": { "type": "integer", "minimum": 0 }
-      },
-      "additionalProperties": false
-    },
-
-    "stageRoutes": {
-      "type": "object",
-      "properties": {
-        "when": { "$ref": "#/$defs/predicate" }
-      },
-      "required": ["when"],
-      "additionalProperties": false
-    },
-
-    "exitPredicates": {
-      "type": "object",
-      "properties": {
-        "done": { "$ref": "#/$defs/predicate" },
-        "stalled": { "$ref": "#/$defs/predicate" },
-        "blocksMerge": { "$ref": "#/$defs/predicate" }
-      },
-      "additionalProperties": false
-    },
-
-    "predicate": {
-      "description": "Typed predicate DSL node. Recursive union discriminated on \"kind\".",
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "all_pass" },
-            "stages": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
-          },
-          "required": ["kind", "stages"],
-          "additionalProperties": false
+        "deadline": {
+          "$ref": "#/$defs/duration",
+          "description": "Fallback stage deadline. Defaults to 30m when unset."
         },
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "any_pass" },
-            "stages": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
-          },
-          "required": ["kind", "stages"],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "majority_pass" },
-            "stages": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
-          },
-          "required": ["kind", "stages"],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "no_open_findings" },
-            "stage": { "type": "string", "minLength": 1 }
-          },
-          "required": ["kind"],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "finding_count_below" },
-            "max": { "type": "integer", "minimum": 0 },
-            "stage": { "type": "string", "minLength": 1 },
-            "severity": { "type": "string", "enum": ["error", "warning", "info"] }
-          },
-          "required": ["kind", "max"],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "loop_rounds_at_least" },
-            "n": { "type": "integer", "minimum": 1 }
-          },
-          "required": ["kind", "n"],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "stage_retried_at_least" },
-            "stage": { "type": "string", "minLength": 1 },
-            "n": { "type": "integer", "minimum": 1 }
-          },
-          "required": ["kind", "stage", "n"],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "stage_verdict" },
-            "stage": { "type": "string", "minLength": 1 },
-            "verdict": { "type": "string", "enum": ["pass", "fail", "neutral"] }
-          },
-          "required": ["kind", "stage", "verdict"],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "and" },
-            "predicates": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/predicate" } }
-          },
-          "required": ["kind", "predicates"],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "or" },
-            "predicates": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/predicate" } }
-          },
-          "required": ["kind", "predicates"],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "kind": { "const": "not" },
-            "predicate": { "$ref": "#/$defs/predicate" }
-          },
-          "required": ["kind", "predicate"],
-          "additionalProperties": false
+        "on_failure": {
+          "type": "string",
+          "description": "Stage every unrouted failure routes to. The named stage does not inherit the default: its own failure ends the branch."
         }
-      ]
+      },
+      "additionalProperties": false
+    },
+
+    "stage": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Unique within the pipeline."
+        },
+        "executor": {
+          "type": "string",
+          "enum": ["agent", "command"],
+          "description": "There is no agent taxonomy. What a stage is contracted to do is expressed by produces, not by an executor variant."
+        },
+        "agent": {
+          "type": "string",
+          "description": "Agent stages only: the agent plugin to spawn (e.g. claude-code)."
+        },
+        "prompt": {
+          "type": "string",
+          "description": "Agent stages only. Shell-interpolated environment variables; there is no expression language."
+        },
+        "produces": {
+          "type": "string",
+          "pattern": "^[^/\\\\]+$",
+          "description": "Agent stages only: a bare filename resolving to <run>/agent-outputs/<filename>, carried in $AO_OUTPUT. Present means the engine verifies it exists non-empty; absent means the signal is the whole contract and the stage settles succeeded_unverified."
+        },
+        "session": { "$ref": "#/$defs/sessionSpec" },
+        "run": {
+          "type": "string",
+          "description": "Command stages only: the script. Its exit status is the outcome."
+        },
+        "credentials": {
+          "type": "array",
+          "description": "Command stages only. Engine-held secrets injected at exec time; rejected on agent stages, because a credential must never enter an agent's environment.",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "workspace": {
+          "type": "string",
+          "enum": ["auto", "inherit", "session", "run", "stage", "checkout"],
+          "description": "The tree the stage runs in. Unset defaults to auto on a success entry and inherit on a failure entry. auto resolves to session when the subject has one, otherwise run."
+        },
+        "deadline": {
+          "$ref": "#/$defs/duration",
+          "description": "Overrides defaults.deadline for this stage."
+        },
+        "on_success": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ],
+          "description": "A stage id, or a list of stage ids. A list fans out; the targets start concurrently. This is the only fan-out mechanism."
+        },
+        "on_failure": {
+          "type": "string",
+          "description": "A single stage id. Entered on first arrival; later arrivals are dropped. Absent, the stage inherits defaults.on_failure."
+        },
+        "needs": {
+          "type": "array",
+          "description": "Required on any stage with more than one inbound success edge, and must match that set exactly. Failure edges are never counted and never require it.",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["id", "executor"],
+      "additionalProperties": false
+    },
+
+    "sessionSpec": {
+      "type": "object",
+      "description": "Agent stages only: what happens to the session once the stage settles.",
+      "properties": {
+        "kill-on": {
+          "type": "array",
+          "description": "Outcomes that kill the session. Omit the key for the default [succeeded, failed], which keeps the session alive on no_output, no_signal and timed_out. An explicit empty list never kills.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "running",
+              "succeeded",
+              "succeeded_unverified",
+              "failed",
+              "no_output",
+              "no_signal",
+              "timed_out",
+              "cancelled",
+              "skipped"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "duration": {
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h)([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))*$",
+      "description": "A Go duration string, e.g. \"45m\", \"90s\", \"1h30m\"."
     }
   }
 }

--- a/backend/internal/pipeline/schema_test.go
+++ b/backend/internal/pipeline/schema_test.go
@@ -1,0 +1,67 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestConfigJSONSchema_ParsesAsJSON(t *testing.T) {
+	var doc map[string]any
+	if err := json.Unmarshal(ConfigJSONSchema(), &doc); err != nil {
+		t.Fatalf("embedded schema.json is not valid JSON: %v", err)
+	}
+	if doc["$schema"] != "https://json-schema.org/draft/2020-12/schema" {
+		t.Fatalf("expected draft 2020-12 $schema, got %v", doc["$schema"])
+	}
+}
+
+func TestConfigJSONSchema_ReturnsCopy(t *testing.T) {
+	a := ConfigJSONSchema()
+	b := ConfigJSONSchema()
+	if len(a) == 0 {
+		t.Fatal("expected non-empty schema")
+	}
+	a[0] = 'X'
+	if string(a[:1]) == string(b[:1]) {
+		t.Fatal("expected mutating one copy to not affect another")
+	}
+}
+
+// TestConfigJSONSchema_CoversEnums is a cheap drift guard: schema.json is a
+// hand-maintained mirror of definition.go, so every Go enum constant on the
+// config surface must appear somewhere in the schema text. A new outcome,
+// workspace kind or trigger event added to the Go enums then fails here until
+// the schema the definitions editor consumes documents it too.
+func TestConfigJSONSchema_CoversEnums(t *testing.T) {
+	schema := string(ConfigJSONSchema())
+
+	contains := func(what, value string) {
+		t.Helper()
+		if !strings.Contains(schema, `"`+value+`"`) {
+			t.Errorf("schema missing %s %q", what, value)
+		}
+	}
+
+	for _, o := range AllOutcomes {
+		contains("outcome", string(o))
+	}
+	for _, w := range AllWorkspaceKinds {
+		contains("workspace kind", string(w))
+	}
+	for _, e := range AllPREvents {
+		contains("pr event", string(e))
+	}
+	for _, e := range AllSessionEvents {
+		contains("session event", string(e))
+	}
+	for _, s := range AllConcurrencyScopes {
+		contains("concurrency scope", string(s))
+	}
+	for _, k := range AllExecutorKinds {
+		contains("executor kind", string(k))
+	}
+	for _, key := range []string{"name", "on", "concurrency", "defaults", "stages"} {
+		contains("top-level key", key)
+	}
+}

--- a/backend/internal/pipeline/state.go
+++ b/backend/internal/pipeline/state.go
@@ -1,0 +1,79 @@
+package pipeline
+
+import "time"
+
+// EntryEdge records how a stage was entered, which decides its workspace
+// default and which ambient failure variables resolve.
+type EntryEdge string
+
+// Every entry edge.
+const (
+	// EntryTrigger is the entry stage, started by the trigger itself.
+	EntryTrigger EntryEdge = "trigger"
+	// EntrySuccess means a predecessor's on_success routed here.
+	EntrySuccess EntryEdge = "success"
+	// EntryFailure means a predecessor's on_failure (or defaults.on_failure)
+	// routed here.
+	EntryFailure EntryEdge = "failure"
+)
+
+// StageState is one stage's slice of a run. It is a value carried in RunState
+// and rewritten copy-on-write by the reducer, never mutated in place.
+type StageState struct {
+	ID      string  `json:"id"`
+	Outcome Outcome `json:"outcome"`
+	// Attempt is 0 until the stage starts, 1 normally, and 2 after a nudge.
+	// It surfaces to the stage as AO_ATTEMPT so a prompt can branch on being
+	// nudged.
+	Attempt    int       `json:"attempt"`
+	EnteredVia EntryEdge `json:"enteredVia"`
+	// PrevStage is the sole success predecessor, and is empty at a join or at
+	// the entry stage. AO_PREV_* is unset where this is empty, because at a
+	// join it would be ambiguous (spec section 12.2).
+	PrevStage string `json:"prevStage,omitempty"`
+	// FailedStage and FailedOutcome are set when EnteredVia is EntryFailure,
+	// and surface as AO_FAILED_STAGE / AO_FAILED_OUTCOME.
+	FailedStage   string  `json:"failedStage,omitempty"`
+	FailedOutcome Outcome `json:"failedOutcome,omitempty"`
+
+	SessionID string `json:"sessionId,omitempty"`
+	// WorkspaceKind is the resolved tree kind, never "auto", "inherit" or
+	// unset: those are plan-time symbols, resolved to a concrete kind by the
+	// time the stage launches.
+	WorkspaceKind WorkspaceKind `json:"workspaceKind,omitempty"`
+	WorkspacePath string        `json:"workspacePath,omitempty"`
+
+	DeadlineAt time.Time `json:"deadlineAt,omitempty"`
+	StartedAt  time.Time `json:"startedAt,omitempty"`
+	SettledAt  time.Time `json:"settledAt,omitempty"`
+
+	// Reason carries the fail reason, cancel reason, or plan-failure reason.
+	Reason string `json:"reason,omitempty"`
+}
+
+// RunState is one run, in full. SQLite stays the store of record; run.json in
+// the run folder is a projection of this for humans and debugging.
+//
+// Def is a frozen snapshot taken when the run was triggered: editing the
+// definition mid-run never changes a run in flight.
+type RunState struct {
+	RunID        RunID     `json:"runId"`
+	ProjectID    string    `json:"projectId"`
+	PipelineID   ID        `json:"pipelineId"`
+	PipelineName string    `json:"pipelineName"`
+	Subject      Subject   `json:"subject"`
+	Status       RunStatus `json:"status"`
+	RunDir       string    `json:"runDir"`
+	Def          Pipeline  `json:"definition"`
+
+	Stages map[string]*StageState `json:"stages"`
+	// Nudged records the one nudge each stage is allowed. Two attempts total,
+	// not configurable: if a second nudge would help, the prompt is wrong.
+	Nudged map[string]bool `json:"nudged,omitempty"`
+
+	CancelReason string `json:"cancelReason,omitempty"`
+
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	SettledAt time.Time `json:"settledAt,omitempty"`
+}

--- a/backend/internal/pipeline/store_types.go
+++ b/backend/internal/pipeline/store_types.go
@@ -6,15 +6,12 @@ import "time"
 // as authored (YAMLSource) and the parsed config snapshot (Config): humans and
 // agents edit YAML, while runs snapshot the normalized form. The envelope
 // fields (ID, timestamps) are assigned by the store on create.
-//
-// Config is a placeholder `any` until the v2 Pipeline type lands; the store
-// round-trips it through JSON either way.
 type Definition struct {
 	ID         ID        `json:"id"`
 	ProjectID  string    `json:"projectId"`
 	Name       string    `json:"name"`
 	YAMLSource string    `json:"yamlSource"`
-	Config     any       `json:"config"`
+	Config     Pipeline  `json:"config"`
 	CreatedAt  time.Time `json:"createdAt"`
 	UpdatedAt  time.Time `json:"updatedAt"`
 }

--- a/backend/internal/pipeline/subject.go
+++ b/backend/internal/pipeline/subject.go
@@ -1,0 +1,100 @@
+package pipeline
+
+import "fmt"
+
+// SubjectKind names what a run is about. A trigger names a subject, and the
+// subject determines the default workspace and which ambient variables
+// resolve (spec section 4).
+type SubjectKind string
+
+// Every subject kind.
+const (
+	SubjectSession SubjectKind = "session"
+	SubjectPR      SubjectKind = "pr"
+	SubjectProject SubjectKind = "project"
+)
+
+// Subject is the thing a run is about.
+//
+// A PR subject may or may not have a session, and both are normal:
+// sessionless is first-class, because a pipeline watching someone else's PR
+// must work with no session anywhere in the picture.
+type Subject struct {
+	Kind      SubjectKind `json:"kind"`
+	ProjectID string      `json:"projectId"`
+	// SessionID is set for session subjects, and for PR subjects that have a
+	// local session tracking the PR.
+	SessionID string `json:"sessionId,omitempty"`
+	// PR is set for PR subjects only.
+	PR *PRRef `json:"pr,omitempty"`
+}
+
+// PRRef identifies the pull request a PR subject is about.
+type PRRef struct {
+	Number     int    `json:"number"`
+	Repo       string `json:"repo"` // owner/name
+	URL        string `json:"url,omitempty"`
+	HeadSHA    string `json:"headSha,omitempty"`
+	HeadBranch string `json:"headBranch,omitempty"`
+	BaseBranch string `json:"baseBranch,omitempty"`
+	// FromFork drives the identity-only rule: a fork PR never gets a
+	// credential injected anywhere in the run, because PR contents are
+	// untrusted input to an LLM with shell access (spec section 8).
+	FromFork bool `json:"fromFork,omitempty"`
+}
+
+// HasSession reports whether the subject resolves to a local session. This is
+// the one thing that decides whether `workspace: session` is possible.
+func (s Subject) HasSession() bool { return s.SessionID != "" }
+
+// DefaultScope is the subject's natural concurrency scope, used when the
+// pipeline declares none (spec section 10).
+func (s Subject) DefaultScope() ConcurrencyScope {
+	switch s.Kind {
+	case SubjectPR:
+		return ConcurrencyScopePR
+	case SubjectSession:
+		return ConcurrencyScopeSession
+	default:
+		return ConcurrencyScopeProject
+	}
+}
+
+// ScopeIdentity resolves the identity half of the effective concurrency key
+// (the other half is the literal group name). An unset scope resolves to the
+// subject's natural scope first, so callers can pass the declared value
+// through unchanged.
+//
+// It returns "" when the subject has no identity at the requested scope, for
+// instance a project subject asked for a PR identity. The supervisor treats an
+// empty identity as ungrouped, so such a run serializes against nothing.
+func (s Subject) ScopeIdentity(scope ConcurrencyScope) string {
+	if scope == ConcurrencyScopeUnset {
+		scope = s.DefaultScope()
+	}
+	switch scope {
+	case ConcurrencyScopePR:
+		if s.PR == nil {
+			return ""
+		}
+		return fmt.Sprintf("%s#%d", s.PR.Repo, s.PR.Number)
+	case ConcurrencyScopeSession:
+		return s.SessionID
+	case ConcurrencyScopeProject:
+		return s.ProjectID
+	default:
+		return ""
+	}
+}
+
+// describe names the subject the way a human-facing failure reason should,
+// e.g. "PR #412".
+func (s Subject) describe() string {
+	if s.Kind == SubjectPR && s.PR != nil {
+		return fmt.Sprintf("PR #%d", s.PR.Number)
+	}
+	if s.Kind == "" {
+		return "the subject"
+	}
+	return fmt.Sprintf("this %s subject", s.Kind)
+}

--- a/backend/internal/pipeline/testdata/release.yaml
+++ b/backend/internal/pipeline/testdata/release.yaml
@@ -1,0 +1,158 @@
+name: release
+on:
+  pr: [merged]
+
+concurrency:
+  scope: project
+  group: release
+  cancel-in-progress: false
+
+defaults:
+  on_failure: notify-failure
+
+stages:
+  - id: prepare
+    executor: command
+    workspace: run
+    run: |
+      test "$(git rev-parse --abbrev-ref HEAD)" = "main"
+      mkdir -p "$AO_RUN_DIR"/{artifacts,digests}
+      ao release resolve-version > "$AO_RUN_DIR/version"
+    on_success: [build-macos, build-windows, build-linux, release-notes]
+
+  - id: build-macos
+    executor: command
+    workspace: stage
+    deadline: 40m
+    run: |
+      npm ci
+      npm run build:mac -- --version "$(cat "$AO_RUN_DIR/version")"
+      sha256sum dist/*.dmg > "$AO_RUN_DIR/digests/macos.txt"
+      cp dist/*.dmg "$AO_RUN_DIR/artifacts/"
+    on_success: verify-digests
+    on_failure: diagnose-build
+
+  - id: build-windows
+    executor: command
+    workspace: stage
+    deadline: 40m
+    run: |
+      npm ci
+      npm run build:win -- --version "$(cat "$AO_RUN_DIR/version")"
+      sha256sum dist/*.exe > "$AO_RUN_DIR/digests/windows.txt"
+      cp dist/*.exe "$AO_RUN_DIR/artifacts/"
+    on_success: verify-digests
+    on_failure: diagnose-build
+
+  - id: build-linux
+    executor: command
+    workspace: stage
+    deadline: 40m
+    run: |
+      npm ci
+      npm run build:linux -- --version "$(cat "$AO_RUN_DIR/version")"
+      sha256sum dist/*.AppImage > "$AO_RUN_DIR/digests/linux.txt"
+      cp dist/*.AppImage "$AO_RUN_DIR/artifacts/"
+    on_success: verify-digests
+    on_failure: diagnose-build
+
+  - id: release-notes
+    executor: agent
+    agent: claude-code
+    workspace: stage
+    produces: release-notes.md
+    deadline: 15m
+    session:
+      kill-on: [succeeded, failed]
+    prompt: |
+      Write release notes for version $(cat "$AO_RUN_DIR/version").
+      Use `git log` since the previous tag. Group by user-visible change,
+      not by commit. Omit internal refactors.
+      Write to $AO_OUTPUT, then `ao pipeline done`.
+      If there are no user-visible changes, `ao pipeline fail --reason "..."`.
+    on_success: publish-github
+
+  - id: verify-digests
+    executor: command
+    needs: [build-macos, build-windows, build-linux]
+    workspace: run
+    run: ao release verify-digests "$AO_RUN_DIR/digests" "$AO_RUN_DIR/artifacts"
+    on_success: sign-macos
+
+  - id: sign-macos
+    executor: command
+    workspace: run
+    credentials: [apple-signing]
+    deadline: 45m
+    run: |
+      ao release sign-dmg   "$AO_RUN_DIR/artifacts/"*.dmg
+      ao release notarize --wait --timeout 40m "$AO_RUN_DIR/artifacts/"*.dmg
+      ao release verify-notarization "$AO_RUN_DIR/artifacts/"*.dmg
+    on_success: publish-github
+
+  - id: publish-github
+    executor: command
+    needs: [sign-macos, release-notes]
+    workspace: run
+    credentials: [github-release]
+    run: |
+      gh release create "v$(cat "$AO_RUN_DIR/version")" \
+        "$AO_RUN_DIR/artifacts/"* \
+        --notes-file "$AO_RUN_DIR/agent-outputs/release-notes.md"
+    on_success: [update-tap, update-feed]
+
+  - id: update-tap
+    executor: command
+    workspace: run
+    credentials: [homebrew-tap]
+    run: ao release bump-cask --version "$(cat "$AO_RUN_DIR/version")"
+    on_success: announce
+    on_failure: notify-partial
+
+  - id: update-feed
+    executor: command
+    workspace: run
+    credentials: [github-release]
+    run: ao release publish-feed --version "$(cat "$AO_RUN_DIR/version")"
+    on_success: announce
+    on_failure: notify-partial
+
+  - id: announce
+    executor: command
+    needs: [update-tap, update-feed]
+    workspace: run
+    credentials: [discord]
+    run: |
+      ao discord post --file "$AO_RUN_DIR/agent-outputs/release-notes.md" \
+        --title "v$(cat "$AO_RUN_DIR/version")"
+
+  - id: diagnose-build
+    executor: agent
+    agent: claude-code
+    produces: diagnosis.md
+    deadline: 15m
+    session:
+      kill-on: []
+    prompt: |
+      Build stage `$AO_FAILED_STAGE` failed. Its log is at
+      $AO_RUN_DIR/stage-logs/$AO_FAILED_STAGE.log and you are in its
+      working tree with the failure state intact.
+      Diagnose the root cause, write to $AO_OUTPUT, then `ao pipeline done`.
+    on_success: notify-failure
+
+  - id: notify-failure
+    executor: command
+    workspace: run
+    credentials: [discord]
+    run: |
+      ao discord post --title "release failed at $AO_FAILED_STAGE" \
+        --body "outcome: $AO_FAILED_OUTCOME"
+
+  - id: notify-partial
+    executor: command
+    workspace: run
+    credentials: [discord]
+    run: |
+      ao discord post --urgent --title "PARTIAL RELEASE" \
+        --body "GitHub release for v$(cat "$AO_RUN_DIR/version") is live but \
+      $AO_FAILED_STAGE failed. Manual reconciliation required."

--- a/backend/internal/pipeline/validate.go
+++ b/backend/internal/pipeline/validate.go
@@ -1,0 +1,358 @@
+package pipeline
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Issue is one validation finding, pointing at the offending location in the
+// definition document (e.g. "stages[2].needs"). The same shape carries both
+// errors and warnings; which one it is depends on where it came back from.
+type Issue struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+// ValidationError collects every Issue found while validating a pipeline
+// definition. Validation runs in one pass and reports everything it finds, so
+// an author fixes all of it at once instead of fixing-and-reloading one error
+// at a time.
+type ValidationError struct {
+	Issues []Issue
+}
+
+// Error joins every issue, one per line, formatted "path: message".
+func (e *ValidationError) Error() string {
+	var b strings.Builder
+	for i, issue := range e.Issues {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(issue.Path)
+		b.WriteString(": ")
+		b.WriteString(issue.Message)
+	}
+	return b.String()
+}
+
+// Validate applies every edit-time rule from spec section 13 and returns the
+// warnings plus, when any rule was broken, a *ValidationError carrying every
+// error found.
+//
+// Warnings are returned alongside errors rather than folded into them: the
+// canvas editor renders them differently, and a warned pipeline still saves
+// and still runs.
+//
+// Two things are deliberately not checked here. Unknown credential names
+// (spec section 13) need the project's credential store, which arrives with
+// the credentials task and widens this seam then. Unknown `workspace:` values
+// are left to the JSON schema the editor consumes, because the plan's rule
+// list is closed and adding rules here would change what later tasks can
+// assume about a validated definition.
+func Validate(p *Pipeline) (warnings []Issue, err error) {
+	v := &validator{p: p}
+	v.run()
+	if len(v.errors) > 0 {
+		return v.warnings, &ValidationError{Issues: v.errors}
+	}
+	return v.warnings, nil
+}
+
+type validator struct {
+	p        *Pipeline
+	errors   []Issue
+	warnings []Issue
+}
+
+func (v *validator) fail(path, format string, args ...any) {
+	v.errors = append(v.errors, Issue{Path: path, Message: fmt.Sprintf(format, args...)})
+}
+
+func (v *validator) warn(path, format string, args ...any) {
+	v.warnings = append(v.warnings, Issue{Path: path, Message: fmt.Sprintf(format, args...)})
+}
+
+func (v *validator) run() {
+	// Sizing hint only: most definitions are clean, and the common case is a
+	// handful of issues on a broken one.
+	v.errors = make([]Issue, 0, len(v.p.Stages))
+	v.warnings = make([]Issue, 0, 2)
+
+	known := v.checkStages()
+	v.checkTriggers()
+	v.checkConcurrency()
+	v.checkReferences(known)
+	v.checkCycles()
+	v.checkJoins(known)
+	v.checkFailureRouteWarning()
+	v.checkSessionWorkspaceWarning()
+
+	if len(v.errors) == 0 {
+		v.errors = nil
+	}
+	if len(v.warnings) == 0 {
+		v.warnings = nil
+	}
+}
+
+// checkStages validates each stage in isolation and returns the set of
+// declared stage ids for the reference checks.
+func (v *validator) checkStages() map[string]bool {
+	if len(v.p.Stages) == 0 {
+		v.fail("stages", "pipeline must declare at least one stage")
+	}
+
+	known := make(map[string]bool, len(v.p.Stages))
+	for i := range v.p.Stages {
+		s := &v.p.Stages[i]
+		base := fmt.Sprintf("stages[%d]", i)
+
+		if known[s.ID] {
+			v.fail(base+".id", "duplicate stage id %q: every stage in a pipeline must have a unique id", s.ID)
+		}
+		known[s.ID] = true
+
+		switch s.Executor {
+		case ExecutorAgent:
+			if strings.TrimSpace(s.Agent) == "" {
+				v.fail(base+".agent", "agent stage must name an agent")
+			}
+			if strings.TrimSpace(s.Prompt) == "" {
+				v.fail(base+".prompt", "agent stage must declare a prompt")
+			}
+			if len(s.Credentials) > 0 {
+				v.fail(base+".credentials", "credentials are engine-held and injected into command stages only; an agent must never see one")
+			}
+		case ExecutorCommand:
+			if strings.TrimSpace(s.Run) == "" {
+				v.fail(base+".run", "command stage must declare a run script")
+			}
+			if s.Produces != "" {
+				v.fail(base+".produces", "produces is an agent-stage contract; a command stage settles on its exit status")
+			}
+		case "":
+			v.fail(base+".executor", "executor is required: %s", quotedExecutorKinds())
+		default:
+			v.fail(base+".executor", "unknown executor kind %q: %s", s.Executor, quotedExecutorKinds())
+		}
+
+		if strings.ContainsAny(s.Produces, `/\`) {
+			v.fail(base+".produces", "produces must be a bare filename without a path separator; it resolves under the run's agent-outputs directory")
+		}
+
+		if s.Session != nil {
+			for j, outcome := range s.Session.KillOn {
+				if !outcome.IsKnown() {
+					v.fail(fmt.Sprintf("%s.session.kill-on[%d]", base, j), "unknown outcome %q", outcome)
+				}
+			}
+		}
+	}
+	return known
+}
+
+func (v *validator) checkTriggers() {
+	for i, e := range v.p.On.PR {
+		if !e.IsKnown() {
+			v.fail(fmt.Sprintf("on.pr[%d]", i), "unknown pr event %q: %s", e, quotedPREvents())
+		}
+	}
+	for i, e := range v.p.On.Session {
+		if !e.IsKnown() {
+			v.fail(fmt.Sprintf("on.session[%d]", i), "unknown session event %q: %s", e, quotedSessionEvents())
+		}
+	}
+	// Declaring no events at all is legal: that is a manual-only pipeline.
+}
+
+func (v *validator) checkConcurrency() {
+	if s := v.p.Concurrency.Scope; s != ConcurrencyScopeUnset && !s.IsKnown() {
+		v.fail("concurrency.scope", "unknown concurrency scope %q: %s", s, quotedConcurrencyScopes())
+	}
+}
+
+// checkReferences rejects every edge naming a stage that does not exist.
+func (v *validator) checkReferences(known map[string]bool) {
+	for i := range v.p.Stages {
+		s := &v.p.Stages[i]
+		base := fmt.Sprintf("stages[%d]", i)
+
+		for j, target := range s.OnSuccess {
+			if !known[target] {
+				v.fail(fmt.Sprintf("%s.on_success[%d]", base, j), "unknown stage id %q", target)
+			}
+		}
+		if s.OnFailure != "" && !known[s.OnFailure] {
+			v.fail(base+".on_failure", "unknown stage id %q", s.OnFailure)
+		}
+		for j, target := range s.Needs {
+			if !known[target] {
+				v.fail(fmt.Sprintf("%s.needs[%d]", base, j), "unknown stage id %q", target)
+			}
+		}
+	}
+	if t := v.p.Defaults.OnFailure; t != "" && !known[t] {
+		v.fail("defaults.on_failure", "unknown stage id %q", t)
+	}
+}
+
+// checkCycles rejects a cycle over the routing graph. The model is a state
+// machine, not a DAG: each stage names its successor, so A --fail--> B
+// --fail--> A is expressible and is an infinite loop (spec section 9.1).
+func (v *validator) checkCycles() {
+	cycle := FindFirstCycle(v.p.stageIDs(), v.p.routingEdges())
+	if cycle == nil {
+		return
+	}
+	v.fail("stages", "stage graph has a cycle: %s", strings.Join(cycle, " -> "))
+}
+
+// checkJoins enforces the needs contract and the inherit-at-a-join rule. Both
+// hang off the inbound success edge set; failure edges are never counted
+// (spec section 9.2).
+func (v *validator) checkJoins(known map[string]bool) {
+	inbound := v.p.inboundSuccess()
+
+	for i := range v.p.Stages {
+		s := &v.p.Stages[i]
+		base := fmt.Sprintf("stages[%d]", i)
+		sources := inbound[s.ID]
+
+		if len(sources) > 1 {
+			if len(s.Needs) == 0 {
+				v.fail(base+".needs", "stage has %d inbound success edges and must declare needs: %s", len(sources), formatIDs(sources))
+			}
+			if s.Workspace == WorkspaceInherit {
+				v.fail(base+".workspace", "workspace: inherit is ambiguous on a stage with %d inbound success edges; name the tree explicitly", len(sources))
+			}
+		}
+
+		// The equality check runs whenever either side is non-empty; the
+		// missing-needs rule above owns the "declared nothing at a join" case.
+		if len(s.Needs) == 0 {
+			continue
+		}
+		missing, unexpected := diffIDs(sources, s.Needs)
+		// Unknown ids are already reported by checkReferences; do not report
+		// them a second time as "unexpected".
+		unexpected = filterIDs(unexpected, known)
+		if len(missing) > 0 || len(unexpected) > 0 {
+			v.fail(base+".needs", "needs does not match the inbound success edges: missing %q, unexpected %q", missing, unexpected)
+		}
+	}
+}
+
+// checkFailureRouteWarning warns when a failure anywhere could end its branch
+// in silence. Not an error: a single-stage pipeline does not need a failure
+// route (spec section 9.4).
+func (v *validator) checkFailureRouteWarning() {
+	if v.p.Defaults.OnFailure != "" {
+		return
+	}
+	for i := range v.p.Stages {
+		if v.p.Stages[i].OnFailure == "" {
+			v.warn("defaults.on_failure",
+				"stage %q declares no on_failure and the pipeline declares no defaults.on_failure, so its failure ends the branch silently",
+				v.p.Stages[i].ID)
+			return
+		}
+	}
+}
+
+// checkSessionWorkspaceWarning warns on the one combination that cannot be
+// rejected at edit time, because a pr trigger may or may not have a session
+// depending on the PR (spec section 5.3). Plan time turns it into a hard
+// failure.
+func (v *validator) checkSessionWorkspaceWarning() {
+	if len(v.p.On.PR) == 0 {
+		return
+	}
+	for i := range v.p.Stages {
+		if v.p.Stages[i].Workspace != WorkspaceSession {
+			continue
+		}
+		v.warn(fmt.Sprintf("stages[%d].workspace", i),
+			"workspace: session under a pr trigger fails at plan time when the PR has no local session")
+	}
+}
+
+// diffIDs compares the actual inbound set against the declared needs and
+// returns the ids missing from needs and the ids needs names that are not
+// actually inbound. Both results are sorted so the message is stable.
+func diffIDs(actual, declared []string) (missing, unexpected []string) {
+	actualSet := make(map[string]bool, len(actual))
+	for _, id := range actual {
+		actualSet[id] = true
+	}
+	declaredSet := make(map[string]bool, len(declared))
+	for _, id := range declared {
+		declaredSet[id] = true
+	}
+
+	missing = make([]string, 0, len(actual))
+	for _, id := range actual {
+		if !declaredSet[id] {
+			missing = append(missing, id)
+		}
+	}
+	unexpected = make([]string, 0, len(declared))
+	for _, id := range declared {
+		if !actualSet[id] {
+			unexpected = append(unexpected, id)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(unexpected)
+	return missing, unexpected
+}
+
+// filterIDs keeps only the ids present in keep.
+func filterIDs(ids []string, keep map[string]bool) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if keep[id] {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func formatIDs(ids []string) string {
+	sorted := make([]string, len(ids))
+	copy(sorted, ids)
+	sort.Strings(sorted)
+	return fmt.Sprintf("%q", sorted)
+}
+
+func quotedExecutorKinds() string {
+	out := make([]string, 0, len(AllExecutorKinds))
+	for _, k := range AllExecutorKinds {
+		out = append(out, string(k))
+	}
+	return "must be one of " + fmt.Sprintf("%q", out)
+}
+
+func quotedPREvents() string {
+	out := make([]string, 0, len(AllPREvents))
+	for _, e := range AllPREvents {
+		out = append(out, string(e))
+	}
+	return "must be one of " + fmt.Sprintf("%q", out)
+}
+
+func quotedSessionEvents() string {
+	out := make([]string, 0, len(AllSessionEvents))
+	for _, e := range AllSessionEvents {
+		out = append(out, string(e))
+	}
+	return "must be one of " + fmt.Sprintf("%q", out)
+}
+
+func quotedConcurrencyScopes() string {
+	out := make([]string, 0, len(AllConcurrencyScopes))
+	for _, s := range AllConcurrencyScopes {
+		out = append(out, string(s))
+	}
+	return "must be one of " + fmt.Sprintf("%q", out)
+}

--- a/backend/internal/pipeline/validate_test.go
+++ b/backend/internal/pipeline/validate_test.go
@@ -1,0 +1,663 @@
+package pipeline
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func asValidationError(err error, target **ValidationError) bool {
+	return errors.As(err, target)
+}
+
+func hasIssue(verr *ValidationError, path string) bool {
+	for _, issue := range verr.Issues {
+		if issue.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func issuePaths(issues []Issue) []string {
+	paths := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		paths = append(paths, issue.Path)
+	}
+	return paths
+}
+
+// validateYAML decodes src (strictly) and validates it, returning the
+// warnings and the *ValidationError (nil when the definition is valid).
+func validateYAML(t *testing.T, src string) ([]Issue, *ValidationError) {
+	t.Helper()
+	var p Pipeline
+	if err := decodeStrict([]byte(src), &p); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	warnings, err := Validate(&p)
+	if err == nil {
+		return warnings, nil
+	}
+	var verr *ValidationError
+	if !asValidationError(err, &verr) {
+		t.Fatalf("expected *ValidationError, got %T: %v", err, err)
+	}
+	return warnings, verr
+}
+
+func TestValidate_ReleaseExampleIsClean(t *testing.T) {
+	warnings, verr := validateYAML(t, string(releaseYAML(t)))
+	if verr != nil {
+		t.Fatalf("expected the spec section 11 example to validate clean, got:\n%v", verr)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", issuePaths(warnings))
+	}
+}
+
+func TestValidate_Rules(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		wantPath  string
+		wantInMsg string
+	}{
+		{
+			name:      "empty stages",
+			yaml:      "name: p\nstages: []\n",
+			wantPath:  "stages",
+			wantInMsg: "at least one stage",
+		},
+		{
+			name: "duplicate stage id",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+  - id: a
+    executor: command
+    run: "true"
+`,
+			wantPath:  "stages[1].id",
+			wantInMsg: "duplicate stage id",
+		},
+		{
+			name: "unknown executor kind",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: wizard
+`,
+			wantPath:  "stages[0].executor",
+			wantInMsg: "unknown executor kind",
+		},
+		{
+			name: "missing executor kind",
+			yaml: `
+name: p
+stages:
+  - id: a
+`,
+			wantPath:  "stages[0].executor",
+			wantInMsg: "executor is required",
+		},
+		{
+			name: "agent stage missing agent",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: agent
+    prompt: hi
+`,
+			wantPath:  "stages[0].agent",
+			wantInMsg: "agent stage must name an agent",
+		},
+		{
+			name: "agent stage missing prompt",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: agent
+    agent: claude-code
+`,
+			wantPath:  "stages[0].prompt",
+			wantInMsg: "agent stage must declare a prompt",
+		},
+		{
+			name: "command stage missing run",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: command
+`,
+			wantPath:  "stages[0].run",
+			wantInMsg: "command stage must declare a run",
+		},
+		{
+			name: "credentials on agent stage",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: agent
+    agent: claude-code
+    prompt: hi
+    credentials: [apple-signing]
+`,
+			wantPath:  "stages[0].credentials",
+			wantInMsg: "command stages only",
+		},
+		{
+			name: "produces on command stage",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    produces: out.md
+`,
+			wantPath:  "stages[0].produces",
+			wantInMsg: "agent-stage contract",
+		},
+		{
+			name: "produces with a path separator",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: agent
+    agent: claude-code
+    prompt: hi
+    produces: sub/out.md
+`,
+			wantPath:  "stages[0].produces",
+			wantInMsg: "bare filename",
+		},
+		{
+			name: "produces with a windows path separator",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: agent
+    agent: claude-code
+    prompt: hi
+    produces: sub\out.md
+`,
+			wantPath:  "stages[0].produces",
+			wantInMsg: "bare filename",
+		},
+		{
+			name: "unknown stage id in on_success",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_success: [b, ghost]
+  - id: b
+    executor: command
+    run: "true"
+`,
+			wantPath:  "stages[0].on_success[1]",
+			wantInMsg: `unknown stage id "ghost"`,
+		},
+		{
+			name: "unknown stage id in on_failure",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_failure: ghost
+`,
+			wantPath:  "stages[0].on_failure",
+			wantInMsg: `unknown stage id "ghost"`,
+		},
+		{
+			name: "unknown stage id in needs",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    needs: [ghost]
+`,
+			wantPath:  "stages[0].needs[0]",
+			wantInMsg: `unknown stage id "ghost"`,
+		},
+		{
+			name: "unknown stage id in defaults.on_failure",
+			yaml: `
+name: p
+defaults:
+  on_failure: ghost
+stages:
+  - id: a
+    executor: command
+    run: "true"
+`,
+			wantPath:  "defaults.on_failure",
+			wantInMsg: `unknown stage id "ghost"`,
+		},
+		{
+			name: "cycle",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_success: b
+    on_failure: c
+  - id: b
+    executor: command
+    run: "true"
+    on_success: a
+    on_failure: c
+  - id: c
+    executor: command
+    run: "true"
+`,
+			wantPath:  "stages",
+			wantInMsg: "a -> b -> a",
+		},
+		{
+			name: "cycle over a failure edge",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_failure: b
+  - id: b
+    executor: command
+    run: "true"
+    on_failure: a
+`,
+			wantPath:  "stages",
+			wantInMsg: "a -> b -> a",
+		},
+		{
+			name: "needs missing on a join",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_success: [b, c]
+  - id: b
+    executor: command
+    run: "true"
+    on_success: d
+  - id: c
+    executor: command
+    run: "true"
+    on_success: d
+  - id: d
+    executor: command
+    run: "true"
+`,
+			wantPath:  "stages[3].needs",
+			wantInMsg: "must declare needs",
+		},
+		{
+			name: "needs does not match the inbound success set",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_success: [b, c]
+  - id: b
+    executor: command
+    run: "true"
+    on_success: d
+  - id: c
+    executor: command
+    run: "true"
+    on_success: d
+  - id: d
+    executor: command
+    run: "true"
+    needs: [b, a]
+`,
+			wantPath:  "stages[3].needs",
+			wantInMsg: `missing ["c"], unexpected ["a"]`,
+		},
+		{
+			name: "needs declared where there are no success edges",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+  - id: b
+    executor: command
+    run: "true"
+    needs: [a]
+`,
+			wantPath:  "stages[1].needs",
+			wantInMsg: `unexpected ["a"]`,
+		},
+		{
+			name: "inherit on a join",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_success: [b, c]
+  - id: b
+    executor: command
+    run: "true"
+    on_success: d
+  - id: c
+    executor: command
+    run: "true"
+    on_success: d
+  - id: d
+    executor: command
+    run: "true"
+    workspace: inherit
+    needs: [b, c]
+`,
+			wantPath:  "stages[3].workspace",
+			wantInMsg: "ambiguous",
+		},
+		{
+			name: "unknown concurrency scope",
+			yaml: `
+name: p
+concurrency:
+  scope: repo
+stages:
+  - id: a
+    executor: command
+    run: "true"
+`,
+			wantPath:  "concurrency.scope",
+			wantInMsg: `unknown concurrency scope "repo"`,
+		},
+		{
+			name: "unknown kill-on outcome",
+			yaml: `
+name: p
+stages:
+  - id: a
+    executor: agent
+    agent: claude-code
+    prompt: hi
+    session:
+      kill-on: [succeeded, exploded]
+`,
+			wantPath:  "stages[0].session.kill-on[1]",
+			wantInMsg: `unknown outcome "exploded"`,
+		},
+		{
+			name: "unknown pr trigger event",
+			yaml: `
+name: p
+on:
+  pr: [opened]
+stages:
+  - id: a
+    executor: command
+    run: "true"
+`,
+			wantPath:  "on.pr[0]",
+			wantInMsg: `unknown pr event "opened"`,
+		},
+		{
+			name: "unknown session trigger event",
+			yaml: `
+name: p
+on:
+  session: [asleep]
+stages:
+  - id: a
+    executor: command
+    run: "true"
+`,
+			wantPath:  "on.session[0]",
+			wantInMsg: `unknown session event "asleep"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, verr := validateYAML(t, tc.yaml)
+			if verr == nil {
+				t.Fatalf("expected a validation error at %q, got none", tc.wantPath)
+			}
+			var found *Issue
+			for i := range verr.Issues {
+				if verr.Issues[i].Path == tc.wantPath {
+					found = &verr.Issues[i]
+					break
+				}
+			}
+			if found == nil {
+				t.Fatalf("no issue at %q; got %v", tc.wantPath, issuePaths(verr.Issues))
+			}
+			if !strings.Contains(found.Message, tc.wantInMsg) {
+				t.Errorf("issue at %q = %q, want it to contain %q", tc.wantPath, found.Message, tc.wantInMsg)
+			}
+		})
+	}
+}
+
+// A manual-only pipeline declares no trigger events at all, which is legal.
+func TestValidate_ManualOnlyPipelineIsLegal(t *testing.T) {
+	_, verr := validateYAML(t, `
+name: p
+defaults:
+  on_failure: b
+stages:
+  - id: a
+    executor: command
+    run: "true"
+  - id: b
+    executor: command
+    run: "true"
+`)
+	if verr != nil {
+		t.Fatalf("expected a manual-only pipeline to validate, got:\n%v", verr)
+	}
+}
+
+// The defaults.on_failure target may be reached from many stages without
+// needing a needs key, because failure edges never join (spec section 9.2),
+// and it does not self-edge (spec section 9.4).
+func TestValidate_DefaultFailureTargetDoesNotSelfEdge(t *testing.T) {
+	_, verr := validateYAML(t, `
+name: p
+defaults:
+  on_failure: notify
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_success: b
+  - id: b
+    executor: command
+    run: "true"
+  - id: notify
+    executor: command
+    run: "true"
+`)
+	if verr != nil {
+		t.Fatalf("expected clean validation, got:\n%v", verr)
+	}
+}
+
+// A stage with one inbound success edge and several inbound failure edges does
+// not need a needs key (spec section 9.2).
+func TestValidate_FailureEdgesDoNotRequireNeeds(t *testing.T) {
+	_, verr := validateYAML(t, `
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_success: c
+    on_failure: c
+  - id: b
+    executor: command
+    run: "true"
+    on_failure: c
+  - id: c
+    executor: command
+    run: "true"
+`)
+	if verr != nil {
+		t.Fatalf("expected clean validation, got:\n%v", verr)
+	}
+}
+
+func TestValidate_CollectsEveryIssueInOnePass(t *testing.T) {
+	_, verr := validateYAML(t, `
+name: p
+concurrency:
+  scope: repo
+stages:
+  - id: a
+    executor: agent
+    agent: claude-code
+    prompt: hi
+    credentials: [x]
+    produces: sub/out.md
+    on_success: ghost
+`)
+	if verr == nil {
+		t.Fatal("expected validation errors, got none")
+	}
+	want := []string{
+		"concurrency.scope",
+		"stages[0].credentials",
+		"stages[0].produces",
+		"stages[0].on_success[0]",
+	}
+	for _, path := range want {
+		if !hasIssue(verr, path) {
+			t.Errorf("missing issue at %q; got %v", path, issuePaths(verr.Issues))
+		}
+	}
+	if got := verr.Error(); !strings.Contains(got, "concurrency.scope: ") {
+		t.Errorf("Error() = %q, want it to render as \"path: message\" lines", got)
+	}
+}
+
+func TestValidate_Warnings(t *testing.T) {
+	t.Run("no failure route anywhere", func(t *testing.T) {
+		warnings, verr := validateYAML(t, `
+name: p
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_success: b
+  - id: b
+    executor: command
+    run: "true"
+`)
+		if verr != nil {
+			t.Fatalf("expected no errors, got:\n%v", verr)
+		}
+		if len(warnings) != 1 || warnings[0].Path != "defaults.on_failure" {
+			t.Fatalf("warnings = %v, want one at defaults.on_failure", warnings)
+		}
+		if !strings.Contains(warnings[0].Message, "silently") {
+			t.Errorf("warning = %q, want it to say failures end the branch silently", warnings[0].Message)
+		}
+	})
+
+	// defaults.on_failure alone suppresses the warning. In practice it is the
+	// only way to: without it, the last stage in the failure chain has nowhere
+	// left to route, and making it route back would be a cycle.
+	t.Run("no warning when defaults.on_failure is declared", func(t *testing.T) {
+		warnings, verr := validateYAML(t, `
+name: p
+defaults:
+  on_failure: notify
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    on_success: b
+  - id: b
+    executor: command
+    run: "true"
+  - id: notify
+    executor: command
+    run: "true"
+`)
+		if verr != nil {
+			t.Fatalf("expected no errors, got:\n%v", verr)
+		}
+		if len(warnings) != 0 {
+			t.Errorf("warnings = %v, want none", issuePaths(warnings))
+		}
+	})
+
+	t.Run("session workspace under a pr trigger", func(t *testing.T) {
+		warnings, verr := validateYAML(t, `
+name: p
+on:
+  pr: [updated]
+defaults:
+  on_failure: a
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    workspace: session
+`)
+		if verr != nil {
+			t.Fatalf("expected no errors, got:\n%v", verr)
+		}
+		if len(warnings) != 1 || warnings[0].Path != "stages[0].workspace" {
+			t.Fatalf("warnings = %v, want one at stages[0].workspace", warnings)
+		}
+		if !strings.Contains(warnings[0].Message, "plan time") {
+			t.Errorf("warning = %q, want it to mention the plan-time failure", warnings[0].Message)
+		}
+	})
+
+	t.Run("no session-workspace warning under a session trigger", func(t *testing.T) {
+		warnings, verr := validateYAML(t, `
+name: p
+on:
+  session: [idle]
+defaults:
+  on_failure: a
+stages:
+  - id: a
+    executor: command
+    run: "true"
+    workspace: session
+`)
+		if verr != nil {
+			t.Fatalf("expected no errors, got:\n%v", verr)
+		}
+		if len(warnings) != 0 {
+			t.Errorf("warnings = %v, want none", issuePaths(warnings))
+		}
+	})
+}


### PR DESCRIPTION
Pipelines v2 Tasks 2 and 3, combined into one PR because Task 2's `EffectiveKillOn()` returns `[]Outcome` and `Outcome` is Task 3's type.

Closes #291

## Task 2: definition schema, parser, edit-time validation

- `definition.go`: the v2 config structs (`Pipeline`, `TriggerSpec`, `ConcurrencySpec`, `DefaultsSpec`, `Stage`, `SessionSpec`) and the `ExecutorKind`, `WorkspaceKind`, `PREvent`, `SessionEvent`, `ConcurrencyScope` enums, exactly per the plan's interface block. `StageList` accepts a scalar or a list, so `on_success: build` and `on_success: [a, b]` both parse. `ParseDefinition` is a strict `yaml.v3` decode (`KnownFields(true)`) plus `Validate`.
- `EffectiveDeadline` resolves stage > defaults > the 30m `DefaultStageDeadline` (D6). `EffectiveKillOn` distinguishes an absent `kill-on` key (default `[succeeded, failed]`) from an explicit empty list (never kill).
- `validate.go`: every error rule listed in the plan plus both warnings, collected in one pass as `*ValidationError{Issues []Issue}`, the harness ported from v1's `config.go`. Failure edges are never counted for `needs`, and the `defaults.on_failure` target does not implicitly self-edge (spec section 9.4).
- `schema.json` rewritten for the v2 shape; `schema_test.go` recreated as an enum-coverage drift guard over every `Outcome`, `WorkspaceKind`, `PREvent`, `SessionEvent`, `ConcurrencyScope` and `ExecutorKind` constant, with the hand-maintained-mirror comment kept.
- `Definition.Config` is now the v2 `Pipeline` rather than the `any` placeholder.

## Task 3: outcomes, subject, run state, plan-at-start

- `outcome.go`: the 10-value `Outcome` taxonomy with `IsSettled` / `IsSuccess` / `RoutesToFailure`, plus the 5-column `RunStatus`. Cancelled and skipped deliberately do not route to failure.
- `subject.go`: `Subject` / `PRRef`, `DefaultScope` (spec section 10) and `ScopeIdentity`, which resolves the identity half of the effective concurrency key.
- `state.go`: `RunState` / `StageState`, the copy-on-write shapes the per-run reducer will rewrite.
- `plan.go`: `ComputePlan` walks from `EntryStage()` over `on_success` union `on_failure` union `defaults.on_failure`, enumerates reachable stages in document order, computes effective deadlines, and resolves workspace defaults (`auto` to `session` or `run` by subject; unset on a failure-only entry stays symbolic `inherit`). A reachable stage requiring `workspace: session` with a sessionless subject fails the plan before any stage runs, with the spec's exact message shape.

## Two notes on the fixture

`testdata/release.yaml` is the spec section 11 worked example, the canonical fixture for both tasks.

1. **It declares 14 stages, not 12.** The implementation plan's assertion ("stage count 12", "reaches all 12 stages") appears to have counted the ASCII diagram, which omits `notify-failure` and `notify-partial`. The spec is the canonical fixture, so the tests assert 14.
2. **One character had to change for it to parse.** `notify-partial`'s last `run:` line sits at column 0 in the spec, below its block scalar's indent, so the spec's YAML document does not parse at all. The fixture indents it to the block indent, which reproduces exactly the shell text the example intends (the content is still at relative column 0).

   The spec doc itself is deliberately left alone. Correcting it there drags the whole file through the prettier check, which wants to reformat 45 unrelated lines (tables, emphasis) and would conflict with every other v2 worker reading that file. **Worth a separate one-line fix later** so the next person extracting section 11 does not hit this.

The example validates with zero errors and zero warnings, and `ComputePlan` reaches all 14 stages with `diagnose-build` correctly left symbolic at `inherit`.

## Deliberately not implemented

`validate.go` does not reject an unknown `workspace:` value. The plan's rule list is closed ("do not invent extra rules") and this rule is not on it, so it is left to the JSON schema the editor consumes. Flagging it because it is a real gap: a typo like `workspace: sesion` currently reaches the executor rather than failing at edit time. Cheap to add later. The same applies to unknown credential names (spec section 13), which need the credential store from Task 12.

## Verification

- `go build ./...` clean
- `go test ./...`: 2591 passed, 3 skipped. The 4 failures in `internal/cli` (`TestSpawn*`, HTTP 404 against a live local daemon) reproduce identically on `origin/pipelines`, verified in a clean worktree at the base commit.
- `gofmt -l .` empty
- `~/go/bin/golangci-lint run ./...`: 0 issues
- No frontend change, so no frontend build needed.