### PR TITLE
feat(pipelines): subject-derived workspace resolver over gitworktree

### DIFF
--- a/backend/internal/pipeline/executors/workspace.go
+++ b/backend/internal/pipeline/executors/workspace.go
@@ -1,0 +1,301 @@
+package executors
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// WorkspaceProvisioner hands a stage the tree it runs in. The engine calls it
+// lazily, when a StartStage effect executes, so a branch that is never taken
+// never pays for a checkout (decision D8).
+//
+// owned reports whether the run created the tree and may therefore destroy it.
+// The teardown policy itself lives with the driver: owned trees are destroyed
+// when the run settles succeeded and kept otherwise (spec section 5.5).
+type WorkspaceProvisioner interface {
+	Provision(ctx context.Context, req WorkspaceRequest) (path string, owned bool, err error)
+	Destroy(ctx context.Context, path string) error
+}
+
+// WorkspaceRequest is one stage's ask, already resolved by ComputePlan: Kind is
+// never auto or unset by the time it reaches the provisioner.
+type WorkspaceRequest struct {
+	Kind        pipeline.WorkspaceKind // resolved: session|run|stage|checkout|inherit
+	ProjectID   string
+	RunID       pipeline.RunID
+	StageID     string
+	Subject     pipeline.Subject
+	InheritPath string // failed stage's tree for inherit
+	BaseRef     string // subject's ref for run/stage worktrees
+	RunDir      string
+}
+
+// Worktrees is the slice of the gitworktree adapter this resolver needs.
+// *gitworktree.Workspace satisfies it as-is, so pipelines create trees through
+// the same checkout-not-clone path sessions use.
+//
+// The injected adapter must be rooted at the pipelines base dir
+// (<AO_DATA_DIR>/pipelines), because run and stage trees live inside the run
+// folder and the adapter refuses any path outside its managed root.
+type Worktrees interface {
+	Restore(ctx context.Context, cfg ports.WorkspaceConfig) (ports.WorkspaceInfo, error)
+	ForceDestroy(ctx context.Context, info ports.WorkspaceInfo) error
+}
+
+// SessionWorkspaces resolves the subject session's existing worktree.
+type SessionWorkspaces interface {
+	Get(ctx context.Context, sessionID string) (path string, ok bool, err error)
+}
+
+// Checkouts resolves a project's primary local checkout, the tree the user is
+// actually coding in.
+type Checkouts interface {
+	CheckoutPath(projectID string) (string, error)
+}
+
+// WorkspaceResolver implements WorkspaceProvisioner over the gitworktree
+// adapter. One instance serves every run of a project, so the memo tables are
+// keyed by run and guarded by a mutex: fan-out stages provision concurrently.
+type WorkspaceResolver struct {
+	trees     Worktrees
+	sessions  SessionWorkspaces
+	checkouts Checkouts
+
+	mu sync.Mutex
+	// runs memoizes the one tree a `workspace: run` run gets, so every later
+	// stage shares the earlier stages' filesystem state (spec section 5.2).
+	runs map[pipeline.RunID]string
+	// entered records stage trees handed out already, so re-entering a stage
+	// destroys the stale tree rather than reusing it.
+	entered map[string]bool
+	// owned maps a provisioned path to the handle needed to destroy it. It is
+	// also the guard on Destroy: a path this resolver did not create is never
+	// removed.
+	owned map[string]ports.WorkspaceInfo
+}
+
+// NewWorkspaceResolver builds the resolver over its three seams.
+func NewWorkspaceResolver(trees Worktrees, sessions SessionWorkspaces, checkouts Checkouts) *WorkspaceResolver {
+	return &WorkspaceResolver{
+		trees:     trees,
+		sessions:  sessions,
+		checkouts: checkouts,
+		runs:      map[pipeline.RunID]string{},
+		entered:   map[string]bool{},
+		owned:     map[string]ports.WorkspaceInfo{},
+	}
+}
+
+var _ WorkspaceProvisioner = (*WorkspaceResolver)(nil)
+
+// Provision resolves the request to a path on disk, creating a worktree when
+// the kind calls for one.
+func (r *WorkspaceResolver) Provision(ctx context.Context, req WorkspaceRequest) (string, bool, error) {
+	switch req.Kind {
+	case pipeline.WorkspaceSession:
+		path, err := r.sessionPath(ctx, req)
+		return path, false, err
+	case pipeline.WorkspaceCheckout:
+		path, err := r.checkouts.CheckoutPath(req.ProjectID)
+		if err != nil {
+			return "", false, fmt.Errorf("resolve checkout for project %q: %w", req.ProjectID, err)
+		}
+		return path, false, nil
+	case pipeline.WorkspaceInherit:
+		// Ownership stays with the stage that created the tree, so an inheriting
+		// stage never destroys what it was handed (spec section 5.4).
+		if req.InheritPath == "" {
+			return "", false, fmt.Errorf("stage %q requires workspace 'inherit' but no stage routed a tree into it", req.StageID)
+		}
+		return req.InheritPath, false, nil
+	case pipeline.WorkspaceRun:
+		path, err := r.runWorkspace(ctx, req)
+		return path, true, err
+	case pipeline.WorkspaceStage:
+		path, err := r.stageWorkspace(ctx, req)
+		return path, true, err
+	default:
+		// auto and unset are resolved by ComputePlan before the first stage
+		// starts; anything else never passed validation.
+		return "", false, fmt.Errorf("stage %q has unresolved workspace kind %q", req.StageID, req.Kind)
+	}
+}
+
+// sessionPath returns the subject session's own worktree. This is belt to the
+// plan-time check in ComputePlan: the session can still vanish between plan and
+// start, and then the stage fails with the reason stated rather than silently
+// running somewhere else (spec section 5.3).
+func (r *WorkspaceResolver) sessionPath(ctx context.Context, req WorkspaceRequest) (string, error) {
+	sessionID := req.Subject.SessionID
+	if sessionID == "" {
+		return "", fmt.Errorf("stage %q requires workspace 'session'; the subject has no local session", req.StageID)
+	}
+	path, ok, err := r.sessions.Get(ctx, sessionID)
+	if err != nil {
+		return "", fmt.Errorf("resolve session %q for stage %q: %w", sessionID, req.StageID, err)
+	}
+	if !ok || path == "" {
+		return "", fmt.Errorf("stage %q requires workspace 'session'; session %q has no workspace", req.StageID, sessionID)
+	}
+	return path, nil
+}
+
+// runWorkspace creates <run>/workspace on first use and returns the same path
+// for every later stage of the run.
+func (r *WorkspaceResolver) runWorkspace(ctx context.Context, req WorkspaceRequest) (string, error) {
+	if err := pathComponent("run id", string(req.RunID)); err != nil {
+		return "", err
+	}
+	r.mu.Lock()
+	memo, ok := r.runs[req.RunID]
+	r.mu.Unlock()
+	if ok {
+		return memo, nil
+	}
+
+	target := pipeline.RunWorkspaceDir(pipeline.RunFolder{Dir: req.RunDir})
+	path, err := r.create(ctx, req, target, r.branch(req.RunID, "run"), "pipeline-"+string(req.RunID))
+	if err != nil {
+		return "", err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Two stages can race to first use; the adapter is idempotent for the same
+	// path, so the loser simply adopts the winner's path.
+	if memo, ok := r.runs[req.RunID]; ok {
+		return memo, nil
+	}
+	r.runs[req.RunID] = path
+	return path, nil
+}
+
+// stageWorkspace creates <run>/workspaces/<stageID>, fresh each time the stage
+// is entered. Concurrent stages get one tree each, which is the whole reason
+// the kind exists (spec section 5.2).
+func (r *WorkspaceResolver) stageWorkspace(ctx context.Context, req WorkspaceRequest) (string, error) {
+	if err := pathComponent("run id", string(req.RunID)); err != nil {
+		return "", err
+	}
+	// Stage ids are author-written and only checked for uniqueness at edit
+	// time, so this is the first place that keeps one from escaping the run
+	// folder.
+	if err := pathComponent("stage id", req.StageID); err != nil {
+		return "", err
+	}
+
+	target := pipeline.StageWorkspaceDir(pipeline.RunFolder{Dir: req.RunDir}, req.StageID)
+	key := string(req.RunID) + "/" + req.StageID
+
+	r.mu.Lock()
+	stale := r.entered[key]
+	info, live := r.owned[target]
+	r.mu.Unlock()
+	if stale && live {
+		if err := r.trees.ForceDestroy(ctx, info); err != nil {
+			return "", fmt.Errorf("discard stale workspace for stage %q: %w", req.StageID, err)
+		}
+		r.forget(target)
+	}
+
+	path, err := r.create(ctx, req, target, r.branch(req.RunID, "stage-"+req.StageID), "pipeline-"+string(req.RunID)+"-"+req.StageID)
+	if err != nil {
+		return "", err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entered[key] = true
+	return path, nil
+}
+
+// create materialises one worktree at an explicit path inside the run folder.
+//
+// name is the adapter's id for the tree: it names the directory for session
+// worktrees, but here the path is supplied outright, so it only has to be a
+// safe, recognisable label.
+func (r *WorkspaceResolver) create(ctx context.Context, req WorkspaceRequest, target, branch, name string) (string, error) {
+	info, err := r.trees.Restore(ctx, ports.WorkspaceConfig{
+		ProjectID: domain.ProjectID(req.ProjectID),
+		SessionID: domain.SessionID(name),
+		Kind:      domain.KindWorker,
+		Branch:    branch,
+		// The subject's ref is where the tree starts. An empty BaseRef lets the
+		// adapter fall back to the repo's default branch.
+		BaseBranch: req.BaseRef,
+		Path:       target,
+	})
+	if err != nil {
+		return "", fmt.Errorf("create workspace for stage %q at %s: %w", req.StageID, target, err)
+	}
+	path := info.Path
+	if path == "" {
+		path = target
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.owned[path] = info
+	return path, nil
+}
+
+// branch names the tree's branch. Both scopes live under one per-run directory
+// so a run branch and a stage branch of the same run cannot collide in git's
+// ref namespace.
+func (r *WorkspaceResolver) branch(runID pipeline.RunID, scope string) string {
+	return "ao/pipeline/" + string(runID) + "/" + scope
+}
+
+// Destroy removes a tree this resolver created. It refuses any other path: the
+// driver's teardown must never be able to delete the user's checkout or a
+// session worktree.
+//
+// Removal is forced. An owned pipeline tree is engine scratch, the run's
+// declared artifacts already live in the run folder, and the driver only ever
+// destroys after a successful run (spec section 5.5), so refusing on
+// uncommitted changes would leak a tree on every run that wrote a file.
+func (r *WorkspaceResolver) Destroy(ctx context.Context, path string) error {
+	r.mu.Lock()
+	info, ok := r.owned[path]
+	r.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("destroy %q: not a workspace this run owns", path)
+	}
+	if err := r.trees.ForceDestroy(ctx, info); err != nil {
+		return fmt.Errorf("destroy workspace %q: %w", path, err)
+	}
+	r.forget(path)
+	return nil
+}
+
+// forget drops every memo entry pointing at a path, so the next request for it
+// provisions a new tree instead of handing back a directory that is gone.
+func (r *WorkspaceResolver) forget(path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.owned, path)
+	for runID, p := range r.runs {
+		if p == path {
+			delete(r.runs, runID)
+		}
+	}
+}
+
+// pathComponent keeps an id from escaping the run folder once joined into a
+// path. Same guard rail as the run folder's own, applied to the ids that reach
+// the workspace layer.
+func pathComponent(what, value string) error {
+	switch {
+	case value == "":
+		return fmt.Errorf("workspace: %s is empty", what)
+	case value == "." || value == "..":
+		return fmt.Errorf("workspace: %s %q is a path segment", what, value)
+	case strings.ContainsAny(value, `/\`):
+		return fmt.Errorf("workspace: %s %q contains a path separator", what, value)
+	}
+	return nil
+}

--- a/backend/internal/pipeline/executors/workspace_test.go
+++ b/backend/internal/pipeline/executors/workspace_test.go
@@ -1,0 +1,399 @@
+package executors
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/gitworktree"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// fakeTrees stands in for the gitworktree adapter: it records what would have
+// been created or destroyed without touching git or the filesystem.
+type fakeTrees struct {
+	mu        sync.Mutex
+	restores  []ports.WorkspaceConfig
+	destroyed []ports.WorkspaceInfo
+	err       error
+}
+
+func (f *fakeTrees) Restore(_ context.Context, cfg ports.WorkspaceConfig) (ports.WorkspaceInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return ports.WorkspaceInfo{}, f.err
+	}
+	f.restores = append(f.restores, cfg)
+	return ports.WorkspaceInfo{Path: cfg.Path, Branch: cfg.Branch, SessionID: cfg.SessionID, ProjectID: cfg.ProjectID}, nil
+}
+
+func (f *fakeTrees) ForceDestroy(_ context.Context, info ports.WorkspaceInfo) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.destroyed = append(f.destroyed, info)
+	return nil
+}
+
+func (f *fakeTrees) paths() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.restores))
+	for _, cfg := range f.restores {
+		out = append(out, cfg.Path)
+	}
+	return out
+}
+
+type fakeSessions map[string]string
+
+func (f fakeSessions) Get(_ context.Context, sessionID string) (string, bool, error) {
+	path, ok := f[sessionID]
+	return path, ok, nil
+}
+
+type fakeCheckouts map[string]string
+
+func (f fakeCheckouts) CheckoutPath(projectID string) (string, error) {
+	path, ok := f[projectID]
+	if !ok {
+		return "", errors.New("no checkout for project " + projectID)
+	}
+	return path, nil
+}
+
+const (
+	testProject = "proj-1"
+	testRunID   = pipeline.RunID("run-7")
+	testRunDir  = "/data/pipelines/proj-1/run-7"
+)
+
+func newTestResolver(t *testing.T) (*WorkspaceResolver, *fakeTrees) {
+	t.Helper()
+	trees := &fakeTrees{}
+	sessions := fakeSessions{"sess-1": "/data/worktrees/proj-1/sess-1"}
+	checkouts := fakeCheckouts{testProject: "/home/dev/proj-1"}
+	return NewWorkspaceResolver(trees, sessions, checkouts), trees
+}
+
+func baseRequest(kind pipeline.WorkspaceKind) WorkspaceRequest {
+	return WorkspaceRequest{
+		Kind:      kind,
+		ProjectID: testProject,
+		RunID:     testRunID,
+		Subject:   pipeline.Subject{Kind: pipeline.SubjectSession, ProjectID: testProject, SessionID: "sess-1"},
+		BaseRef:   "main",
+		RunDir:    testRunDir,
+	}
+}
+
+func TestProvisionRunWorkspaceIsMemoized(t *testing.T) {
+	r, trees := newTestResolver(t)
+	ctx := context.Background()
+
+	req := baseRequest(pipeline.WorkspaceRun)
+	req.StageID = "build"
+	first, owned, err := r.Provision(ctx, req)
+	if err != nil {
+		t.Fatalf("first provision: %v", err)
+	}
+	if !owned {
+		t.Fatal("run workspace must be owned by the run")
+	}
+	want := filepath.Join(testRunDir, "workspace")
+	if first != want {
+		t.Fatalf("run workspace path = %q, want %q", first, want)
+	}
+
+	req.StageID = "test"
+	second, owned, err := r.Provision(ctx, req)
+	if err != nil {
+		t.Fatalf("second provision: %v", err)
+	}
+	if !owned || second != first {
+		t.Fatalf("second provision = (%q, %v), want the memoized (%q, true)", second, owned, first)
+	}
+	if got := trees.paths(); len(got) != 1 {
+		t.Fatalf("worktree created %d times, want exactly once: %v", len(got), got)
+	}
+}
+
+func TestProvisionRunWorkspacePassesSubjectRef(t *testing.T) {
+	r, trees := newTestResolver(t)
+
+	if _, _, err := r.Provision(context.Background(), baseRequest(pipeline.WorkspaceRun)); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	cfg := trees.restores[0]
+	if cfg.BaseBranch != "main" {
+		t.Fatalf("base branch = %q, want the subject ref %q", cfg.BaseBranch, "main")
+	}
+	if cfg.ProjectID != testProject {
+		t.Fatalf("project id = %q, want %q", cfg.ProjectID, testProject)
+	}
+	if cfg.Branch == "" || !strings.Contains(cfg.Branch, string(testRunID)) {
+		t.Fatalf("branch %q must be run-scoped", cfg.Branch)
+	}
+	if cfg.SessionID == "" {
+		t.Fatal("session id must be set: the adapter requires a name for the tree")
+	}
+}
+
+func TestProvisionStageWorkspacesAreDistinctPerStage(t *testing.T) {
+	r, trees := newTestResolver(t)
+	ctx := context.Background()
+
+	paths := map[string]string{}
+	for _, stage := range []string{"lint", "build"} {
+		req := baseRequest(pipeline.WorkspaceStage)
+		req.StageID = stage
+		path, owned, err := r.Provision(ctx, req)
+		if err != nil {
+			t.Fatalf("provision %s: %v", stage, err)
+		}
+		if !owned {
+			t.Fatalf("stage workspace for %s must be owned", stage)
+		}
+		paths[stage] = path
+	}
+	if paths["lint"] == paths["build"] {
+		t.Fatalf("stage workspaces collided at %q", paths["lint"])
+	}
+	if want := filepath.Join(testRunDir, "workspaces", "lint"); paths["lint"] != want {
+		t.Fatalf("stage workspace = %q, want %q", paths["lint"], want)
+	}
+	if len(trees.restores) != 2 {
+		t.Fatalf("created %d worktrees, want 2", len(trees.restores))
+	}
+	if trees.restores[0].Branch == trees.restores[1].Branch {
+		t.Fatalf("stage branches collided at %q", trees.restores[0].Branch)
+	}
+}
+
+func TestProvisionStageWorkspaceIsFreshOnReentry(t *testing.T) {
+	r, trees := newTestResolver(t)
+	ctx := context.Background()
+
+	req := baseRequest(pipeline.WorkspaceStage)
+	req.StageID = "flaky"
+	first, _, err := r.Provision(ctx, req)
+	if err != nil {
+		t.Fatalf("first entry: %v", err)
+	}
+	second, _, err := r.Provision(ctx, req)
+	if err != nil {
+		t.Fatalf("second entry: %v", err)
+	}
+	if second != first {
+		t.Fatalf("second entry path = %q, want the same path %q", second, first)
+	}
+	if len(trees.destroyed) != 1 || trees.destroyed[0].Path != first {
+		t.Fatalf("re-entry must destroy the stale tree first, got %v", trees.destroyed)
+	}
+	if len(trees.restores) != 2 {
+		t.Fatalf("created %d worktrees, want a fresh one per entry", len(trees.restores))
+	}
+}
+
+func TestProvisionInheritPassesThrough(t *testing.T) {
+	r, trees := newTestResolver(t)
+
+	req := baseRequest(pipeline.WorkspaceInherit)
+	req.StageID = "diagnose"
+	req.InheritPath = "/data/pipelines/proj-1/run-7/workspaces/build"
+	path, owned, err := r.Provision(context.Background(), req)
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	if path != req.InheritPath {
+		t.Fatalf("inherit path = %q, want %q", path, req.InheritPath)
+	}
+	if owned {
+		t.Fatal("inherit must not be owned: ownership stays with the originating stage")
+	}
+	if len(trees.restores) != 0 {
+		t.Fatalf("inherit must not create a worktree, got %v", trees.paths())
+	}
+}
+
+func TestProvisionInheritWithoutPathFails(t *testing.T) {
+	r, _ := newTestResolver(t)
+
+	req := baseRequest(pipeline.WorkspaceInherit)
+	req.StageID = "diagnose"
+	if _, _, err := r.Provision(context.Background(), req); err == nil {
+		t.Fatal("inherit with no originating tree must fail")
+	}
+}
+
+func TestProvisionSessionUsesExistingWorktree(t *testing.T) {
+	r, trees := newTestResolver(t)
+
+	path, owned, err := r.Provision(context.Background(), baseRequest(pipeline.WorkspaceSession))
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	if path != "/data/worktrees/proj-1/sess-1" {
+		t.Fatalf("session workspace = %q", path)
+	}
+	if owned {
+		t.Fatal("the subject's session worktree is not owned by the run")
+	}
+	if len(trees.restores) != 0 {
+		t.Fatalf("session must reuse the existing tree, not create one: %v", trees.paths())
+	}
+}
+
+func TestProvisionSessionFailsWhenSessionMissing(t *testing.T) {
+	r, _ := newTestResolver(t)
+	ctx := context.Background()
+
+	gone := baseRequest(pipeline.WorkspaceSession)
+	gone.Subject.SessionID = "sess-gone"
+	if _, _, err := r.Provision(ctx, gone); err == nil {
+		t.Fatal("a vanished session must fail the stage, never silently fall back")
+	}
+
+	none := baseRequest(pipeline.WorkspaceSession)
+	none.Subject = pipeline.Subject{Kind: pipeline.SubjectPR, ProjectID: testProject}
+	if _, _, err := r.Provision(ctx, none); err == nil {
+		t.Fatal("a sessionless subject must fail the stage, never silently fall back")
+	}
+}
+
+func TestProvisionCheckoutUsesPrimaryCheckout(t *testing.T) {
+	r, trees := newTestResolver(t)
+
+	path, owned, err := r.Provision(context.Background(), baseRequest(pipeline.WorkspaceCheckout))
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	if path != "/home/dev/proj-1" {
+		t.Fatalf("checkout = %q", path)
+	}
+	if owned {
+		t.Fatal("the primary checkout is never owned by the run")
+	}
+	if len(trees.restores) != 0 {
+		t.Fatalf("checkout must not create a worktree: %v", trees.paths())
+	}
+}
+
+func TestProvisionOwnedFlagPerKind(t *testing.T) {
+	cases := []struct {
+		kind  pipeline.WorkspaceKind
+		owned bool
+	}{
+		{pipeline.WorkspaceSession, false},
+		{pipeline.WorkspaceRun, true},
+		{pipeline.WorkspaceStage, true},
+		{pipeline.WorkspaceCheckout, false},
+		{pipeline.WorkspaceInherit, false},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			r, _ := newTestResolver(t)
+			req := baseRequest(tc.kind)
+			req.StageID = "build"
+			req.InheritPath = "/data/pipelines/proj-1/run-7/workspaces/prev"
+			_, owned, err := r.Provision(context.Background(), req)
+			if err != nil {
+				t.Fatalf("provision: %v", err)
+			}
+			if owned != tc.owned {
+				t.Fatalf("owned = %v, want %v", owned, tc.owned)
+			}
+		})
+	}
+}
+
+func TestProvisionRejectsUnresolvedKinds(t *testing.T) {
+	r, _ := newTestResolver(t)
+	for _, kind := range []pipeline.WorkspaceKind{pipeline.WorkspaceAuto, pipeline.WorkspaceUnset, "bogus"} {
+		req := baseRequest(kind)
+		req.StageID = "build"
+		if _, _, err := r.Provision(context.Background(), req); err == nil {
+			t.Fatalf("kind %q must be rejected: ComputePlan resolves it before the run starts", kind)
+		}
+	}
+}
+
+func TestProvisionRejectsUnsafeIDs(t *testing.T) {
+	r, _ := newTestResolver(t)
+	ctx := context.Background()
+
+	traversal := baseRequest(pipeline.WorkspaceStage)
+	traversal.StageID = "../escape"
+	if _, _, err := r.Provision(ctx, traversal); err == nil {
+		t.Fatal("a stage id with a path separator must be rejected")
+	}
+
+	empty := baseRequest(pipeline.WorkspaceStage)
+	if _, _, err := r.Provision(ctx, empty); err == nil {
+		t.Fatal("an empty stage id must be rejected")
+	}
+
+	badRun := baseRequest(pipeline.WorkspaceRun)
+	badRun.RunID = "../escape"
+	if _, _, err := r.Provision(ctx, badRun); err == nil {
+		t.Fatal("a run id with a path separator must be rejected")
+	}
+}
+
+func TestDestroyRemovesOwnedTreeAndForgetsIt(t *testing.T) {
+	r, trees := newTestResolver(t)
+	ctx := context.Background()
+
+	path, _, err := r.Provision(ctx, baseRequest(pipeline.WorkspaceRun))
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	if err := r.Destroy(ctx, path); err != nil {
+		t.Fatalf("destroy: %v", err)
+	}
+	if len(trees.destroyed) != 1 || trees.destroyed[0].Path != path {
+		t.Fatalf("destroyed = %v, want one entry for %q", trees.destroyed, path)
+	}
+	if _, _, err := r.Provision(ctx, baseRequest(pipeline.WorkspaceRun)); err != nil {
+		t.Fatalf("re-provision: %v", err)
+	}
+	if len(trees.restores) != 2 {
+		t.Fatalf("a destroyed run workspace must be re-created, restores = %d", len(trees.restores))
+	}
+}
+
+func TestDestroyRefusesUnknownPath(t *testing.T) {
+	r, trees := newTestResolver(t)
+
+	if err := r.Destroy(context.Background(), "/etc"); err == nil {
+		t.Fatal("destroying a path this resolver never provisioned must fail")
+	}
+	if len(trees.destroyed) != 0 {
+		t.Fatalf("nothing must be destroyed, got %v", trees.destroyed)
+	}
+}
+
+func TestProvisionSurfacesAdapterErrors(t *testing.T) {
+	trees := &fakeTrees{err: errors.New("worktree add failed")}
+	r := NewWorkspaceResolver(trees, fakeSessions{}, fakeCheckouts{testProject: "/home/dev/proj-1"})
+
+	_, _, err := r.Provision(context.Background(), baseRequest(pipeline.WorkspaceRun))
+	if err == nil || !strings.Contains(err.Error(), "worktree add failed") {
+		t.Fatalf("err = %v, want the adapter failure surfaced", err)
+	}
+	if _, ok := r.runs[testRunID]; ok {
+		t.Fatal("a failed provision must not be memoized")
+	}
+}
+
+var _ WorkspaceProvisioner = (*WorkspaceResolver)(nil)
+
+// The shipped adapter satisfies the seam as-is: pipelines create trees through
+// the same checkout-not-clone path sessions use, with no new adapter and no
+// glue type. Kept in the test file so the production code stays free of the
+// concrete dependency.
+var _ Worktrees = (*gitworktree.Workspace)(nil)


### PR DESCRIPTION
Pipelines v2 Task 7: the workspace resolver the engine calls on every `StartStage` effect.

Closes #303

## What

`backend/internal/pipeline/executors/workspace.go` adds `WorkspaceProvisioner` / `WorkspaceRequest` exactly as the plan's Task 7 block specifies, plus `WorkspaceResolver`, the implementation over the existing gitworktree adapter.

Semantics per resolved kind (`auto` never reaches here, `ComputePlan` resolved it):

| kind | tree | owned |
|---|---|---|
| `session` | the subject session's existing worktree, via the `SessionWorkspaces.Get` seam | no |
| `run` | `<run>/workspace`, created on first request and memoized for the rest of the run | yes |
| `stage` | `<run>/workspaces/<stageID>`, fresh per entry | yes |
| `checkout` | the project's primary checkout | no |
| `inherit` | `InheritPath`, the failed stage's tree | no (ownership stays with the originating stage, spec 5.4) |

Teardown policy stays with Task 15's driver; this returns `owned` honestly and exposes `Destroy(ctx, path)`, which refuses any path it did not provision.

## Notes

- **No new adapter and no adapter change.** Trees are created through `gitworktree.Workspace.Restore` with an explicit `Path`, which is the one entry point that materialises a worktree at a caller-chosen location inside the managed root. The pseudo id (`pipeline-<runID>`, `pipeline-<runID>-<stageID>`) already passes the adapter's `validatePathComponent`, so no generalization was needed there and every traversal guard is untouched. A compile-time `var _ Worktrees = (*gitworktree.Workspace)(nil)` in the test file pins that.
- The injected adapter must be rooted at the pipelines base dir (`<AO_DATA_DIR>/pipelines`), documented on the `Worktrees` seam, since run and stage trees live inside the run folder.
- Paths come from Task 6's `RunWorkspaceDir` / `StageWorkspaceDir`; no path construction is duplicated.
- Stage ids are author-written and only checked for uniqueness at edit time, so the resolver validates run and stage ids as path components before joining.
- Owned trees are removed with `ForceDestroy`: they are engine scratch, artifacts already live in the run folder, and `Destroy` would refuse on any run that wrote a file.

## Tests

`workspace_test.go`, fake git layer, no shelling out to git: run workspace memoized (one create for two requests), stage workspaces distinct per stage, stage re-entry destroys the stale tree first, inherit passthrough plus failure with no originating tree, session resolution failing when the session is missing or the subject is sessionless, checkout passthrough, `owned` correct for all five kinds, unresolved kinds rejected, traversal ids rejected, `Destroy` forgets the memo and refuses unknown paths, adapter errors surfaced and not memoized.

Verified: `go build ./...`, `go test ./...`, `gofmt -l .` (empty), `golangci-lint run ./...` (0 issues). Four `internal/cli` spawn tests fail identically on `origin/pipelines` without this commit (daemon HTTP 404), so they are not from this change.

## Risks

- `BaseRef` is passed as the adapter's `BaseBranch`, so it must be a branch or tag name; a bare SHA resolves to `ErrBranchNotFetched`. Existing adapter behavior, called out for Task 15.
- A stage re-entered after a retry gets a fresh checkout of the same run-scoped branch, not a re-cut from the subject ref, since the adapter has no branch-delete surface.