### PR TITLE
feat(pipelines): v2 sqlite schema, store, hydration, signals, credentials

### DIFF
--- a/backend/internal/pipeline/signal.go
+++ b/backend/internal/pipeline/signal.go
@@ -1,0 +1,29 @@
+package pipeline
+
+import "time"
+
+// SignalKind is how an agent settled its own stage: `ao pipeline done` or
+// `ao pipeline fail --reason "..."` (spec section 6.3). The failure channel is
+// its own kind rather than a flag, because an agent that concludes the task is
+// impossible must route to the failure edge instead of hanging until deadline.
+type SignalKind string
+
+// Every signal kind.
+const (
+	SignalDone SignalKind = "done"
+	SignalFail SignalKind = "fail"
+)
+
+// IsKnown reports whether k is a defined signal kind.
+func (k SignalKind) IsKnown() bool { return k == SignalDone || k == SignalFail }
+
+// StageSignal is one settlement signal, as persisted. Signals are appended,
+// never updated: reads take the latest row for a (run, stage), so a second
+// signal after a nudge supersedes the first without losing the history.
+type StageSignal struct {
+	RunID     RunID      `json:"runId"`
+	StageID   string     `json:"stageId"`
+	Kind      SignalKind `json:"kind"`
+	Reason    string     `json:"reason,omitempty"`
+	CreatedAt time.Time  `json:"createdAt"`
+}

--- a/backend/internal/pipeline/state.go
+++ b/backend/internal/pipeline/state.go
@@ -49,6 +49,11 @@ type StageState struct {
 
 	// Reason carries the fail reason, cancel reason, or plan-failure reason.
 	Reason string `json:"reason,omitempty"`
+	// OutputTail is the capped tail of the stage's captured stdout+stderr,
+	// kept so run detail can show why a command failed without fetching the
+	// full log from the run folder. The executor caps it; the store persists
+	// whatever it is handed.
+	OutputTail string `json:"outputTail,omitempty"`
 }
 
 // RunState is one run, in full. SQLite stays the store of record; run.json in

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -128,18 +128,12 @@ type PRReviewThread struct {
 	UpdatedAt    time.Time
 }
 
