### PR TITLE
feat(pipelines): failure routing, nudge, deadlines, cancellation in v2 reducer

### DIFF
--- a/backend/internal/pipeline/reducer.go
+++ b/backend/internal/pipeline/reducer.go
@@ -32,11 +32,21 @@ func Reduce(run RunState, ev Event) (RunState, []Effect) {
 	switch e := ev.(type) {
 	case StageLaunched:
 		return reduceStageLaunched(run, e)
+	case StageLaunchFailed:
+		// The stage never got to run at all, so it settles failed with the
+		// driver's reason and routes like any other failure.
+		return settleFailure(run, e.Stage, OutcomeFailed, e.Reason, e.Now, nil)
 	case AgentSignaled:
-		if !e.Done || !e.ArtifactOK {
-			// An explicit fail, and a done whose artifact is missing, are
-			// failure routing and the nudge: the next task owns both.
-			return run, nil
+		if !e.Done {
+			// Never nudge an explicit `ao pipeline fail`. The agent decided;
+			// respect it (spec section 7.1).
+			return settleFailure(run, e.Stage, OutcomeFailed, e.Reason, e.Now, nil)
+		}
+		if !e.ArtifactOK {
+			// Signalled done with the declared artifact missing or empty: one
+			// nudge, then no_output. ArtifactOK is true when nothing is
+			// declared, so getting here means there is a contract to point at.
+			return nudgeOrSettle(run, e.Stage, e.ArtifactOK, e.Now)
 		}
 		// Nothing declared means nothing verified, and the signal was the whole
 		// contract.
@@ -47,13 +57,24 @@ func Reduce(run RunState, ev Event) (RunState, []Effect) {
 		return settleSuccess(run, e.Stage, outcome, e.Now)
 	case CommandExited:
 		if e.ExitCode != 0 {
-			return run, nil // failure settlement: next task
+			return settleFailure(run, e.Stage, OutcomeFailed, fmt.Sprintf("command exited %d", e.ExitCode), e.Now, nil)
 		}
 		return settleSuccess(run, e.Stage, OutcomeSucceeded, e.Now)
+	case SessionIdle:
+		// Idle-without-signal is where the nudge is most valuable: it is the
+		// disambiguator between "finished and forgot to call the CLI" and
+		// "stuck waiting" (spec section 7.1).
+		return nudgeOrSettle(run, e.Stage, e.ArtifactOK, e.Now)
+	case SessionGone:
+		// Never nudge an exited session. Nothing to nudge.
+		return settleFailure(run, e.Stage, OutcomeNoSignal, "session exited without signalling", e.Now, nil)
+	case NudgeDelivered:
+		return reduceNudgeDelivered(run, e)
+	case Tick:
+		return reduceTick(run, e)
+	case CancelRequested:
+		return reduceCancel(run, e)
 	default:
-		// StageLaunchFailed, SessionIdle, SessionGone, NudgeDelivered, Tick and
-		// CancelRequested are failure routing, the nudge, deadlines and
-		// cancellation, all owned by the second half of the reducer.
 		return run, nil
 	}
 }
@@ -168,12 +189,215 @@ func settleSuccess(run RunState, stageID string, outcome Outcome, now time.Time)
 		})
 	}
 	effects = append(effects, PersistRun{})
+	effects = appendSessionDisposition(effects, &next, stageID, outcome)
 
 	// advance writes through next, so it has to run before next is copied into
 	// the result.
 	starts := startSuccessTargets(&next, stageID, now)
 	effects = append(effects, advance(&next, starts, now)...)
 	return next, effects
