### PR TITLE
feat(pipelines): v2 per-run reducer, lifecycle transitions

### DIFF
--- a/backend/internal/pipeline/events.go
+++ b/backend/internal/pipeline/events.go
@@ -1,0 +1,226 @@
+package pipeline
+
+import "time"
+
+// Event and Effect are the input and output of the per-run reducer. Neither is
+// ever parsed from YAML or JSON: they are constructed in-process by the engine
+// driver.
+//
+// Both are sealed interfaces (an unexported marker method), so the union of
+// concrete types is closed to this package and a type switch over it is
+// exhaustive by construction.
+//
+// Every Event carries a driver-stamped Now and the reducer never reads the
+// clock itself, which is what makes the whole transition core testable without
+// a fake clock.
+type Event interface {
+	// When reports the driver-stamped time the event happened.
+	When() time.Time
+	// isEvent seals the interface to this package.
+	isEvent()
+}
+
+// TriggerFired starts a run: a trigger resolved a subject and the driver has
+// allocated the run id and created the run folder. Def is the frozen
+// definition snapshot the run executes, so editing the definition mid-run
+// cannot change a run in flight.
+type TriggerFired struct {
+	Def     Pipeline
+	Subject Subject
+	RunID   RunID
+	RunDir  string
+	Now     time.Time
+}
+
+// When implements Event.
+func (e TriggerFired) When() time.Time { return e.Now }
+func (TriggerFired) isEvent()          {}
+
+// StageLaunched reports that the driver provisioned the stage's workspace and
+// started its executor.
+type StageLaunched struct {
+	Stage         string
+	SessionID     string
+	WorkspacePath string
+	Now           time.Time
+}
+
+// When implements Event.
+func (e StageLaunched) When() time.Time { return e.Now }
+func (StageLaunched) isEvent()          {}
+
+// StageLaunchFailed reports that the driver could not provision or start the
+// stage at all, for instance because its workspace could not be created.
+type StageLaunchFailed struct {
+	Stage  string
+	Reason string
+	Now    time.Time
+}
+
+// When implements Event.
+func (e StageLaunchFailed) When() time.Time { return e.Now }
+func (StageLaunchFailed) isEvent()          {}
+
+// AgentSignaled reports an `ao pipeline done|fail` from an agent stage.
+//
+// ArtifactOK is the driver's verification of the declared artifact: it stat'd
+// $AO_OUTPUT and found it non-empty. It is true when the stage declares no
+// produces, because then there is nothing to verify.
+type AgentSignaled struct {
+	Stage      string
+	Done       bool
+	Reason     string
+	ArtifactOK bool
+	Now        time.Time
+}
+
+// When implements Event.
+func (e AgentSignaled) When() time.Time { return e.Now }
+func (AgentSignaled) isEvent()          {}
+
+// CommandExited reports that a command stage's process exited. The exit code
+// is the whole outcome: a command stage has no artifact contract.
+type CommandExited struct {
+	Stage    string
+	ExitCode int
+	Now      time.Time
+}
+
+// When implements Event.
+func (e CommandExited) When() time.Time { return e.Now }
+func (CommandExited) isEvent()          {}
+
+// SessionIdle reports that an agent stage's session went idle without
+// signalling. This is the disambiguation the nudge exists for: "finished and
+// forgot to call the CLI" versus "stuck waiting".
+type SessionIdle struct {
+	Stage      string
+	ArtifactOK bool
+	Now        time.Time
+}
+
+// When implements Event.
+func (e SessionIdle) When() time.Time { return e.Now }
+func (SessionIdle) isEvent()          {}
+
+// SessionGone reports that an agent stage's session exited without
+// signalling. There is nothing left to nudge.
+type SessionGone struct {
+	Stage string
+	Now   time.Time
+}
+
+// When implements Event.
+func (e SessionGone) When() time.Time { return e.Now }
+func (SessionGone) isEvent()          {}
+
+// NudgeDelivered reports that the driver delivered the stage's one nudge, so
+// the stage is on its second and last attempt.
+type NudgeDelivered struct {
+	Stage string
+	Now   time.Time
+}
+
+// When implements Event.
+func (e NudgeDelivered) When() time.Time { return e.Now }
+func (NudgeDelivered) isEvent()          {}
+
+// Tick is the driver heartbeat, letting the reducer enforce deadlines without
+// a state-changing input.
+type Tick struct {
+	Now time.Time
+}
+
+// When implements Event.
+func (e Tick) When() time.Time { return e.Now }
+func (Tick) isEvent()          {}
+
+// CancelRequested tears the run down: superseded by concurrency, or killed by
+// a human.
+type CancelRequested struct {
+	Reason string
+	Now    time.Time
+}
+
+// When implements Event.
+func (e CancelRequested) When() time.Time { return e.Now }
+func (CancelRequested) isEvent()          {}
+
+// Effect is a command the reducer hands back for the engine driver to execute
+// after the reduction. The reducer decides; the driver touches the world.
+type Effect interface {
+	// isEffect seals the interface to this package.
+	isEffect()
+}
+
+// StartStage instructs the driver to provision the stage's workspace and
+// launch its executor. Workspaces are provisioned lazily, here, so a branch
+// that never runs never pays for a checkout.
+type StartStage struct {
+	Stage   string
+	Attempt int
+}
+
+func (StartStage) isEffect() {}
+
+// NudgeStage instructs the driver to send the stage's one nudge message into
+// its live session.
+type NudgeStage struct {
+	Stage     string
+	SessionID string
+	Message   string
+}
+
+func (NudgeStage) isEffect() {}
+
+// InterruptStage instructs the driver to kill a timed-out stage's process
+// while keeping its session: a timed-out agent may still be running, and the
+// scrollback is the point.
+type InterruptStage struct {
+	Stage string
+}
+
+func (InterruptStage) isEffect() {}
+
+// CancelStageExec instructs the driver to tear down a running stage as part of
+// cancelling the run.
+type CancelStageExec struct {
+	Stage string
+}
+
+func (CancelStageExec) isEffect() {}
+
+// SettleSession hands the driver an agent stage's settled outcome so it can
+// apply the stage's kill-on rule: kill the session, or keep it and mark it
+// pipeline-orphaned.
+type SettleSession struct {
+	Stage     string
+	SessionID string
+	Outcome   Outcome
+}
+
+func (SettleSession) isEffect() {}
+
+// AppendContext instructs the driver to append one pointer line to the run's
+// Context.md. Pointer lines, never content: Context.md is an index.
+type AppendContext struct {
+	Line string
+}
+
+func (AppendContext) isEffect() {}
+
+// PersistRun instructs the driver to durably write the run state the reduction
+// returned (SQLite is the store of record; run.json in the run folder is a
+// projection of the same state).
+type PersistRun struct{}
+
+func (PersistRun) isEffect() {}
+
+// RunSettled reports the run reached a terminal status, so the driver can tear
+// down the workspaces the run owns (destroyed on success, kept on failure) and
+// release its concurrency slot.
+type RunSettled struct {
+	Status RunStatus
+}
+
+func (RunSettled) isEffect() {}

