### PR TITLE
feat(pipelines): run folder layout, Context.md writer, run.json projection

### DIFF
--- a/backend/internal/pipeline/context.go
+++ b/backend/internal/pipeline/context.go
@@ -1,0 +1,53 @@
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ContextPath is the engine-written index pasted verbatim into the next
+// agent's prompt as $AO_CONTEXT (spec section 12.1).
+func (f RunFolder) ContextPath() string { return filepath.Join(f.Dir, contextFile) }
+
+// AppendContext adds one pointer line to Context.md, creating the file if it
+// is missing. Context.md holds pointers, never content: agent output files are
+// read off disk by whoever wants the detail, which keeps prompt size bounded
+// regardless of output size.
+//
+//	stage `review` finished, its output is at agent-outputs/review.md
+func (f RunFolder) AppendContext(line string) error {
+	path := f.ContextPath()
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, runFolderFilePerm)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	if !strings.HasSuffix(line, "\n") {
+		line += "\n"
+	}
+	if _, err := file.WriteString(line); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("append to %s: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", path, err)
+	}
+	return nil
+}
+
+// VerifyArtifact reports whether the stage honoured its `produces` contract.
+// A stage that declares no artifact has nothing to verify and always passes;
+// otherwise the declared file must exist and be non-empty. This is what
+// separates `succeeded` from `no_output`, and it gates the Context.md line.
+func (f RunFolder) VerifyArtifact(stage *Stage) bool {
+	path := f.OutputPath(stage)
+	if path == "" {
+		return true
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular() && info.Size() > 0
+}

--- a/backend/internal/pipeline/runfolder.go
+++ b/backend/internal/pipeline/runfolder.go
@@ -1,0 +1,123 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Run folder layout, spec section 3:
+//
+//	<base>/<project-id>/<run-id>/
+//	  definition.yaml            frozen copy, what actually ran
+//	  run.json                   projection of RunState for humans
+//	  Context.md                 engine-written index
+//	  agent-outputs/<produces>   declared artifacts
+//	  stage-logs/<stage>.log     stdout+stderr, both executors
+//	  workspace/                 if any stage uses `workspace: run`
+//	  workspaces/<stage>/        if any stage uses `workspace: stage`
+//
+// The base dir is always <AO_DATA_DIR>/pipelines, which defaults under ~/.ao.
+// No app state ever lands in an OS-default application-data location.
+const (
+	agentOutputsDir = "agent-outputs"
+	stageLogsDir    = "stage-logs"
+	definitionFile  = "definition.yaml"
+	runJSONFile     = "run.json"
+	contextFile     = "Context.md"
+
+	runFolderDirPerm  os.FileMode = 0o750
+	runFolderFilePerm os.FileMode = 0o600
+)
+
+// RunFolder is one run's directory on disk. Run id keys the folder, so
+// concurrent runs of the same pipeline cannot collide.
+type RunFolder struct{ Dir string }
+
+// CreateRunFolder makes <base>/<projectID>/<runID> with its agent-outputs and
+// stage-logs subdirectories, and freezes defYAML into definition.yaml
+// byte-identical to the input. The run executes that copy, so editing a
+// definition can never corrupt a run in flight (spec section 3).
+//
+// It is safe to call twice for the same run: the directories are created if
+// missing and the frozen definition is rewritten as-is.
+func CreateRunFolder(baseDir, projectID string, runID RunID, defYAML []byte) (RunFolder, error) {
+	if err := checkPathComponent("project id", projectID); err != nil {
+		return RunFolder{}, err
+	}
+	if err := checkPathComponent("run id", string(runID)); err != nil {
+		return RunFolder{}, err
+	}
+
+	dir := filepath.Join(baseDir, projectID, string(runID))
+	for _, sub := range []string{agentOutputsDir, stageLogsDir} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), runFolderDirPerm); err != nil {
+			return RunFolder{}, fmt.Errorf("create run folder %s: %w", dir, err)
+		}
+	}
+
+	defPath := filepath.Join(dir, definitionFile)
+	if err := os.WriteFile(defPath, defYAML, runFolderFilePerm); err != nil {
+		return RunFolder{}, fmt.Errorf("freeze definition %s: %w", defPath, err)
+	}
+	return RunFolder{Dir: dir}, nil
+}
+
+// checkPathComponent keeps a caller-supplied id from escaping the base dir.
+// Project and run ids are engine-generated, so this is a guard rail rather
+// than a parser: anything with a separator or a dot-segment is rejected
+// outright instead of being sanitized into something surprising.
+func checkPathComponent(what, value string) error {
+	switch {
+	case value == "":
+		return fmt.Errorf("run folder: %s is empty", what)
+	case value == "." || value == "..":
+		return fmt.Errorf("run folder: %s %q is a path segment", what, value)
+	case strings.ContainsAny(value, `/\`) || strings.ContainsRune(value, os.PathSeparator):
+		return fmt.Errorf("run folder: %s %q contains a path separator", what, value)
+	}
+	return nil
+}
+
+// OutputPath is where a stage's declared artifact lives. It is empty when the
+// stage declares no `produces`, because then there is no artifact to name.
+// Validation guarantees `produces` is a bare filename.
+func (f RunFolder) OutputPath(stage *Stage) string {
+	if stage == nil || stage.Produces == "" {
+		return ""
+	}
+	return filepath.Join(f.Dir, agentOutputsDir, stage.Produces)
+}
+
+// LogPath is where a stage's combined stdout and stderr is streamed. Both
+// executors always capture one.
+func (f RunFolder) LogPath(stageID string) string {
+	return filepath.Join(f.Dir, stageLogsDir, stageID+".log")
+}
+
+// WriteRunJSON writes a pretty-printed projection of the run state. SQLite
+// stays the store of record; this file exists for humans and debugging
+// (decision D2), so it is rewritten in full on every persist.
+func (f RunFolder) WriteRunJSON(run RunState) error {
+	raw, err := json.MarshalIndent(run, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal run.json: %w", err)
+	}
+	path := filepath.Join(f.Dir, runJSONFile)
+	if err := os.WriteFile(path, append(raw, '\n'), runFolderFilePerm); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// RunWorkspaceDir is the single worktree shared by every `workspace: run`
+// stage, created at first use.
+func RunWorkspaceDir(f RunFolder) string { return filepath.Join(f.Dir, "workspace") }
+
+// StageWorkspaceDir is the fresh worktree a `workspace: stage` stage gets each
+// time it is entered.
+func StageWorkspaceDir(f RunFolder, stageID string) string {
+	return filepath.Join(f.Dir, "workspaces", stageID)
+}

--- a/backend/internal/pipeline/runfolder_test.go
+++ b/backend/internal/pipeline/runfolder_test.go
@@ -1,0 +1,299 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const sampleDefYAML = `name: review
+on:
+  pr: [created]
+stages:
+  - id: review
+    executor: agent
+    agent: claude
+    prompt: review the diff
+    produces: review.md
+`
+
+func TestCreateRunFolderLayout(t *testing.T) {
+	base := t.TempDir()
+
+	f, err := CreateRunFolder(base, "proj-1", RunID("run-1"), []byte(sampleDefYAML))
+	if err != nil {
+		t.Fatalf("CreateRunFolder: %v", err)
+	}
+
+	want := filepath.Join(base, "proj-1", "run-1")
+	if f.Dir != want {
+		t.Fatalf("Dir = %q, want %q", f.Dir, want)
+	}
+
+	for _, sub := range []string{"agent-outputs", "stage-logs"} {
+		info, statErr := os.Stat(filepath.Join(f.Dir, sub))
+		if statErr != nil {
+			t.Fatalf("stat %s: %v", sub, statErr)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s is not a directory", sub)
+		}
+	}
+
+	got, err := os.ReadFile(filepath.Join(f.Dir, "definition.yaml"))
+	if err != nil {
+		t.Fatalf("read definition.yaml: %v", err)
+	}
+	if string(got) != sampleDefYAML {
+		t.Fatalf("definition.yaml not byte-identical:\ngot:  %q\nwant: %q", got, sampleDefYAML)
+	}
+}
+
+func TestCreateRunFolderIsIdempotent(t *testing.T) {
+	base := t.TempDir()
+
+	if _, err := CreateRunFolder(base, "proj-1", RunID("run-1"), []byte(sampleDefYAML)); err != nil {
+		t.Fatalf("first CreateRunFolder: %v", err)
+	}
+	if _, err := CreateRunFolder(base, "proj-1", RunID("run-1"), []byte(sampleDefYAML)); err != nil {
+		t.Fatalf("second CreateRunFolder: %v", err)
+	}
+}
+
+func TestCreateRunFolderRejectsBadPathComponents(t *testing.T) {
+	base := t.TempDir()
+
+	cases := []struct {
+		name      string
+		projectID string
+		runID     RunID
+	}{
+		{"empty project", "", "run-1"},
+		{"empty run", "proj-1", ""},
+		{"traversal project", "..", "run-1"},
+		{"traversal run", "proj-1", ".."},
+		{"separator project", "a/b", "run-1"},
+		{"separator run", "proj-1", "a/b"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := CreateRunFolder(base, tc.projectID, tc.runID, []byte(sampleDefYAML)); err == nil {
+				t.Fatalf("CreateRunFolder(%q, %q) = nil error, want rejection", tc.projectID, tc.runID)
+			}
+		})
+	}
+}
+
+func TestPaths(t *testing.T) {
+	f := RunFolder{Dir: "/base/proj/run"}
+
+	if got, want := f.OutputPath(&Stage{ID: "review", Produces: "review.md"}), "/base/proj/run/agent-outputs/review.md"; got != want {
+		t.Fatalf("OutputPath = %q, want %q", got, want)
+	}
+	if got := f.OutputPath(&Stage{ID: "build"}); got != "" {
+		t.Fatalf("OutputPath with no produces = %q, want empty", got)
+	}
+	if got := f.OutputPath(nil); got != "" {
+		t.Fatalf("OutputPath(nil) = %q, want empty", got)
+	}
+	if got, want := f.LogPath("build"), "/base/proj/run/stage-logs/build.log"; got != want {
+		t.Fatalf("LogPath = %q, want %q", got, want)
+	}
+	if got, want := f.ContextPath(), "/base/proj/run/Context.md"; got != want {
+		t.Fatalf("ContextPath = %q, want %q", got, want)
+	}
+	if got, want := RunWorkspaceDir(f), "/base/proj/run/workspace"; got != want {
+		t.Fatalf("RunWorkspaceDir = %q, want %q", got, want)
+	}
+	if got, want := StageWorkspaceDir(f, "build"), "/base/proj/run/workspaces/build"; got != want {
+		t.Fatalf("StageWorkspaceDir = %q, want %q", got, want)
+	}
+}
+
+func TestVerifyArtifact(t *testing.T) {
+	base := t.TempDir()
+	f, err := CreateRunFolder(base, "proj-1", RunID("run-1"), []byte(sampleDefYAML))
+	if err != nil {
+		t.Fatalf("CreateRunFolder: %v", err)
+	}
+
+	// No produces: nothing is contracted, so the stage verifies.
+	if !f.VerifyArtifact(&Stage{ID: "build"}) {
+		t.Fatal("VerifyArtifact with no produces = false, want true")
+	}
+	if !f.VerifyArtifact(nil) {
+		t.Fatal("VerifyArtifact(nil) = false, want true")
+	}
+
+	stage := &Stage{ID: "review", Produces: "review.md"}
+
+	if f.VerifyArtifact(stage) {
+		t.Fatal("VerifyArtifact on missing file = true, want false")
+	}
+
+	if err := os.WriteFile(f.OutputPath(stage), nil, 0o600); err != nil {
+		t.Fatalf("write empty artifact: %v", err)
+	}
+	if f.VerifyArtifact(stage) {
+		t.Fatal("VerifyArtifact on empty file = true, want false")
+	}
+
+	if err := os.WriteFile(f.OutputPath(stage), []byte("looks good\n"), 0o600); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	if !f.VerifyArtifact(stage) {
+		t.Fatal("VerifyArtifact on non-empty file = false, want true")
+	}
+
+	// A directory at the artifact path is not an artifact.
+	dirStage := &Stage{ID: "dir", Produces: "dir.md"}
+	if err := os.Mkdir(f.OutputPath(dirStage), 0o750); err != nil {
+		t.Fatalf("mkdir artifact dir: %v", err)
+	}
+	if f.VerifyArtifact(dirStage) {
+		t.Fatal("VerifyArtifact on a directory = true, want false")
+	}
+}
+
+func TestAppendContextAccumulates(t *testing.T) {
+	base := t.TempDir()
+	f, err := CreateRunFolder(base, "proj-1", RunID("run-1"), []byte(sampleDefYAML))
+	if err != nil {
+		t.Fatalf("CreateRunFolder: %v", err)
+	}
+
+	if _, err := os.Stat(f.ContextPath()); !os.IsNotExist(err) {
+		t.Fatalf("Context.md exists before any append: %v", err)
+	}
+
+	lines := []string{
+		"stage `review` finished, its output is at agent-outputs/review.md",
+		"stage `fix` finished, its output is at agent-outputs/fix.md",
+	}
+	for _, line := range lines {
+		if err := f.AppendContext(line); err != nil {
+			t.Fatalf("AppendContext: %v", err)
+		}
+	}
+	// A line that already ends in a newline must not gain a second one.
+	if err := f.AppendContext("stage `ship` finished\n"); err != nil {
+		t.Fatalf("AppendContext: %v", err)
+	}
+
+	got, err := os.ReadFile(f.ContextPath())
+	if err != nil {
+		t.Fatalf("read Context.md: %v", err)
+	}
+	want := lines[0] + "\n" + lines[1] + "\n" + "stage `ship` finished\n"
+	if string(got) != want {
+		t.Fatalf("Context.md =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestWriteRunJSONRoundTrips(t *testing.T) {
+	base := t.TempDir()
+	f, err := CreateRunFolder(base, "proj-1", RunID("run-1"), []byte(sampleDefYAML))
+	if err != nil {
+		t.Fatalf("CreateRunFolder: %v", err)
+	}
+
+	created := time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC)
+	run := RunState{
+		RunID:        RunID("run-1"),
+		ProjectID:    "proj-1",
+		PipelineID:   ID("pl-1"),
+		PipelineName: "review",
+		Subject: Subject{
+			Kind:      SubjectPR,
+			ProjectID: "proj-1",
+			PR:        &PRRef{Number: 412, Repo: "acme/widget"},
+		},
+		Status: RunRunning,
+		RunDir: f.Dir,
+		Def: Pipeline{
+			Name:   "review",
+			Stages: []Stage{{ID: "review", Executor: ExecutorAgent, Agent: "claude", Prompt: "review the diff", Produces: "review.md"}},
+		},
+		Stages: map[string]*StageState{
+			"review": {ID: "review", Outcome: OutcomeRunning, Attempt: 1, EnteredVia: EntryTrigger, StartedAt: created},
+		},
+		Nudged:    map[string]bool{"review": true},
+		CreatedAt: created,
+		UpdatedAt: created.Add(time.Minute),
+	}
+
+	if err := f.WriteRunJSON(run); err != nil {
+		t.Fatalf("WriteRunJSON: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(f.Dir, "run.json"))
+	if err != nil {
+		t.Fatalf("read run.json: %v", err)
+	}
+	if !json.Valid(raw) {
+		t.Fatal("run.json is not valid JSON")
+	}
+	// Pretty printed, per decision D2: this file is for humans.
+	if !hasIndentedLine(raw) {
+		t.Fatalf("run.json is not pretty printed:\n%s", raw)
+	}
+
+	var got RunState
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal run.json: %v", err)
+	}
+	if got.RunID != run.RunID || got.ProjectID != run.ProjectID || got.Status != run.Status {
+		t.Fatalf("round trip lost identity: %+v", got)
+	}
+	if got.Subject.PR == nil || got.Subject.PR.Number != 412 {
+		t.Fatalf("round trip lost the subject: %+v", got.Subject)
+	}
+	if len(got.Def.Stages) != 1 || got.Def.Stages[0].Produces != "review.md" {
+		t.Fatalf("round trip lost the frozen definition: %+v", got.Def)
+	}
+	stage, ok := got.Stages["review"]
+	if !ok || stage.Outcome != OutcomeRunning || stage.Attempt != 1 {
+		t.Fatalf("round trip lost the stage state: %+v", got.Stages)
+	}
+	if !got.CreatedAt.Equal(run.CreatedAt) {
+		t.Fatalf("CreatedAt = %v, want %v", got.CreatedAt, run.CreatedAt)
+	}
+}
+
+func TestWriteRunJSONOverwrites(t *testing.T) {
+	base := t.TempDir()
+	f, err := CreateRunFolder(base, "proj-1", RunID("run-1"), []byte(sampleDefYAML))
+	if err != nil {
+		t.Fatalf("CreateRunFolder: %v", err)
+	}
+
+	if err := f.WriteRunJSON(RunState{RunID: "run-1", Status: RunRunning}); err != nil {
+		t.Fatalf("first WriteRunJSON: %v", err)
+	}
+	if err := f.WriteRunJSON(RunState{RunID: "run-1", Status: RunSucceeded}); err != nil {
+		t.Fatalf("second WriteRunJSON: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(f.Dir, "run.json"))
+	if err != nil {
+		t.Fatalf("read run.json: %v", err)
+	}
+	var got RunState
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal run.json: %v", err)
+	}
+	if got.Status != RunSucceeded {
+		t.Fatalf("Status = %q, want %q", got.Status, RunSucceeded)
+	}
+}
+
+func hasIndentedLine(raw []byte) bool {
+	for i := 0; i < len(raw)-1; i++ {
+		if raw[i] == '\n' && raw[i+1] == ' ' {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Pipelines v2 Task 6. Adds the run folder on disk: the frozen definition, the engine-written `Context.md` index, the `run.json` projection, and `produces` artifact verification.

## What lands

`backend/internal/pipeline/runfolder.go`
- `CreateRunFolder(baseDir, projectID, runID, defYAML)` makes `<base>/<project>/<run>/{agent-outputs,stage-logs}` and freezes `definition.yaml` byte-identical to the input (spec §3). Idempotent, so a retried create is harmless.
- `OutputPath`, `LogPath`, `RunWorkspaceDir`, `StageWorkspaceDir` path helpers (Task 7 consumes the workspace ones).
- `WriteRunJSON` writes a pretty-printed projection of `RunState`. SQLite stays the store of record (decision D2); this file is for humans and debugging, rewritten in full on every persist.
- Project and run ids are checked as single path components before they are joined, so a bad id cannot escape the base dir.

`backend/internal/pipeline/context.go`
- `ContextPath` / `AppendContext`: create-if-missing, append the pointer line plus a newline (spec §12.1, decision D4). Pointer lines only, never content.
- `VerifyArtifact`: true when the stage declares no `produces`; otherwise the declared file must exist, be a regular file, and be non-empty. This is what separates `succeeded` from `no_output`.

Base dir is `<AO_DATA_DIR>/pipelines`, defaulting under `~/.ao`. Nothing resolves to an OS-default app-data location.

## Tests

`runfolder_test.go`, all against `t.TempDir()`: layout plus byte-identical `definition.yaml`; idempotent create; bad path components rejected; every path helper; `VerifyArtifact` false on missing, false on empty, false on a directory, true on content, true with no `produces`; `AppendContext` accumulates and does not double a trailing newline; `WriteRunJSON` is pretty printed, round-trips through `json.Unmarshal`, and overwrites.

## Verification

- `go build ./...` clean, `gofmt -l .` empty.
- `go test ./...`: 2605 passed. The 4 `internal/cli` `TestSpawn*` failures are pre-existing: the same 4 fail on `origin/pipelines` in a clean worktree (they hit a local daemon and get HTTP 404).
- `golangci-lint run ./...`: 0 issues.

## Risks and follow-ups

- Run folders are never auto-deleted (decision D9, GC deferred).
- `run.json` is a full rewrite per persist rather than an atomic write-and-rename. It is a debugging projection, not the store of record, so a torn file after a crash costs nothing; worth revisiting only if anything ever reads it back.

Closes #295