+}
+
+// settleFailure settles an in-flight stage on one of the four outcomes that
+// route to failure, then takes that stage's failure edge.
+//
+// extra carries the effects that belong to this particular failure and must
+// land before the session disposition: today that is only the InterruptStage a
+// timeout needs.
+func settleFailure(run RunState, stageID string, outcome Outcome, reason string, now time.Time, extra []Effect) (RunState, []Effect) {
+	if st := run.Stages[stageID]; st == nil || !inFlight(st) {
+		return run, nil
+	}
+	next := run.clone()
+	st := next.Stages[stageID]
+	st.Outcome = outcome
+	st.SettledAt = now
+	if reason != "" {
+		st.Reason = reason
+	}
+	next.UpdatedAt = now
+
+	effects := make([]Effect, 0, len(extra)+4)
+	effects = append(effects, PersistRun{})
+	effects = append(effects, extra...)
+	effects = appendSessionDisposition(effects, &next, stageID, outcome)
+
+	// advance writes through next, so it has to run before next is copied into
+	// the result.
+	starts := startFailureTarget(&next, stageID, outcome, now)
+	effects = append(effects, advance(&next, starts, now)...)
+	return next, effects
+}
+
+// startFailureTarget takes the settled stage's failure edge: its own
+// on_failure, else defaults.on_failure, else the branch ends. The one carve-out
+// (the default target does not route into itself) lives in failureEdges.
+//
+// Failure entry is first-arrival-wins (spec section 9.3): a second stage
+// routing into a target that is no longer pending is dropped. The run is
+// already failing, and three notifications from three dead builds is noise.
+// needs is deliberately not consulted, because failure edges never join.
+func startFailureTarget(run *RunState, from string, outcome Outcome, now time.Time) []Effect {
+	targets := run.Def.failureEdges()[from]
+	if len(targets) == 0 || !canEnter(run, targets[0]) {
+		return nil
+	}
+	target := targets[0]
+	st := run.Stages[target]
+	st.FailedStage = from
+	st.FailedOutcome = outcome
+	// PrevStage stays empty: AO_PREV_* names the success predecessor, and a
+	// failure entry surfaces as AO_FAILED_* instead (spec section 12.2). The
+	// stage's workspace stays the symbolic `inherit`; the driver resolves it at
+	// launch to FailedStage's tree, which is the whole point of the failure
+	// default (spec section 5.4).
+	return []Effect{startStage(run, target, EntryFailure, "", now)}
+}
+
+// nudgeMissingArtifactFormat is the spec section 7.1 nudge, verbatim. It says
+// overwrite, not write: there is no reliable way to detect a partial file after
+// the fact, so the fix is prescriptive rather than detective.
+const nudgeMissingArtifactFormat = "You signaled done but agent-outputs/%s does not exist or is empty.\n" +
+	"Overwrite it now, then signal again."
+
+// nudgeUnsignalledMessage is the nudge for a session that went idle with
+// nothing left to verify: what is missing is the signal, not the artifact.
+const nudgeUnsignalledMessage = "You appear to be finished but have not signalled. " +
+	"Run 'ao pipeline done' or 'ao pipeline fail --reason ...' now."
+
+// nudgeOrSettle is the one nudge each stage gets, and the settlement that
+// follows a second arrival at the same dead end.
+//
+// The discriminator is artifactOK, not the presence of `produces`: the driver
+// reports artifactOK true when nothing is declared, so a stage with no contract
+// and a stage whose file is actually there take the same branch, and neither is
+// told its artifact is missing. What each is missing is the signal.
+//
+// Two attempts total, not configurable. If a second nudge would help, the
+// prompt is wrong (spec section 7.1).
+func nudgeOrSettle(run RunState, stageID string, artifactOK bool, now time.Time) (RunState, []Effect) {
+	st := run.Stages[stageID]
+	if st == nil || st.Outcome != OutcomeRunning {
+		return run, nil
+	}
+
+	outcome, message, reason := OutcomeNoSignal, nudgeUnsignalledMessage, "session went idle without signalling"
+	if !artifactOK {
+		produces := ""
+		if def := run.Def.StageByID(stageID); def != nil {
+			produces = def.Produces
+		}
+		outcome = OutcomeNoOutput
+		message = fmt.Sprintf(nudgeMissingArtifactFormat, produces)
+		reason = fmt.Sprintf("declared artifact agent-outputs/%s is missing or empty", produces)
+	}
+
+	if run.Nudged[stageID] {
+		return settleFailure(run, stageID, outcome, reason, now, nil)
+	}
+
+	next := run.clone()
+	if next.Nudged == nil {
+		next.Nudged = map[string]bool{}
+	}
+	next.Nudged[stageID] = true
+	next.UpdatedAt = now
+	// The stage stays running: the nudge never leaves it, and it works because
+	// the session is still alive with its context. Attempt becomes 2 only once
+	// the driver reports the nudge delivered.
+	return next, []Effect{
+		PersistRun{},
+		NudgeStage{Stage: stageID, SessionID: st.SessionID, Message: message},
+	}
+}
+
+// reduceNudgeDelivered records that the stage is on its second and last
+// attempt, which surfaces to the prompt as AO_ATTEMPT.
+func reduceNudgeDelivered(run RunState, e NudgeDelivered) (RunState, []Effect) {
+	st := run.Stages[e.Stage]
+	if st == nil || st.Outcome != OutcomeRunning || !run.Nudged[e.Stage] || st.Attempt >= 2 {
+		return run, nil
+	}
+	next := run.clone()
+	next.Stages[e.Stage].Attempt = 2
+	next.UpdatedAt = e.Now
+	return next, []Effect{PersistRun{}}
+}
+
+// reduceTick enforces deadlines. Every stage has one: an agent that hangs must
+// eventually settle as timed_out, or the run board grows entries nobody ever
+// closes (spec section 13.1).
+//
+// Stages are walked in document order, because map iteration is random and the
+// effect list the driver walks has to be deterministic.
+func reduceTick(run RunState, e Tick) (RunState, []Effect) {
+	effects := make([]Effect, 0, len(run.Stages))
+	for _, id := range run.Def.stageIDs() {
+		st := run.Stages[id]
+		if st == nil || st.Outcome != OutcomeRunning || st.DeadlineAt.IsZero() || !e.Now.After(st.DeadlineAt) {
+			continue
+		}
+		// InterruptStage kills the process and keeps the session: a timed-out
+		// agent may still be running, and the scrollback is the point, but
+		// keeping a runaway agent burning tokens for a day is not (spec 7.2).
+		var settled []Effect
+		run, settled = settleFailure(run, id, OutcomeTimedOut, "deadline exceeded", e.Now, []Effect{InterruptStage{Stage: id}})
+		effects = append(effects, settled...)
+	}
+	return run, effects
+}
+
+// reduceCancel tears the run down: superseded by concurrency, or killed by a
+// human. A cancelled stage does not route to on_failure, because the run is
+// being torn down rather than routed (spec section 13.2).
+func reduceCancel(run RunState, e CancelRequested) (RunState, []Effect) {
+	next := run.clone()
+	next.CancelReason = e.Reason
+	next.UpdatedAt = e.Now
+
+	effects := make([]Effect, 0, 2*len(next.Stages)+2)
+	effects = append(effects, PersistRun{})
+	for _, id := range next.Def.stageIDs() {
+		st := next.Stages[id]
+		if st == nil || st.Outcome.IsSettled() {
+			continue
+		}
+		st.SettledAt = e.Now
+		if st.Outcome != OutcomeRunning {
+			// It never ran, and skipped is not failed.
+			st.Outcome = OutcomeSkipped
+			continue
+		}
+		st.Outcome = OutcomeCancelled
+		effects = append(effects, CancelStageExec{Stage: id})
+		effects = appendSessionDisposition(effects, &next, id, OutcomeCancelled)
+	}
+
+	next.Status = RunCancelled
+	next.SettledAt = e.Now
+	return next, append(effects, RunSettled{Status: RunCancelled})
+}
+
+// appendSessionDisposition hands the driver an agent stage's settled outcome so
+// it can apply the stage's kill-on rule. The reducer only reports the
+// settlement; kill versus keep-and-mark-orphaned is EffectiveKillOn's call.
+//
+// A command stage and a stage that never launched have no session, so neither
+// produces one.
+func appendSessionDisposition(effects []Effect, run *RunState, stageID string, outcome Outcome) []Effect {
+	st := run.Stages[stageID]
+	def := run.Def.StageByID(stageID)
+	if st == nil || st.SessionID == "" || def == nil || def.Executor != ExecutorAgent {
+		return effects
+	}
+	return append(effects, SettleSession{Stage: stageID, SessionID: st.SessionID, Outcome: outcome})
+}
+
+// inFlight reports whether a stage can still settle: running, or pending with a
+// launch already committed. The second case is how a launch that never got off
+// the ground settles.
+func inFlight(st *StageState) bool {
+	return st.Outcome == OutcomeRunning || (st.Outcome == OutcomePending && st.Attempt > 0)
 }
 
 // advance runs the two passes that follow any settlement, then settles the run