--- a/backend/internal/pipeline/reducer.go
+++ b/backend/internal/pipeline/reducer.go
@@ -1,0 +1,362 @@
+package pipeline
+
+import (
+	"fmt"
+	"maps"
+	"time"
+)
+
+// Reduce applies one event to one run and returns the next run state plus the
+// effects the driver should execute. It is the whole transition core: fan-out,
+// joins, cascading skip and run settlement all live here.
+//
+// The reducer is per-run (one run is an independent snapshot) and pure: it
+// never mutates its input, never reads the clock, and never touches the world.
+// Purity is load-bearing, because the engine keeps the pre-reduce state around
+// until the returned effects have been walked.
+//
+// Effects come back in the order the driver should apply them: Context.md
+// pointer lines first (the next stage's prompt reads them), then PersistRun so
+// the state is durable before anything is launched, then the stage commands,
+// then RunSettled last.
+func Reduce(run RunState, ev Event) (RunState, []Effect) {
+	if fired, ok := ev.(TriggerFired); ok {
+		return reduceTriggerFired(run, fired)
+	}
+	// A settled run is done: late events from an executor that was already
+	// torn down change nothing.
+	if run.Status.isSettled() {
+		return run, nil
+	}
+
+	switch e := ev.(type) {
+	case StageLaunched:
+		return reduceStageLaunched(run, e)
+	case AgentSignaled:
+		if !e.Done || !e.ArtifactOK {
+			// An explicit fail, and a done whose artifact is missing, are
+			// failure routing and the nudge: the next task owns both.
+			return run, nil
+		}
+		// Nothing declared means nothing verified, and the signal was the whole
+		// contract.
+		outcome := OutcomeSucceededUnverified
+		if s := run.Def.StageByID(e.Stage); s != nil && s.Produces != "" {
+			outcome = OutcomeSucceeded
+		}
+		return settleSuccess(run, e.Stage, outcome, e.Now)
+	case CommandExited:
+		if e.ExitCode != 0 {
+			return run, nil // failure settlement: next task
+		}
+		return settleSuccess(run, e.Stage, OutcomeSucceeded, e.Now)
+	default:
+		// StageLaunchFailed, SessionIdle, SessionGone, NudgeDelivered, Tick and
+		// CancelRequested are failure routing, the nudge, deadlines and
+		// cancellation, all owned by the second half of the reducer.
+		return run, nil
+	}
+}
+
+// reduceTriggerFired seeds the run: every reachable stage lands `pending` so
+// the board renders the whole shape immediately, and the entry stage starts.
+func reduceTriggerFired(run RunState, e TriggerFired) (RunState, []Effect) {
+	next := run.clone()
+	next.RunID = e.RunID
+	next.RunDir = e.RunDir
+	next.Subject = e.Subject
+	next.Def = e.Def
+	next.PipelineName = e.Def.Name
+	if e.Subject.ProjectID != "" {
+		next.ProjectID = e.Subject.ProjectID
+	}
+	if next.CreatedAt.IsZero() {
+		next.CreatedAt = e.Now
+	}
+	next.UpdatedAt = e.Now
+	next.Stages = map[string]*StageState{}
+
+	plan, err := ComputePlan(&next.Def, e.Subject)
+	if err != nil {
+		return failAtPlanTime(next, err, e.Now)
+	}
+
+	for _, id := range plan.Reachable {
+		next.Stages[id] = &StageState{
+			ID:      id,
+			Outcome: OutcomePending,
+			// A failure-entered stage keeps the symbolic "inherit" here: the
+			// tree it gets is whichever stage routes into it, known only when
+			// that happens.
+			WorkspaceKind: plan.Workspaces[id],
+		}
+	}
+
+	next.Status = RunRunning
+	entry := next.Def.EntryStage()
+	starts := []Effect{startStage(&next, entry.ID, EntryTrigger, "", e.Now)}
+
+	return next, append([]Effect{PersistRun{}}, advance(&next, starts, e.Now)...)
+}
+
+// failAtPlanTime settles the run before any stage runs, which is the point of
+// planning at start: the one impossible workspace combination fails with the
+// reason stated rather than half way through (spec section 5.3).
+//
+// The reason lands on the entry stage because that is the stage that never got
+// to run, and it is what run detail renders.
+func failAtPlanTime(next RunState, planErr error, now time.Time) (RunState, []Effect) {
+	if entry := next.Def.EntryStage(); entry != nil {
+		next.Stages[entry.ID] = &StageState{
+			ID:         entry.ID,
+			Outcome:    OutcomeFailed,
+			EnteredVia: EntryTrigger,
+			SettledAt:  now,
+			Reason:     planErr.Error(),
+		}
+	}
+	next.Status = RunFailed
+	next.SettledAt = now
+	return next, []Effect{PersistRun{}, RunSettled{Status: RunFailed}}
+}
+
+// reduceStageLaunched moves a stage from pending to running and stamps its
+// deadline from the moment it actually started, not from when the run did.
+func reduceStageLaunched(run RunState, e StageLaunched) (RunState, []Effect) {
+	if st := run.Stages[e.Stage]; st == nil || st.Outcome != OutcomePending {
+		return run, nil
+	}
+	next := run.clone()
+	st := next.Stages[e.Stage]
+	st.Outcome = OutcomeRunning
+	st.StartedAt = e.Now
+	st.SessionID = e.SessionID
+	st.WorkspacePath = e.WorkspacePath
+	if st.Attempt == 0 {
+		st.Attempt = 1
+	}
+	if s := next.Def.StageByID(e.Stage); s != nil {
+		st.DeadlineAt = e.Now.Add(s.EffectiveDeadline(next.Def.Defaults))
+	}
+	next.Status = RunRunning
+	next.UpdatedAt = e.Now
+	return next, []Effect{PersistRun{}}
+}
+
+// settleSuccess settles a running stage successfully and lets the run advance:
+// on_success fans out, joins that are now complete start, and whatever can no
+// longer be entered is skipped.
+func settleSuccess(run RunState, stageID string, outcome Outcome, now time.Time) (RunState, []Effect) {
+	if st := run.Stages[stageID]; st == nil || st.Outcome != OutcomeRunning {
+		return run, nil
+	}
+	next := run.clone()
+	st := next.Stages[stageID]
+	st.Outcome = outcome
+	st.SettledAt = now
+	next.UpdatedAt = now
+
+	effects := make([]Effect, 0, 4)
+	// Context.md gets a pointer line only for a verified artifact: an
+	// unverified success has nothing to point at.
+	if def := next.Def.StageByID(stageID); outcome == OutcomeSucceeded && def != nil && def.Produces != "" {
+		effects = append(effects, AppendContext{
+			Line: fmt.Sprintf("stage `%s` finished, its output is at agent-outputs/%s", stageID, def.Produces),
+		})
+	}
+	effects = append(effects, PersistRun{})
+
+	return next, append(effects, advance(&next, startSuccessTargets(&next, stageID, now), now)...)
+}
+
+// advance runs the two passes that follow any settlement, then settles the run
+// if nothing is left in flight. It takes the stage commands the caller already
+// decided on, so they land in effect order ahead of RunSettled.
+//
+// run is already a copy-on-write clone by the time advance sees it, so it is
+// written through in place.
+func advance(run *RunState, effects []Effect, now time.Time) []Effect {
+	skipUnreachable(run, now)
+	if !allSettled(run) {
+		return effects
+	}
+	run.Status = settledRunStatus(run)
+	run.SettledAt = now
+	return append(effects, RunSettled{Status: run.Status})
+}
+
+// startSuccessTargets takes the settled stage's on_success edges. A list fans
+// out and the targets start concurrently; a target that is a join starts only
+// once every stage in its needs has succeeded.
+func startSuccessTargets(run *RunState, from string, now time.Time) []Effect {
+	src := run.Def.StageByID(from)
+	if src == nil {
+		return nil
+	}
+	effects := make([]Effect, 0, len(src.OnSuccess))
+	for _, target := range src.OnSuccess {
+		def := run.Def.StageByID(target)
+		if def == nil || !canEnter(run, target) || !needsMet(run, def) {
+			continue
+		}
+		// A join has no sole predecessor, so AO_PREV_* stays unset there
+		// (spec section 12.2). Same ambiguity that rejects `inherit` at a join.
+		prev := from
+		if len(def.Needs) > 1 {
+			prev = ""
+		}
+		effects = append(effects, startStage(run, target, EntrySuccess, prev, now))
+	}
+	return effects
+}
+
+// canEnter reports whether a stage can still be entered: it must be seeded,
+// pending, and not already committed to a launch. The attempt check is what
+// makes a second arrival at the same stage a no-op.
+func canEnter(run *RunState, id string) bool {
+	st := run.Stages[id]
+	return st != nil && st.Outcome == OutcomePending && st.Attempt == 0
+}
+
+// needsMet reports whether every stage in the target's needs has succeeded. A
+// need that settled any other way never becomes met, and the join is skipped
+// by skipUnreachable rather than started here.
+func needsMet(run *RunState, def *Stage) bool {
+	for _, need := range def.Needs {
+		st := run.Stages[need]
+		if st == nil || !st.Outcome.IsSuccess() {
+			return false
+		}
+	}
+	return true
+}
+
+// startStage commits a stage to a launch and returns the effect that performs
+// it. The stage stays pending until the driver reports it launched; Attempt is
+// what records that a launch is already in flight.
+func startStage(run *RunState, id string, via EntryEdge, prev string, now time.Time) Effect {
+	st := run.Stages[id]
+	st.Attempt = 1
+	st.EnteredVia = via
+	st.PrevStage = prev
+	run.UpdatedAt = now
+	return StartStage{Stage: id, Attempt: st.Attempt}
+}
+
+// skipUnreachable settles every pending stage that nothing can route into any
+// more. Without it a run never settles: plan-at-start seeds the failure path
+// too, and a run where everything succeeded must still close those cards.
+//
+// A stage is skipped, not failed. When B does not run because A died, B did
+// not fail, and conflating them makes the board unreadable at exactly the
+// moment someone is debugging.
+func skipUnreachable(run *RunState, now time.Time) {
+	dead := map[string]bool{}
+	for {
+		live := enterable(run, dead)
+		grew := false
+		for id, st := range run.Stages {
+			if st.Outcome != OutcomePending || st.Attempt > 0 || live[id] || dead[id] {
+				continue
+			}
+			// A join whose need did not succeed dies here even while another
+			// need is still running, so the board stops promising a stage that
+			// cannot happen. Its own targets die on the next pass.
+			dead[id] = true
+			grew = true
+		}
+		if !grew {
+			break
+		}
+	}
+	for id := range dead {
+		st := run.Stages[id]
+		st.Outcome = OutcomeSkipped
+		st.SettledAt = now
+		run.UpdatedAt = now
+	}
+}
+
+// enterable is the set of stages the run can still reach: everything in flight
+// (running, or committed to a launch), plus the forward closure of that over
+// success and failure edges. Stages already known dead are not traversed, so
+// the skip cascades down the branch behind them.
+//
+// A settled stage is never included: it already routed, so it cannot route
+// again.
+func enterable(run *RunState, dead map[string]bool) map[string]bool {
+	live := make(map[string]bool, len(run.Stages))
+	queue := make([]string, 0, len(run.Stages))
+	for id, st := range run.Stages {
+		if dead[id] {
+			continue
+		}
+		if st.Outcome == OutcomeRunning || (st.Outcome == OutcomePending && st.Attempt > 0) {
+			live[id] = true
+			queue = append(queue, id)
+		}
+	}
+
+	edges := run.Def.routingEdges()
+	for len(queue) > 0 {
+		id := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+		for _, target := range edges[id] {
+			st := run.Stages[target]
+			if st == nil || dead[target] || live[target] || st.Outcome.IsSettled() {
+				continue
+			}
+			live[target] = true
+			queue = append(queue, target)
+		}
+	}
+	return live
+}
+
+// allSettled reports whether no stage is pending or running, which is exactly
+// when the run is over.
+func allSettled(run *RunState) bool {
+	for _, st := range run.Stages {
+		if !st.Outcome.IsSettled() {
+			return false
+		}
+	}
+	return true
+}
+
+// settledRunStatus rolls the stage outcomes up into the run's board column:
+// cancelled if the run was cancelled, else failed if any stage settled in
+// {failed, no_output, no_signal, timed_out}, else succeeded. A
+// succeeded_unverified stage still yields a succeeded run, and so does a
+// skipped one.
+func settledRunStatus(run *RunState) RunStatus {
+	if run.Status == RunCancelled || run.CancelReason != "" {
+		return RunCancelled
+	}
+	for _, st := range run.Stages {
+		if st.Outcome.RoutesToFailure() {
+			return RunFailed
+		}
+	}
+	return RunSucceeded
+}
+
+// isSettled reports whether the run reached a terminal status.
+func (s RunStatus) isSettled() bool {
+	return s == RunSucceeded || s == RunFailed || s == RunCancelled
+}
+
+// clone returns a copy the reducer can write through without touching the
+// caller's state. Def and Subject are frozen for the life of the run and only
+// ever read, so they are shared rather than deep-copied; the stage map is
+// rewritten entry by entry because that is the part every transition touches.
+func (r RunState) clone() RunState {
+	out := r
+	out.Stages = make(map[string]*StageState, len(r.Stages))
+	for id, st := range r.Stages {
+		cp := *st
+		out.Stages[id] = &cp
+	}
+	out.Nudged = maps.Clone(r.Nudged)
+	return out
+}

