### PR TITLE
feat(pipelines): concurrency groups, cancel-in-progress, queue depth 1

### DIFF
--- a/backend/internal/pipeline/engine/concurrency.go
+++ b/backend/internal/pipeline/engine/concurrency.go
@@ -1,0 +1,150 @@
+// Package engine runs pipelines. This file holds the concurrency table, the
+// bookkeeping behind spec section 10: runs that share an effective concurrency
+// key serialize, queue depth is 1, and `cancel-in-progress` lets a newcomer
+// take the key from the run holding it.
+package engine
+
+import (
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// groupKey is the effective concurrency key: the literal group name paired
+// with the resolved scope identity. `group` decides which pipelines share a
+// bucket, `scope` decides which runs collide (spec section 10).
+type groupKey struct{ Group, ScopeIdentity string }
+
+// keyFor builds the effective concurrency key for one definition and the
+// subject a run is about. The group defaults to the pipeline name and the
+// scope to the subject's natural scope, which Subject.ScopeIdentity already
+// resolves for an unset value.
+func keyFor(def pipeline.Definition, subject pipeline.Subject) groupKey {
+	group := def.Config.Concurrency.Group
+	if group == "" {
+		group = def.Config.Name
+	}
+	return groupKey{
+		Group:         group,
+		ScopeIdentity: subject.ScopeIdentity(def.Config.Concurrency.Scope),
+	}
+}
+
+// ungrouped reports whether the subject has no identity at the requested
+// scope, for instance a project subject under `scope: pr`. Such a run
+// serializes against nothing, per Subject.ScopeIdentity.
+func (k groupKey) ungrouped() bool { return k.ScopeIdentity == "" }
+
+// pendingTrigger is a trigger waiting for its key to free up. It carries what
+// the supervisor needs to start the run once Release hands it back, which is
+// the trigger request it arrived on plus the run id.
+//
+// The run id is allocated before admission so that admission and release are
+// each a single atomic decision: the table can move a trigger from queued to
+// running without a window where the key is held by nobody. A trigger evicted
+// from the queue simply drops its id, which costs nothing.
+type pendingTrigger struct {
+	Definition pipeline.Definition
+	Event      string
+	Subject    pipeline.Subject
+	RunID      pipeline.RunID
+}
+
+// AdmissionKind is what the supervisor must do with a trigger it just offered
+// to the table.
+type AdmissionKind string
+
+// Every admission outcome.
+const (
+	// StartNow means the trigger holds the key and the run starts immediately.
+	StartNow AdmissionKind = "start-now"
+	// Queued means a run holds the key and the trigger waits for it. Queue
+	// depth is 1, so this trigger replaced any previously queued one.
+	Queued AdmissionKind = "queued"
+	// CancelThenStart means `cancel-in-progress` is set and a run held the
+	// key: cancel the victim, then start this trigger, which now holds it.
+	CancelThenStart AdmissionKind = "cancel-then-start"
+)
+
+// Admission is the table's answer for one trigger.
+type Admission struct {
+	Kind AdmissionKind
+	// Victim is the in-flight run to cancel, set only for CancelThenStart.
+	Victim pipeline.RunID
+}
+
+// ConcurrencyTable tracks which run holds each effective concurrency key and
+// which trigger is waiting for it. The supervisor calls it from more than one
+// goroutine, so every method takes the mutex. The zero value is ready to use.
+type ConcurrencyTable struct {
+	mu      sync.Mutex
+	running map[groupKey]pipeline.RunID
+	queued  map[groupKey]pendingTrigger
+}
+
+// Admit decides what happens to a trigger that wants key. cancelInProgress is
+// the arriving pipeline's `concurrency.cancel-in-progress`, read per arrival
+// because two pipelines sharing a group need not agree on it.
+func (t *ConcurrencyTable) Admit(key groupKey, cancelInProgress bool, trigger pendingTrigger) Admission {
+	if key.ungrouped() {
+		return Admission{Kind: StartNow}
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	victim, held := t.running[key]
+	if !held {
+		t.hold(key, trigger.RunID)
+		return Admission{Kind: StartNow}
+	}
+	if cancelInProgress {
+		// cancel-in-progress targets the in-flight run only. A trigger already
+		// waiting keeps its place and starts when this one settles.
+		t.hold(key, trigger.RunID)
+		return Admission{Kind: CancelThenStart, Victim: victim}
+	}
+	// Queue depth is 1: this trigger replaces any previously queued one rather
+	// than stacking behind it (spec section 10).
+	if t.queued == nil {
+		t.queued = make(map[groupKey]pendingTrigger)
+	}
+	t.queued[key] = trigger
+	return Admission{Kind: Queued}
+}
+
+// Release gives up key on behalf of a settled run and returns the trigger that
+// was waiting for it, if any. The returned trigger already holds the key, so
+// the caller starts it without admitting it again.
+//
+// runID is the run that settled. A run that no longer holds the key releases
+// nothing: that is the ordinary cancel-in-progress path, where the victim
+// settles after its replacement has already taken the key.
+func (t *ConcurrencyTable) Release(key groupKey, runID pipeline.RunID) (pendingTrigger, bool) {
+	if key.ungrouped() {
+		return pendingTrigger{}, false
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if holder, held := t.running[key]; !held || holder != runID {
+		return pendingTrigger{}, false
+	}
+	next, queued := t.queued[key]
+	if !queued {
+		delete(t.running, key)
+		return pendingTrigger{}, false
+	}
+	delete(t.queued, key)
+	t.hold(key, next.RunID)
+	return next, true
+}
+
+// hold records runID as the holder of key. The caller holds the mutex.
+func (t *ConcurrencyTable) hold(key groupKey, runID pipeline.RunID) {
+	if t.running == nil {
+		t.running = make(map[groupKey]pipeline.RunID)
+	}
+	t.running[key] = runID
+}

--- a/backend/internal/pipeline/engine/concurrency_test.go
+++ b/backend/internal/pipeline/engine/concurrency_test.go
@@ -1,0 +1,337 @@
+package engine
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// prSubject is a PR subject on the given number, with a local session so the
+// session scope also has an identity to resolve.
+func prSubject(number int) pipeline.Subject {
+	return pipeline.Subject{
+		Kind:      pipeline.SubjectPR,
+		ProjectID: "proj",
+		SessionID: "sess-1",
+		PR:        &pipeline.PRRef{Number: number, Repo: "acme/app"},
+	}
+}
+
+func sessionSubject(id string) pipeline.Subject {
+	return pipeline.Subject{Kind: pipeline.SubjectSession, ProjectID: "proj", SessionID: id}
+}
+
+// reviewPipeline is the per-PR shape from spec section 10: no explicit scope,
+// so it defaults to the subject's natural scope.
+func reviewPipeline() pipeline.Definition {
+	return pipeline.Definition{
+		ID:        "def-review",
+		ProjectID: "proj",
+		Name:      "review",
+		Config: pipeline.Pipeline{
+			Name:        "review",
+			On:          pipeline.TriggerSpec{PR: []pipeline.PREvent{pipeline.PREventUpdated}},
+			Concurrency: pipeline.ConcurrencySpec{CancelInProgress: true},
+		},
+	}
+}
+
+// releasePipeline is the spec section 11 example: a pr.merged trigger with an
+// explicit project scope, so every PR merge serializes against every other.
+func releasePipeline() pipeline.Definition {
+	return pipeline.Definition{
+		ID:        "def-release",
+		ProjectID: "proj",
+		Name:      "release",
+		Config: pipeline.Pipeline{
+			Name: "release",
+			On:   pipeline.TriggerSpec{PR: []pipeline.PREvent{pipeline.PREventMerged}},
+			Concurrency: pipeline.ConcurrencySpec{
+				Scope:            pipeline.ConcurrencyScopeProject,
+				Group:            "release",
+				CancelInProgress: false,
+			},
+		},
+	}
+}
+
+func trigger(def pipeline.Definition, subject pipeline.Subject, runID pipeline.RunID) pendingTrigger {
+	return pendingTrigger{Definition: def, Event: "pr.updated", Subject: subject, RunID: runID}
+}
+
+func admit(t *testing.T, table *ConcurrencyTable, def pipeline.Definition, subject pipeline.Subject, runID pipeline.RunID) Admission {
+	t.Helper()
+	return table.Admit(keyFor(def, subject), def.Config.Concurrency.CancelInProgress, trigger(def, subject, runID))
+}
+
+func TestKeyForDefaultsGroupToPipelineName(t *testing.T) {
+	def := reviewPipeline()
+	key := keyFor(def, prSubject(412))
+	if key.Group != "review" {
+		t.Errorf("group = %q, want the pipeline name %q", key.Group, "review")
+	}
+	if key.ScopeIdentity != "acme/app#412" {
+		t.Errorf("scope identity = %q, want %q", key.ScopeIdentity, "acme/app#412")
+	}
+}
+
+// Scope defaults by trigger family: pr.* subjects get pr scope, session.*
+// subjects get session scope (spec section 10).
+func TestKeyForScopeDefaultsByTriggerFamily(t *testing.T) {
+	def := reviewPipeline()
+	if got := keyFor(def, prSubject(412)).ScopeIdentity; got != "acme/app#412" {
+		t.Errorf("pr subject identity = %q, want %q", got, "acme/app#412")
+	}
+	if got := keyFor(def, sessionSubject("sess-7")).ScopeIdentity; got != "sess-7" {
+		t.Errorf("session subject identity = %q, want %q", got, "sess-7")
+	}
+	project := pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: "proj"}
+	if got := keyFor(def, project).ScopeIdentity; got != "proj" {
+		t.Errorf("project subject identity = %q, want %q", got, "proj")
+	}
+}
+
+// Two different PRs on the same pipeline never collide: different identities,
+// so both start now.
+func TestAdmitDifferentPRsRunConcurrently(t *testing.T) {
+	var table ConcurrencyTable
+	def := reviewPipeline()
+
+	first := admit(t, &table, def, prSubject(412), "run-1")
+	second := admit(t, &table, def, prSubject(413), "run-2")
+
+	if first.Kind != StartNow {
+		t.Errorf("PR 412 admission = %q, want %q", first.Kind, StartNow)
+	}
+	if second.Kind != StartNow {
+		t.Errorf("PR 413 admission = %q, want %q", second.Kind, StartNow)
+	}
+}
+
+// The same PR serializes: with cancel-in-progress off, the second arrival
+// queues behind the first.
+func TestAdmitSamePRSerializes(t *testing.T) {
+	var table ConcurrencyTable
+	def := reviewPipeline()
+	def.Config.Concurrency.CancelInProgress = false
+
+	if got := admit(t, &table, def, prSubject(412), "run-1"); got.Kind != StartNow {
+		t.Fatalf("first admission = %q, want %q", got.Kind, StartNow)
+	}
+	second := admit(t, &table, def, prSubject(412), "run-2")
+	if second.Kind != Queued {
+		t.Errorf("second admission = %q, want %q", second.Kind, Queued)
+	}
+	if second.Victim != "" {
+		t.Errorf("queued admission carries victim %q, want none", second.Victim)
+	}
+}
+
+// Two pipelines that declare the same group share a bucket even though their
+// names differ.
+func TestAdmitSharedGroupSerializesAcrossPipelines(t *testing.T) {
+	var table ConcurrencyTable
+	first := reviewPipeline()
+	first.Config.Concurrency.Group = "review"
+	first.Config.Concurrency.CancelInProgress = false
+	second := reviewPipeline()
+	second.Name = "deep-review"
+	second.Config.Name = "deep-review"
+	second.Config.Concurrency.Group = "review"
+	second.Config.Concurrency.CancelInProgress = false
+
+	if got := admit(t, &table, first, prSubject(412), "run-1"); got.Kind != StartNow {
+		t.Fatalf("first admission = %q, want %q", got.Kind, StartNow)
+	}
+	if got := admit(t, &table, second, prSubject(412), "run-2"); got.Kind != Queued {
+		t.Errorf("second admission = %q, want %q", got.Kind, Queued)
+	}
+}
+
+// cancel-in-progress: true names the in-flight run as the victim and hands the
+// key to the newcomer.
+func TestAdmitCancelInProgressReturnsVictim(t *testing.T) {
+	var table ConcurrencyTable
+	def := reviewPipeline()
+
+	if got := admit(t, &table, def, prSubject(412), "run-1"); got.Kind != StartNow {
+		t.Fatalf("first admission = %q, want %q", got.Kind, StartNow)
+	}
+	second := admit(t, &table, def, prSubject(412), "run-2")
+	if second.Kind != CancelThenStart {
+		t.Fatalf("second admission = %q, want %q", second.Kind, CancelThenStart)
+	}
+	if second.Victim != "run-1" {
+		t.Errorf("victim = %q, want %q", second.Victim, "run-1")
+	}
+
+	// The newcomer now holds the key, so a third arrival cancels it in turn.
+	third := admit(t, &table, def, prSubject(412), "run-3")
+	if third.Kind != CancelThenStart || third.Victim != "run-2" {
+		t.Errorf("third admission = %q victim %q, want %q victim %q", third.Kind, third.Victim, CancelThenStart, "run-2")
+	}
+}
+
+// Queue depth is 1: a third arrival evicts the queued trigger instead of
+// stacking behind it.
+func TestAdmitThirdArrivalEvictsQueued(t *testing.T) {
+	var table ConcurrencyTable
+	def := reviewPipeline()
+	def.Config.Concurrency.CancelInProgress = false
+	subject := prSubject(412)
+	key := keyFor(def, subject)
+
+	admit(t, &table, def, subject, "run-1")
+	admit(t, &table, def, subject, "run-2")
+	if got := admit(t, &table, def, subject, "run-3"); got.Kind != Queued {
+		t.Fatalf("third admission = %q, want %q", got.Kind, Queued)
+	}
+
+	next, ok := table.Release(key, "run-1")
+	if !ok {
+		t.Fatal("Release returned no queued trigger, want the newest one")
+	}
+	if next.RunID != "run-3" {
+		t.Errorf("queued run = %q, want the newest arrival %q", next.RunID, "run-3")
+	}
+}
+
+// Release hands the queued trigger back so the caller can start it, and the
+// released run stops holding the key.
+func TestReleaseStartsQueuedTrigger(t *testing.T) {
+	var table ConcurrencyTable
+	def := reviewPipeline()
+	def.Config.Concurrency.CancelInProgress = false
+	subject := prSubject(412)
+	key := keyFor(def, subject)
+
+	admit(t, &table, def, subject, "run-1")
+	admit(t, &table, def, subject, "run-2")
+
+	next, ok := table.Release(key, "run-1")
+	if !ok {
+		t.Fatal("Release returned no queued trigger, want run-2")
+	}
+	if next.RunID != "run-2" || next.Definition.ID != def.ID {
+		t.Errorf("queued trigger = %+v, want run-2 on %q", next, def.ID)
+	}
+
+	// run-2 now holds the key, and nothing is queued behind it.
+	if got := admit(t, &table, def, subject, "run-3"); got.Kind != Queued {
+		t.Errorf("admission after release = %q, want %q", got.Kind, Queued)
+	}
+	if _, ok := table.Release(key, "run-2"); !ok {
+		t.Error("Release after re-queue returned nothing, want run-3")
+	}
+	if _, ok := table.Release(key, "run-3"); ok {
+		t.Error("Release on an empty queue returned a trigger, want none")
+	}
+}
+
+// A settling run that no longer holds the key must not evict the run that
+// replaced it. This is the normal cancel-in-progress path: the victim settles
+// after its replacement already started.
+func TestReleaseByStaleRunIsIgnored(t *testing.T) {
+	var table ConcurrencyTable
+	def := reviewPipeline()
+	subject := prSubject(412)
+	key := keyFor(def, subject)
+
+	admit(t, &table, def, subject, "run-1")
+	if got := admit(t, &table, def, subject, "run-2"); got.Kind != CancelThenStart {
+		t.Fatalf("second admission = %q, want %q", got.Kind, CancelThenStart)
+	}
+
+	if _, ok := table.Release(key, "run-1"); ok {
+		t.Error("stale Release returned a trigger, want none")
+	}
+
+	// run-2 still holds the key.
+	third := admit(t, &table, def, subject, "run-3")
+	if third.Kind != CancelThenStart || third.Victim != "run-2" {
+		t.Errorf("third admission = %q victim %q, want %q victim %q", third.Kind, third.Victim, CancelThenStart, "run-2")
+	}
+}
+
+// A trigger already waiting keeps its place when a cancel-in-progress arrival
+// takes over the key: cancel-in-progress targets the in-flight run only.
+func TestAdmitCancelInProgressKeepsQueuedTrigger(t *testing.T) {
+	var table ConcurrencyTable
+	patient := reviewPipeline()
+	patient.Config.Concurrency.CancelInProgress = false
+	impatient := reviewPipeline()
+	subject := prSubject(412)
+	key := keyFor(patient, subject)
+
+	admit(t, &table, patient, subject, "run-1")
+	admit(t, &table, patient, subject, "run-2")
+	if got := admit(t, &table, impatient, subject, "run-3"); got.Kind != CancelThenStart {
+		t.Fatalf("cancelling admission = %q, want %q", got.Kind, CancelThenStart)
+	}
+
+	next, ok := table.Release(key, "run-3")
+	if !ok || next.RunID != "run-2" {
+		t.Errorf("Release = %q ok=%v, want the still-queued %q", next.RunID, ok, "run-2")
+	}
+}
+
+// The spec section 11 release pipeline: scope: project on a pr.merged trigger,
+// so two merges on different PRs serialize instead of releasing concurrently.
+func TestAdmitProjectScopeSerializesAcrossPRs(t *testing.T) {
+	var table ConcurrencyTable
+	def := releasePipeline()
+
+	if got := admit(t, &table, def, prSubject(412), "run-1"); got.Kind != StartNow {
+		t.Fatalf("first merge admission = %q, want %q", got.Kind, StartNow)
+	}
+	second := admit(t, &table, def, prSubject(998), "run-2")
+	if second.Kind != Queued {
+		t.Errorf("second merge admission = %q, want %q", second.Kind, Queued)
+	}
+	if second.Victim != "" {
+		t.Errorf("cancel-in-progress is false, but admission named victim %q", second.Victim)
+	}
+}
+
+// A subject with no identity at the requested scope is ungrouped and
+// serializes against nothing (see Subject.ScopeIdentity).
+func TestAdmitUngroupedKeyNeverSerializes(t *testing.T) {
+	var table ConcurrencyTable
+	def := reviewPipeline()
+	def.Config.Concurrency.Scope = pipeline.ConcurrencyScopePR
+	project := pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: "proj"}
+	key := keyFor(def, project)
+
+	if key.ScopeIdentity != "" {
+		t.Fatalf("scope identity = %q, want empty for a project subject at pr scope", key.ScopeIdentity)
+	}
+	for _, runID := range []pipeline.RunID{"run-1", "run-2", "run-3"} {
+		if got := admit(t, &table, def, project, runID); got.Kind != StartNow {
+			t.Errorf("admission for %q = %q, want %q", runID, got.Kind, StartNow)
+		}
+	}
+	if _, ok := table.Release(key, "run-1"); ok {
+		t.Error("Release on an ungrouped key returned a trigger, want none")
+	}
+}
+
+// The supervisor calls the table from more than one goroutine, so the whole
+// surface has to be race free. Run with -race.
+func TestConcurrentAdmitAndRelease(t *testing.T) {
+	var table ConcurrencyTable
+	def := reviewPipeline()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			subject := prSubject(400 + i%4)
+			key := keyFor(def, subject)
+			table.Admit(key, true, trigger(def, subject, pipeline.RunID("run")))
+			table.Release(key, "run")
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Pipelines v2 Task 14. Adds `backend/internal/pipeline/engine/concurrency.go`, the bookkeeping behind spec §10. Nothing else lands in the `engine` package here; Task 15 brings the actor and supervisor.

## What it does

- `keyFor(def, subject)` builds the effective key `(group or pipeline name, Subject.ScopeIdentity(scope or the subject's default scope))`. Scope resolution is Task 3's, not reimplemented.
- `ConcurrencyTable.Admit(key, cancelInProgress, trigger)` returns `StartNow`, `Queued` (depth 1, a newer trigger replaces the queued one), or `CancelThenStart{Victim}` when `cancel-in-progress` is set and a run holds the key.
- `ConcurrencyTable.Release(key, runID)` returns the queued trigger, already holding the key, so the caller starts it without admitting again.
- Mutex-guarded throughout; the zero value is ready to use.

## Two decisions the plan left open

1. **`Release` takes the settling run id.** With `cancel-in-progress`, the victim settles *after* its replacement has taken the key, so a bare `Release(key)` would have the victim's settlement evict the run that replaced it. A run that no longer holds the key now releases nothing. Task 15 passes the settled run's id at `RunSettled`.
2. **The run id is allocated before admission** and travels on `pendingTrigger`, so admit and release are each one atomic decision with no window where the key is held by nobody. An evicted queued trigger drops its id, which costs nothing.

Also noted in comments: `cancel-in-progress` targets the in-flight run only, so a trigger already waiting keeps its place (reachable when two pipelines share a group but disagree on the flag). An empty scope identity is ungrouped and serializes against nothing, per `Subject.ScopeIdentity`'s contract.

## Tests

Every case the plan lists, plus the ones above: two PRs on one pipeline run concurrently, the same PR serializes, shared group serializes across pipelines, cancel-in-progress names the victim, a third arrival evicts the queued trigger, release starts the queued trigger, scope defaults by trigger family, the §11 `scope: project` release pipeline serializes across PRs, stale release is a no-op, ungrouped keys never serialize, and a `-race` hammer over concurrent admit/release.

## Verification

`go build ./...`, `go test ./...` (2604 passed), `go test -race ./internal/pipeline/...`, `gofmt -l .` empty, `golangci-lint run ./internal/pipeline/...` clean. Four `cli` spawn tests fail locally against a live daemon (HTTP 404); they are untouched by this diff, which adds one package nothing imports yet.

Closes #296