--- a/backend/internal/pipeline/reducer_failure_test.go
+++ b/backend/internal/pipeline/reducer_failure_test.go
@@ -1,0 +1,400 @@
+package pipeline
+
+import (
+	"reflect"
+	"testing"
+)
+
+// findEffect returns the first effect of the requested type.
+func findEffect[T Effect](effects []Effect) (T, bool) {
+	for _, e := range effects {
+		if t, ok := e.(T); ok {
+			return t, true
+		}
+	}
+	var zero T
+	return zero, false
+}
+
+// failStage settles an agent stage through an explicit `ao pipeline fail`.
+func failStage(run RunState, stage, reason string, now int) (RunState, []Effect) {
+	return Reduce(run, AgentSignaled{Stage: stage, Done: false, Reason: reason, Now: at(now)})
+}
+
+const explicitFailureYAML = `
+name: explicit-failure
+stages:
+  - id: build
+    executor: command
+    run: make
+    on_success: ship
+    on_failure: diagnose
+  - id: ship
+    executor: command
+    run: ship
+  - id: diagnose
+    executor: agent
+    agent: claude-code
+    produces: diagnosis.md
+    prompt: why did it fail
+`
+
+const defaultFailureYAML = `
+name: default-failure
+defaults:
+  on_failure: notify
+stages:
+  - id: build
+    executor: command
+    run: make
+    on_success: ship
+  - id: ship
+    executor: command
+    run: ship
+  - id: notify
+    executor: command
+    run: echo notify
+`
+
+const twoBuildsYAML = `
+name: two-builds
+stages:
+  - id: fan
+    executor: command
+    run: echo fan
+    on_success: [build-a, build-b]
+  - id: build-a
+    executor: command
+    run: make a
+    on_failure: diagnose
+  - id: build-b
+    executor: command
+    run: make b
+    on_failure: diagnose
+  - id: diagnose
+    executor: agent
+    agent: claude-code
+    produces: diagnosis.md
+    prompt: diagnose $AO_FAILED_STAGE
+`
+
+func TestReduce_CommandExitNonZeroSettlesFailedAndTakesTheFailureEdge(t *testing.T) {
+	run, _ := fire(t, explicitFailureYAML)
+	run = launch(run, "build", at(1))
+
+	run, effects := exit(run, "build", 2, at(2))
+
+	if got := outcomeOf(t, run, "build"); got != OutcomeFailed {
+		t.Errorf("build = %q, want failed: a non-zero exit is the whole outcome", got)
+	}
+	if got := startedStages(effects); !reflect.DeepEqual(got, []string{"diagnose"}) {
+		t.Fatalf("started %v, want [diagnose]", got)
+	}
+	st := run.Stages["diagnose"]
+	if st.EnteredVia != EntryFailure {
+		t.Errorf("diagnose entered via %q, want failure", st.EnteredVia)
+	}
+	if st.FailedStage != "build" || st.FailedOutcome != OutcomeFailed {
+		t.Errorf("diagnose failed-stage = %q/%q, want build/failed", st.FailedStage, st.FailedOutcome)
+	}
+	if st.PrevStage != "" {
+		t.Errorf("diagnose prev = %q, want empty: AO_PREV_* names the success predecessor", st.PrevStage)
+	}
+	if st.WorkspaceKind != WorkspaceInherit {
+		t.Errorf("diagnose workspace = %q, want inherit: it resolves at launch to the failed stage's tree", st.WorkspaceKind)
+	}
+	if got := outcomeOf(t, run, "ship"); got != OutcomeSkipped {
+		t.Errorf("ship = %q, want skipped: its predecessor did not succeed", got)
+	}
+	if countEffect[RunSettled](effects) != 0 {
+		t.Errorf("run settled while diagnose was still to run: %v", effects)
+	}
+}
+
+func TestReduce_ExplicitFailSettlesFailedWithTheStatedReason(t *testing.T) {
+	const src = `
+name: agent-fails
+stages:
+  - id: work
+    executor: agent
+    agent: claude-code
+    prompt: do it
+    on_failure: notify
+  - id: notify
+    executor: command
+    run: echo notify
+`
+	run, _ := fire(t, src)
+	run = launch(run, "work", at(1))
+
+	run, effects := failStage(run, "work", "the task is impossible", 2)
+
+	if got := outcomeOf(t, run, "work"); got != OutcomeFailed {
+		t.Errorf("work = %q, want failed", got)
+	}
+	if got := run.Stages["work"].Reason; got != "the task is impossible" {
+		t.Errorf("reason = %q, want the agent's stated reason", got)
+	}
+	if got := startedStages(effects); !reflect.DeepEqual(got, []string{"notify"}) {
+		t.Errorf("started %v, want [notify]", got)
+	}
+}
+
+func TestReduce_FailureFallsBackToTheDefaultTarget(t *testing.T) {
+	run, _ := fire(t, defaultFailureYAML)
+	run = launch(run, "build", at(1))
+
+	run, effects := exit(run, "build", 1, at(2))
+
+	if got := startedStages(effects); !reflect.DeepEqual(got, []string{"notify"}) {
+		t.Fatalf("started %v, want [notify] from defaults.on_failure", got)
+	}
+	if got := run.Stages["notify"].FailedStage; got != "build" {
+		t.Errorf("notify failed-stage = %q, want build", got)
+	}
+}
+
+func TestReduce_DefaultTargetsOwnFailureEndsTheBranch(t *testing.T) {
+	// The spec section 9.4 carve-out: the stage named by defaults.on_failure does
+	// not inherit the default, because routing to itself would be a self-edge.
+	run, _ := fire(t, defaultFailureYAML)
+	run = launch(run, "build", at(1))
+	run, _ = exit(run, "build", 1, at(2))
+	run = launch(run, "notify", at(3))
+
+	run, effects := exit(run, "notify", 1, at(4))
+
+	if got := outcomeOf(t, run, "notify"); got != OutcomeFailed {
+		t.Errorf("notify = %q, want failed", got)
+	}
+	if got := startedStages(effects); len(got) != 0 {
+		t.Errorf("started %v, want nothing: the default target does not route into itself", got)
+	}
+	if got := settledStatus(t, effects); got != RunFailed {
+		t.Errorf("run settled %q, want failed", got)
+	}
+}
+
+func TestReduce_FailureRoutingIsFirstArrivalWins(t *testing.T) {
+	run, _ := fire(t, twoBuildsYAML)
+	run = launch(run, "fan", at(1))
+	run, _ = exit(run, "fan", 0, at(2))
+	run = launch(run, "build-a", at(3))
+	run = launch(run, "build-b", at(3))
+
+	run, effects := exit(run, "build-a", 1, at(4))
+	if got := startedStages(effects); !reflect.DeepEqual(got, []string{"diagnose"}) {
+		t.Fatalf("started %v on the first failure, want [diagnose]", got)
+	}
+
+	run, effects = exit(run, "build-b", 1, at(5))
+	if got := startedStages(effects); len(got) != 0 {
+		t.Errorf("started %v on the second failure, want nothing: later arrivals are dropped", got)
+	}
+	st := run.Stages["diagnose"]
+	if st.Attempt != 1 {
+		t.Errorf("diagnose attempt = %d, want 1: it runs exactly once", st.Attempt)
+	}
+	if st.FailedStage != "build-a" {
+		t.Errorf("diagnose failed-stage = %q, want build-a: the first arrival owns the entry", st.FailedStage)
+	}
+}
+
+func TestReduce_FailureWithNoRouteEndsTheBranch(t *testing.T) {
+	run, _ := fire(t, linearYAML)
+	run = launch(run, "a", at(1))
+
+	run, effects := exit(run, "a", 1, at(2))
+
+	if got := startedStages(effects); len(got) != 0 {
+		t.Errorf("started %v, want nothing: no on_failure and no default means the branch ends", got)
+	}
+	if got := outcomeOf(t, run, "b"); got != OutcomeSkipped {
+		t.Errorf("b = %q, want skipped", got)
+	}
+	if got := settledStatus(t, effects); got != RunFailed {
+		t.Errorf("run settled %q, want failed", got)
+	}
+}
+
+func TestReduce_StageLaunchFailedSettlesFailedAndRoutes(t *testing.T) {
+	run, _ := fire(t, explicitFailureYAML)
+
+	run, effects := Reduce(run, StageLaunchFailed{Stage: "build", Reason: "workspace could not be created", Now: at(1)})
+
+	if got := outcomeOf(t, run, "build"); got != OutcomeFailed {
+		t.Errorf("build = %q, want failed: it never got to run", got)
+	}
+	if got := run.Stages["build"].Reason; got != "workspace could not be created" {
+		t.Errorf("reason = %q, want the driver's stated reason", got)
+	}
+	if got := startedStages(effects); !reflect.DeepEqual(got, []string{"diagnose"}) {
+		t.Errorf("started %v, want [diagnose]: a launch failure routes like any other failure", got)
+	}
+}
+
+func TestReduce_TickSettlesAStagePastItsDeadline(t *testing.T) {
+	const src = `
+name: slow
+stages:
+  - id: work
+    executor: agent
+    agent: claude-code
+    prompt: think about it
+    deadline: 5m
+    on_failure: notify
+  - id: notify
+    executor: command
+    run: echo notify
+`
+	run, _ := fire(t, src)
+	run = launch(run, "work", at(1))
+
+	quiet, effects := Reduce(run, Tick{Now: at(5)})
+	if len(effects) != 0 {
+		t.Fatalf("effects = %v at t+5, want none: the deadline is at t+6", effects)
+	}
+	if !reflect.DeepEqual(quiet, run) {
+		t.Errorf("state changed on a tick inside the deadline")
+	}
+
+	run, effects = Reduce(run, Tick{Now: at(7)})
+
+	if got := outcomeOf(t, run, "work"); got != OutcomeTimedOut {
+		t.Errorf("work = %q, want timed_out", got)
+	}
+	if _, ok := findEffect[InterruptStage](effects); !ok {
+		t.Errorf("effects = %v, want an InterruptStage: a timed-out agent may still be running", effects)
+	}
+	settle, ok := findEffect[SettleSession](effects)
+	if !ok || settle.Outcome != OutcomeTimedOut || settle.SessionID != "sess-work" {
+		t.Errorf("SettleSession = %+v (found %v), want work/sess-work/timed_out", settle, ok)
+	}
+	if got := startedStages(effects); !reflect.DeepEqual(got, []string{"notify"}) {
+		t.Errorf("started %v, want [notify]: a timeout routes to failure", got)
+	}
+}
+
+func TestReduce_TickIgnoresStagesThatAreNotRunning(t *testing.T) {
+	run, _ := fire(t, linearYAML)
+
+	next, effects := Reduce(run, Tick{Now: at(9999)})
+
+	if len(effects) != 0 {
+		t.Errorf("effects = %v, want none: a pending stage has no deadline yet", effects)
+	}
+	if !reflect.DeepEqual(next, run) {
+		t.Errorf("state changed on a tick with nothing running")
+	}
+}
+
+func TestReduce_CancelSettlesEverythingAndRoutesNowhere(t *testing.T) {
+	run, _ := fire(t, defaultFailureYAML)
+	run = launch(run, "build", at(1))
+
+	run, effects := Reduce(run, CancelRequested{Reason: "superseded", Now: at(2)})
+
+	if got := outcomeOf(t, run, "build"); got != OutcomeCancelled {
+		t.Errorf("build = %q, want cancelled: a running stage is torn down", got)
+	}
+	if got := outcomeOf(t, run, "ship"); got != OutcomeSkipped {
+		t.Errorf("ship = %q, want skipped: a pending stage never ran", got)
+	}
+	if got := outcomeOf(t, run, "notify"); got != OutcomeSkipped {
+		t.Errorf("notify = %q, want skipped, not entered: a cancelled stage does not route to on_failure", got)
+	}
+	if got := startedStages(effects); len(got) != 0 {
+		t.Errorf("started %v, want nothing: the run is being torn down, not routed", got)
+	}
+	cancel, ok := findEffect[CancelStageExec](effects)
+	if !ok || cancel.Stage != "build" {
+		t.Errorf("CancelStageExec = %+v (found %v), want build", cancel, ok)
+	}
+	if countEffect[CancelStageExec](effects) != 1 {
+		t.Errorf("effects = %v, want exactly one CancelStageExec: only build was running", effects)
+	}
+	if got := settledStatus(t, effects); got != RunCancelled {
+		t.Errorf("run settled %q, want cancelled", got)
+	}
+	if run.CancelReason != "superseded" {
+		t.Errorf("cancel reason = %q, want superseded", run.CancelReason)
+	}
+	if !run.SettledAt.Equal(at(2)) {
+		t.Errorf("settled at %v, want %v", run.SettledAt, at(2))
+	}
+}
+
+func TestReduce_CancelOfAnAgentStageHandsTheSessionToTheDriver(t *testing.T) {
+	const src = `
+name: agent-cancel
+stages:
+  - id: work
+    executor: agent
+    agent: claude-code
+    prompt: do it
+`
+	run, _ := fire(t, src)
+	run = launch(run, "work", at(1))
+
+	_, effects := Reduce(run, CancelRequested{Reason: "killed", Now: at(2)})
+
+	settle, ok := findEffect[SettleSession](effects)
+	if !ok || settle.Outcome != OutcomeCancelled || settle.SessionID != "sess-work" {
+		t.Errorf("SettleSession = %+v (found %v), want work/sess-work/cancelled", settle, ok)
+	}
+}
+
+func TestReduce_AgentSettlementHandsTheSessionToTheDriver(t *testing.T) {
+	const src = `
+name: dispositions
+stages:
+  - id: review
+    executor: agent
+    agent: claude-code
+    produces: review.md
+    prompt: review it
+`
+	run, _ := fire(t, src)
+	run = launch(run, "review", at(1))
+
+	_, effects := Reduce(run, AgentSignaled{Stage: "review", Done: true, ArtifactOK: true, Now: at(2)})
+
+	settle, ok := findEffect[SettleSession](effects)
+	if !ok || settle.Stage != "review" || settle.SessionID != "sess-review" || settle.Outcome != OutcomeSucceeded {
+		t.Errorf("SettleSession = %+v (found %v), want review/sess-review/succeeded", settle, ok)
+	}
+}
+
+func TestReduce_CommandSettlementHasNoSessionDisposition(t *testing.T) {
+	run, _ := fire(t, linearYAML)
+	run = launch(run, "a", at(1))
+
+	_, effects := exit(run, "a", 1, at(2))
+
+	if countEffect[SettleSession](effects) != 0 {
+		t.Errorf("effects = %v, want no SettleSession: a command stage has no session to dispose of", effects)
+	}
+}
+
+func TestReduce_FailureRoutingDoesNotMutateInput(t *testing.T) {
+	run, _ := fire(t, twoBuildsYAML)
+	before, _ := fire(t, twoBuildsYAML)
+	for _, mutate := range []func(RunState) RunState{
+		func(r RunState) RunState { return launch(r, "fan", at(1)) },
+		func(r RunState) RunState { next, _ := exit(r, "fan", 0, at(2)); return next },
+		func(r RunState) RunState { return launch(r, "build-a", at(3)) },
+		func(r RunState) RunState { return launch(r, "build-b", at(3)) },
+	} {
+		run = mutate(run)
+		before = mutate(before)
+	}
+	if !reflect.DeepEqual(run, before) {
+		t.Fatalf("fixtures diverged before the call under test")
+	}
+
+	Reduce(run, CommandExited{Stage: "build-a", ExitCode: 1, Now: at(4)})
+
+	if !reflect.DeepEqual(run, before) {
+		t.Errorf("Reduce mutated its input:\n got %+v\nwant %+v", run, before)
+	}
+}