--- a/backend/internal/pipeline/reducer.go
+++ b/backend/internal/pipeline/reducer.go
@@ -96,7 +96,10 @@ func reduceTriggerFired(run RunState, e TriggerFired) (RunState, []Effect) {
 	entry := next.Def.EntryStage()
 	starts := []Effect{startStage(&next, entry.ID, EntryTrigger, "", e.Now)}
 
-	return next, append([]Effect{PersistRun{}}, advance(&next, starts, e.Now)...)
+	// advance writes through next, so it has to run before next is copied into
+	// the result.
+	effects := append([]Effect{PersistRun{}}, advance(&next, starts, e.Now)...)
+	return next, effects
 }
 
 // failAtPlanTime settles the run before any stage runs, which is the point of
@@ -166,7 +169,11 @@ func settleSuccess(run RunState, stageID string, outcome Outcome, now time.Time)
 	}
 	effects = append(effects, PersistRun{})
 
-	return next, append(effects, advance(&next, startSuccessTargets(&next, stageID, now), now)...)
+	// advance writes through next, so it has to run before next is copied into
+	// the result.
+	starts := startSuccessTargets(&next, stageID, now)
+	effects = append(effects, advance(&next, starts, now)...)
+	return next, effects
 }
 
 // advance runs the two passes that follow any settlement, then settles the run