-type PipelineArtifact struct {
-	ID            string
-	PipelineRunID string
-	ProjectID     domain.ProjectID
-	StageRunID    string
-	StageName     string
-	Kind          string
-	Fingerprint   string
-	Status        string
-	SentToAgentAt sql.NullTime
-	Payload       string
-	CreatedAt     time.Time
+type PipelineCredential struct {
+	ProjectID domain.ProjectID
+	Name      string
+	EnvJson   string
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 type PipelineDefinition struct {
@@ -153,37 +147,56 @@ type PipelineDefinition struct {
 }
 
 type PipelineRun struct {
-	ID                string
-	ProjectID         domain.ProjectID
-	PipelineID        string
-	PipelineName      string
-	SessionID         string
-	HeadSha           string
-	LoopState         string
-	TerminationReason string
-	LoopRounds        int64
-	ConfigSnapshot    string
-	Fingerprints      string
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
-	ContextJson       string
-	BlocksMerge       int64
+	ID             string
+	ProjectID      domain.ProjectID
+	PipelineID     string
+	PipelineName   string
+	SubjectKind    string
+	SessionID      string
+	PRNumber       int64
+	PRRepo         string
+	PRURL          string
+	HeadSha        string
+	PRHeadBranch   string
+	PRBaseBranch   string
+	FromFork       int64
+	Status         string
+	RunDir         string
+	DefinitionJson string
+	CancelReason   string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	SettledAt      sql.NullTime
 }
 
 type PipelineStageRun struct {
-	RunID        string
-	ProjectID    domain.ProjectID
-	StageName    string
-	StageRunID   string
-	Status       string
-	Attempt      int64
-	Verdict      string
-	StartedAt    sql.NullTime
-	CompletedAt  sql.NullTime
-	ErrorMessage string
-	SessionID    string
-	Notes        string
-	Output       string
+	RunID         string
+	ProjectID     domain.ProjectID
+	StageID       string
+	Outcome       string
+	Attempt       int64
+	EnteredVia    string
+	PrevStage     string
+	FailedStage   string
+	FailedOutcome string
+	SessionID     string
+	WorkspaceKind string
+	WorkspacePath string
+	DeadlineAt    sql.NullTime
+	StartedAt     sql.NullTime
+	SettledAt     sql.NullTime
+	Reason        string
+	OutputTail    string
+	Nudged        int64
+}
+
+type PipelineStageSignal struct {
+	ID        int64
+	RunID     string
+	StageID   string
+	Kind      string
+	Reason    string
+	CreatedAt time.Time
 }
 
 type Project struct {

--- a/backend/internal/storage/sqlite/gen/pipeline.sql.go
+++ b/backend/internal/storage/sqlite/gen/pipeline.sql.go
@@ -43,6 +43,23 @@ func (q *Queries) CreatePipelineDefinition(ctx context.Context, arg CreatePipeli
 	return err
 }
 
+const deletePipelineCredential = `-- name: DeletePipelineCredential :execrows
+DELETE FROM pipeline_credentials WHERE project_id = ? AND name = ?
+`
+
+type DeletePipelineCredentialParams struct {
+	ProjectID domain.ProjectID
+	Name      string
+}
+
+func (q *Queries) DeletePipelineCredential(ctx context.Context, arg DeletePipelineCredentialParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deletePipelineCredential, arg.ProjectID, arg.Name)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const deletePipelineDefinition = `-- name: DeletePipelineDefinition :execrows
 DELETE FROM pipeline_definitions WHERE id = ?
 `
@@ -55,73 +72,56 @@ func (q *Queries) DeletePipelineDefinition(ctx context.Context, id string) (int6
 	return result.RowsAffected()
 }
 
-const getLatestSettledPipelineRunByPR = `-- name: GetLatestSettledPipelineRunByPR :one
-SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
-       loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at, context_json, blocks_merge
-FROM pipeline_runs
-WHERE project_id = ?
-  AND json_extract(context_json, '$.prUrl') = ?2
-  AND loop_state IN ('done', 'stalled')
+const getLatestPipelineStageSignal = `-- name: GetLatestPipelineStageSignal :one
+SELECT run_id, stage_id, kind, reason, created_at
+FROM pipeline_stage_signals
+WHERE run_id = ? AND stage_id = ?
 ORDER BY created_at DESC, id DESC
 LIMIT 1
 `
 
-type GetLatestSettledPipelineRunByPRParams struct {
-	ProjectID domain.ProjectID
-	PRURL     string
+type GetLatestPipelineStageSignalParams struct {
+	RunID   string
+	StageID string
 }
 
-// Latest settled (done or stalled) run for a PR, matched by the RunContext PR
-// URL stored in context_json. The lifecycle merge-readiness path compares the
-// returned run's head SHA against the PR's current head to decide whether the
-// decision is fresh; a stale-SHA run is treated as no opinion by the caller.
-func (q *Queries) GetLatestSettledPipelineRunByPR(ctx context.Context, arg GetLatestSettledPipelineRunByPRParams) (PipelineRun, error) {
-	row := q.db.QueryRowContext(ctx, getLatestSettledPipelineRunByPR, arg.ProjectID, arg.PRURL)
-	var i PipelineRun
+type GetLatestPipelineStageSignalRow struct {
+	RunID     string
+	StageID   string
+	Kind      string
+	Reason    string
+	CreatedAt time.Time
+}
+
+// Latest-wins: a stage signalled twice (once after a nudge) settles on the
+// newest signal, with the earlier one kept for the record.
+func (q *Queries) GetLatestPipelineStageSignal(ctx context.Context, arg GetLatestPipelineStageSignalParams) (GetLatestPipelineStageSignalRow, error) {
+	row := q.db.QueryRowContext(ctx, getLatestPipelineStageSignal, arg.RunID, arg.StageID)
+	var i GetLatestPipelineStageSignalRow
 	err := row.Scan(
-		&i.ID,
-		&i.ProjectID,
-		&i.PipelineID,
-		&i.PipelineName,
-		&i.SessionID,
-		&i.HeadSha,
-		&i.LoopState,
-		&i.TerminationReason,
-		&i.LoopRounds,
-		&i.ConfigSnapshot,
-		&i.Fingerprints,
+		&i.RunID,
+		&i.StageID,
+		&i.Kind,
+		&i.Reason,
 		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.ContextJson,
-		&i.BlocksMerge,
 	)
 	return i, err
 }
 
-const getPipelineArtifact = `-- name: GetPipelineArtifact :one
-SELECT id, pipeline_run_id, project_id, stage_run_id, stage_name, kind,
-       fingerprint, status, sent_to_agent_at, payload, created_at
-FROM pipeline_artifacts WHERE id = ?
+const getPipelineCredential = `-- name: GetPipelineCredential :one
+SELECT env_json FROM pipeline_credentials WHERE project_id = ? AND name = ?
 `
 
-func (q *Queries) GetPipelineArtifact(ctx context.Context, id string) (PipelineArtifact, error) {
-	row := q.db.QueryRowContext(ctx, getPipelineArtifact, id)
-	var i PipelineArtifact
-	err := row.Scan(
-		&i.ID,
-		&i.PipelineRunID,
-		&i.ProjectID,
-		&i.StageRunID,
-		&i.StageName,
-		&i.Kind,
-		&i.Fingerprint,
-		&i.Status,
-		&i.SentToAgentAt,
-		&i.Payload,
-		&i.CreatedAt,
-	)
-	return i, err
+type GetPipelineCredentialParams struct {
+	ProjectID domain.ProjectID
+	Name      string
+}
+
+func (q *Queries) GetPipelineCredential(ctx context.Context, arg GetPipelineCredentialParams) (string, error) {
+	row := q.db.QueryRowContext(ctx, getPipelineCredential, arg.ProjectID, arg.Name)
+	var env_json string
+	err := row.Scan(&env_json)
+	return env_json, err
 }
 
 const getPipelineDefinition = `-- name: GetPipelineDefinition :one
@@ -170,10 +170,7 @@ func (q *Queries) GetPipelineDefinitionByName(ctx context.Context, arg GetPipeli
 }
 
 const getPipelineRun = `-- name: GetPipelineRun :one
-SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
-       loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at, context_json, blocks_merge
-FROM pipeline_runs WHERE id = ?
+SELECT id, project_id, pipeline_id, pipeline_name, subject_kind, session_id, pr_number, pr_repo, pr_url, head_sha, pr_head_branch, pr_base_branch, from_fork, status, run_dir, definition_json, cancel_reason, created_at, updated_at, settled_at FROM pipeline_runs WHERE id = ?
 `
 
 func (q *Queries) GetPipelineRun(ctx context.Context, id string) (PipelineRun, error) {
@@ -184,92 +181,71 @@ func (q *Queries) GetPipelineRun(ctx context.Context, id string) (PipelineRun, e
 		&i.ProjectID,
 		&i.PipelineID,
 		&i.PipelineName,
+		&i.SubjectKind,
 		&i.SessionID,
+		&i.PRNumber,
+		&i.PRRepo,
+		&i.PRURL,
 		&i.HeadSha,
-		&i.LoopState,
-		&i.TerminationReason,
-		&i.LoopRounds,
-		&i.ConfigSnapshot,
-		&i.Fingerprints,
+		&i.PRHeadBranch,
+		&i.PRBaseBranch,
+		&i.FromFork,
+		&i.Status,
+		&i.RunDir,
+		&i.DefinitionJson,
+		&i.CancelReason,
 		&i.CreatedAt,
 		&i.UpdatedAt,
-		&i.ContextJson,
-		&i.BlocksMerge,
+		&i.SettledAt,
 	)
 	return i, err
 }
 
-const insertPipelineArtifact = `-- name: InsertPipelineArtifact :exec
+const insertPipelineStageSignal = `-- name: InsertPipelineStageSignal :exec
 
-INSERT INTO pipeline_artifacts (
-    id, pipeline_run_id, project_id, stage_run_id, stage_name, kind,
-    fingerprint, status, sent_to_agent_at, payload, created_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO pipeline_stage_signals (run_id, stage_id, kind, reason, created_at)
+VALUES (?, ?, ?, ?, ?)
 `
 
-type InsertPipelineArtifactParams struct {
-	ID            string
-	PipelineRunID string
-	ProjectID     domain.ProjectID
-	StageRunID    string
-	StageName     string
-	Kind          string
-	Fingerprint   string
-	Status        string
-	SentToAgentAt sql.NullTime
-	Payload       string
-	CreatedAt     time.Time
+type InsertPipelineStageSignalParams struct {
+	RunID     string
+	StageID   string
+	Kind      string
+	Reason    string
+	CreatedAt time.Time
 }
 
-// Pipeline artifacts ---------------------------------------------------------
-func (q *Queries) InsertPipelineArtifact(ctx context.Context, arg InsertPipelineArtifactParams) error {
-	_, err := q.db.ExecContext(ctx, insertPipelineArtifact,
-		arg.ID,
-		arg.PipelineRunID,
-		arg.ProjectID,
-		arg.StageRunID,
-		arg.StageName,
+// Pipeline stage signals -----------------------------------------------------
+func (q *Queries) InsertPipelineStageSignal(ctx context.Context, arg InsertPipelineStageSignalParams) error {
+	_, err := q.db.ExecContext(ctx, insertPipelineStageSignal,
+		arg.RunID,
+		arg.StageID,
 		arg.Kind,
-		arg.Fingerprint,
-		arg.Status,
-		arg.SentToAgentAt,
-		arg.Payload,
+		arg.Reason,
 		arg.CreatedAt,
 	)
 	return err
 }
 
-const listPipelineArtifactsByRun = `-- name: ListPipelineArtifactsByRun :many
-SELECT id, pipeline_run_id, project_id, stage_run_id, stage_name, kind,
-       fingerprint, status, sent_to_agent_at, payload, created_at
-FROM pipeline_artifacts WHERE pipeline_run_id = ? ORDER BY created_at ASC, id ASC
+const listPipelineCredentialNames = `-- name: ListPipelineCredentialNames :many
+SELECT name FROM pipeline_credentials WHERE project_id = ? ORDER BY name ASC
 `
 
-func (q *Queries) ListPipelineArtifactsByRun(ctx context.Context, pipelineRunID string) ([]PipelineArtifact, error) {
-	rows, err := q.db.QueryContext(ctx, listPipelineArtifactsByRun, pipelineRunID)
+// Names only. A credential value never leaves the daemon through a read path a
+// human can reach (decision D13).
+func (q *Queries) ListPipelineCredentialNames(ctx context.Context, projectID domain.ProjectID) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listPipelineCredentialNames, projectID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []PipelineArtifact{}
+	items := []string{}
 	for rows.Next() {
-		var i PipelineArtifact
-		if err := rows.Scan(
-			&i.ID,
-			&i.PipelineRunID,
-			&i.ProjectID,
-			&i.StageRunID,
-			&i.StageName,
-			&i.Kind,
-			&i.Fingerprint,
-			&i.Status,
-			&i.SentToAgentAt,
-			&i.Payload,
-			&i.CreatedAt,
-		); err != nil {
+		var name string
+		if err := rows.Scan(&name); err != nil {
 			return nil, err
 		}
-		items = append(items, i)
+		items = append(items, name)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -317,13 +293,10 @@ func (q *Queries) ListPipelineDefinitions(ctx context.Context, projectID domain.
 }
 
 const listPipelineRuns = `-- name: ListPipelineRuns :many
-SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
-       loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at, context_json, blocks_merge
-FROM pipeline_runs
+SELECT id, project_id, pipeline_id, pipeline_name, subject_kind, session_id, pr_number, pr_repo, pr_url, head_sha, pr_head_branch, pr_base_branch, from_fork, status, run_dir, definition_json, cancel_reason, created_at, updated_at, settled_at FROM pipeline_runs
 WHERE project_id = ?
   AND (?2 IS NULL OR pipeline_name = ?2)
-  AND (?3 IS NULL OR loop_state = ?3)
+  AND (?3 IS NULL OR status = ?3)
 ORDER BY created_at DESC, id DESC
 LIMIT ?4
 `
@@ -331,7 +304,7 @@ LIMIT ?4
 type ListPipelineRunsParams struct {
 	ProjectID    domain.ProjectID
 	PipelineName interface{}
-	LoopState    interface{}
+	Status       interface{}
 	Lim          int64
 }
 
@@ -339,7 +312,7 @@ func (q *Queries) ListPipelineRuns(ctx context.Context, arg ListPipelineRunsPara
 	rows, err := q.db.QueryContext(ctx, listPipelineRuns,
 		arg.ProjectID,
 		arg.PipelineName,
-		arg.LoopState,
+		arg.Status,
 		arg.Lim,
 	)
 	if err != nil {
@@ -354,17 +327,22 @@ func (q *Queries) ListPipelineRuns(ctx context.Context, arg ListPipelineRunsPara
 			&i.ProjectID,
 			&i.PipelineID,
 			&i.PipelineName,
+			&i.SubjectKind,
 			&i.SessionID,
+			&i.PRNumber,
+			&i.PRRepo,
+			&i.PRURL,
 			&i.HeadSha,
-			&i.LoopState,
-			&i.TerminationReason,
-			&i.LoopRounds,
-			&i.ConfigSnapshot,
-			&i.Fingerprints,
+			&i.PRHeadBranch,
+			&i.PRBaseBranch,
+			&i.FromFork,
+			&i.Status,
+			&i.RunDir,
+			&i.DefinitionJson,
+			&i.CancelReason,
 			&i.CreatedAt,
 			&i.UpdatedAt,
-			&i.ContextJson,
-			&i.BlocksMerge,
+			&i.SettledAt,
 		); err != nil {
 			return nil, err
 		}
@@ -380,9 +358,7 @@ func (q *Queries) ListPipelineRuns(ctx context.Context, arg ListPipelineRunsPara
 }
 
 const listPipelineStageRunsByRun = `-- name: ListPipelineStageRunsByRun :many
-SELECT run_id, project_id, stage_name, stage_run_id, status, attempt, verdict,
-       started_at, completed_at, error_message, session_id, notes, output
-FROM pipeline_stage_runs WHERE run_id = ? ORDER BY stage_name ASC
+SELECT run_id, project_id, stage_id, outcome, attempt, entered_via, prev_stage, failed_stage, failed_outcome, session_id, workspace_kind, workspace_path, deadline_at, started_at, settled_at, reason, output_tail, nudged FROM pipeline_stage_runs WHERE run_id = ? ORDER BY stage_id ASC
 `
 
 func (q *Queries) ListPipelineStageRunsByRun(ctx context.Context, runID string) ([]PipelineStageRun, error) {
@@ -397,17 +373,22 @@ func (q *Queries) ListPipelineStageRunsByRun(ctx context.Context, runID string) 
 		if err := rows.Scan(
 			&i.RunID,
 			&i.ProjectID,
-			&i.StageName,
-			&i.StageRunID,
-			&i.Status,
+			&i.StageID,
+			&i.Outcome,
 			&i.Attempt,
-			&i.Verdict,
-			&i.StartedAt,
-			&i.CompletedAt,
-			&i.ErrorMessage,
+			&i.EnteredVia,
+			&i.PrevStage,
+			&i.FailedStage,
+			&i.FailedOutcome,
 			&i.SessionID,
-			&i.Notes,
-			&i.Output,
+			&i.WorkspaceKind,
+			&i.WorkspacePath,
+			&i.DeadlineAt,
+			&i.StartedAt,
+			&i.SettledAt,
+			&i.Reason,
+			&i.OutputTail,
+			&i.Nudged,
 		); err != nil {
 			return nil, err
 		}
@@ -422,22 +403,56 @@ func (q *Queries) ListPipelineStageRunsByRun(ctx context.Context, runID string) 
 	return items, nil
 }
 
-const updatePipelineArtifactStatus = `-- name: UpdatePipelineArtifactStatus :execrows
-UPDATE pipeline_artifacts SET status = ?, sent_to_agent_at = ? WHERE id = ?
+const listUnsettledPipelineRuns = `-- name: ListUnsettledPipelineRuns :many
+SELECT id, project_id, pipeline_id, pipeline_name, subject_kind, session_id, pr_number, pr_repo, pr_url, head_sha, pr_head_branch, pr_base_branch, from_fork, status, run_dir, definition_json, cancel_reason, created_at, updated_at, settled_at FROM pipeline_runs
+WHERE project_id = ? AND settled_at IS NULL
+ORDER BY created_at ASC, id ASC
 `
 
-type UpdatePipelineArtifactStatusParams struct {
-	Status        string
-	SentToAgentAt sql.NullTime
-	ID            string
-}
-
-func (q *Queries) UpdatePipelineArtifactStatus(ctx context.Context, arg UpdatePipelineArtifactStatusParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, updatePipelineArtifactStatus, arg.Status, arg.SentToAgentAt, arg.ID)
+// Hydration on engine start: the runs that still owe work, oldest first so the
+// engine replays them in creation order.
+func (q *Queries) ListUnsettledPipelineRuns(ctx context.Context, projectID domain.ProjectID) ([]PipelineRun, error) {
+	rows, err := q.db.QueryContext(ctx, listUnsettledPipelineRuns, projectID)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	return result.RowsAffected()
+	defer rows.Close()
+	items := []PipelineRun{}
+	for rows.Next() {
+		var i PipelineRun
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.PipelineID,
+			&i.PipelineName,
+			&i.SubjectKind,
+			&i.SessionID,
+			&i.PRNumber,
+			&i.PRRepo,
+			&i.PRURL,
+			&i.HeadSha,
+			&i.PRHeadBranch,
+			&i.PRBaseBranch,
+			&i.FromFork,
+			&i.Status,
+			&i.RunDir,
+			&i.DefinitionJson,
+			&i.CancelReason,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.SettledAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const updatePipelineDefinition = `-- name: UpdatePipelineDefinition :execrows
@@ -468,43 +483,83 @@ func (q *Queries) UpdatePipelineDefinition(ctx context.Context, arg UpdatePipeli
 	return result.RowsAffected()
 }
 
-const upsertPipelineRun = `-- name: UpsertPipelineRun :exec
+const upsertPipelineCredential = `-- name: UpsertPipelineCredential :exec
 
-INSERT INTO pipeline_runs (
-    id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
-    loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-    created_at, updated_at, context_json, blocks_merge
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-ON CONFLICT (id) DO UPDATE SET
-    pipeline_name = excluded.pipeline_name,
-    session_id = excluded.session_id,
-    head_sha = excluded.head_sha,
-    loop_state = excluded.loop_state,
-    termination_reason = excluded.termination_reason,
-    loop_rounds = excluded.loop_rounds,
-    config_snapshot = excluded.config_snapshot,
-    fingerprints = excluded.fingerprints,
-    context_json = excluded.context_json,
-    blocks_merge = excluded.blocks_merge,
+INSERT INTO pipeline_credentials (project_id, name, env_json, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT (project_id, name) DO UPDATE SET
+    env_json = excluded.env_json,
     updated_at = excluded.updated_at
 `
 
+type UpsertPipelineCredentialParams struct {
+	ProjectID domain.ProjectID
+	Name      string
+	EnvJson   string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// Pipeline credentials -------------------------------------------------------
+func (q *Queries) UpsertPipelineCredential(ctx context.Context, arg UpsertPipelineCredentialParams) error {
+	_, err := q.db.ExecContext(ctx, upsertPipelineCredential,
+		arg.ProjectID,
+		arg.Name,
+		arg.EnvJson,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+	)
+	return err
+}
+
+const upsertPipelineRun = `-- name: UpsertPipelineRun :exec
+
+INSERT INTO pipeline_runs (
+    id, project_id, pipeline_id, pipeline_name, subject_kind, session_id,
+    pr_number, pr_repo, pr_url, head_sha, pr_head_branch, pr_base_branch,
+    from_fork, status, run_dir, definition_json, cancel_reason,
+    created_at, updated_at, settled_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (id) DO UPDATE SET
+    pipeline_name = excluded.pipeline_name,
+    subject_kind = excluded.subject_kind,
+    session_id = excluded.session_id,
+    pr_number = excluded.pr_number,
+    pr_repo = excluded.pr_repo,
+    pr_url = excluded.pr_url,
+    head_sha = excluded.head_sha,
+    pr_head_branch = excluded.pr_head_branch,
+    pr_base_branch = excluded.pr_base_branch,
+    from_fork = excluded.from_fork,
+    status = excluded.status,
+    run_dir = excluded.run_dir,
+    definition_json = excluded.definition_json,
+    cancel_reason = excluded.cancel_reason,
+    updated_at = excluded.updated_at,
+    settled_at = excluded.settled_at
+`
+
 type UpsertPipelineRunParams struct {
-	ID                string
-	ProjectID         domain.ProjectID
-	PipelineID        string
-	PipelineName      string
-	SessionID         string
-	HeadSha           string
-	LoopState         string
-	TerminationReason string
-	LoopRounds        int64
-	ConfigSnapshot    string
-	Fingerprints      string
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
-	ContextJson       string
-	BlocksMerge       int64
+	ID             string
+	ProjectID      domain.ProjectID
+	PipelineID     string
+	PipelineName   string
+	SubjectKind    string
+	SessionID      string
+	PRNumber       int64
+	PRRepo         string
+	PRURL          string
+	HeadSha        string
+	PRHeadBranch   string
+	PRBaseBranch   string
+	FromFork       int64
+	Status         string
+	RunDir         string
+	DefinitionJson string
+	CancelReason   string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	SettledAt      sql.NullTime
 }
 
 // Pipeline runs --------------------------------------------------------------
@@ -514,17 +569,22 @@ func (q *Queries) UpsertPipelineRun(ctx context.Context, arg UpsertPipelineRunPa
 		arg.ProjectID,
 		arg.PipelineID,
 		arg.PipelineName,
+		arg.SubjectKind,
 		arg.SessionID,
+		arg.PRNumber,
+		arg.PRRepo,
+		arg.PRURL,
 		arg.HeadSha,
-		arg.LoopState,
-		arg.TerminationReason,
-		arg.LoopRounds,
-		arg.ConfigSnapshot,
-		arg.Fingerprints,
+		arg.PRHeadBranch,
+		arg.PRBaseBranch,
+		arg.FromFork,
+		arg.Status,
+		arg.RunDir,
+		arg.DefinitionJson,
+		arg.CancelReason,
 		arg.CreatedAt,
 		arg.UpdatedAt,
-		arg.ContextJson,
-		arg.BlocksMerge,
+		arg.SettledAt,
 	)
 	return err
 }
@@ -532,36 +592,47 @@ func (q *Queries) UpsertPipelineRun(ctx context.Context, arg UpsertPipelineRunPa
 const upsertPipelineStageRun = `-- name: UpsertPipelineStageRun :exec
 
 INSERT INTO pipeline_stage_runs (
-    run_id, project_id, stage_name, stage_run_id, status, attempt, verdict,
-    started_at, completed_at, error_message, session_id, notes, output
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-ON CONFLICT (run_id, stage_name) DO UPDATE SET
-    stage_run_id = excluded.stage_run_id,
-    status = excluded.status,
+    run_id, project_id, stage_id, outcome, attempt, entered_via, prev_stage,
+    failed_stage, failed_outcome, session_id, workspace_kind, workspace_path,
+    deadline_at, started_at, settled_at, reason, output_tail, nudged
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (run_id, stage_id) DO UPDATE SET
+    outcome = excluded.outcome,
     attempt = excluded.attempt,
-    verdict = excluded.verdict,
-    started_at = excluded.started_at,
-    completed_at = excluded.completed_at,
-    error_message = excluded.error_message,
+    entered_via = excluded.entered_via,
+    prev_stage = excluded.prev_stage,
+    failed_stage = excluded.failed_stage,
+    failed_outcome = excluded.failed_outcome,
     session_id = excluded.session_id,
-    notes = excluded.notes,
-    output = excluded.output
+    workspace_kind = excluded.workspace_kind,
+    workspace_path = excluded.workspace_path,
+    deadline_at = excluded.deadline_at,
+    started_at = excluded.started_at,
+    settled_at = excluded.settled_at,
+    reason = excluded.reason,
+    output_tail = excluded.output_tail,
+    nudged = excluded.nudged
 `
 
 type UpsertPipelineStageRunParams struct {
-	RunID        string
-	ProjectID    domain.ProjectID
-	StageName    string
-	StageRunID   string
-	Status       string
-	Attempt      int64
-	Verdict      string
-	StartedAt    sql.NullTime
-	CompletedAt  sql.NullTime
-	ErrorMessage string
-	SessionID    string
-	Notes        string
-	Output       string
+	RunID         string
+	ProjectID     domain.ProjectID
+	StageID       string
+	Outcome       string
+	Attempt       int64
+	EnteredVia    string
+	PrevStage     string
+	FailedStage   string
+	FailedOutcome string
+	SessionID     string
+	WorkspaceKind string
+	WorkspacePath string
+	DeadlineAt    sql.NullTime
+	StartedAt     sql.NullTime
+	SettledAt     sql.NullTime
+	Reason        string
+	OutputTail    string
+	Nudged        int64
 }
 
 // Pipeline stage runs --------------------------------------------------------
@@ -569,17 +640,22 @@ func (q *Queries) UpsertPipelineStageRun(ctx context.Context, arg UpsertPipeline
 	_, err := q.db.ExecContext(ctx, upsertPipelineStageRun,
 		arg.RunID,
 		arg.ProjectID,
-		arg.StageName,
-		arg.StageRunID,
-		arg.Status,
+		arg.StageID,
+		arg.Outcome,
 		arg.Attempt,
-		arg.Verdict,
-		arg.StartedAt,
-		arg.CompletedAt,
-		arg.ErrorMessage,
+		arg.EnteredVia,
+		arg.PrevStage,
+		arg.FailedStage,
+		arg.FailedOutcome,
 		arg.SessionID,
-		arg.Notes,
-		arg.Output,
+		arg.WorkspaceKind,
+		arg.WorkspacePath,
+		arg.DeadlineAt,
+		arg.StartedAt,
+		arg.SettledAt,
+		arg.Reason,
+		arg.OutputTail,
+		arg.Nudged,
 	)
 	return err
 }

--- a/backend/internal/storage/sqlite/migrations/0047_pipelines_v2.sql
+++ b/backend/internal/storage/sqlite/migrations/0047_pipelines_v2.sql
@@ -1,0 +1,431 @@
+-- Pipelines v2 store. v1 shipped only behind the AO_PIPELINES flag and was
+-- never released, so no data is owed a migration: the run tables are dropped
+-- and recreated in the v2 shape rather than backfilled.
+--
+--   pipeline_definitions  UNCHANGED. Definitions travel as raw YAML plus a
+--                         parsed snapshot; v1 YAML simply fails v2 validation
+--                         when the editor opens it.
+--   pipeline_runs         one row per run. Run-level scalars, the flattened
+--                         subject, and the frozen definition the run executes.
+--   pipeline_stage_runs   one row per (run, stage), mirroring pipeline.StageState.
+--   pipeline_stage_signals  append-only `ao pipeline done|fail` signals; reads
+--                         take the latest row for a (run, stage).
+--   pipeline_credentials  engine-held command-stage credentials. Values live
+--                         only in the daemon and are never echoed by a read
+--                         path a human can reach.
+--   pipeline_artifacts    DROPPED with the whole findings subsystem.
+--
+-- Three columns are not in the v2 design's scalar list but are required for a
+-- run to survive a daemon restart, since SQLite (not the run folder) is the
+-- store of record: definition_json (the frozen definition), the PR branch pair
+-- (a `workspace: checkout` stage needs them after a restart), and the per-stage
+-- nudged flag (RunState.Nudged).
+--
+-- change_log keeps its CHECK list as written in 0040: 'pipeline_artifact_updated'
+-- stays a legal value with no emitter, because narrowing the CHECK means
+-- rebuilding change_log and re-creating every CDC trigger in the schema for no
+-- behavioural gain.
+
+-- +goose Up
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS pipeline_artifacts_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_artifacts_cdc_insert;
+DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_insert;
+DROP TRIGGER IF EXISTS pipeline_runs_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_runs_cdc_insert;
+DROP INDEX IF EXISTS idx_pipeline_artifacts_stage_run;
+DROP INDEX IF EXISTS idx_pipeline_artifacts_run;
+DROP INDEX IF EXISTS idx_pipeline_runs_loop;
+DROP INDEX IF EXISTS idx_pipeline_runs_project_created;
+DROP TABLE IF EXISTS pipeline_artifacts;
+DROP TABLE IF EXISTS pipeline_stage_runs;
+DROP TABLE IF EXISTS pipeline_runs;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE pipeline_runs (
+    id              TEXT PRIMARY KEY,
+    project_id      TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    -- pipeline_id names the definition this run came from but is NOT a foreign
+    -- key: a run freezes its definition and outlives a definition delete.
+    pipeline_id     TEXT NOT NULL,
+    pipeline_name   TEXT NOT NULL,
+    -- Subject, flattened. session_id is set for session subjects and for PR
+    -- subjects that have a local session; the pr_* columns are set for PR
+    -- subjects only (a sessionless PR subject is first class).
+    subject_kind    TEXT NOT NULL,
+    session_id      TEXT NOT NULL DEFAULT '',
+    pr_number       INTEGER NOT NULL DEFAULT 0,
+    pr_repo         TEXT NOT NULL DEFAULT '',
+    pr_url          TEXT NOT NULL DEFAULT '',
+    head_sha        TEXT NOT NULL DEFAULT '',
+    pr_head_branch  TEXT NOT NULL DEFAULT '',
+    pr_base_branch  TEXT NOT NULL DEFAULT '',
+    from_fork       INTEGER NOT NULL DEFAULT 0,
+    status          TEXT NOT NULL,
+    run_dir         TEXT NOT NULL DEFAULT '',
+    -- The definition as frozen at trigger time. Editing a definition never
+    -- changes a run in flight, and hydration on restart replays what ran.
+    definition_json TEXT NOT NULL CHECK (json_valid(definition_json)),
+    cancel_reason   TEXT NOT NULL DEFAULT '',
+    created_at      TIMESTAMP NOT NULL,
+    updated_at      TIMESTAMP NOT NULL,
+    -- NULL while the run is in flight. Hydration selects on it, so it is the
+    -- one nullable timestamp on the row.
+    settled_at      TIMESTAMP
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- The Kanban board lists a project's runs newest-first.
+CREATE INDEX idx_pipeline_runs_project_created ON pipeline_runs (project_id, created_at DESC);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Hydration on engine start reads exactly the unsettled runs of one project.
+CREATE INDEX idx_pipeline_runs_unsettled ON pipeline_runs (project_id, created_at) WHERE settled_at IS NULL;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE pipeline_stage_runs (
+    run_id         TEXT NOT NULL REFERENCES pipeline_runs (id) ON DELETE CASCADE,
+    project_id     TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    stage_id       TEXT NOT NULL,
+    outcome        TEXT NOT NULL,
+    attempt        INTEGER NOT NULL DEFAULT 0,
+    entered_via    TEXT NOT NULL DEFAULT '',
+    prev_stage     TEXT NOT NULL DEFAULT '',
+    failed_stage   TEXT NOT NULL DEFAULT '',
+    failed_outcome TEXT NOT NULL DEFAULT '',
+    session_id     TEXT NOT NULL DEFAULT '',
+    workspace_kind TEXT NOT NULL DEFAULT '',
+    workspace_path TEXT NOT NULL DEFAULT '',
+    -- Nullable rather than zero-defaulted: a stage that has not started has no
+    -- deadline yet, and a zero time is not the same statement.
+    deadline_at    TIMESTAMP,
+    started_at     TIMESTAMP,
+    settled_at     TIMESTAMP,
+    reason         TEXT NOT NULL DEFAULT '',
+    output_tail    TEXT NOT NULL DEFAULT '',
+    -- RunState.Nudged, stored where it belongs: one nudge per stage, ever.
+    nudged         INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (run_id, stage_id)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Append-only. The engine's SignalReader takes the newest row per (run, stage),
+-- so a post-nudge signal supersedes the first without losing it.
+CREATE TABLE pipeline_stage_signals (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id     TEXT NOT NULL REFERENCES pipeline_runs (id) ON DELETE CASCADE,
+    stage_id   TEXT NOT NULL,
+    kind       TEXT NOT NULL CHECK (kind IN ('done', 'fail')),
+    reason     TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMP NOT NULL
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_pipeline_stage_signals_stage ON pipeline_stage_signals (run_id, stage_id, created_at DESC, id DESC);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- env_json is a JSON object of environment variables injected into a command
+-- stage's process at exec time. Same trust level as the gh token already on
+-- disk: no UI editor, no read path that echoes a value back.
+CREATE TABLE pipeline_credentials (
+    project_id TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    name       TEXT NOT NULL,
+    env_json   TEXT NOT NULL CHECK (json_valid(env_json)),
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    PRIMARY KEY (project_id, name)
+);
+-- +goose StatementEnd
+
+-- Pipeline CDC triggers. All pipeline events are project-level (session_id
+-- NULL) because a run's session id may be absent or may not be a sessions row.
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_runs_cdc_insert
+AFTER INSERT ON pipeline_runs
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_run_updated',
+        json_object(
+            'runId', NEW.id,
+            'pipelineId', NEW.pipeline_id,
+            'pipelineName', NEW.pipeline_name,
+            'status', NEW.status,
+            'subjectKind', NEW.subject_kind,
+            'sessionId', NEW.session_id,
+            'prNumber', NEW.pr_number,
+            'headSha', NEW.head_sha),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_runs_cdc_update
+AFTER UPDATE ON pipeline_runs
+WHEN OLD.status <> NEW.status
+    OR OLD.updated_at <> NEW.updated_at
+    OR OLD.cancel_reason <> NEW.cancel_reason
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_run_updated',
+        json_object(
+            'runId', NEW.id,
+            'pipelineId', NEW.pipeline_id,
+            'pipelineName', NEW.pipeline_name,
+            'status', NEW.status,
+            'subjectKind', NEW.subject_kind,
+            'sessionId', NEW.session_id,
+            'prNumber', NEW.pr_number,
+            'headSha', NEW.head_sha),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_stage_runs_cdc_insert
+AFTER INSERT ON pipeline_stage_runs
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_stage_run_updated',
+        json_object(
+            'runId', NEW.run_id,
+            'stageId', NEW.stage_id,
+            'outcome', NEW.outcome,
+            'attempt', NEW.attempt,
+            'sessionId', NEW.session_id),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_stage_runs_cdc_update
+AFTER UPDATE ON pipeline_stage_runs
+WHEN OLD.outcome <> NEW.outcome
+    OR OLD.attempt <> NEW.attempt
+    OR OLD.session_id <> NEW.session_id
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_stage_run_updated',
+        json_object(
+            'runId', NEW.run_id,
+            'stageId', NEW.stage_id,
+            'outcome', NEW.outcome,
+            'attempt', NEW.attempt,
+            'sessionId', NEW.session_id),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_insert;
+DROP TRIGGER IF EXISTS pipeline_runs_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_runs_cdc_insert;
+DROP INDEX IF EXISTS idx_pipeline_stage_signals_stage;
+DROP INDEX IF EXISTS idx_pipeline_runs_unsettled;
+DROP INDEX IF EXISTS idx_pipeline_runs_project_created;
+DROP TABLE IF EXISTS pipeline_credentials;
+DROP TABLE IF EXISTS pipeline_stage_signals;
+DROP TABLE IF EXISTS pipeline_stage_runs;
+DROP TABLE IF EXISTS pipeline_runs;
+-- +goose StatementEnd
+
+-- Recreate the v1 tables and their triggers as 0040 through 0046 left them, so
+-- a down migration lands on the schema those migrations describe. The rows are
+-- gone either way: the up migration dropped them.
+-- +goose StatementBegin
+CREATE TABLE pipeline_runs (
+    id                 TEXT PRIMARY KEY,
+    project_id         TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    pipeline_id        TEXT NOT NULL,
+    pipeline_name      TEXT NOT NULL,
+    session_id         TEXT NOT NULL DEFAULT '',
+    head_sha           TEXT NOT NULL DEFAULT '',
+    loop_state         TEXT NOT NULL,
+    termination_reason TEXT NOT NULL DEFAULT '',
+    loop_rounds        INTEGER NOT NULL DEFAULT 0,
+    config_snapshot    TEXT NOT NULL CHECK (json_valid(config_snapshot)),
+    fingerprints       TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(fingerprints)),
+    created_at         TIMESTAMP NOT NULL,
+    updated_at         TIMESTAMP NOT NULL,
+    context_json       TEXT NOT NULL DEFAULT '{}',
+    blocks_merge       INTEGER NOT NULL DEFAULT 0
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_pipeline_runs_project_created ON pipeline_runs (project_id, created_at DESC);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_pipeline_runs_loop ON pipeline_runs (project_id, session_id, pipeline_name, created_at);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE pipeline_stage_runs (
+    run_id        TEXT NOT NULL REFERENCES pipeline_runs (id) ON DELETE CASCADE,
+    project_id    TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    stage_name    TEXT NOT NULL,
+    stage_run_id  TEXT NOT NULL,
+    status        TEXT NOT NULL,
+    attempt       INTEGER NOT NULL DEFAULT 0,
+    verdict       TEXT NOT NULL DEFAULT '',
+    started_at    TIMESTAMP,
+    completed_at  TIMESTAMP,
+    error_message TEXT NOT NULL DEFAULT '',
+    session_id    TEXT NOT NULL DEFAULT '',
+    notes         TEXT NOT NULL DEFAULT '',
+    output        TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (run_id, stage_name)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE pipeline_artifacts (
+    id               TEXT PRIMARY KEY,
+    pipeline_run_id  TEXT NOT NULL REFERENCES pipeline_runs (id) ON DELETE CASCADE,
+    project_id       TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    stage_run_id     TEXT NOT NULL,
+    stage_name       TEXT NOT NULL,
+    kind             TEXT NOT NULL,
+    fingerprint      TEXT NOT NULL DEFAULT '',
+    status           TEXT NOT NULL DEFAULT 'open',
+    sent_to_agent_at TIMESTAMP,
+    payload          TEXT NOT NULL CHECK (json_valid(payload)),
+    created_at       TIMESTAMP NOT NULL
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_pipeline_artifacts_run ON pipeline_artifacts (pipeline_run_id, created_at);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_pipeline_artifacts_stage_run ON pipeline_artifacts (stage_run_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_runs_cdc_insert
+AFTER INSERT ON pipeline_runs
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_run_updated',
+        json_object(
+            'runId', NEW.id,
+            'pipelineId', NEW.pipeline_id,
+            'pipelineName', NEW.pipeline_name,
+            'sessionId', NEW.session_id,
+            'headSha', NEW.head_sha,
+            'loopState', NEW.loop_state,
+            'terminationReason', NEW.termination_reason,
+            'loopRounds', NEW.loop_rounds),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_runs_cdc_update
+AFTER UPDATE ON pipeline_runs
+WHEN OLD.updated_at <> NEW.updated_at
+    OR OLD.loop_state <> NEW.loop_state
+    OR OLD.loop_rounds <> NEW.loop_rounds
+    OR OLD.termination_reason <> NEW.termination_reason
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_run_updated',
+        json_object(
+            'runId', NEW.id,
+            'pipelineId', NEW.pipeline_id,
+            'pipelineName', NEW.pipeline_name,
+            'sessionId', NEW.session_id,
+            'headSha', NEW.head_sha,
+            'loopState', NEW.loop_state,
+            'terminationReason', NEW.termination_reason,
+            'loopRounds', NEW.loop_rounds),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_stage_runs_cdc_insert
+AFTER INSERT ON pipeline_stage_runs
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_stage_run_updated',
+        json_object(
+            'runId', NEW.run_id,
+            'stageRunId', NEW.stage_run_id,
+            'stageName', NEW.stage_name,
+            'status', NEW.status,
+            'attempt', NEW.attempt,
+            'verdict', NEW.verdict),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_stage_runs_cdc_update
+AFTER UPDATE ON pipeline_stage_runs
+WHEN OLD.status <> NEW.status
+    OR OLD.attempt <> NEW.attempt
+    OR OLD.verdict <> NEW.verdict
+    OR OLD.stage_run_id <> NEW.stage_run_id
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_stage_run_updated',
+        json_object(
+            'runId', NEW.run_id,
+            'stageRunId', NEW.stage_run_id,
+            'stageName', NEW.stage_name,
+            'status', NEW.status,
+            'attempt', NEW.attempt,
+            'verdict', NEW.verdict),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_artifacts_cdc_insert
+AFTER INSERT ON pipeline_artifacts
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_artifact_updated',
+        json_object(
+            'artifactId', NEW.id,
+            'runId', NEW.pipeline_run_id,
+            'stageRunId', NEW.stage_run_id,
+            'stageName', NEW.stage_name,
+            'kind', NEW.kind,
+            'status', NEW.status,
+            'fingerprint', NEW.fingerprint),
+        NEW.created_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_artifacts_cdc_update
+AFTER UPDATE ON pipeline_artifacts
+WHEN OLD.status <> NEW.status
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_artifact_updated',
+        json_object(
+            'artifactId', NEW.id,
+            'runId', NEW.pipeline_run_id,
+            'stageRunId', NEW.stage_run_id,
+            'stageName', NEW.stage_name,
+            'kind', NEW.kind,
+            'status', NEW.status,
+            'fingerprint', NEW.fingerprint),
+        datetime('now'));
+END;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/pipeline.sql
+++ b/backend/internal/storage/sqlite/queries/pipeline.sql
@@ -28,96 +28,106 @@ DELETE FROM pipeline_definitions WHERE id = ?;
 
 -- name: UpsertPipelineRun :exec
 INSERT INTO pipeline_runs (
-    id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
-    loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-    created_at, updated_at, context_json, blocks_merge
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    id, project_id, pipeline_id, pipeline_name, subject_kind, session_id,
+    pr_number, pr_repo, pr_url, head_sha, pr_head_branch, pr_base_branch,
+    from_fork, status, run_dir, definition_json, cancel_reason,
+    created_at, updated_at, settled_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (id) DO UPDATE SET
     pipeline_name = excluded.pipeline_name,
+    subject_kind = excluded.subject_kind,
     session_id = excluded.session_id,
+    pr_number = excluded.pr_number,
+    pr_repo = excluded.pr_repo,
+    pr_url = excluded.pr_url,
     head_sha = excluded.head_sha,
-    loop_state = excluded.loop_state,
-    termination_reason = excluded.termination_reason,
-    loop_rounds = excluded.loop_rounds,
-    config_snapshot = excluded.config_snapshot,
-    fingerprints = excluded.fingerprints,
-    context_json = excluded.context_json,
-    blocks_merge = excluded.blocks_merge,
-    updated_at = excluded.updated_at;
+    pr_head_branch = excluded.pr_head_branch,
+    pr_base_branch = excluded.pr_base_branch,
+    from_fork = excluded.from_fork,
+    status = excluded.status,
+    run_dir = excluded.run_dir,
+    definition_json = excluded.definition_json,
+    cancel_reason = excluded.cancel_reason,
+    updated_at = excluded.updated_at,
+    settled_at = excluded.settled_at;
 
 -- name: GetPipelineRun :one
-SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
-       loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at, context_json, blocks_merge
-FROM pipeline_runs WHERE id = ?;
+SELECT * FROM pipeline_runs WHERE id = ?;
 
 -- name: ListPipelineRuns :many
-SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
-       loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at, context_json, blocks_merge
-FROM pipeline_runs
+SELECT * FROM pipeline_runs
 WHERE project_id = ?
   AND (sqlc.narg('pipeline_name') IS NULL OR pipeline_name = sqlc.narg('pipeline_name'))
-  AND (sqlc.narg('loop_state') IS NULL OR loop_state = sqlc.narg('loop_state'))
+  AND (sqlc.narg('status') IS NULL OR status = sqlc.narg('status'))
 ORDER BY created_at DESC, id DESC
 LIMIT sqlc.arg('lim');
 
--- name: GetLatestSettledPipelineRunByPR :one
--- Latest settled (done or stalled) run for a PR, matched by the RunContext PR
--- URL stored in context_json. The lifecycle merge-readiness path compares the
--- returned run's head SHA against the PR's current head to decide whether the
--- decision is fresh; a stale-SHA run is treated as no opinion by the caller.
-SELECT id, project_id, pipeline_id, pipeline_name, session_id, head_sha,
-       loop_state, termination_reason, loop_rounds, config_snapshot, fingerprints,
-       created_at, updated_at, context_json, blocks_merge
-FROM pipeline_runs
-WHERE project_id = ?
-  AND json_extract(context_json, '$.prUrl') = sqlc.arg('pr_url')
-  AND loop_state IN ('done', 'stalled')
-ORDER BY created_at DESC, id DESC
-LIMIT 1;
+-- name: ListUnsettledPipelineRuns :many
+-- Hydration on engine start: the runs that still owe work, oldest first so the
+-- engine replays them in creation order.
+SELECT * FROM pipeline_runs
+WHERE project_id = ? AND settled_at IS NULL
+ORDER BY created_at ASC, id ASC;
 
 -- Pipeline stage runs --------------------------------------------------------
 
 -- name: UpsertPipelineStageRun :exec
 INSERT INTO pipeline_stage_runs (
-    run_id, project_id, stage_name, stage_run_id, status, attempt, verdict,
-    started_at, completed_at, error_message, session_id, notes, output
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-ON CONFLICT (run_id, stage_name) DO UPDATE SET
-    stage_run_id = excluded.stage_run_id,
-    status = excluded.status,
+    run_id, project_id, stage_id, outcome, attempt, entered_via, prev_stage,
+    failed_stage, failed_outcome, session_id, workspace_kind, workspace_path,
+    deadline_at, started_at, settled_at, reason, output_tail, nudged
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (run_id, stage_id) DO UPDATE SET
+    outcome = excluded.outcome,
     attempt = excluded.attempt,
-    verdict = excluded.verdict,
-    started_at = excluded.started_at,
-    completed_at = excluded.completed_at,
-    error_message = excluded.error_message,
+    entered_via = excluded.entered_via,
+    prev_stage = excluded.prev_stage,
+    failed_stage = excluded.failed_stage,
+    failed_outcome = excluded.failed_outcome,
     session_id = excluded.session_id,
-    notes = excluded.notes,
-    output = excluded.output;
+    workspace_kind = excluded.workspace_kind,
+    workspace_path = excluded.workspace_path,
+    deadline_at = excluded.deadline_at,
+    started_at = excluded.started_at,
+    settled_at = excluded.settled_at,
+    reason = excluded.reason,
+    output_tail = excluded.output_tail,
+    nudged = excluded.nudged;
 
 -- name: ListPipelineStageRunsByRun :many
-SELECT run_id, project_id, stage_name, stage_run_id, status, attempt, verdict,
-       started_at, completed_at, error_message, session_id, notes, output
-FROM pipeline_stage_runs WHERE run_id = ? ORDER BY stage_name ASC;
+SELECT * FROM pipeline_stage_runs WHERE run_id = ? ORDER BY stage_id ASC;
 
--- Pipeline artifacts ---------------------------------------------------------
+-- Pipeline stage signals -----------------------------------------------------
 
--- name: InsertPipelineArtifact :exec
-INSERT INTO pipeline_artifacts (
-    id, pipeline_run_id, project_id, stage_run_id, stage_name, kind,
-    fingerprint, status, sent_to_agent_at, payload, created_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+-- name: InsertPipelineStageSignal :exec
+INSERT INTO pipeline_stage_signals (run_id, stage_id, kind, reason, created_at)
+VALUES (?, ?, ?, ?, ?);
 
--- name: UpdatePipelineArtifactStatus :execrows
-UPDATE pipeline_artifacts SET status = ?, sent_to_agent_at = ? WHERE id = ?;
+-- name: GetLatestPipelineStageSignal :one
+-- Latest-wins: a stage signalled twice (once after a nudge) settles on the
+-- newest signal, with the earlier one kept for the record.
+SELECT run_id, stage_id, kind, reason, created_at
+FROM pipeline_stage_signals
+WHERE run_id = ? AND stage_id = ?
+ORDER BY created_at DESC, id DESC
+LIMIT 1;
 
--- name: GetPipelineArtifact :one
-SELECT id, pipeline_run_id, project_id, stage_run_id, stage_name, kind,
-       fingerprint, status, sent_to_agent_at, payload, created_at
-FROM pipeline_artifacts WHERE id = ?;
+-- Pipeline credentials -------------------------------------------------------
 
--- name: ListPipelineArtifactsByRun :many
-SELECT id, pipeline_run_id, project_id, stage_run_id, stage_name, kind,
-       fingerprint, status, sent_to_agent_at, payload, created_at
-FROM pipeline_artifacts WHERE pipeline_run_id = ? ORDER BY created_at ASC, id ASC;
+-- name: UpsertPipelineCredential :exec
+INSERT INTO pipeline_credentials (project_id, name, env_json, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT (project_id, name) DO UPDATE SET
+    env_json = excluded.env_json,
+    updated_at = excluded.updated_at;
+
+-- name: GetPipelineCredential :one
+SELECT env_json FROM pipeline_credentials WHERE project_id = ? AND name = ?;
+
+-- name: ListPipelineCredentialNames :many
+-- Names only. A credential value never leaves the daemon through a read path a
+-- human can reach (decision D13).
+SELECT name FROM pipeline_credentials WHERE project_id = ? ORDER BY name ASC;
+
+-- name: DeletePipelineCredential :execrows
+DELETE FROM pipeline_credentials WHERE project_id = ? AND name = ?;

--- a/backend/internal/storage/sqlite/store/pipeline_hydrate.go
+++ b/backend/internal/storage/sqlite/store/pipeline_hydrate.go
@@ -1,0 +1,27 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// HydratePipelineEngineState returns the runs a freshly constructed
+// per-project engine has to take back over: the unsettled ones, oldest first.
+//
+// Settled runs are deliberately absent. v2 runs are independent snapshots with
+// no cross-run history to rebuild (decision D1), so a settled run is only ever
+// read back through the run list on the board.
+//
+// Stages persisted as running whose in-process handle is gone are reconciled
+// by the engine on start (decision D16); the store hands them back exactly as
+// they were written.
+func (s *Store) HydratePipelineEngineState(ctx context.Context, projectID domain.ProjectID) ([]pipeline.RunState, error) {
+	rows, err := s.qr.ListUnsettledPipelineRuns(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("hydrate pipeline runs for %s: %w", projectID, err)
+	}
+	return hydrateRuns(ctx, s.qr, rows)
+}

--- a/backend/internal/storage/sqlite/store/pipeline_store.go
+++ b/backend/internal/storage/sqlite/store/pipeline_store.go
@@ -1,0 +1,520 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/gen"
+)
+
+// This file backs Pipelines v2. SQLite is the store of record: the run folder's
+// run.json is a projection for humans, and everything the engine needs to
+// resume after a restart lives here (decision D2).
+//
+// A run is normalized across two tables: pipeline_runs holds the run scalars,
+// the flattened subject, and the frozen definition; pipeline_stage_runs holds
+// one row per stage. hydrateRun reassembles a pipeline.RunState from both, and
+// SavePipelineRun writes both in one transaction so a reader never sees a run
+// whose stages are half-updated.
+
+// ---------------------------------------------------------------------------
+// Definitions
+// ---------------------------------------------------------------------------
+
+// CreatePipelineDefinition inserts a new definition. The raw YAML as authored
+// and the parsed snapshot are stored side by side: humans edit YAML, runs
+// freeze the parsed form.
+func (s *Store) CreatePipelineDefinition(ctx context.Context, def pipeline.Definition) error {
+	cfg, err := json.Marshal(def.Config)
+	if err != nil {
+		return fmt.Errorf("marshal pipeline config %s: %w", def.Name, err)
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return s.qw.CreatePipelineDefinition(ctx, gen.CreatePipelineDefinitionParams{
+		ID:         string(def.ID),
+		ProjectID:  domain.ProjectID(def.ProjectID),
+		Name:       def.Name,
+		YamlSource: def.YAMLSource,
+		ConfigJson: string(cfg),
+		CreatedAt:  def.CreatedAt,
+		UpdatedAt:  def.UpdatedAt,
+	})
+}
+
+// GetPipelineDefinition returns a definition by id, ok=false if none.
+func (s *Store) GetPipelineDefinition(ctx context.Context, id pipeline.ID) (pipeline.Definition, bool, error) {
+	row, err := s.qr.GetPipelineDefinition(ctx, string(id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return pipeline.Definition{}, false, nil
+	}
+	if err != nil {
+		return pipeline.Definition{}, false, fmt.Errorf("get pipeline definition %s: %w", id, err)
+	}
+	def, err := definitionFromRow(row)
+	if err != nil {
+		return pipeline.Definition{}, false, err
+	}
+	return def, true, nil
+}
+
+// GetPipelineDefinitionByName resolves a definition by (project, name), the
+// natural reference for CLI and manual triggers. ok=false if none.
+func (s *Store) GetPipelineDefinitionByName(ctx context.Context, projectID domain.ProjectID, name string) (pipeline.Definition, bool, error) {
+	row, err := s.qr.GetPipelineDefinitionByName(ctx, gen.GetPipelineDefinitionByNameParams{ProjectID: projectID, Name: name})
+	if errors.Is(err, sql.ErrNoRows) {
+		return pipeline.Definition{}, false, nil
+	}
+	if err != nil {
+		return pipeline.Definition{}, false, fmt.Errorf("get pipeline definition %s/%s: %w", projectID, name, err)
+	}
+	def, err := definitionFromRow(row)
+	if err != nil {
+		return pipeline.Definition{}, false, err
+	}
+	return def, true, nil
+}
+
+// ListPipelineDefinitions returns every definition for a project, by name.
+func (s *Store) ListPipelineDefinitions(ctx context.Context, projectID domain.ProjectID) ([]pipeline.Definition, error) {
+	rows, err := s.qr.ListPipelineDefinitions(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("list pipeline definitions for %s: %w", projectID, err)
+	}
+	out := make([]pipeline.Definition, 0, len(rows))
+	for _, row := range rows {
+		def, err := definitionFromRow(row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, def)
+	}
+	return out, nil
+}
+
+// UpdatePipelineDefinition overwrites a definition's name, YAML and config in
+// place (there is no version history). Runs freeze their definition, so an
+// edit never touches a run in flight. ok=false when no row matched the id.
+func (s *Store) UpdatePipelineDefinition(ctx context.Context, def pipeline.Definition) (bool, error) {
+	cfg, err := json.Marshal(def.Config)
+	if err != nil {
+		return false, fmt.Errorf("marshal pipeline config %s: %w", def.Name, err)
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	n, err := s.qw.UpdatePipelineDefinition(ctx, gen.UpdatePipelineDefinitionParams{
+		Name:       def.Name,
+		YamlSource: def.YAMLSource,
+		ConfigJson: string(cfg),
+		UpdatedAt:  def.UpdatedAt,
+		ID:         string(def.ID),
+	})
+	if err != nil {
+		return false, fmt.Errorf("update pipeline definition %s: %w", def.ID, err)
+	}
+	return n > 0, nil
+}
+
+// DeletePipelineDefinition removes a definition. Existing runs keep their
+// frozen copy and are untouched. ok=false if no row matched.
+func (s *Store) DeletePipelineDefinition(ctx context.Context, id pipeline.ID) (bool, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	n, err := s.qw.DeletePipelineDefinition(ctx, string(id))
+	if err != nil {
+		return false, fmt.Errorf("delete pipeline definition %s: %w", id, err)
+	}
+	return n > 0, nil
+}
+
+// ---------------------------------------------------------------------------
+// Runs (+ stage runs, persisted atomically)
+// ---------------------------------------------------------------------------
+
+// SavePipelineRun upserts a run and every one of its stage rows in a single
+// transaction (the engine's persist effect). Stage rows are never deleted
+// here: the plan-at-start walk enumerates every reachable stage before
+// anything runs, so the stage set of a run does not shrink.
+func (s *Store) SavePipelineRun(ctx context.Context, run pipeline.RunState) error {
+	params, err := runUpsertParams(run)
+	if err != nil {
+		return err
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return s.inTx(ctx, "save pipeline run", func(q *gen.Queries) error {
+		if err := q.UpsertPipelineRun(ctx, params); err != nil {
+			return err
+		}
+		for id, st := range run.Stages {
+			if st == nil {
+				continue
+			}
+			if err := q.UpsertPipelineStageRun(ctx, stageUpsertParams(run, id, st)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// GetPipelineRun returns a fully reconstructed run, ok=false if none.
+func (s *Store) GetPipelineRun(ctx context.Context, id pipeline.RunID) (pipeline.RunState, bool, error) {
+	row, err := s.qr.GetPipelineRun(ctx, string(id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return pipeline.RunState{}, false, nil
+	}
+	if err != nil {
+		return pipeline.RunState{}, false, fmt.Errorf("get pipeline run %s: %w", id, err)
+	}
+	run, err := hydrateRun(ctx, s.qr, row)
+	if err != nil {
+		return pipeline.RunState{}, false, err
+	}
+	return run, true, nil
+}
+
+// ListPipelineRuns returns a project's runs newest-first, optionally narrowed
+// by pipeline name, run status and count. Each run comes back fully
+// reconstructed, because the Kanban card renders stage outcomes.
+func (s *Store) ListPipelineRuns(ctx context.Context, projectID domain.ProjectID, filter pipeline.RunFilter) ([]pipeline.RunState, error) {
+	params := gen.ListPipelineRunsParams{ProjectID: projectID, Lim: -1}
+	if filter.PipelineName != "" {
+		params.PipelineName = sql.NullString{String: filter.PipelineName, Valid: true}
+	}
+	if filter.Status != "" {
+		params.Status = sql.NullString{String: filter.Status, Valid: true}
+	}
+	if filter.Limit > 0 {
+		params.Lim = int64(filter.Limit)
+	}
+	rows, err := s.qr.ListPipelineRuns(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("list pipeline runs for %s: %w", projectID, err)
+	}
+	return hydrateRuns(ctx, s.qr, rows)
+}
+
+// ---------------------------------------------------------------------------
+// Stage signals
+// ---------------------------------------------------------------------------
+
+// AppendPipelineStageSignal records one `ao pipeline done|fail`. Signals are
+// append-only; a stage signalled again after a nudge gets a second row and the
+// reader takes the newest.
+func (s *Store) AppendPipelineStageSignal(ctx context.Context, sig pipeline.StageSignal) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	err := s.qw.InsertPipelineStageSignal(ctx, gen.InsertPipelineStageSignalParams{
+		RunID:     string(sig.RunID),
+		StageID:   sig.StageID,
+		Kind:      string(sig.Kind),
+		Reason:    sig.Reason,
+		CreatedAt: sig.CreatedAt,
+	})
+	if err != nil {
+		return fmt.Errorf("append pipeline stage signal %s/%s: %w", sig.RunID, sig.StageID, err)
+	}
+	return nil
+}
+
+// LatestPipelineStageSignal returns the newest signal for a (run, stage),
+// ok=false when the stage has not signalled.
+func (s *Store) LatestPipelineStageSignal(ctx context.Context, runID pipeline.RunID, stageID string) (pipeline.StageSignal, bool, error) {
+	row, err := s.qr.GetLatestPipelineStageSignal(ctx, gen.GetLatestPipelineStageSignalParams{
+		RunID:   string(runID),
+		StageID: stageID,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return pipeline.StageSignal{}, false, nil
+	}
+	if err != nil {
+		return pipeline.StageSignal{}, false, fmt.Errorf("latest pipeline stage signal %s/%s: %w", runID, stageID, err)
+	}
+	return pipeline.StageSignal{
+		RunID:     pipeline.RunID(row.RunID),
+		StageID:   row.StageID,
+		Kind:      pipeline.SignalKind(row.Kind),
+		Reason:    row.Reason,
+		CreatedAt: row.CreatedAt,
+	}, true, nil
+}
+
+// ---------------------------------------------------------------------------
+// Credentials
+// ---------------------------------------------------------------------------
+
+// SetPipelineCredential creates or replaces a named credential. The env map is
+// stored wholesale: setting a name again replaces its whole environment rather
+// than merging, so removing a variable is possible.
+func (s *Store) SetPipelineCredential(ctx context.Context, projectID domain.ProjectID, name string, env map[string]string, now time.Time) error {
+	if env == nil {
+		env = map[string]string{}
+	}
+	blob, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal pipeline credential %s/%s: %w", projectID, name, err)
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	err = s.qw.UpsertPipelineCredential(ctx, gen.UpsertPipelineCredentialParams{
+		ProjectID: projectID,
+		Name:      name,
+		EnvJson:   string(blob),
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	if err != nil {
+		return fmt.Errorf("set pipeline credential %s/%s: %w", projectID, name, err)
+	}
+	return nil
+}
+
+// GetPipelineCredential returns a credential's environment for injection into
+// a command stage. This is the only read path that returns values, and it is
+// daemon-internal: nothing that reaches a user, a log line or an agent's
+// environment goes through it (decision D13).
+func (s *Store) GetPipelineCredential(ctx context.Context, projectID domain.ProjectID, name string) (map[string]string, bool, error) {
+	blob, err := s.qr.GetPipelineCredential(ctx, gen.GetPipelineCredentialParams{ProjectID: projectID, Name: name})
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("get pipeline credential %s/%s: %w", projectID, name, err)
+	}
+	var env map[string]string
+	if err := json.Unmarshal([]byte(blob), &env); err != nil {
+		return nil, false, fmt.Errorf("unmarshal pipeline credential %s/%s: %w", projectID, name, err)
+	}
+	return env, true, nil
+}
+
+// ListPipelineCredentialNames returns the declared credential names for a
+// project, sorted. Names only, never values.
+func (s *Store) ListPipelineCredentialNames(ctx context.Context, projectID domain.ProjectID) ([]string, error) {
+	names, err := s.qr.ListPipelineCredentialNames(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("list pipeline credentials for %s: %w", projectID, err)
+	}
+	return names, nil
+}
+
+// DeletePipelineCredential removes a credential, ok=false if no row matched.
+func (s *Store) DeletePipelineCredential(ctx context.Context, projectID domain.ProjectID, name string) (bool, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	n, err := s.qw.DeletePipelineCredential(ctx, gen.DeletePipelineCredentialParams{ProjectID: projectID, Name: name})
+	if err != nil {
+		return false, fmt.Errorf("delete pipeline credential %s/%s: %w", projectID, name, err)
+	}
+	return n > 0, nil
+}
+
+// ---------------------------------------------------------------------------
+// Reconstruction
+// ---------------------------------------------------------------------------
+
+// hydrateRuns reassembles every run in rows, preserving their order.
+func hydrateRuns(ctx context.Context, q *gen.Queries, rows []gen.PipelineRun) ([]pipeline.RunState, error) {
+	out := make([]pipeline.RunState, 0, len(rows))
+	for _, row := range rows {
+		run, err := hydrateRun(ctx, q, row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, run)
+	}
+	return out, nil
+}
+
+// hydrateRun reassembles a pipeline.RunState from its run row plus its stage
+// rows. Nudged is rebuilt from the per-stage flag and stays nil when no stage
+// was ever nudged, which is the state the reducer produces for a fresh run.
+func hydrateRun(ctx context.Context, q *gen.Queries, row gen.PipelineRun) (pipeline.RunState, error) {
+	var def pipeline.Pipeline
+	if err := json.Unmarshal([]byte(row.DefinitionJson), &def); err != nil {
+		return pipeline.RunState{}, fmt.Errorf("unmarshal frozen definition for run %s: %w", row.ID, err)
+	}
+
+	stageRows, err := q.ListPipelineStageRunsByRun(ctx, row.ID)
+	if err != nil {
+		return pipeline.RunState{}, fmt.Errorf("list stage runs for run %s: %w", row.ID, err)
+	}
+	stages := make(map[string]*pipeline.StageState, len(stageRows))
+	var nudged map[string]bool
+	for _, sr := range stageRows {
+		st := stageStateFromRow(sr)
+		stages[sr.StageID] = &st
+		if sr.Nudged != 0 {
+			if nudged == nil {
+				nudged = make(map[string]bool, len(stageRows))
+			}
+			nudged[sr.StageID] = true
+		}
+	}
+
+	return pipeline.RunState{
+		RunID:        pipeline.RunID(row.ID),
+		ProjectID:    string(row.ProjectID),
+		PipelineID:   pipeline.ID(row.PipelineID),
+		PipelineName: row.PipelineName,
+		Subject:      subjectFromRow(row),
+		Status:       pipeline.RunStatus(row.Status),
+		RunDir:       row.RunDir,
+		Def:          def,
+		Stages:       stages,
+		Nudged:       nudged,
+		CancelReason: row.CancelReason,
+		CreatedAt:    row.CreatedAt,
+		UpdatedAt:    row.UpdatedAt,
+		SettledAt:    timeFromNullTime(row.SettledAt),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Row <-> domain mapping
+// ---------------------------------------------------------------------------
+
+func definitionFromRow(r gen.PipelineDefinition) (pipeline.Definition, error) {
+	var cfg pipeline.Pipeline
+	if err := json.Unmarshal([]byte(r.ConfigJson), &cfg); err != nil {
+		return pipeline.Definition{}, fmt.Errorf("unmarshal pipeline config %s: %w", r.ID, err)
+	}
+	return pipeline.Definition{
+		ID:         pipeline.ID(r.ID),
+		ProjectID:  string(r.ProjectID),
+		Name:       r.Name,
+		YAMLSource: r.YamlSource,
+		Config:     cfg,
+		CreatedAt:  r.CreatedAt,
+		UpdatedAt:  r.UpdatedAt,
+	}, nil
+}
+
+func runUpsertParams(run pipeline.RunState) (gen.UpsertPipelineRunParams, error) {
+	def, err := json.Marshal(run.Def)
+	if err != nil {
+		return gen.UpsertPipelineRunParams{}, fmt.Errorf("marshal frozen definition for run %s: %w", run.RunID, err)
+	}
+	params := gen.UpsertPipelineRunParams{
+		ID:             string(run.RunID),
+		ProjectID:      domain.ProjectID(run.ProjectID),
+		PipelineID:     string(run.PipelineID),
+		PipelineName:   run.PipelineName,
+		SubjectKind:    string(run.Subject.Kind),
+		SessionID:      run.Subject.SessionID,
+		Status:         string(run.Status),
+		RunDir:         run.RunDir,
+		DefinitionJson: string(def),
+		CancelReason:   run.CancelReason,
+		CreatedAt:      run.CreatedAt,
+		UpdatedAt:      run.UpdatedAt,
+		SettledAt:      nullTimeFromTime(run.SettledAt),
+	}
+	if pr := run.Subject.PR; pr != nil {
+		params.PRNumber = int64(pr.Number)
+		params.PRRepo = pr.Repo
+		params.PRURL = pr.URL
+		params.HeadSha = pr.HeadSHA
+		params.PRHeadBranch = pr.HeadBranch
+		params.PRBaseBranch = pr.BaseBranch
+		params.FromFork = boolToInt64(pr.FromFork)
+	}
+	return params, nil
+}
+
+// subjectFromRow rebuilds the subject from its flattened columns. The PR half
+// is present exactly when the row carries a PR identity, so a session or
+// project subject never comes back holding a zero-valued PRRef.
+func subjectFromRow(r gen.PipelineRun) pipeline.Subject {
+	s := pipeline.Subject{
+		Kind:      pipeline.SubjectKind(r.SubjectKind),
+		ProjectID: string(r.ProjectID),
+		SessionID: r.SessionID,
+	}
+	if r.PRNumber != 0 || r.PRRepo != "" || r.PRURL != "" {
+		s.PR = &pipeline.PRRef{
+			Number:     int(r.PRNumber),
+			Repo:       r.PRRepo,
+			URL:        r.PRURL,
+			HeadSHA:    r.HeadSha,
+			HeadBranch: r.PRHeadBranch,
+			BaseBranch: r.PRBaseBranch,
+			FromFork:   r.FromFork != 0,
+		}
+	}
+	return s
+}
+
+func stageUpsertParams(run pipeline.RunState, stageID string, st *pipeline.StageState) gen.UpsertPipelineStageRunParams {
+	return gen.UpsertPipelineStageRunParams{
+		RunID:         string(run.RunID),
+		ProjectID:     domain.ProjectID(run.ProjectID),
+		StageID:       stageID,
+		Outcome:       string(st.Outcome),
+		Attempt:       int64(st.Attempt),
+		EnteredVia:    string(st.EnteredVia),
+		PrevStage:     st.PrevStage,
+		FailedStage:   st.FailedStage,
+		FailedOutcome: string(st.FailedOutcome),
+		SessionID:     st.SessionID,
+		WorkspaceKind: string(st.WorkspaceKind),
+		WorkspacePath: st.WorkspacePath,
+		DeadlineAt:    nullTimeFromTime(st.DeadlineAt),
+		StartedAt:     nullTimeFromTime(st.StartedAt),
+		SettledAt:     nullTimeFromTime(st.SettledAt),
+		Reason:        st.Reason,
+		OutputTail:    st.OutputTail,
+		Nudged:        boolToInt64(run.Nudged[stageID]),
+	}
+}
+
+func stageStateFromRow(r gen.PipelineStageRun) pipeline.StageState {
+	return pipeline.StageState{
+		ID:            r.StageID,
+		Outcome:       pipeline.Outcome(r.Outcome),
+		Attempt:       int(r.Attempt),
+		EnteredVia:    pipeline.EntryEdge(r.EnteredVia),
+		PrevStage:     r.PrevStage,
+		FailedStage:   r.FailedStage,
+		FailedOutcome: pipeline.Outcome(r.FailedOutcome),
+		SessionID:     r.SessionID,
+		WorkspaceKind: pipeline.WorkspaceKind(r.WorkspaceKind),
+		WorkspacePath: r.WorkspacePath,
+		DeadlineAt:    timeFromNullTime(r.DeadlineAt),
+		StartedAt:     timeFromNullTime(r.StartedAt),
+		SettledAt:     timeFromNullTime(r.SettledAt),
+		Reason:        r.Reason,
+		OutputTail:    r.OutputTail,
+	}
+}
+
+// boolToInt64 maps a Go bool onto the SQLite integer-bool column convention.
+func boolToInt64(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// nullTimeFromTime treats the zero time as "not set", which is what the state
+// structs mean by it: a stage that has not settled has a zero SettledAt.
+func nullTimeFromTime(t time.Time) sql.NullTime {
+	if t.IsZero() {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: t, Valid: true}
+}
+
+func timeFromNullTime(t sql.NullTime) time.Time {
+	if !t.Valid {
+		return time.Time{}
+	}
+	return t.Time
+}

--- a/backend/internal/storage/sqlite/store/pipeline_store_test.go
+++ b/backend/internal/storage/sqlite/store/pipeline_store_test.go
@@ -1,0 +1,560 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// samplePipelineV2 returns a small but real-shaped v2 definition: one agent
+// stage with a produces contract routing to one command stage, so the frozen
+// definition column is exercised with nested content rather than a stub.
+func samplePipelineV2(name string) pipeline.Pipeline {
+	return pipeline.Pipeline{
+		Name: name,
+		On:   pipeline.TriggerSpec{PR: []pipeline.PREvent{pipeline.PREventCreated}},
+		Defaults: pipeline.DefaultsSpec{
+			Deadline:  20 * time.Minute,
+			OnFailure: "notify",
+		},
+		Stages: []pipeline.Stage{
+			{
+				ID:        "review",
+				Executor:  pipeline.ExecutorAgent,
+				Agent:     "claude-code",
+				Produces:  "review.md",
+				Prompt:    "review the diff",
+				Session:   &pipeline.SessionSpec{KillOn: []pipeline.Outcome{pipeline.OutcomeSucceeded}},
+				OnSuccess: pipeline.StageList{"publish"},
+			},
+			{
+				ID:          "publish",
+				Executor:    pipeline.ExecutorCommand,
+				Run:         "gh release create",
+				Credentials: []string{"gh-release"},
+				Workspace:   pipeline.WorkspaceRun,
+			},
+			{ID: "notify", Executor: pipeline.ExecutorCommand, Run: "echo failed"},
+		},
+	}
+}
+
+func sampleDefinitionV2(project, name string, now time.Time) pipeline.Definition {
+	return pipeline.Definition{
+		ID:         pipeline.ID("pl-" + name),
+		ProjectID:  project,
+		Name:       name,
+		YAMLSource: "name: " + name + "\nstages:\n  - id: review\n    executor: agent\n",
+		Config:     samplePipelineV2(name),
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+}
+
+func TestPipelineDefinitionCRUDRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	now := time.Now().UTC().Truncate(time.Second)
+
+	def := sampleDefinitionV2("mer", "review", now)
+	if err := s.CreatePipelineDefinition(ctx, def); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, ok, err := s.GetPipelineDefinition(ctx, def.ID)
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	if got.YAMLSource != def.YAMLSource {
+		t.Fatalf("yaml column not round-tripped:\n got %q\nwant %q", got.YAMLSource, def.YAMLSource)
+	}
+	if !reflect.DeepEqual(got.Config, def.Config) {
+		t.Fatalf("config column not round-tripped:\n got %+v\nwant %+v", got.Config, def.Config)
+	}
+
+	byName, ok, err := s.GetPipelineDefinitionByName(ctx, "mer", "review")
+	if err != nil || !ok || byName.ID != def.ID {
+		t.Fatalf("get by name: ok=%v err=%v id=%v", ok, err, byName.ID)
+	}
+
+	def.YAMLSource = "name: review\nstages: []\n"
+	def.Config.Stages = nil
+	def.UpdatedAt = now.Add(time.Minute)
+	updated, err := s.UpdatePipelineDefinition(ctx, def)
+	if err != nil || !updated {
+		t.Fatalf("update: ok=%v err=%v", updated, err)
+	}
+	got, _, _ = s.GetPipelineDefinition(ctx, def.ID)
+	if len(got.Config.Stages) != 0 || got.YAMLSource != def.YAMLSource {
+		t.Fatalf("update not persisted: %+v", got)
+	}
+
+	if list, err := s.ListPipelineDefinitions(ctx, "mer"); err != nil || len(list) != 1 {
+		t.Fatalf("list = %d err=%v, want 1", len(list), err)
+	}
+
+	deleted, err := s.DeletePipelineDefinition(ctx, def.ID)
+	if err != nil || !deleted {
+		t.Fatalf("delete: ok=%v err=%v", deleted, err)
+	}
+	if _, ok, _ := s.GetPipelineDefinition(ctx, def.ID); ok {
+		t.Fatal("definition still present after delete")
+	}
+	// Deleting a missing id is a no-op (ok=false), not an error.
+	if deleted, err := s.DeletePipelineDefinition(ctx, def.ID); err != nil || deleted {
+		t.Fatalf("delete missing = %v %v, want false nil", deleted, err)
+	}
+}
+
+// prRun builds a settled PR-subject run whose stages cover every outcome in the
+// taxonomy, so no column is exercised only by its zero value.
+func prRun(now time.Time) pipeline.RunState {
+	started := now.Add(time.Second)
+	settled := now.Add(time.Minute)
+	stages := make(map[string]*pipeline.StageState, len(pipeline.AllOutcomes))
+	for i, outcome := range pipeline.AllOutcomes {
+		st := &pipeline.StageState{
+			ID:            string(outcome),
+			Outcome:       outcome,
+			Attempt:       i % 3,
+			EnteredVia:    pipeline.EntrySuccess,
+			PrevStage:     "review",
+			SessionID:     "mer-1",
+			WorkspaceKind: pipeline.WorkspaceRun,
+			WorkspacePath: "/runs/run-1/workspace",
+			DeadlineAt:    now.Add(20 * time.Minute),
+			StartedAt:     started,
+			Reason:        "because " + string(outcome),
+			OutputTail:    "tail for " + string(outcome),
+		}
+		if outcome.IsSettled() {
+			st.SettledAt = settled
+		}
+		if outcome.RoutesToFailure() {
+			st.EnteredVia = pipeline.EntryFailure
+			st.PrevStage = ""
+			st.FailedStage = "review"
+			st.FailedOutcome = pipeline.OutcomeTimedOut
+		}
+		stages[st.ID] = st
+	}
+	stages["entry"] = &pipeline.StageState{
+		ID: "entry", Outcome: pipeline.OutcomeSucceeded, Attempt: 1,
+		EnteredVia: pipeline.EntryTrigger, StartedAt: started, SettledAt: settled,
+	}
+	return pipeline.RunState{
+		RunID:        "run-1",
+		ProjectID:    "mer",
+		PipelineID:   "pl-review",
+		PipelineName: "review",
+		Subject: pipeline.Subject{
+			Kind:      pipeline.SubjectPR,
+			ProjectID: "mer",
+			SessionID: "mer-1",
+			PR: &pipeline.PRRef{
+				Number: 412, Repo: "o/r", URL: "https://github.com/o/r/pull/412",
+				HeadSHA: "abc123", HeadBranch: "feat/x", BaseBranch: "main", FromFork: true,
+			},
+		},
+		Status:       pipeline.RunFailed,
+		RunDir:       "/data/pipelines/mer/run-1",
+		Def:          samplePipelineV2("review"),
+		Stages:       stages,
+		Nudged:       map[string]bool{"no_signal": true},
+		CancelReason: "",
+		CreatedAt:    now,
+		UpdatedAt:    now.Add(2 * time.Minute),
+		SettledAt:    settled,
+	}
+}
+
+func TestPipelineRunSaveGetRoundTripPRSubject(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	now := time.Now().UTC().Truncate(time.Second)
+
+	want := prRun(now)
+	if err := s.SavePipelineRun(ctx, want); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, ok, err := s.GetPipelineRun(ctx, want.RunID)
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("run did not round-trip:\n got %s\nwant %s", mustJSON(t, got), mustJSON(t, want))
+	}
+
+	// Save is an upsert: re-saving a mutated run overwrites in place, and a
+	// stage that changed outcome carries its new columns.
+	want.Status = pipeline.RunCancelled
+	want.CancelReason = "superseded by concurrency"
+	want.Stages["pending"].Outcome = pipeline.OutcomeCancelled
+	want.Stages["pending"].SettledAt = now.Add(3 * time.Minute)
+	want.UpdatedAt = now.Add(3 * time.Minute)
+	if err := s.SavePipelineRun(ctx, want); err != nil {
+		t.Fatalf("re-save: %v", err)
+	}
+	got, _, _ = s.GetPipelineRun(ctx, want.RunID)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("upsert did not round-trip:\n got %s\nwant %s", mustJSON(t, got), mustJSON(t, want))
+	}
+
+	if _, ok, err := s.GetPipelineRun(ctx, "nope"); err != nil || ok {
+		t.Fatalf("get missing = %v %v, want false nil", ok, err)
+	}
+}
+
+// A session subject and a project subject carry no PR, and must not come back
+// with a zero-valued PRRef attached.
+func TestPipelineRunSaveGetRoundTripSessionAndProjectSubjects(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	now := time.Now().UTC().Truncate(time.Second)
+
+	subjects := map[string]pipeline.Subject{
+		"session": {Kind: pipeline.SubjectSession, ProjectID: "mer", SessionID: "mer-7"},
+		"project": {Kind: pipeline.SubjectProject, ProjectID: "mer"},
+	}
+	for id, subject := range subjects {
+		want := pipeline.RunState{
+			RunID: pipeline.RunID("run-" + id), ProjectID: "mer", PipelineID: "pl-review",
+			PipelineName: "review", Subject: subject, Status: pipeline.RunRunning,
+			RunDir: "/data/pipelines/mer/run-" + id, Def: samplePipelineV2("review"),
+			Stages: map[string]*pipeline.StageState{
+				"entry": {ID: "entry", Outcome: pipeline.OutcomeRunning, Attempt: 1, EnteredVia: pipeline.EntryTrigger, StartedAt: now},
+			},
+			CreatedAt: now, UpdatedAt: now,
+		}
+		if err := s.SavePipelineRun(ctx, want); err != nil {
+			t.Fatalf("save %s: %v", id, err)
+		}
+		got, ok, err := s.GetPipelineRun(ctx, want.RunID)
+		if err != nil || !ok {
+			t.Fatalf("get %s: ok=%v err=%v", id, ok, err)
+		}
+		if got.Subject.PR != nil {
+			t.Fatalf("%s subject came back with a PR: %+v", id, got.Subject.PR)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("%s run did not round-trip:\n got %s\nwant %s", id, mustJSON(t, got), mustJSON(t, want))
+		}
+	}
+}
+
+func TestPipelineListRunsFilters(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	seedProject(t, s, "other")
+	base := time.Now().UTC().Truncate(time.Second)
+
+	save := func(id, project, name string, status pipeline.RunStatus, at time.Time) {
+		t.Helper()
+		run := pipeline.RunState{
+			RunID: pipeline.RunID(id), ProjectID: project, PipelineID: pipeline.ID("pl-" + name),
+			PipelineName: name, Subject: pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: project},
+			Status: status, Def: samplePipelineV2(name),
+			Stages:    map[string]*pipeline.StageState{"entry": {ID: "entry", Outcome: pipeline.OutcomePending}},
+			CreatedAt: at, UpdatedAt: at,
+		}
+		if err := s.SavePipelineRun(ctx, run); err != nil {
+			t.Fatalf("save %s: %v", id, err)
+		}
+	}
+	save("r1", "mer", "review", pipeline.RunSucceeded, base)
+	save("r2", "mer", "review", pipeline.RunRunning, base.Add(time.Minute))
+	save("r3", "mer", "release", pipeline.RunFailed, base.Add(2*time.Minute))
+	save("r4", "other", "review", pipeline.RunRunning, base.Add(3*time.Minute))
+
+	// Unfiltered: this project only, newest first.
+	all, err := s.ListPipelineRuns(ctx, "mer", pipeline.RunFilter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if got := runIDs(all); !reflect.DeepEqual(got, []pipeline.RunID{"r3", "r2", "r1"}) {
+		t.Fatalf("unfiltered = %v, want [r3 r2 r1]", got)
+	}
+	// Stages come back on listed runs, not just on Get.
+	if len(all[0].Stages) != 1 {
+		t.Fatalf("listed run has %d stages, want 1", len(all[0].Stages))
+	}
+
+	byPipeline, _ := s.ListPipelineRuns(ctx, "mer", pipeline.RunFilter{PipelineName: "review"})
+	if got := runIDs(byPipeline); !reflect.DeepEqual(got, []pipeline.RunID{"r2", "r1"}) {
+		t.Fatalf("by pipeline = %v, want [r2 r1]", got)
+	}
+
+	byStatus, _ := s.ListPipelineRuns(ctx, "mer", pipeline.RunFilter{Status: string(pipeline.RunRunning)})
+	if got := runIDs(byStatus); !reflect.DeepEqual(got, []pipeline.RunID{"r2"}) {
+		t.Fatalf("by status = %v, want [r2]", got)
+	}
+
+	both, _ := s.ListPipelineRuns(ctx, "mer", pipeline.RunFilter{PipelineName: "review", Status: string(pipeline.RunSucceeded)})
+	if got := runIDs(both); !reflect.DeepEqual(got, []pipeline.RunID{"r1"}) {
+		t.Fatalf("by pipeline+status = %v, want [r1]", got)
+	}
+
+	limited, _ := s.ListPipelineRuns(ctx, "mer", pipeline.RunFilter{Limit: 2})
+	if got := runIDs(limited); !reflect.DeepEqual(got, []pipeline.RunID{"r3", "r2"}) {
+		t.Fatalf("limited = %v, want [r3 r2]", got)
+	}
+}
+
+func TestPipelineHydrateReturnsUnsettledRunsOnly(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	seedProject(t, s, "other")
+	base := time.Now().UTC().Truncate(time.Second)
+
+	save := func(id, project string, status pipeline.RunStatus, at time.Time) {
+		t.Helper()
+		run := pipeline.RunState{
+			RunID: pipeline.RunID(id), ProjectID: project, PipelineID: "pl-review", PipelineName: "review",
+			Subject: pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: project},
+			Status:  status, Def: samplePipelineV2("review"),
+			Stages:    map[string]*pipeline.StageState{"entry": {ID: "entry", Outcome: pipeline.OutcomeRunning}},
+			CreatedAt: at, UpdatedAt: at,
+		}
+		if status == pipeline.RunSucceeded || status == pipeline.RunFailed || status == pipeline.RunCancelled {
+			run.SettledAt = at
+		}
+		if err := s.SavePipelineRun(ctx, run); err != nil {
+			t.Fatalf("save %s: %v", id, err)
+		}
+	}
+	save("live-1", "mer", pipeline.RunRunning, base)
+	save("live-2", "mer", pipeline.RunPending, base.Add(time.Minute))
+	save("done", "mer", pipeline.RunSucceeded, base.Add(2*time.Minute))
+	save("failed", "mer", pipeline.RunFailed, base.Add(3*time.Minute))
+	save("cancelled", "mer", pipeline.RunCancelled, base.Add(4*time.Minute))
+	save("other-live", "other", pipeline.RunRunning, base.Add(5*time.Minute))
+
+	runs, err := s.HydratePipelineEngineState(ctx, "mer")
+	if err != nil {
+		t.Fatalf("hydrate: %v", err)
+	}
+	// Oldest first, so the engine replays them in the order they were created.
+	if got := runIDs(runs); !reflect.DeepEqual(got, []pipeline.RunID{"live-1", "live-2"}) {
+		t.Fatalf("hydrated = %v, want [live-1 live-2]", got)
+	}
+	if len(runs[0].Stages) != 1 || runs[0].Stages["entry"].Outcome != pipeline.OutcomeRunning {
+		t.Fatalf("hydrated run lost its stages: %+v", runs[0].Stages)
+	}
+}
+
+func TestPipelineStageSignalLatestWins(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	now := time.Now().UTC().Truncate(time.Second)
+
+	run := prRun(now)
+	if err := s.SavePipelineRun(ctx, run); err != nil {
+		t.Fatalf("save run: %v", err)
+	}
+
+	if _, ok, err := s.LatestPipelineStageSignal(ctx, "run-1", "review"); err != nil || ok {
+		t.Fatalf("no signal yet = %v %v, want false nil", ok, err)
+	}
+
+	first := pipeline.StageSignal{RunID: "run-1", StageID: "review", Kind: pipeline.SignalFail, Reason: "impossible", CreatedAt: now}
+	if err := s.AppendPipelineStageSignal(ctx, first); err != nil {
+		t.Fatalf("append first: %v", err)
+	}
+	got, ok, err := s.LatestPipelineStageSignal(ctx, "run-1", "review")
+	if err != nil || !ok || !reflect.DeepEqual(got, first) {
+		t.Fatalf("first signal = %+v ok=%v err=%v", got, ok, err)
+	}
+
+	// A second signal (the nudged attempt) supersedes the first without
+	// deleting it: latest-wins on read.
+	second := pipeline.StageSignal{RunID: "run-1", StageID: "review", Kind: pipeline.SignalDone, CreatedAt: now.Add(time.Minute)}
+	if err := s.AppendPipelineStageSignal(ctx, second); err != nil {
+		t.Fatalf("append second: %v", err)
+	}
+	got, ok, _ = s.LatestPipelineStageSignal(ctx, "run-1", "review")
+	if !ok || !reflect.DeepEqual(got, second) {
+		t.Fatalf("latest signal = %+v, want %+v", got, second)
+	}
+
+	// Another stage in the same run is unaffected.
+	if _, ok, _ := s.LatestPipelineStageSignal(ctx, "run-1", "publish"); ok {
+		t.Fatal("signal leaked across stages")
+	}
+}
+
+func TestPipelineCredentialRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	seedProject(t, s, "other")
+	now := time.Now().UTC().Truncate(time.Second)
+
+	env := map[string]string{"GH_TOKEN": "ghp_secret", "NPM_TOKEN": "npm_secret"}
+	if err := s.SetPipelineCredential(ctx, "mer", "gh-release", env, now); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, ok, err := s.GetPipelineCredential(ctx, "mer", "gh-release")
+	if err != nil || !ok || !reflect.DeepEqual(got, env) {
+		t.Fatalf("get = %v ok=%v err=%v, want %v", got, ok, err, env)
+	}
+
+	// Set is an upsert: the same name overwrites its env wholesale.
+	next := map[string]string{"GH_TOKEN": "ghp_rotated"}
+	if err := s.SetPipelineCredential(ctx, "mer", "gh-release", next, now.Add(time.Minute)); err != nil {
+		t.Fatalf("re-set: %v", err)
+	}
+	got, _, _ = s.GetPipelineCredential(ctx, "mer", "gh-release")
+	if !reflect.DeepEqual(got, next) {
+		t.Fatalf("upsert = %v, want %v", got, next)
+	}
+
+	if err := s.SetPipelineCredential(ctx, "mer", "apple-signing", map[string]string{"A": "b"}, now); err != nil {
+		t.Fatalf("set second: %v", err)
+	}
+	if err := s.SetPipelineCredential(ctx, "other", "gh-release", map[string]string{"A": "b"}, now); err != nil {
+		t.Fatalf("set other project: %v", err)
+	}
+
+	// The list path is names only: values never leave the daemon on a read a
+	// human can reach (decision D13).
+	names, err := s.ListPipelineCredentialNames(ctx, "mer")
+	if err != nil || !reflect.DeepEqual(names, []string{"apple-signing", "gh-release"}) {
+		t.Fatalf("list = %v err=%v, want [apple-signing gh-release]", names, err)
+	}
+
+	deleted, err := s.DeletePipelineCredential(ctx, "mer", "gh-release")
+	if err != nil || !deleted {
+		t.Fatalf("delete: ok=%v err=%v", deleted, err)
+	}
+	if _, ok, _ := s.GetPipelineCredential(ctx, "mer", "gh-release"); ok {
+		t.Fatal("credential still present after delete")
+	}
+	// The other project's same-named credential survives.
+	if _, ok, _ := s.GetPipelineCredential(ctx, "other", "gh-release"); !ok {
+		t.Fatal("delete crossed the project boundary")
+	}
+	if deleted, err := s.DeletePipelineCredential(ctx, "mer", "gh-release"); err != nil || deleted {
+		t.Fatalf("delete missing = %v %v, want false nil", deleted, err)
+	}
+}
+
+func runIDs(runs []pipeline.RunState) []pipeline.RunID {
+	out := make([]pipeline.RunID, 0, len(runs))
+	for _, r := range runs {
+		out = append(out, r.RunID)
+	}
+	return out
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+// TestPipelineCDCTriggersEmitProjectLevelEvents asserts each pipeline_* row
+// change writes the expected change_log entry: right type, project-scoped
+// (session_id NULL), and the payload shape live clients key off.
+func TestPipelineCDCTriggersEmitProjectLevelEvents(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	now := time.Now().UTC().Truncate(time.Second)
+
+	if err := s.CreatePipelineDefinition(ctx, sampleDefinitionV2("mer", "review", now)); err != nil {
+		t.Fatalf("create def: %v", err)
+	}
+	run := pipeline.RunState{
+		RunID: "run-1", ProjectID: "mer", PipelineID: "pl-review", PipelineName: "review",
+		Subject: pipeline.Subject{Kind: pipeline.SubjectSession, ProjectID: "mer", SessionID: "mer-1"},
+		Status:  pipeline.RunRunning, RunDir: "/data/pipelines/mer/run-1", Def: samplePipelineV2("review"),
+		Stages: map[string]*pipeline.StageState{
+			"review": {ID: "review", Outcome: pipeline.OutcomeRunning, Attempt: 1, EnteredVia: pipeline.EntryTrigger},
+		},
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.SavePipelineRun(ctx, run); err != nil {
+		t.Fatalf("save run: %v", err)
+	}
+
+	// Settling the run and its stage must fire an update event for each.
+	run.Status = pipeline.RunSucceeded
+	run.SettledAt = now.Add(time.Minute)
+	run.UpdatedAt = now.Add(time.Minute)
+	run.Stages["review"].Outcome = pipeline.OutcomeSucceeded
+	run.Stages["review"].Attempt = 2
+	if err := s.SavePipelineRun(ctx, run); err != nil {
+		t.Fatalf("settle run: %v", err)
+	}
+
+	evs, err := s.EventsAfter(ctx, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byType := map[cdc.EventType][]cdc.Event{}
+	for _, e := range evs {
+		switch e.Type {
+		case cdc.EventPipelineDefinitionChanged, cdc.EventPipelineRunUpdated, cdc.EventPipelineStageRunUpdated:
+		default:
+			continue
+		}
+		if e.ProjectID != "mer" {
+			t.Fatalf("pipeline event project = %q, want mer", e.ProjectID)
+		}
+		if e.SessionID != "" {
+			t.Fatalf("pipeline event must be project-level (empty session), got %q", e.SessionID)
+		}
+		byType[e.Type] = append(byType[e.Type], e)
+	}
+
+	if len(byType[cdc.EventPipelineDefinitionChanged]) != 1 {
+		t.Fatalf("definition events = %d, want 1", len(byType[cdc.EventPipelineDefinitionChanged]))
+	}
+	assertPayload(t, byType[cdc.EventPipelineDefinitionChanged][0], map[string]any{"name": "review", "change": "created"})
+
+	if len(byType[cdc.EventPipelineRunUpdated]) != 2 {
+		t.Fatalf("run events = %d, want 2 (insert + settle)", len(byType[cdc.EventPipelineRunUpdated]))
+	}
+	assertPayload(t, byType[cdc.EventPipelineRunUpdated][0], map[string]any{
+		"runId": "run-1", "pipelineId": "pl-review", "pipelineName": "review",
+		"status": "running", "subjectKind": "session", "sessionId": "mer-1",
+	})
+	assertPayload(t, byType[cdc.EventPipelineRunUpdated][1], map[string]any{"runId": "run-1", "status": "succeeded"})
+
+	if len(byType[cdc.EventPipelineStageRunUpdated]) != 2 {
+		t.Fatalf("stage events = %d, want 2 (insert + settle)", len(byType[cdc.EventPipelineStageRunUpdated]))
+	}
+	assertPayload(t, byType[cdc.EventPipelineStageRunUpdated][0], map[string]any{
+		"runId": "run-1", "stageId": "review", "outcome": "running", "attempt": float64(1),
+	})
+	assertPayload(t, byType[cdc.EventPipelineStageRunUpdated][1], map[string]any{
+		"runId": "run-1", "stageId": "review", "outcome": "succeeded", "attempt": float64(2),
+	})
+}
+
+func assertPayload(t *testing.T, e cdc.Event, want map[string]any) {
+	t.Helper()
+	var got map[string]any
+	if err := json.Unmarshal(e.Payload, &got); err != nil {
+		t.Fatalf("payload JSON for %s: %v", e.Type, err)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("%s payload[%q] = %#v, want %#v (full: %s)", e.Type, k, got[k], v, e.Payload)
+		}
+	}
+}

--- a/backend/sqlc.yaml
+++ b/backend/sqlc.yaml
@@ -148,7 +148,7 @@ sql:
             go_type:
               import: "github.com/aoagents/agent-orchestrator/backend/internal/domain"
               type: "ProjectID"
-          - column: "pipeline_artifacts.project_id"
+          - column: "pipeline_credentials.project_id"
             go_type:
               import: "github.com/aoagents/agent-orchestrator/backend/internal/domain"
               type: "ProjectID"


### PR DESCRIPTION
Task 17 of the Pipelines v2 rebuild: the SQLite layer the engine, the HTTP API and the CLI all sit on.

Closes #297

## What lands

**Migration `0047_pipelines_v2.sql`.** Drops `pipeline_artifacts` with the rest of the findings subsystem (D10), recreates `pipeline_runs` and `pipeline_stage_runs` in the v2 shape, and adds `pipeline_stage_signals` (D12) and `pipeline_credentials` (D13). `pipeline_definitions` is untouched: definitions travel as raw YAML, and v1 YAML simply fails v2 validation when the editor opens it. v1 never shipped outside the flag, so the migration is destructive by design and owes no backfill.

**Store rewrite.** The columns mirror the Task 3 state structs.

- `SavePipelineRun(ctx, RunState)` upserts the run and every stage row in one transaction, so a reader never sees a run whose stages are half-updated.
- `GetPipelineRun` / `ListPipelineRuns` reassemble full `RunState`s; the list filters by pipeline name, status and limit, newest first.
- `HydratePipelineEngineState(ctx, projectID)` returns the unsettled runs only, oldest first, so a restarted engine takes back over in creation order. Settled runs stay out: v2 runs are independent snapshots with no cross-run history to rebuild (D1).
- Signals are append-only with latest-wins reads, so a post-nudge signal supersedes the first without losing it.
- Credential values are returned only by the daemon-internal get path used for command-stage injection; the list path is names only (D13).

**CDC.** Run and stage triggers are recreated for the v2 columns; the artifact trigger is gone. `change_log` keeps its CHECK list as written in 0040, so `pipeline_artifact_updated` stays a legal value with no emitter: narrowing the CHECK means rebuilding `change_log` and re-creating every CDC trigger in the schema for no behavioural gain.

## Judgment calls worth a look

The plan's exact column list cannot round-trip a full `RunState`, which the same task's test list requires. Nothing was removed from the list; four things were added, and each is noted in the migration:

- `pipeline_runs.definition_json`: the frozen definition. D2 makes SQLite the store of record, so a run has to be replayable without reading the run folder.
- `pipeline_runs.pr_head_branch` / `pr_base_branch`: `PRRef` fields a `workspace: checkout` stage needs after a restart.
- `pipeline_stage_runs.nudged`: `RunState.Nudged`, stored per stage where it belongs.
- `pipeline.StageState.OutputTail`: the plan lists an `output_tail` column and Task 18's `PipelineStageView` DTO carries `outputTail`, but Task 3's struct had no field for it. Added so the column has a carrier.

`pipeline.StageSignal` / `SignalKind` land in `internal/pipeline/signal.go`. Task 11 is not in flight yet; when it lands it wires the HTTP and CLI surfaces onto `AppendPipelineStageSignal` / `LatestPipelineStageSignal` and drops its in-memory registry.

## Tests

`pipeline_store_test.go`, written first and watched fail:

- save/get round-trip of a full `RunState` whose stages cover every outcome in the taxonomy, plus each subject variant (PR with a fork identity, session, project). A session or project subject must not come back holding a zero-valued `PRRef`.
- re-save is an upsert, in place.
- hydrate returns unsettled runs only, oldest first, scoped to one project.
- list filters by pipeline, status, limit, and combinations.
- signal latest-wins, and does not leak across stages.
- credential round-trip: upsert replaces the env wholesale, list is names only, delete respects the project boundary.
- CDC: insert and settle each fire one run event and one stage event, project-level, with the v2 payload keys.

`cd backend && go build ./... && go test ./... && gofmt -l .` and `golangci-lint run ./...` are clean. Four `internal/cli` spawn tests fail identically on `origin/pipelines`, unrelated to this change (verified against the base branch in a scratch worktree).

## Risks

The migration is destructive: any local v1 run rows are dropped on upgrade. That is the intended behaviour per the plan's global constraints, and definitions survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)