--- a/backend/internal/pipeline/reducer_nudge_test.go
+++ b/backend/internal/pipeline/reducer_nudge_test.go
@@ -1,0 +1,274 @@
+package pipeline
+
+import (
+	"reflect"
+	"testing"
+)
+
+const producesYAML = `
+name: verified-agent
+stages:
+  - id: review
+    executor: agent
+    agent: claude-code
+    produces: review.md
+    prompt: review it
+    on_failure: notify
+  - id: notify
+    executor: command
+    run: echo notify
+`
+
+const noProducesYAML = `
+name: unverified-agent
+stages:
+  - id: work
+    executor: agent
+    agent: claude-code
+    prompt: do the thing
+    on_failure: notify
+  - id: notify
+    executor: command
+    run: echo notify
+`
+
+// signalDone settles an agent stage through `ao pipeline done`, carrying the
+// driver's verification of the declared artifact.
+func signalDone(run RunState, stage string, artifactOK bool, now int) (RunState, []Effect) {
+	return Reduce(run, AgentSignaled{Stage: stage, Done: true, ArtifactOK: artifactOK, Now: at(now)})
+}
+
+func idle(run RunState, stage string, artifactOK bool, now int) (RunState, []Effect) {
+	return Reduce(run, SessionIdle{Stage: stage, ArtifactOK: artifactOK, Now: at(now)})
+}
+
+func nudgeMessages(effects []Effect) []string {
+	out := make([]string, 0, len(effects))
+	for _, e := range effects {
+		if n, ok := e.(NudgeStage); ok {
+			out = append(out, n.Message)
+		}
+	}
+	return out
+}
+
+// runningAgent fires a one-agent pipeline and gets its stage running.
+func runningAgent(t *testing.T, src, stage string) RunState {
+	t.Helper()
+	run, _ := fire(t, src)
+	return launch(run, stage, at(1))
+}
+
+func TestReduce_DoneWithAMissingArtifactNudgesOnceThenSettlesNoOutput(t *testing.T) {
+	run := runningAgent(t, producesYAML, "review")
+
+	run, effects := signalDone(run, "review", false, 2)
+
+	if got := outcomeOf(t, run, "review"); got != OutcomeRunning {
+		t.Fatalf("review = %q, want running: the nudge never leaves the stage", got)
+	}
+	nudge, ok := findEffect[NudgeStage](effects)
+	if !ok || nudge.Stage != "review" || nudge.SessionID != "sess-review" {
+		t.Fatalf("NudgeStage = %+v (found %v), want review/sess-review", nudge, ok)
+	}
+	if !run.Nudged["review"] {
+		t.Errorf("Nudged[review] = false, want true: one nudge, two attempts total")
+	}
+	if got := run.Stages["review"].Attempt; got != 1 {
+		t.Errorf("attempt = %d, want 1: it becomes 2 only once the nudge is delivered", got)
+	}
+	if countEffect[SettleSession](effects) != 0 {
+		t.Errorf("effects = %v, want no SettleSession: the stage has not settled", effects)
+	}
+
+	run, effects = Reduce(run, NudgeDelivered{Stage: "review", Now: at(3)})
+	if got := run.Stages["review"].Attempt; got != 2 {
+		t.Errorf("attempt = %d after delivery, want 2 (AO_ATTEMPT lets a prompt tell it is being nudged)", got)
+	}
+	if countEffect[PersistRun](effects) != 1 {
+		t.Errorf("effects = %v, want one PersistRun: the attempt count is recorded", effects)
+	}
+
+	run, effects = signalDone(run, "review", false, 4)
+
+	if got := outcomeOf(t, run, "review"); got != OutcomeNoOutput {
+		t.Errorf("review = %q, want no_output on the second attempt", got)
+	}
+	if got := nudgeMessages(effects); len(got) != 0 {
+		t.Errorf("nudged again with %v, want one nudge per stage, not configurable", got)
+	}
+	if got := startedStages(effects); !reflect.DeepEqual(got, []string{"notify"}) {
+		t.Errorf("started %v, want [notify]: no_output routes to failure", got)
+	}
+}
+
+func TestReduce_NudgeMessageMatchesTheSpecCharacterForCharacter(t *testing.T) {
+	run := runningAgent(t, producesYAML, "review")
+
+	_, effects := signalDone(run, "review", false, 2)
+
+	want := "You signaled done but agent-outputs/review.md does not exist or is empty.\n" +
+		"Overwrite it now, then signal again."
+	if got := nudgeMessages(effects); len(got) != 1 || got[0] != want {
+		t.Errorf("nudge = %q, want %q", got, want)
+	}
+}
+
+func TestReduce_ExplicitFailIsNeverNudged(t *testing.T) {
+	run := runningAgent(t, producesYAML, "review")
+
+	run, effects := failStage(run, "review", "cannot be done", 2)
+
+	if got := nudgeMessages(effects); len(got) != 0 {
+		t.Errorf("nudged %v, want nothing: the agent decided, respect it", got)
+	}
+	if got := outcomeOf(t, run, "review"); got != OutcomeFailed {
+		t.Errorf("review = %q, want failed", got)
+	}
+	if run.Nudged["review"] {
+		t.Errorf("Nudged[review] = true, want false")
+	}
+}
+
+func TestReduce_ExitedSessionIsNeverNudged(t *testing.T) {
+	run := runningAgent(t, producesYAML, "review")
+
+	run, effects := Reduce(run, SessionGone{Stage: "review", Now: at(2)})
+
+	if got := nudgeMessages(effects); len(got) != 0 {
+		t.Errorf("nudged %v, want nothing: there is nothing left to nudge", got)
+	}
+	if got := outcomeOf(t, run, "review"); got != OutcomeNoSignal {
+		t.Errorf("review = %q, want no_signal", got)
+	}
+	settle, ok := findEffect[SettleSession](effects)
+	if !ok || settle.Outcome != OutcomeNoSignal {
+		t.Errorf("SettleSession = %+v (found %v), want no_signal", settle, ok)
+	}
+	if got := startedStages(effects); !reflect.DeepEqual(got, []string{"notify"}) {
+		t.Errorf("started %v, want [notify]: no_signal routes to failure", got)
+	}
+}
+
+func TestReduce_IdleWithAMissingArtifactNudgesThenSettlesNoOutput(t *testing.T) {
+	run := runningAgent(t, producesYAML, "review")
+
+	run, effects := idle(run, "review", false, 2)
+
+	want := "You signaled done but agent-outputs/review.md does not exist or is empty.\n" +
+		"Overwrite it now, then signal again."
+	if got := nudgeMessages(effects); len(got) != 1 || got[0] != want {
+		t.Fatalf("nudge = %q, want %q", got, want)
+	}
+	if got := outcomeOf(t, run, "review"); got != OutcomeRunning {
+		t.Fatalf("review = %q, want running", got)
+	}
+
+	run, _ = Reduce(run, NudgeDelivered{Stage: "review", Now: at(3)})
+	run, _ = idle(run, "review", false, 4)
+
+	if got := outcomeOf(t, run, "review"); got != OutcomeNoOutput {
+		t.Errorf("review = %q, want no_output: the declared artifact is still missing", got)
+	}
+}
+
+func TestReduce_IdleWithoutAnArtifactContractNudgesForTheSignalThenSettlesNoSignal(t *testing.T) {
+	run := runningAgent(t, noProducesYAML, "work")
+
+	run, effects := idle(run, "work", true, 2)
+
+	want := "You appear to be finished but have not signalled. " +
+		"Run 'ao pipeline done' or 'ao pipeline fail --reason ...' now."
+	if got := nudgeMessages(effects); len(got) != 1 || got[0] != want {
+		t.Fatalf("nudge = %q, want %q", got, want)
+	}
+	if got := outcomeOf(t, run, "work"); got != OutcomeRunning {
+		t.Fatalf("work = %q, want running: idle is the disambiguation, not a settlement", got)
+	}
+
+	run, effects = idle(run, "work", true, 3)
+
+	if got := outcomeOf(t, run, "work"); got != OutcomeNoSignal {
+		t.Errorf("work = %q, want no_signal: it went idle twice without signalling", got)
+	}
+	if got := startedStages(effects); !reflect.DeepEqual(got, []string{"notify"}) {
+		t.Errorf("started %v, want [notify]", got)
+	}
+}
+
+func TestReduce_IdleWithAVerifiedArtifactStillAsksForTheSignal(t *testing.T) {
+	// produces is declared and the file is there, so the missing-artifact text
+	// would be a lie: what is missing is the signal.
+	run := runningAgent(t, producesYAML, "review")
+
+	run, effects := idle(run, "review", true, 2)
+
+	want := "You appear to be finished but have not signalled. " +
+		"Run 'ao pipeline done' or 'ao pipeline fail --reason ...' now."
+	if got := nudgeMessages(effects); len(got) != 1 || got[0] != want {
+		t.Fatalf("nudge = %q, want %q", got, want)
+	}
+
+	run, _ = idle(run, "review", true, 3)
+	if got := outcomeOf(t, run, "review"); got != OutcomeNoSignal {
+		t.Errorf("review = %q, want no_signal", got)
+	}
+}
+
+func TestReduce_ANudgedStageCanStillSucceed(t *testing.T) {
+	run := runningAgent(t, producesYAML, "review")
+	run, _ = signalDone(run, "review", false, 2)
+	run, _ = Reduce(run, NudgeDelivered{Stage: "review", Now: at(3)})
+
+	run, effects := signalDone(run, "review", true, 4)
+
+	if got := outcomeOf(t, run, "review"); got != OutcomeSucceeded {
+		t.Errorf("review = %q, want succeeded: succeeded after one nudge is the point", got)
+	}
+	if got := settledStatus(t, effects); got != RunSucceeded {
+		t.Errorf("run settled %q, want succeeded", got)
+	}
+}
+
+func TestReduce_OneNudgePerStageAcrossEventKinds(t *testing.T) {
+	// The idle nudge and the done-with-no-artifact nudge share the one budget:
+	// if a second nudge would help, the prompt is wrong.
+	run := runningAgent(t, producesYAML, "review")
+	run, _ = idle(run, "review", false, 2)
+
+	run, effects := signalDone(run, "review", false, 3)
+
+	if got := nudgeMessages(effects); len(got) != 0 {
+		t.Errorf("nudged %v, want nothing: the stage already had its one nudge", got)
+	}
+	if got := outcomeOf(t, run, "review"); got != OutcomeNoOutput {
+		t.Errorf("review = %q, want no_output", got)
+	}
+}
+
+func TestReduce_NudgeDeliveredForAStageThatWasNotNudgedChangesNothing(t *testing.T) {
+	run := runningAgent(t, producesYAML, "review")
+
+	next, effects := Reduce(run, NudgeDelivered{Stage: "review", Now: at(2)})
+
+	if len(effects) != 0 {
+		t.Errorf("effects = %v, want none", effects)
+	}
+	if !reflect.DeepEqual(next, run) {
+		t.Errorf("state changed on a delivery for a nudge that was never sent")
+	}
+}
+
+func TestReduce_NudgeDoesNotMutateInput(t *testing.T) {
+	run := runningAgent(t, producesYAML, "review")
+	before := runningAgent(t, producesYAML, "review")
+	if !reflect.DeepEqual(run, before) {
+		t.Fatalf("fixtures diverged before the call under test")
+	}
+
+	Reduce(run, SessionIdle{Stage: "review", ArtifactOK: false, Now: at(2)})
+
+	if !reflect.DeepEqual(run, before) {
+		t.Errorf("Reduce mutated its input:\n got %+v\nwant %+v", run, before)
+	}
+}