--- a/backend/internal/pipeline/reducer_test.go
+++ b/backend/internal/pipeline/reducer_test.go
@@ -1,0 +1,470 @@
+package pipeline
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// reducerT0 anchors every reducer test on a fixed clock. The reducer never
+// reads the clock itself: every event carries a driver-stamped Now, which is
+// what makes the whole thing testable without a fake clock.
+var reducerT0 = time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+
+func at(minutes int) time.Time { return reducerT0.Add(time.Duration(minutes) * time.Minute) }
+
+func sessionSubject() Subject {
+	return Subject{Kind: SubjectSession, ProjectID: "proj", SessionID: "sess-1"}
+}
+
+// fire builds a run from YAML and reduces the TriggerFired that starts it.
+func fire(t *testing.T, src string) (RunState, []Effect) {
+	t.Helper()
+	def := mustParse(t, []byte(src))
+	return Reduce(RunState{PipelineID: "pl-1"}, TriggerFired{
+		Def:     *def,
+		Subject: sessionSubject(),
+		RunID:   "run-1",
+		RunDir:  "/runs/run-1",
+		Now:     reducerT0,
+	})
+}
+
+// launch runs a stage through the pending-to-running transition.
+func launch(run RunState, stage string, now time.Time) RunState {
+	next, _ := Reduce(run, StageLaunched{Stage: stage, SessionID: "sess-" + stage, WorkspacePath: "/w/" + stage, Now: now})
+	return next
+}
+
+// exit settles a command stage on its exit code.
+func exit(run RunState, stage string, code int, now time.Time) (RunState, []Effect) {
+	return Reduce(run, CommandExited{Stage: stage, ExitCode: code, Now: now})
+}
+
+func startedStages(effects []Effect) []string {
+	out := make([]string, 0, len(effects))
+	for _, e := range effects {
+		if s, ok := e.(StartStage); ok {
+			out = append(out, s.Stage)
+		}
+	}
+	return out
+}
+
+func contextLines(effects []Effect) []string {
+	out := make([]string, 0, len(effects))
+	for _, e := range effects {
+		if c, ok := e.(AppendContext); ok {
+			out = append(out, c.Line)
+		}
+	}
+	return out
+}
+
+func countEffect[T Effect](effects []Effect) int {
+	n := 0
+	for _, e := range effects {
+		if _, ok := e.(T); ok {
+			n++
+		}
+	}
+	return n
+}
+
+func settledStatus(t *testing.T, effects []Effect) RunStatus {
+	t.Helper()
+	for _, e := range effects {
+		if s, ok := e.(RunSettled); ok {
+			return s.Status
+		}
+	}
+	t.Fatalf("no RunSettled effect in %v", effects)
+	return ""
+}
+
+func outcomeOf(t *testing.T, run RunState, stage string) Outcome {
+	t.Helper()
+	st, ok := run.Stages[stage]
+	if !ok {
+		t.Fatalf("stage %q not in run (have %v)", stage, stageIDsOf(run))
+	}
+	return st.Outcome
+}
+
+func stageIDsOf(run RunState) []string {
+	out := make([]string, 0, len(run.Stages))
+	for id := range run.Stages {
+		out = append(out, id)
+	}
+	return out
+}
+
+const linearYAML = `
+name: linear
+stages:
+  - id: a
+    executor: command
+    run: echo a
+    on_success: b
+  - id: b
+    executor: command
+    run: echo b
+`
+
+const fanOutYAML = `
+name: fan-out
+stages:
+  - id: a
+    executor: command
+    run: echo a
+    on_success: [b, c, d]
+  - id: b
+    executor: command
+    run: echo b
+  - id: c
+    executor: command
+    run: echo c
+  - id: d
+    executor: command
+    run: echo d
+`
+
+const joinYAML = `
+name: join
+stages:
+  - id: a
+    executor: command
+    run: echo a
+    on_success: [b, c]
+  - id: b
+    executor: command
+    run: echo b
+    on_success: j
+  - id: c
+    executor: command
+    run: echo c
+    on_success: j
+  - id: j
+    executor: command
+    run: echo j
+    needs: [b, c]
+    on_success: k
+  - id: k
+    executor: command
+    run: echo k
+`
+
+func TestReduce_TriggerSeedsReachableStagesAndStartsEntry(t *testing.T) {
+	run, effects := fire(t, linearYAML)
+
+	if run.RunID != "run-1" || run.RunDir != "/runs/run-1" {
+		t.Errorf("run identity = %q %q, want run-1 /runs/run-1", run.RunID, run.RunDir)
+	}
+	if run.PipelineName != "linear" {
+		t.Errorf("pipeline name = %q, want linear", run.PipelineName)
+	}
+	if run.ProjectID != "proj" {
+		t.Errorf("project = %q, want proj (from the subject)", run.ProjectID)
+	}
+	if run.Status != RunRunning {
+		t.Errorf("status = %q, want running", run.Status)
+	}
+	if len(run.Stages) != 2 {
+		t.Fatalf("seeded %d stages, want 2", len(run.Stages))
+	}
+	if got := outcomeOf(t, run, "b"); got != OutcomePending {
+		t.Errorf("b = %q, want pending: every reachable stage is seeded so the board renders it", got)
+	}
+	if got := run.Stages["a"].EnteredVia; got != EntryTrigger {
+		t.Errorf("a entered via %q, want trigger", got)
+	}
+	if got := run.Stages["a"].Attempt; got != 1 {
+		t.Errorf("a attempt = %d, want 1", got)
+	}
+	if got := run.Stages["a"].WorkspaceKind; got != WorkspaceSession {
+		t.Errorf("a workspace = %q, want session (auto under a session subject)", got)
+	}
+	if got := startedStages(effects); !reflect.DeepEqual(got, []string{"a"}) {
+		t.Errorf("started %v, want [a] only", got)
+	}
+	if countEffect[PersistRun](effects) != 1 {
+		t.Errorf("effects = %v, want exactly one PersistRun", effects)
+	}
+}
+
+func TestReduce_LinearHappyPath(t *testing.T) {
+	run, _ := fire(t, linearYAML)
+
+	run = launch(run, "a", at(1))
+	if got := outcomeOf(t, run, "a"); got != OutcomeRunning {
+		t.Fatalf("a = %q, want running", got)
+	}
+	if got, want := run.Stages["a"].DeadlineAt, at(1).Add(DefaultStageDeadline); !got.Equal(want) {
+		t.Errorf("a deadline = %v, want %v", got, want)
+	}
+
+	run, effects := exit(run, "a", 0, at(2))
+	if got := outcomeOf(t, run, "a"); got != OutcomeSucceeded {
+		t.Errorf("a = %q, want succeeded", got)
+	}
+	if got := startedStages(effects); !reflect.DeepEqual(got, []string{"b"}) {
+		t.Fatalf("started %v, want [b]", got)
+	}
+	if got := run.Stages["b"].EnteredVia; got != EntrySuccess {
+		t.Errorf("b entered via %q, want success", got)
+	}
+	if got := run.Stages["b"].PrevStage; got != "a" {
+		t.Errorf("b prev = %q, want a", got)
+	}
+	if countEffect[RunSettled](effects) != 0 {
+		t.Errorf("run settled while b was still to run: %v", effects)
+	}
+
+	run = launch(run, "b", at(3))
+	run, effects = exit(run, "b", 0, at(4))
+	if got := outcomeOf(t, run, "b"); got != OutcomeSucceeded {
+		t.Errorf("b = %q, want succeeded", got)
+	}
+	if got := settledStatus(t, effects); got != RunSucceeded {
+		t.Errorf("run settled %q, want succeeded", got)
+	}
+	if run.Status != RunSucceeded || !run.SettledAt.Equal(at(4)) {
+		t.Errorf("run = %q settled %v, want succeeded at %v", run.Status, run.SettledAt, at(4))
+	}
+	if countEffect[StartStage](effects) != 0 {
+		t.Errorf("absent on_success ends the branch, got %v", effects)
+	}
+}
+
+func TestReduce_FanOutStartsEveryTargetInOneReduction(t *testing.T) {
+	run, _ := fire(t, fanOutYAML)
+	run = launch(run, "a", at(1))
+
+	_, effects := exit(run, "a", 0, at(2))
+
+	if got := startedStages(effects); !reflect.DeepEqual(got, []string{"b", "c", "d"}) {
+		t.Errorf("started %v, want [b c d] in declaration order from one reduction", got)
+	}
+}
+
+func TestReduce_JoinWaitsForEveryNeed(t *testing.T) {
+	run, _ := fire(t, joinYAML)
+	run = launch(run, "a", at(1))
+	run, _ = exit(run, "a", 0, at(2))
+	run = launch(run, "b", at(3))
+	run = launch(run, "c", at(3))
+
+	run, effects := exit(run, "b", 0, at(4))
+	if got := startedStages(effects); len(got) != 0 {
+		t.Fatalf("started %v on the first need, want nothing until every need succeeds", got)
+	}
+	if got := outcomeOf(t, run, "j"); got != OutcomePending {
+		t.Errorf("j = %q, want pending", got)
+	}
+
+	run, effects = exit(run, "c", 0, at(5))
+	if got := startedStages(effects); !reflect.DeepEqual(got, []string{"j"}) {
+		t.Fatalf("started %v on the last need, want [j] exactly once", got)
+	}
+	if got := run.Stages["j"].PrevStage; got != "" {
+		t.Errorf("j prev = %q, want empty: a join has no sole predecessor", got)
+	}
+}
+
+func TestReduce_JoinCascadeSkipsWhenANeedDoesNotSucceed(t *testing.T) {
+	run, _ := fire(t, joinYAML)
+	run = launch(run, "a", at(1))
+	run, _ = exit(run, "a", 0, at(2))
+	run = launch(run, "b", at(3))
+	run = launch(run, "c", at(3))
+
+	// c settles failed with nothing routing anywhere (this pipeline declares no
+	// on_failure and no defaults.on_failure). Failure settlement itself is the
+	// next task's; what is under test here is the cascade it leaves behind.
+	run.Stages["c"].Outcome = OutcomeFailed
+	run.Stages["c"].SettledAt = at(4)
+
+	run, effects := exit(run, "b", 0, at(5))
+
+	if got := outcomeOf(t, run, "j"); got != OutcomeSkipped {
+		t.Errorf("j = %q, want skipped: a join whose need did not succeed is skipped, not failed", got)
+	}
+	if got := outcomeOf(t, run, "k"); got != OutcomeSkipped {
+		t.Errorf("k = %q, want skipped: the skip cascades", got)
+	}
+	if got := settledStatus(t, effects); got != RunFailed {
+		t.Errorf("run settled %q, want failed: a stage settled failed", got)
+	}
+}
+
+func TestReduce_UnreachedFailurePathIsSkippedSoTheRunSettles(t *testing.T) {
+	const src = `
+name: with-failure-route
+defaults:
+  on_failure: notify
+stages:
+  - id: a
+    executor: command
+    run: echo a
+  - id: notify
+    executor: command
+    run: echo notify
+`
+	run, _ := fire(t, src)
+	if got := outcomeOf(t, run, "notify"); got != OutcomePending {
+		t.Fatalf("notify = %q, want pending while a could still fail into it", got)
+	}
+
+	run = launch(run, "a", at(1))
+	run, effects := exit(run, "a", 0, at(2))
+
+	if got := outcomeOf(t, run, "notify"); got != OutcomeSkipped {
+		t.Errorf("notify = %q, want skipped once nothing can route into it", got)
+	}
+	if got := settledStatus(t, effects); got != RunSucceeded {
+		t.Errorf("run settled %q, want succeeded: skipped is not failed", got)
+	}
+}
+
+func TestReduce_AgentSucceedsUnverifiedWithoutProduces(t *testing.T) {
+	const src = `
+name: unverified
+stages:
+  - id: solo
+    executor: agent
+    agent: claude-code
+    prompt: do the thing
+`
+	run, _ := fire(t, src)
+	run = launch(run, "solo", at(1))
+
+	run, effects := Reduce(run, AgentSignaled{Stage: "solo", Done: true, ArtifactOK: true, Now: at(2)})
+
+	if got := outcomeOf(t, run, "solo"); got != OutcomeSucceededUnverified {
+		t.Errorf("solo = %q, want succeeded_unverified: nothing was declared, so nothing was verified", got)
+	}
+	if got := contextLines(effects); len(got) != 0 {
+		t.Errorf("appended %v to Context.md, want nothing: there is no artifact to point at", got)
+	}
+	if got := settledStatus(t, effects); got != RunSucceeded {
+		t.Errorf("run settled %q, want succeeded", got)
+	}
+}
+
+func TestReduce_AgentSucceedsAndPointsContextAtItsArtifact(t *testing.T) {
+	const src = `
+name: verified
+stages:
+  - id: review
+    executor: agent
+    agent: claude-code
+    produces: review.md
+    prompt: review it
+`
+	run, _ := fire(t, src)
+	run = launch(run, "review", at(1))
+
+	run, effects := Reduce(run, AgentSignaled{Stage: "review", Done: true, ArtifactOK: true, Now: at(2)})
+
+	if got := outcomeOf(t, run, "review"); got != OutcomeSucceeded {
+		t.Errorf("review = %q, want succeeded", got)
+	}
+	want := "stage `review` finished, its output is at agent-outputs/review.md"
+	if got := contextLines(effects); len(got) != 1 || got[0] != want {
+		t.Errorf("context lines = %v, want [%q]", got, want)
+	}
+}
+
+func TestReduce_CommandExitZeroSucceedsWithoutAContextLine(t *testing.T) {
+	run, _ := fire(t, linearYAML)
+	run = launch(run, "a", at(1))
+
+	_, effects := exit(run, "a", 0, at(2))
+
+	if got := contextLines(effects); len(got) != 0 {
+		t.Errorf("appended %v, want nothing: a command stage declares no artifact", got)
+	}
+}
+
+func TestReduceDoesNotMutateInput(t *testing.T) {
+	// Two independently allocated fixtures of the same run: one to reduce, one
+	// to compare against. Purity is load-bearing, because the engine keeps the
+	// pre-reduce state around until the effects are walked.
+	run, _ := fire(t, joinYAML)
+	before, _ := fire(t, joinYAML)
+	run = launch(run, "a", at(1))
+	before = launch(before, "a", at(1))
+
+	if !reflect.DeepEqual(run, before) {
+		t.Fatalf("fixtures diverged before the call under test")
+	}
+
+	Reduce(run, CommandExited{Stage: "a", ExitCode: 0, Now: at(2)})
+
+	if !reflect.DeepEqual(run, before) {
+		t.Errorf("Reduce mutated its input:\n got %+v\nwant %+v", run, before)
+	}
+}
+
+func TestReduce_IgnoresEventsForAStageThatIsNotRunning(t *testing.T) {
+	run, _ := fire(t, linearYAML)
+
+	next, effects := exit(run, "b", 0, at(2))
+
+	if len(effects) != 0 {
+		t.Errorf("effects = %v, want none: b never started", effects)
+	}
+	if !reflect.DeepEqual(next, run) {
+		t.Errorf("state changed on an event for a stage that never started")
+	}
+}
+
+func TestReduce_IgnoresEventsAfterTheRunSettles(t *testing.T) {
+	run, _ := fire(t, linearYAML)
+	run = launch(run, "a", at(1))
+	run, _ = exit(run, "a", 0, at(2))
+	run = launch(run, "b", at(3))
+	run, _ = exit(run, "b", 0, at(4))
+
+	next, effects := Reduce(run, CommandExited{Stage: "b", ExitCode: 1, Now: at(5)})
+
+	if len(effects) != 0 {
+		t.Errorf("effects = %v, want none after the run settled", effects)
+	}
+	if !reflect.DeepEqual(next, run) {
+		t.Errorf("state changed after the run settled")
+	}
+}
+
+func TestReduce_PlanFailureSettlesTheRunWithTheReasonStated(t *testing.T) {
+	const src = `
+name: needs-a-session
+on:
+  pr: [created]
+stages:
+  - id: review
+    executor: agent
+    agent: claude-code
+    prompt: review it
+    workspace: session
+`
+	def := mustParse(t, []byte(src))
+	run, effects := Reduce(RunState{PipelineID: "pl-1"}, TriggerFired{
+		Def:     *def,
+		Subject: prSubject(412),
+		RunID:   "run-1",
+		RunDir:  "/runs/run-1",
+		Now:     reducerT0,
+	})
+
+	if got := settledStatus(t, effects); got != RunFailed {
+		t.Fatalf("run settled %q, want failed", got)
+	}
+	if got := outcomeOf(t, run, "review"); got != OutcomeFailed {
+		t.Errorf("review = %q, want failed", got)
+	}
+	want := "stage 'review' requires workspace 'session'; PR #412 has no local session"
+	if got := run.Stages["review"].Reason; got != want {
+		t.Errorf("reason = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Pipelines v2 Task 4: the per-run reducer's lifecycle half. `Reduce(RunState, Event) (RunState, []Effect)` plus the sealed Event/Effect unions it runs on.

Closes #294

## What lands

- `events.go`: the full v2 Event and Effect unions, sealed with unexported marker methods. Every event carries a driver-stamped `Now`, so the reducer never reads the clock. The events this task does not act on yet (`StageLaunchFailed`, `SessionIdle`, `SessionGone`, `NudgeDelivered`, `Tick`, `CancelRequested`) are defined here because they are the contract Task 5 and the engine build on.
- `reducer.go`:
  - `TriggerFired` computes the plan, seeds every reachable stage `pending` (so the board renders the whole shape immediately), and starts the entry stage. A plan-time workspace failure settles the run `failed` with the reason stated, before any stage runs.
  - `StageLaunched` moves pending to running and stamps `DeadlineAt` from the effective deadline.
  - Success settlement: `AgentSignaled{Done, ArtifactOK}` settles `succeeded` when `produces:` is declared and `succeeded_unverified` when it is not; `CommandExited{0}` settles `succeeded`.
  - `on_success` fan-out: a list starts every target in one reduction. `needs` joins start only once every need has succeeded, and a join carries no `PrevStage` because it has no sole predecessor.
  - Cascading skip: any pending stage nothing can route into any more settles `skipped`, not `failed`. This is what closes the unreached failure path so a fully successful run can settle at all.
  - Run settlement per decision D11, `AppendContext` on a verified artifact, `PersistRun` on every state change.

Failure routing, the nudge, deadlines and cancellation are deliberately out of scope; they are Task 5 against this same `Reduce`.

## Notes

- Purity is load-bearing (the engine keeps the pre-reduce state until the effects are walked), so every map and stage is copy-on-write and `TestReduceDoesNotMutateInput` guards it with `reflect.DeepEqual` against an independently built fixture.
- The `Context.md` pointer line follows spec section 12.1 verbatim, backticks included: ``stage `review` finished, its output is at agent-outputs/review.md``.
- Effect order is deliberate: context lines, then `PersistRun` (state durable before anything launches), then the stage commands, then `RunSettled`.
- `gocritic` caught a genuine hazard in the first pass: `return next, append(..., advance(&next, ...)...)` mutates `next` through a pointer while it is also the returned value, and Go does not order those. The effects are now built into a variable before the return.

## Tests

`reducer_test.go`, all new: linear two-stage happy path; fan-out of 3 in one reduction; join waits for every need then starts once; join and its downstream cascade-skip when a need did not succeed; unreached failure path skipped so the run settles `succeeded`; `succeeded_unverified` with no `produces`; the context pointer line; late and out-of-order events ignored; plan-time failure; the no-mutate test.

## Verification

- `go build ./...`, `gofmt -l .` clean, `go test ./internal/pipeline/` green (116 tests).
- `golangci-lint run ./...` clean.
- Full `go test ./...`: 4 pre-existing failures in `internal/cli` (`TestSpawn*`, HTTP 404 against the test stub), confirmed identical on `origin/pipelines` at the same line numbers and untouched by this change.