### PR DESCRIPTION
Pipelines v2, Task 5. Extends the Task 4 `Reduce` (PR #301) with the second half of the transition core. No new reducer, no new package: same function, same copy-on-write purity discipline.

Closes #305

## What lands

**Failure settlement and routing**
- `AgentSignaled{Done:false}` settles `failed` and is never nudged; `CommandExited{!=0}` settles `failed`; `SessionGone` settles `no_signal` and is never nudged; `StageLaunchFailed` settles `failed` with the driver's reason (Task 4 deferred it here).
- Routing target is the stage's `on_failure`, else `defaults.on_failure`, else the branch ends. The §9.4 carve-out (the default target does not route into itself) already lives in `failureEdges`, so it is reused rather than re-derived.
- The entered-via-failure stage gets `EnteredVia: failure` plus `FailedStage`/`FailedOutcome`. `PrevStage` stays empty: `AO_PREV_*` names the success predecessor (§12.2). Its workspace stays the symbolic `inherit`; the driver resolves it at launch to `FailedStage`'s tree.
- First arrival wins (§9.3): a second stage routing into a target that is no longer pending is dropped, so two builds failing into one diagnose stage run diagnose exactly once. `needs` is deliberately not consulted, because failure edges never join.

**Nudge, exactly once per stage**
The discriminator is `ArtifactOK`, not the presence of `produces`. The driver reports `ArtifactOK: true` when nothing is declared, so a stage with no contract and a stage whose file is actually there take the same branch, and neither is told its artifact is missing. What each is missing is the signal.

- `!ArtifactOK` (implies `produces` declared): first arrival nudges with the §7.1 message verbatim, second settles `no_output`.
- `ArtifactOK` on `SessionIdle` (no `produces`, or `produces` present and verified): first arrival nudges with the plan's "you appear to be finished but have not signalled" text, second settles `no_signal`.
- The nudge keeps the stage `running` and sets `Nudged[stage]`; `Attempt` becomes 2 only on `NudgeDelivered`. The budget is per stage, shared across event kinds: an idle nudge spends the same one a done-with-no-artifact nudge would.
- Both message strings are asserted character for character in a test.

**Deadlines.** `Tick` settles any running stage past `DeadlineAt` as `timed_out`, emits `InterruptStage` (process killed, session kept) and routes failure. Stages are walked in document order so the effect list is deterministic.

**Cancellation.** `CancelRequested` settles every pending stage `skipped` and every running stage `cancelled` with `CancelStageExec`, sets run status `cancelled`, and does no failure routing (§13.2).

**Session disposition.** Every settlement of an agent stage with a live session emits `SettleSession{stage, sessionID, outcome}`, success included. The reducer only reports the settlement; kill versus keep-and-mark-orphaned is `EffectiveKillOn()`'s call in Task 15/16.

## Effect ordering

`PersistRun` first, then `InterruptStage` where a timeout needs it, then `SettleSession`, then the stage commands, then `RunSettled` last. Same contract the Task 4 doc comment states.

## Tests

New `reducer_failure_test.go` (14 cases) and `reducer_nudge_test.go` (11 cases), including a no-mutate test per file. Every Task 4 test passes untouched.

- `cd backend && go build ./... && gofmt -l .` clean.
- `go test ./...`: 2664 pass. The 4 `internal/cli` `TestSpawn*` failures reproduce identically on `origin/pipelines` in a clean worktree (stub server 404s an endpoint the CLI now calls); they are not from this branch.
- `~/go/bin/golangci-lint run ./...`: 0 issues.

## Risks

- `no_signal` versus `no_output` on a second `SessionIdle` for a `produces` stage follows `ArtifactOK` at the time of that second idle, so a stage that writes its file between the two idles settles `no_signal` rather than `no_output`. That is the honest reading: it never signalled.
- A pending stage with a launch already committed settles `skipped` on cancel per the plan, not `cancelled`. Aborting an in-flight launch is the driver's job (Task 15), which holds the handle map.