### PR TITLE
feat(pipelines): v2 PR trigger bridge and session trigger bridge

### DIFF
--- a/backend/internal/pipeline/triggers/prbridge.go
+++ b/backend/internal/pipeline/triggers/prbridge.go
@@ -1,0 +1,331 @@
+// Package triggers turns change events into pipeline runs. It holds the two
+// event sources v2 ships: the PR bridge (this file) and the session bridge
+// (sessionbridge.go). A trigger names a subject, and the subject is what the
+// run is about (spec section 4).
+//
+// Both bridges share one shape, ported from v1 because it is proven: the CDC
+// broadcaster delivers events synchronously on its poller goroutine and must
+// not be blocked (cdc.Broadcaster.Subscribe contract), so the subscribe
+// callback only filters and enqueues onto a buffered channel, and one owned
+// worker goroutine does every store read and every (blocking) engine call.
+// Engine methods are therefore only ever called from that worker, never from
+// the poller, so the engine actor mailbox cannot deadlock against it.
+//
+// Both bridges also detect transitions rather than states: a PR that stays
+// merge-ready across ten polls fires once, and so does a session that stays
+// idle. The bridges hold that memory themselves, in a map owned exclusively by
+// the worker goroutine, so neither needs a lock and neither depends on the
+// engine deduplicating for it.
+//
+// The engine seam (Engine, EngineProvider, TriggerRequest) is declared here
+// rather than in the engine package: these bridges are the callers, and
+// declaring the port next to the caller keeps the dependency pointing one way.
+// The engine actor implements it.
+package triggers
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// queueCap bounds the hand-off buffer between the CDC poller goroutine and a
+// bridge worker. PR and session events arrive at poll cadence (100ms, a handful
+// of rows), so this is never pressured in practice; an overflow is logged and
+// dropped rather than blocking the poller.
+//
+// ponytail: fixed drop-on-full buffer. Swap for an unbounded queue only if a
+// real workload ever overflows it.
+const queueCap = 256
+
+// Definitions lists a project's pipeline definitions. Satisfied by
+// *storage/sqlite/store.Store.
+type Definitions interface {
+	ListPipelineDefinitions(ctx context.Context, projectID domain.ProjectID) ([]pipeline.Definition, error)
+}
+
+// TriggerRequest is one run a bridge asks the engine to start.
+//
+// Event is the trigger event as the definition writes it, a pipeline.PREvent or
+// a pipeline.SessionEvent. It is a plain string because both families ride this
+// one seam, and the engine only records it.
+type TriggerRequest struct {
+	Definition pipeline.Definition
+	Event      string
+	Subject    pipeline.Subject
+}
+
+// Engine is the subset of the per-project engine actor a bridge drives.
+type Engine interface {
+	TriggerRun(req TriggerRequest) (pipeline.RunID, error)
+}
+
+// EngineProvider resolves (and lazily starts) the engine for a project.
+// Satisfied by an adapter over the engine supervisor.
+type EngineProvider interface {
+	For(ctx context.Context, projectID domain.ProjectID) (Engine, error)
+}
+
+// PRReader reads the facts of one exact PR by url: the PR named in a CDC
+// payload, not the session's display PR. Satisfied by
+// *storage/sqlite/store.Store.
+//
+// Two reads because neither query is complete on its own: the facts row carries
+// fork provenance and the merge-readiness inputs, while the PR row carries the
+// repo, the branches, and the session tracking it. Both are primary-key reads
+// at PR-event rates, so the cost is noise.
+type PRReader interface {
+	GetPRFactsByURL(ctx context.Context, url string) (domain.PRFacts, bool, error)
+	GetPR(ctx context.Context, url string) (domain.PullRequest, bool, error)
+}
+
+// PRConfig constructs a PRBridge. Broadcaster, Defs, PRs, and Engines are
+// required; Logger defaults.
+type PRConfig struct {
+	Broadcaster *cdc.Broadcaster
+	Defs        Definitions
+	PRs         PRReader
+	Engines     EngineProvider
+	Logger      *slog.Logger
+}
+
+// prSnapshot is the bridge's memory of one PR's last-seen derivation inputs,
+// which is what makes merge-ready and merged transitions rather than states.
+type prSnapshot struct {
+	mergeReady bool
+	merged     bool
+}
+
+// PRBridge turns CDC PR events into pipeline runs with a PR subject.
+type PRBridge struct {
+	defs    Definitions
+	prs     PRReader
+	engines EngineProvider
+
+	broadcaster *cdc.Broadcaster
+	log         *slog.Logger
+
+	queue  chan cdc.Event
+	unsub  func()
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	// prev is owned exclusively by the worker goroutine, so it needs no lock.
+	// Keyed by PR url so a stacked-PR session tracks each PR independently.
+	prev map[string]prSnapshot
+}
+
+// NewPRBridge builds a PRBridge. It does not subscribe or start any goroutine;
+// call Start.
+func NewPRBridge(cfg PRConfig) *PRBridge {
+	log := cfg.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+	return &PRBridge{
+		defs:        cfg.Defs,
+		prs:         cfg.PRs,
+		engines:     cfg.Engines,
+		broadcaster: cfg.Broadcaster,
+		log:         log,
+		queue:       make(chan cdc.Event, queueCap),
+		prev:        map[string]prSnapshot{},
+	}
+}
+
+// Start subscribes to the broadcaster and launches the worker goroutine, which
+// runs until Stop (or ctx cancellation).
+func (b *PRBridge) Start(ctx context.Context) {
+	wctx, cancel := context.WithCancel(ctx)
+	b.cancel = cancel
+	b.unsub = b.broadcaster.Subscribe(b.enqueue)
+	b.wg.Add(1)
+	go b.run(wctx)
+}
+
+// Stop unsubscribes (no new events), stops the worker, and waits for it to
+// finish. Stop on an unstarted bridge is a no-op.
+func (b *PRBridge) Stop() {
+	if b == nil || b.cancel == nil {
+		return
+	}
+	b.unsub()
+	b.cancel()
+	b.wg.Wait()
+}
+
+// enqueue runs on the poller goroutine, so it must not block: it keeps only PR
+// events and hands them to the worker, dropping (with a log) if the buffer is
+// somehow full.
+func (b *PRBridge) enqueue(e cdc.Event) {
+	if e.Type != cdc.EventPRCreated && e.Type != cdc.EventPRUpdated {
+		return
+	}
+	select {
+	case b.queue <- e:
+	default:
+		b.log.Warn("pipeline pr trigger bridge: event queue full, dropping", "seq", e.Seq, "type", e.Type)
+	}
+}
+
+func (b *PRBridge) run(ctx context.Context) {
+	defer b.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case e := <-b.queue:
+			b.process(ctx, e)
+		}
+	}
+}
+
+// prPayload is the subset of the CDC pr_created/pr_updated payload the bridge
+// needs. Every other fact is re-read from the store by url, so a stale payload
+// cannot produce a stale run.
+type prPayload struct {
+	URL     string `json:"url"`
+	Session string `json:"session"`
+}
+
+// process handles one PR event on the worker goroutine.
+func (b *PRBridge) process(ctx context.Context, e cdc.Event) {
+	var p prPayload
+	if err := json.Unmarshal(e.Payload, &p); err != nil {
+		b.log.Warn("pipeline pr trigger bridge: bad pr payload", "seq", e.Seq, "err", err)
+		return
+	}
+	// No session requirement: a PR subject may have no local session and that is
+	// first-class (spec section 4). The project is required, because definitions
+	// are per project.
+	if p.URL == "" || e.ProjectID == "" {
+		return
+	}
+
+	facts, ok, err := b.prs.GetPRFactsByURL(ctx, p.URL)
+	if err != nil {
+		b.log.Warn("pipeline pr trigger bridge: read pr facts", "url", p.URL, "err", err)
+		return
+	}
+	if !ok {
+		return
+	}
+	row, ok, err := b.prs.GetPR(ctx, p.URL)
+	if err != nil {
+		b.log.Warn("pipeline pr trigger bridge: read pr", "url", p.URL, "err", err)
+		return
+	}
+	if !ok {
+		return
+	}
+
+	projectID := domain.ProjectID(e.ProjectID)
+	defs, err := b.defs.ListPipelineDefinitions(ctx, projectID)
+	if err != nil {
+		b.log.Warn("pipeline pr trigger bridge: list definitions", "project", projectID, "err", err)
+		return
+	}
+	if len(defs) == 0 {
+		return
+	}
+
+	events := b.transition(e.Type, p.URL, facts)
+
+	eng, err := b.engines.For(ctx, projectID)
+	if err != nil {
+		b.log.Warn("pipeline pr trigger bridge: resolve engine", "project", projectID, "err", err)
+		return
+	}
+
+	session := string(row.SessionID)
+	if session == "" {
+		session = e.SessionID
+	}
+	subject := pipeline.Subject{
+		Kind:      pipeline.SubjectPR,
+		ProjectID: e.ProjectID,
+		SessionID: session,
+		PR: &pipeline.PRRef{
+			Number:     facts.Number,
+			Repo:       row.Repo,
+			URL:        facts.URL,
+			HeadSHA:    facts.HeadSHA,
+			HeadBranch: row.SourceBranch,
+			BaseBranch: row.TargetBranch,
+			FromFork:   fromFork(facts.IsFromFork),
+		},
+	}
+
+	for _, def := range defs {
+		for _, ev := range events {
+			if !subscribesPR(def.Config, ev) {
+				continue
+			}
+			if _, err := eng.TriggerRun(TriggerRequest{Definition: def, Event: string(ev), Subject: subject}); err != nil {
+				b.log.Warn("pipeline pr trigger bridge: trigger run",
+					"pipeline", def.Name, "event", ev, "url", p.URL, "err", err)
+			}
+		}
+	}
+}
+
+// transition derives which PR events this change represents and records the new
+// snapshot. `created` and `updated` come straight from the CDC event type;
+// `merge-ready` and `merged` fire on the transition INTO their state, so a PR
+// that holds there does not re-fire on every poll. A PR first seen already in
+// the state counts as a transition, so a pipeline armed after the fact still
+// runs.
+//
+// New-SHA cancel-and-rearm is not here: in v2 that is
+// `concurrency.cancel-in-progress` on the `updated` trigger, decided by the
+// engine's concurrency table, not by the bridge.
+func (b *PRBridge) transition(evType cdc.EventType, url string, facts domain.PRFacts) []pipeline.PREvent {
+	prev, seen := b.prev[url]
+	cur := prSnapshot{mergeReady: isMergeReady(facts), merged: facts.Merged}
+	b.prev[url] = cur
+
+	events := make([]pipeline.PREvent, 0, 3)
+	if evType == cdc.EventPRCreated {
+		events = append(events, pipeline.PREventCreated)
+	} else {
+		events = append(events, pipeline.PREventUpdated)
+	}
+	if cur.mergeReady && (!seen || !prev.mergeReady) {
+		events = append(events, pipeline.PREventMergeReady)
+	}
+	if cur.merged && (!seen || !prev.merged) {
+		events = append(events, pipeline.PREventMerged)
+	}
+	return events
+}
+
+// isMergeReady ports the v1 derivation as-is: the PR is open, CI is not
+// failing, review is approved-or-none, and the PR is mergeable.
+func isMergeReady(f domain.PRFacts) bool {
+	open := !f.Draft && !f.Merged && !f.Closed
+	ciNotFailing := f.CI != domain.CIFailing
+	reviewOK := f.Review == domain.ReviewApproved || f.Review == domain.ReviewNone || f.Review == ""
+	mergeable := f.Mergeability == domain.MergeMergeable
+	return open && ciNotFailing && reviewOK && mergeable
+}
+
+// fromFork collapses the tri-state fork provenance for the subject. Unknown
+// (nil) is treated as a fork, which is the fail-safe direction: the identity
+// only rule then withholds credentials from the run rather than handing them to
+// a PR whose provenance nobody established (spec section 8).
+func fromFork(v *bool) bool { return v == nil || *v }
+
+// subscribesPR reports whether the pipeline's `on.pr` list contains ev.
+func subscribesPR(p pipeline.Pipeline, ev pipeline.PREvent) bool {
+	for _, on := range p.On.PR {
+		if on == ev {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/pipeline/triggers/prbridge_test.go
+++ b/backend/internal/pipeline/triggers/prbridge_test.go
@@ -1,0 +1,543 @@
+package triggers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes shared by prbridge_test.go and sessionbridge_test.go
+// ---------------------------------------------------------------------------
+
+type fakeDefs struct {
+	byProject map[domain.ProjectID][]pipeline.Definition
+	err       error
+}
+
+func (f *fakeDefs) ListPipelineDefinitions(_ context.Context, projectID domain.ProjectID) ([]pipeline.Definition, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.byProject[projectID], nil
+}
+
+// fakeEngine records the trigger requests it was handed, in order.
+type fakeEngine struct {
+	mu       sync.Mutex
+	requests []TriggerRequest
+	nextID   int
+}
+
+func (f *fakeEngine) TriggerRun(req TriggerRequest) (pipeline.RunID, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.requests = append(f.requests, req)
+	f.nextID++
+	return pipeline.RunID(fmt.Sprintf("run-%d", f.nextID)), nil
+}
+
+func (f *fakeEngine) all() []TriggerRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]TriggerRequest(nil), f.requests...)
+}
+
+// count is how many runs were triggered for one event name, across definitions.
+func (f *fakeEngine) count(event string) int {
+	n := 0
+	for _, r := range f.all() {
+		if r.Event == event {
+			n++
+		}
+	}
+	return n
+}
+
+// countFor is how many runs were triggered for one event name on one pipeline.
+func (f *fakeEngine) countFor(pipelineName, event string) int {
+	n := 0
+	for _, r := range f.all() {
+		if r.Event == event && r.Definition.Name == pipelineName {
+			n++
+		}
+	}
+	return n
+}
+
+type fakeProvider struct{ eng Engine }
+
+func (p fakeProvider) For(context.Context, domain.ProjectID) (Engine, error) { return p.eng, nil }
+
+type fakePRs struct {
+	facts map[string]domain.PRFacts
+	rows  map[string]domain.PullRequest
+}
+
+func (f *fakePRs) GetPRFactsByURL(_ context.Context, url string) (domain.PRFacts, bool, error) {
+	fct, ok := f.facts[url]
+	return fct, ok, nil
+}
+
+func (f *fakePRs) GetPR(_ context.Context, url string) (domain.PullRequest, bool, error) {
+	row, ok := f.rows[url]
+	return row, ok, nil
+}
+
+// logSink captures what a bridge logged so the drop-and-log contract is
+// assertable.
+func logSink() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})), &buf
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const (
+	testProject = "proj-1"
+	testSession = "sess-1"
+	testURL     = "https://github.com/o/r/pull/1"
+	testRepo    = "o/r"
+)
+
+// prDefOn builds a definition subscribing to exactly the given PR events.
+func prDefOn(name string, events ...pipeline.PREvent) pipeline.Definition {
+	return pipeline.Definition{
+		ID:        pipeline.ID("def-" + name),
+		ProjectID: testProject,
+		Name:      name,
+		Config: pipeline.Pipeline{
+			Name:   name,
+			On:     pipeline.TriggerSpec{PR: events},
+			Stages: []pipeline.Stage{{ID: "review", Executor: pipeline.ExecutorAgent, Agent: "claude-code", Prompt: "look"}},
+		},
+	}
+}
+
+// sessionDefOn builds a definition subscribing to exactly the given session
+// events. It lives here with the other fixtures because both bridge tests use
+// the same fakes.
+func sessionDefOn(name string, events ...pipeline.SessionEvent) pipeline.Definition {
+	def := prDefOn(name)
+	def.Config.On = pipeline.TriggerSpec{Session: events}
+	return def
+}
+
+func readyFacts(sha string) domain.PRFacts {
+	fork := false
+	return domain.PRFacts{
+		URL: testURL, Number: 1, CI: domain.CIPassing, Review: domain.ReviewApproved,
+		Mergeability: domain.MergeMergeable, HeadSHA: sha, IsFromFork: &fork,
+	}
+}
+
+// notReadyFacts is not merge-ready: failing CI blocks it.
+func notReadyFacts(sha string) domain.PRFacts {
+	f := readyFacts(sha)
+	f.CI = domain.CIFailing
+	return f
+}
+
+func mergedFacts(sha string) domain.PRFacts {
+	f := readyFacts(sha)
+	f.Merged = true
+	f.Mergeability = domain.MergeUnknown
+	return f
+}
+
+func prRow(sha string) domain.PullRequest {
+	return domain.PullRequest{
+		URL: testURL, SessionID: testSession, Number: 1, Repo: testRepo,
+		SourceBranch: "feature", TargetBranch: "main", HeadSHA: sha,
+	}
+}
+
+func prEvent(t cdc.EventType) cdc.Event {
+	payload, _ := json.Marshal(prPayload{URL: testURL, Session: testSession})
+	return cdc.Event{Seq: 1, ProjectID: testProject, SessionID: testSession, Type: t, Payload: payload}
+}
+
+// newPRBridge wires a PRBridge over fakes. The returned maps are the live
+// fixtures, so a test can mutate the PR between events.
+func newPRBridge(defs []pipeline.Definition, facts map[string]domain.PRFacts, rows map[string]domain.PullRequest) (*PRBridge, *fakeEngine) {
+	eng := &fakeEngine{}
+	log, _ := logSink()
+	b := NewPRBridge(PRConfig{
+		Broadcaster: cdc.NewBroadcaster(),
+		Defs:        &fakeDefs{byProject: map[domain.ProjectID][]pipeline.Definition{testProject: defs}},
+		PRs:         &fakePRs{facts: facts, rows: rows},
+		Engines:     fakeProvider{eng: eng},
+		Logger:      log,
+	})
+	return b, eng
+}
+
+// newReadyPRBridge is newPRBridge with a single merge-ready PR at sha1.
+func newReadyPRBridge(defs ...pipeline.Definition) (*PRBridge, *fakeEngine) {
+	return newPRBridge(defs,
+		map[string]domain.PRFacts{testURL: readyFacts("sha1")},
+		map[string]domain.PullRequest{testURL: prRow("sha1")})
+}
+
+// ---------------------------------------------------------------------------
+// Event mapping
+// ---------------------------------------------------------------------------
+
+func TestPRCreatedFiresCreated(t *testing.T) {
+	b, eng := newReadyPRBridge(prDefOn("opener", pipeline.PREventCreated))
+
+	b.process(context.Background(), prEvent(cdc.EventPRCreated))
+
+	if got := eng.count(string(pipeline.PREventCreated)); got != 1 {
+		t.Fatalf("created triggers = %d, want 1", got)
+	}
+}
+
+func TestPRUpdatedFiresUpdated(t *testing.T) {
+	b, eng := newReadyPRBridge(prDefOn("watcher", pipeline.PREventUpdated))
+
+	b.process(context.Background(), prEvent(cdc.EventPRUpdated))
+
+	if got := eng.count(string(pipeline.PREventUpdated)); got != 1 {
+		t.Fatalf("updated triggers = %d, want 1", got)
+	}
+	if got := eng.count(string(pipeline.PREventCreated)); got != 0 {
+		t.Fatalf("created triggers = %d, want 0 on a pr_updated event", got)
+	}
+}
+
+func TestPRCreatedDoesNotFireUpdated(t *testing.T) {
+	b, eng := newReadyPRBridge(prDefOn("watcher", pipeline.PREventUpdated))
+
+	b.process(context.Background(), prEvent(cdc.EventPRCreated))
+
+	if got := len(eng.all()); got != 0 {
+		t.Fatalf("triggers = %d, want 0 (created is not updated)", got)
+	}
+}
+
+func TestNonSubscribingDefinitionDoesNotFire(t *testing.T) {
+	// A session-only pipeline must ignore PR events entirely.
+	b, eng := newReadyPRBridge(sessionDefOn("sessionOnly", pipeline.SessionEventIdle))
+
+	b.process(context.Background(), prEvent(cdc.EventPRCreated))
+	b.process(context.Background(), prEvent(cdc.EventPRUpdated))
+
+	if got := len(eng.all()); got != 0 {
+		t.Fatalf("triggers = %d, want 0 for a definition with no pr events", got)
+	}
+}
+
+func TestTriggerCarriesPRSubject(t *testing.T) {
+	def := prDefOn("opener", pipeline.PREventCreated)
+	b, eng := newReadyPRBridge(def)
+
+	b.process(context.Background(), prEvent(cdc.EventPRCreated))
+
+	reqs := eng.all()
+	if len(reqs) != 1 {
+		t.Fatalf("triggers = %d, want 1", len(reqs))
+	}
+	req := reqs[0]
+	if req.Definition.ID != def.ID {
+		t.Fatalf("definition id = %q, want %q", req.Definition.ID, def.ID)
+	}
+	s := req.Subject
+	if s.Kind != pipeline.SubjectPR || s.ProjectID != testProject || s.SessionID != testSession {
+		t.Fatalf("subject envelope = %+v", s)
+	}
+	if s.PR == nil {
+		t.Fatalf("subject has no PR ref: %+v", s)
+	}
+	want := pipeline.PRRef{
+		Number: 1, Repo: testRepo, URL: testURL, HeadSHA: "sha1",
+		HeadBranch: "feature", BaseBranch: "main", FromFork: false,
+	}
+	if *s.PR != want {
+		t.Fatalf("pr ref = %+v, want %+v", *s.PR, want)
+	}
+}
+
+func TestSessionlessPRStillTriggers(t *testing.T) {
+	// Sessionless is first-class (spec section 4): a pipeline watching someone
+	// else's PR must run with no session anywhere in the picture.
+	facts := map[string]domain.PRFacts{testURL: readyFacts("sha1")}
+	row := prRow("sha1")
+	row.SessionID = ""
+	b, eng := newPRBridge([]pipeline.Definition{prDefOn("opener", pipeline.PREventCreated)},
+		facts, map[string]domain.PullRequest{testURL: row})
+
+	ev := prEvent(cdc.EventPRCreated)
+	ev.SessionID = ""
+	ev.Payload, _ = json.Marshal(prPayload{URL: testURL})
+
+	b.process(context.Background(), ev)
+
+	reqs := eng.all()
+	if len(reqs) != 1 {
+		t.Fatalf("triggers = %d, want 1 for a sessionless PR", len(reqs))
+	}
+	if reqs[0].Subject.SessionID != "" {
+		t.Fatalf("subject session = %q, want empty", reqs[0].Subject.SessionID)
+	}
+}
+
+func TestForkProvenanceUnknownTreatedAsFork(t *testing.T) {
+	// nil IsFromFork means unknown, and the identity-only rule fails safe:
+	// unknown provenance is treated as a fork so no credential is injected.
+	facts := readyFacts("sha1")
+	facts.IsFromFork = nil
+	b, eng := newPRBridge([]pipeline.Definition{prDefOn("opener", pipeline.PREventCreated)},
+		map[string]domain.PRFacts{testURL: facts},
+		map[string]domain.PullRequest{testURL: prRow("sha1")})
+
+	b.process(context.Background(), prEvent(cdc.EventPRCreated))
+
+	reqs := eng.all()
+	if len(reqs) != 1 {
+		t.Fatalf("triggers = %d, want 1", len(reqs))
+	}
+	if !reqs[0].Subject.PR.FromFork {
+		t.Fatalf("FromFork = false for unknown provenance, want true (fail-safe)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Transition detection
+// ---------------------------------------------------------------------------
+
+func TestMergeReadyFiresOnceOnTransition(t *testing.T) {
+	ctx := context.Background()
+	facts := map[string]domain.PRFacts{testURL: notReadyFacts("sha1")}
+	b, eng := newPRBridge([]pipeline.Definition{prDefOn("gate", pipeline.PREventMergeReady)},
+		facts, map[string]domain.PullRequest{testURL: prRow("sha1")})
+
+	// Not ready yet.
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+	if got := eng.count(string(pipeline.PREventMergeReady)); got != 0 {
+		t.Fatalf("merge-ready before the transition = %d, want 0", got)
+	}
+
+	// Transition into ready fires once, and holding there fires nothing more.
+	facts[testURL] = readyFacts("sha1")
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+
+	if got := eng.count(string(pipeline.PREventMergeReady)); got != 1 {
+		t.Fatalf("merge-ready across the hold = %d, want exactly 1", got)
+	}
+}
+
+func TestMergeReadyFirstSeenAlreadyReadyFires(t *testing.T) {
+	// A PR first seen already merge-ready counts as a transition, so a pipeline
+	// armed after the fact still runs.
+	b, eng := newReadyPRBridge(prDefOn("gate", pipeline.PREventMergeReady))
+
+	b.process(context.Background(), prEvent(cdc.EventPRUpdated))
+
+	if got := eng.count(string(pipeline.PREventMergeReady)); got != 1 {
+		t.Fatalf("first-seen merge-ready = %d, want 1", got)
+	}
+}
+
+func TestMergeReadyRefiresAfterLeavingTheState(t *testing.T) {
+	ctx := context.Background()
+	facts := map[string]domain.PRFacts{testURL: readyFacts("sha1")}
+	b, eng := newPRBridge([]pipeline.Definition{prDefOn("gate", pipeline.PREventMergeReady)},
+		facts, map[string]domain.PullRequest{testURL: prRow("sha1")})
+
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+	facts[testURL] = notReadyFacts("sha1")
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+	facts[testURL] = readyFacts("sha1")
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+
+	if got := eng.count(string(pipeline.PREventMergeReady)); got != 2 {
+		t.Fatalf("merge-ready across a leave-and-return = %d, want 2", got)
+	}
+}
+
+func TestMergedFiresOnceOnTransition(t *testing.T) {
+	ctx := context.Background()
+	facts := map[string]domain.PRFacts{testURL: readyFacts("sha1")}
+	b, eng := newPRBridge([]pipeline.Definition{prDefOn("onMerge", pipeline.PREventMerged)},
+		facts, map[string]domain.PullRequest{testURL: prRow("sha1")})
+
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+	if got := eng.count(string(pipeline.PREventMerged)); got != 0 {
+		t.Fatalf("merged while open = %d, want 0", got)
+	}
+
+	facts[testURL] = mergedFacts("sha1")
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+
+	if got := eng.count(string(pipeline.PREventMerged)); got != 1 {
+		t.Fatalf("merged across the hold = %d, want exactly 1", got)
+	}
+}
+
+func TestTransitionsAreTrackedPerPR(t *testing.T) {
+	// A stacked-PR session tracks each PR independently: the second PR's first
+	// sighting is its own transition.
+	ctx := context.Background()
+	const otherURL = "https://github.com/o/r/pull/2"
+	other := readyFacts("sha2")
+	other.URL = otherURL
+	other.Number = 2
+	otherRow := prRow("sha2")
+	otherRow.URL = otherURL
+	otherRow.Number = 2
+
+	b, eng := newPRBridge([]pipeline.Definition{prDefOn("gate", pipeline.PREventMergeReady)},
+		map[string]domain.PRFacts{testURL: readyFacts("sha1"), otherURL: other},
+		map[string]domain.PullRequest{testURL: prRow("sha1"), otherURL: otherRow})
+
+	b.process(ctx, prEvent(cdc.EventPRUpdated))
+	ev := prEvent(cdc.EventPRUpdated)
+	ev.Payload, _ = json.Marshal(prPayload{URL: otherURL, Session: testSession})
+	b.process(ctx, ev)
+
+	if got := eng.count(string(pipeline.PREventMergeReady)); got != 2 {
+		t.Fatalf("merge-ready across two PRs = %d, want 2", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fan-out
+// ---------------------------------------------------------------------------
+
+func TestFanOutAcrossDefinitions(t *testing.T) {
+	b, eng := newReadyPRBridge(
+		prDefOn("a", pipeline.PREventUpdated),
+		prDefOn("b", pipeline.PREventUpdated, pipeline.PREventMergeReady),
+		prDefOn("c", pipeline.PREventMerged),
+	)
+
+	b.process(context.Background(), prEvent(cdc.EventPRUpdated))
+
+	if got := eng.countFor("a", string(pipeline.PREventUpdated)); got != 1 {
+		t.Fatalf("a updated = %d, want 1", got)
+	}
+	if got := eng.countFor("b", string(pipeline.PREventUpdated)); got != 1 {
+		t.Fatalf("b updated = %d, want 1", got)
+	}
+	if got := eng.countFor("b", string(pipeline.PREventMergeReady)); got != 1 {
+		t.Fatalf("b merge-ready = %d, want 1", got)
+	}
+	if got := eng.countFor("c", string(pipeline.PREventMerged)); got != 0 {
+		t.Fatalf("c merged = %d, want 0 (the PR is not merged)", got)
+	}
+	if got := len(eng.all()); got != 3 {
+		t.Fatalf("total triggers = %d, want 3", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Queue discipline
+// ---------------------------------------------------------------------------
+
+func TestPREnqueueIgnoresOtherEventTypes(t *testing.T) {
+	b, _ := newReadyPRBridge(prDefOn("opener", pipeline.PREventCreated))
+
+	b.enqueue(cdc.Event{Type: cdc.EventSessionUpdated, ProjectID: testProject})
+	b.enqueue(cdc.Event{Type: cdc.EventPipelineRunUpdated, ProjectID: testProject})
+
+	if got := len(b.queue); got != 0 {
+		t.Fatalf("queued = %d, want 0 for non-PR events", got)
+	}
+}
+
+func TestPREnqueueDropsWhenQueueFull(t *testing.T) {
+	eng := &fakeEngine{}
+	log, buf := logSink()
+	b := NewPRBridge(PRConfig{
+		Broadcaster: cdc.NewBroadcaster(),
+		Defs:        &fakeDefs{},
+		PRs:         &fakePRs{},
+		Engines:     fakeProvider{eng: eng},
+		Logger:      log,
+	})
+
+	// No worker is running, so the buffer fills and the overflow is dropped
+	// rather than blocking the CDC poller goroutine.
+	for i := 0; i < queueCap+5; i++ {
+		b.enqueue(prEvent(cdc.EventPRUpdated))
+	}
+
+	if got := len(b.queue); got != queueCap {
+		t.Fatalf("queued = %d, want %d (buffer cap)", got, queueCap)
+	}
+	if !strings.Contains(buf.String(), "dropping") {
+		t.Fatalf("overflow was not logged: %s", buf.String())
+	}
+}
+
+func TestPRBridgeDeliversThroughBroadcaster(t *testing.T) {
+	bcast := cdc.NewBroadcaster()
+	eng := &fakeEngine{}
+	b := NewPRBridge(PRConfig{
+		Broadcaster: bcast,
+		Defs:        &fakeDefs{byProject: map[domain.ProjectID][]pipeline.Definition{testProject: {prDefOn("opener", pipeline.PREventCreated)}}},
+		PRs: &fakePRs{
+			facts: map[string]domain.PRFacts{testURL: readyFacts("sha1")},
+			rows:  map[string]domain.PullRequest{testURL: prRow("sha1")},
+		},
+		Engines: fakeProvider{eng: eng},
+	})
+	b.Start(context.Background())
+	t.Cleanup(b.Stop)
+
+	bcast.Publish(prEvent(cdc.EventPRCreated))
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if eng.count(string(pipeline.PREventCreated)) == 1 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("created trigger not observed within the deadline (async delivery failed)")
+}
+
+func TestPRProcessIgnoresIncompleteEvents(t *testing.T) {
+	ctx := context.Background()
+	b, eng := newReadyPRBridge(prDefOn("opener", pipeline.PREventCreated))
+
+	noProject := prEvent(cdc.EventPRCreated)
+	noProject.ProjectID = ""
+	b.process(ctx, noProject)
+
+	noURL := prEvent(cdc.EventPRCreated)
+	noURL.Payload, _ = json.Marshal(prPayload{Session: testSession})
+	b.process(ctx, noURL)
+
+	badPayload := prEvent(cdc.EventPRCreated)
+	badPayload.Payload = []byte("not json")
+	b.process(ctx, badPayload)
+
+	unknownPR := prEvent(cdc.EventPRCreated)
+	unknownPR.Payload, _ = json.Marshal(prPayload{URL: "https://github.com/o/r/pull/99", Session: testSession})
+	b.process(ctx, unknownPR)
+
+	if got := len(eng.all()); got != 0 {
+		t.Fatalf("triggers = %d, want 0 for incomplete events", got)
+	}
+}
+
+func TestPRStopWithoutStartIsSafe(t *testing.T) {
+	b, _ := newReadyPRBridge(prDefOn("opener", pipeline.PREventCreated))
+	b.Stop()
+}

--- a/backend/internal/pipeline/triggers/sessionbridge.go
+++ b/backend/internal/pipeline/triggers/sessionbridge.go
@@ -1,0 +1,260 @@
+package triggers
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// SessionSpawnCheck reports whether a session was itself spawned by a pipeline
+// run. It is the loop guard, and it is why the session bridge is not a footgun:
+// without it, a pipeline agent going idle fires the session pipelines, whose
+// agents go idle, forever.
+//
+// The real implementation reads the PipelineRunID marker written onto session
+// metadata at spawn time. That marker lands with the orphan/pipeline session
+// metadata work, so this narrow port exists to be implemented then; until it is
+// wired, the bridge refuses to start (see Start).
+type SessionSpawnCheck interface {
+	IsPipelineSpawned(ctx context.Context, sessionID domain.SessionID) (bool, error)
+}
+
+// SessionConfig constructs a SessionBridge. Broadcaster, Defs, Engines, and
+// Spawned are required; Logger defaults.
+type SessionConfig struct {
+	Broadcaster *cdc.Broadcaster
+	Defs        Definitions
+	Engines     EngineProvider
+	// Spawned is the loop guard. It is required: a bridge without one does not
+	// subscribe at all, because firing session pipelines off pipeline-spawned
+	// sessions is worse than firing none.
+	Spawned SessionSpawnCheck
+	Logger  *slog.Logger
+}
+
+// SessionBridge turns CDC session activity changes into pipeline runs with a
+// session subject.
+type SessionBridge struct {
+	defs    Definitions
+	engines EngineProvider
+	spawned SessionSpawnCheck
+
+	broadcaster *cdc.Broadcaster
+	log         *slog.Logger
+
+	queue  chan cdc.Event
+	unsub  func()
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	// prev is the last activity state seen per session, owned exclusively by the
+	// worker goroutine so it needs no lock. It is what makes idle a transition
+	// rather than a state: session_updated also fires on renames and preview
+	// changes, so the same idle reading arrives repeatedly.
+	prev map[string]domain.ActivityState
+}
+
+// NewSessionBridge builds a SessionBridge. It does not subscribe or start any
+// goroutine; call Start.
+func NewSessionBridge(cfg SessionConfig) *SessionBridge {
+	log := cfg.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+	return &SessionBridge{
+		defs:        cfg.Defs,
+		engines:     cfg.Engines,
+		spawned:     cfg.Spawned,
+		broadcaster: cfg.Broadcaster,
+		log:         log,
+		queue:       make(chan cdc.Event, queueCap),
+		prev:        map[string]domain.ActivityState{},
+	}
+}
+
+// Start subscribes to the broadcaster and launches the worker goroutine, which
+// runs until Stop (or ctx cancellation).
+//
+// With no loop guard configured, Start logs and does nothing: an inert bridge
+// beats one that can start an unbounded chain of runs.
+func (b *SessionBridge) Start(ctx context.Context) {
+	if b.spawned == nil {
+		b.log.Error("pipeline session trigger bridge: no loop guard configured, session triggers disabled")
+		return
+	}
+	wctx, cancel := context.WithCancel(ctx)
+	b.cancel = cancel
+	b.unsub = b.broadcaster.Subscribe(b.enqueue)
+	b.wg.Add(1)
+	go b.run(wctx)
+}
+
+// Stop unsubscribes (no new events), stops the worker, and waits for it to
+// finish. Stop on an unstarted bridge is a no-op.
+func (b *SessionBridge) Stop() {
+	if b == nil || b.cancel == nil {
+		return
+	}
+	b.unsub()
+	b.cancel()
+	b.wg.Wait()
+}
+
+// enqueue runs on the poller goroutine, so it must not block: it keeps only
+// session updates and hands them to the worker, dropping (with a log) if the
+// buffer is somehow full.
+//
+// Only session_updated, never session_created: a brand new session has no
+// previous state, so it cannot yet be a transition.
+func (b *SessionBridge) enqueue(e cdc.Event) {
+	if e.Type != cdc.EventSessionUpdated {
+		return
+	}
+	select {
+	case b.queue <- e:
+	default:
+		b.log.Warn("pipeline session trigger bridge: event queue full, dropping", "seq", e.Seq, "session", e.SessionID)
+	}
+}
+
+func (b *SessionBridge) run(ctx context.Context) {
+	defer b.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case e := <-b.queue:
+			b.process(ctx, e)
+		}
+	}
+}
+
+// sessionPayload is the subset of the CDC session_updated payload the bridge
+// needs. The activity state is the payload's own reading, which is the value
+// the change was captured for.
+type sessionPayload struct {
+	ID       string `json:"id"`
+	Activity string `json:"activity"`
+}
+
+// process handles one session update on the worker goroutine.
+func (b *SessionBridge) process(ctx context.Context, e cdc.Event) {
+	var p sessionPayload
+	if err := json.Unmarshal(e.Payload, &p); err != nil {
+		b.log.Warn("pipeline session trigger bridge: bad session payload", "seq", e.Seq, "err", err)
+		return
+	}
+	sessionID := e.SessionID
+	if sessionID == "" {
+		sessionID = p.ID
+	}
+	if sessionID == "" || e.ProjectID == "" {
+		return
+	}
+
+	ev, ok := b.transition(sessionID, domain.ActivityState(p.Activity))
+	if !ok {
+		return
+	}
+
+	projectID := domain.ProjectID(e.ProjectID)
+	defs, err := b.defs.ListPipelineDefinitions(ctx, projectID)
+	if err != nil {
+		b.log.Warn("pipeline session trigger bridge: list definitions", "project", projectID, "err", err)
+		return
+	}
+	matching := make([]pipeline.Definition, 0, len(defs))
+	for _, def := range defs {
+		if subscribesSession(def.Config, ev) {
+			matching = append(matching, def)
+		}
+	}
+	if len(matching) == 0 {
+		return
+	}
+
+	// The loop guard costs a read, so it runs only once a definition actually
+	// wants this event. An unanswerable guard skips the session: no run is the
+	// fail-safe answer when provenance is unknown.
+	spawned, err := b.spawned.IsPipelineSpawned(ctx, domain.SessionID(sessionID))
+	if err != nil {
+		b.log.Warn("pipeline session trigger bridge: loop guard read failed, skipping session",
+			"session", sessionID, "err", err)
+		return
+	}
+	if spawned {
+		b.log.Debug("pipeline session trigger bridge: ignoring pipeline-spawned session",
+			"session", sessionID, "event", ev)
+		return
+	}
+
+	eng, err := b.engines.For(ctx, projectID)
+	if err != nil {
+		b.log.Warn("pipeline session trigger bridge: resolve engine", "project", projectID, "err", err)
+		return
+	}
+
+	subject := pipeline.Subject{
+		Kind:      pipeline.SubjectSession,
+		ProjectID: e.ProjectID,
+		SessionID: sessionID,
+	}
+	for _, def := range matching {
+		if _, err := eng.TriggerRun(TriggerRequest{Definition: def, Event: string(ev), Subject: subject}); err != nil {
+			b.log.Warn("pipeline session trigger bridge: trigger run",
+				"pipeline", def.Name, "event", ev, "session", sessionID, "err", err)
+		}
+	}
+}
+
+// transition records the new activity state and reports the trigger event this
+// change represents, if any. It fires only when the state actually changed and
+// the new state is one of the three the spec names, so a session holding at idle
+// fires once and not on every subsequent update.
+//
+// A first sighting never fires: the bridge has not observed a transition, only
+// a state. That matters after a daemon restart, where the first update for an
+// already-idle session is usually a rename or an `ao preview`, and firing there
+// would start a run nothing asked for. The cost is that a session already idle
+// when the bridge starts waits for its next real transition.
+func (b *SessionBridge) transition(sessionID string, cur domain.ActivityState) (pipeline.SessionEvent, bool) {
+	prev, seen := b.prev[sessionID]
+	b.prev[sessionID] = cur
+	if !seen || prev == cur {
+		return "", false
+	}
+	return sessionEventFor(cur)
+}
+
+// sessionEventFor maps an activity state onto its trigger event. Only the three
+// states spec section 4 names have one: active is the absence of an event, and
+// waiting_input deliberately has none, so an agent parked at an empty prompt
+// does not start pipelines behind the user.
+func sessionEventFor(s domain.ActivityState) (pipeline.SessionEvent, bool) {
+	switch s {
+	case domain.ActivityIdle:
+		return pipeline.SessionEventIdle, true
+	case domain.ActivityExited:
+		return pipeline.SessionEventExited, true
+	case domain.ActivityBlocked:
+		return pipeline.SessionEventBlocked, true
+	default:
+		return "", false
+	}
+}
+
+// subscribesSession reports whether the pipeline's `on.session` list contains
+// ev.
+func subscribesSession(p pipeline.Pipeline, ev pipeline.SessionEvent) bool {
+	for _, on := range p.On.Session {
+		if on == ev {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/pipeline/triggers/sessionbridge_test.go
+++ b/backend/internal/pipeline/triggers/sessionbridge_test.go
@@ -1,0 +1,351 @@
+package triggers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// fakeSpawnCheck is the loop guard: the ids it holds are pipeline-spawned.
+type fakeSpawnCheck struct {
+	spawned map[domain.SessionID]bool
+	err     error
+	calls   int
+}
+
+func (f *fakeSpawnCheck) IsPipelineSpawned(_ context.Context, id domain.SessionID) (bool, error) {
+	f.calls++
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.spawned[id], nil
+}
+
+func sessionEventCDC(id string, state domain.ActivityState) cdc.Event {
+	payload, _ := json.Marshal(sessionPayload{ID: id, Activity: string(state)})
+	return cdc.Event{Seq: 1, ProjectID: testProject, SessionID: id, Type: cdc.EventSessionUpdated, Payload: payload}
+}
+
+func newSessionBridge(defs []pipeline.Definition, guard *fakeSpawnCheck) (*SessionBridge, *fakeEngine) {
+	eng := &fakeEngine{}
+	log, _ := logSink()
+	b := NewSessionBridge(SessionConfig{
+		Broadcaster: cdc.NewBroadcaster(),
+		Defs:        &fakeDefs{byProject: map[domain.ProjectID][]pipeline.Definition{testProject: defs}},
+		Engines:     fakeProvider{eng: eng},
+		Spawned:     guard,
+		Logger:      log,
+	})
+	return b, eng
+}
+
+func openGuard() *fakeSpawnCheck {
+	return &fakeSpawnCheck{spawned: map[domain.SessionID]bool{}}
+}
+
+// ---------------------------------------------------------------------------
+// Transition detection
+// ---------------------------------------------------------------------------
+
+func TestSessionIdleFiresOncePerTransition(t *testing.T) {
+	ctx := context.Background()
+	b, eng := newSessionBridge([]pipeline.Definition{sessionDefOn("onIdle", pipeline.SessionEventIdle)}, openGuard())
+
+	// First sighting: active, no trigger event, and nothing fires.
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityActive))
+	// Transition into idle fires once.
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityIdle))
+	// session_updated also fires on renames and preview changes, so the same
+	// idle reading arrives again and again. It must not re-trigger.
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityIdle))
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityIdle))
+
+	if got := eng.count(string(pipeline.SessionEventIdle)); got != 1 {
+		t.Fatalf("idle triggers = %d, want exactly 1 (transition only)", got)
+	}
+}
+
+func TestSessionIdleRefiresAfterGoingActive(t *testing.T) {
+	ctx := context.Background()
+	b, eng := newSessionBridge([]pipeline.Definition{sessionDefOn("onIdle", pipeline.SessionEventIdle)}, openGuard())
+
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityActive))
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityIdle))
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityActive))
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityIdle))
+
+	if got := eng.count(string(pipeline.SessionEventIdle)); got != 2 {
+		t.Fatalf("idle triggers = %d, want 2 (one per transition)", got)
+	}
+}
+
+func TestSessionFirstSightingDoesNotFire(t *testing.T) {
+	// The bridge only knows a transition happened when it saw the previous
+	// state. Firing on a first sighting would turn any post-restart session
+	// update (a rename, an `ao preview`) into a spurious run, so the first
+	// sighting only seeds the map.
+	ctx := context.Background()
+	b, eng := newSessionBridge([]pipeline.Definition{sessionDefOn("onIdle", pipeline.SessionEventIdle)}, openGuard())
+
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityIdle))
+
+	if got := len(eng.all()); got != 0 {
+		t.Fatalf("triggers = %d, want 0 on a first sighting", got)
+	}
+}
+
+func TestSessionExitedAndBlockedMap(t *testing.T) {
+	ctx := context.Background()
+	def := sessionDefOn("all", pipeline.SessionEventIdle, pipeline.SessionEventExited, pipeline.SessionEventBlocked)
+	b, eng := newSessionBridge([]pipeline.Definition{def}, openGuard())
+
+	b.process(ctx, sessionEventCDC("s-blocked", domain.ActivityActive))
+	b.process(ctx, sessionEventCDC("s-blocked", domain.ActivityBlocked))
+	b.process(ctx, sessionEventCDC("s-exited", domain.ActivityActive))
+	b.process(ctx, sessionEventCDC("s-exited", domain.ActivityExited))
+
+	if got := eng.count(string(pipeline.SessionEventBlocked)); got != 1 {
+		t.Fatalf("blocked triggers = %d, want 1", got)
+	}
+	if got := eng.count(string(pipeline.SessionEventExited)); got != 1 {
+		t.Fatalf("exited triggers = %d, want 1", got)
+	}
+	if got := eng.count(string(pipeline.SessionEventIdle)); got != 0 {
+		t.Fatalf("idle triggers = %d, want 0", got)
+	}
+}
+
+func TestSessionNonTriggerStatesDoNotFire(t *testing.T) {
+	// waiting_input is a real activity state with no trigger in spec section 4.
+	ctx := context.Background()
+	def := sessionDefOn("all", pipeline.SessionEventIdle, pipeline.SessionEventExited, pipeline.SessionEventBlocked)
+	b, eng := newSessionBridge([]pipeline.Definition{def}, openGuard())
+
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityIdle))
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityWaitingInput))
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityActive))
+
+	if got := len(eng.all()); got != 0 {
+		t.Fatalf("triggers = %d, want 0", got)
+	}
+}
+
+func TestSessionTriggerCarriesSessionSubject(t *testing.T) {
+	ctx := context.Background()
+	def := sessionDefOn("onIdle", pipeline.SessionEventIdle)
+	b, eng := newSessionBridge([]pipeline.Definition{def}, openGuard())
+
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityActive))
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityIdle))
+
+	reqs := eng.all()
+	if len(reqs) != 1 {
+		t.Fatalf("triggers = %d, want 1", len(reqs))
+	}
+	req := reqs[0]
+	if req.Definition.ID != def.ID || req.Event != string(pipeline.SessionEventIdle) {
+		t.Fatalf("request = %+v", req)
+	}
+	want := pipeline.Subject{Kind: pipeline.SubjectSession, ProjectID: testProject, SessionID: testSession}
+	if req.Subject != want {
+		t.Fatalf("subject = %+v, want %+v", req.Subject, want)
+	}
+}
+
+func TestSessionFanOutAcrossDefinitions(t *testing.T) {
+	ctx := context.Background()
+	b, eng := newSessionBridge([]pipeline.Definition{
+		sessionDefOn("a", pipeline.SessionEventIdle),
+		sessionDefOn("b", pipeline.SessionEventIdle, pipeline.SessionEventExited),
+		sessionDefOn("c", pipeline.SessionEventExited),
+		prDefOn("pronly", pipeline.PREventUpdated),
+	}, openGuard())
+
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityActive))
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityIdle))
+
+	if got := len(eng.all()); got != 2 {
+		t.Fatalf("triggers = %d, want 2 (a and b)", got)
+	}
+	if got := eng.countFor("a", string(pipeline.SessionEventIdle)); got != 1 {
+		t.Fatalf("a idle = %d, want 1", got)
+	}
+	if got := eng.countFor("b", string(pipeline.SessionEventIdle)); got != 1 {
+		t.Fatalf("b idle = %d, want 1", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Loop guard
+// ---------------------------------------------------------------------------
+
+func TestPipelineSpawnedSessionsAreIgnored(t *testing.T) {
+	// A pipeline agent going idle must not fire session pipelines, or every run
+	// spawns the next one forever.
+	ctx := context.Background()
+	guard := openGuard()
+	guard.spawned["s-pipeline"] = true
+	b, eng := newSessionBridge([]pipeline.Definition{sessionDefOn("onIdle", pipeline.SessionEventIdle)}, guard)
+
+	b.process(ctx, sessionEventCDC("s-pipeline", domain.ActivityActive))
+	b.process(ctx, sessionEventCDC("s-pipeline", domain.ActivityIdle))
+	b.process(ctx, sessionEventCDC("s-human", domain.ActivityActive))
+	b.process(ctx, sessionEventCDC("s-human", domain.ActivityIdle))
+
+	reqs := eng.all()
+	if len(reqs) != 1 {
+		t.Fatalf("triggers = %d, want 1 (the human session only)", len(reqs))
+	}
+	if reqs[0].Subject.SessionID != "s-human" {
+		t.Fatalf("triggered for %q, want s-human", reqs[0].Subject.SessionID)
+	}
+}
+
+func TestSessionGuardErrorSkipsTheSession(t *testing.T) {
+	// Unknown provenance fails safe: no run rather than a possible loop.
+	ctx := context.Background()
+	guard := openGuard()
+	guard.err = errors.New("store down")
+	b, eng := newSessionBridge([]pipeline.Definition{sessionDefOn("onIdle", pipeline.SessionEventIdle)}, guard)
+
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityActive))
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityIdle))
+
+	if got := len(eng.all()); got != 0 {
+		t.Fatalf("triggers = %d, want 0 when the loop guard cannot answer", got)
+	}
+}
+
+func TestSessionBridgeRefusesToStartWithoutLoopGuard(t *testing.T) {
+	bcast := cdc.NewBroadcaster()
+	log, buf := logSink()
+	b := NewSessionBridge(SessionConfig{
+		Broadcaster: bcast,
+		Defs:        &fakeDefs{},
+		Engines:     fakeProvider{eng: &fakeEngine{}},
+		Logger:      log,
+	})
+
+	b.Start(context.Background())
+	t.Cleanup(b.Stop)
+
+	if got := bcast.SubscriberCount(); got != 0 {
+		t.Fatalf("subscribers = %d, want 0 without a loop guard", got)
+	}
+	if !strings.Contains(buf.String(), "loop guard") {
+		t.Fatalf("refusal was not logged: %s", buf.String())
+	}
+}
+
+func TestSessionGuardNotConsultedWhenNoDefinitionSubscribes(t *testing.T) {
+	// The guard is a store read per event, so it only runs once a definition
+	// actually wants this event.
+	ctx := context.Background()
+	guard := openGuard()
+	b, _ := newSessionBridge([]pipeline.Definition{sessionDefOn("onExit", pipeline.SessionEventExited)}, guard)
+
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityActive))
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityIdle))
+
+	if guard.calls != 0 {
+		t.Fatalf("loop guard calls = %d, want 0", guard.calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Queue discipline
+// ---------------------------------------------------------------------------
+
+func TestSessionEnqueueIgnoresOtherEventTypes(t *testing.T) {
+	b, _ := newSessionBridge([]pipeline.Definition{sessionDefOn("onIdle", pipeline.SessionEventIdle)}, openGuard())
+
+	b.enqueue(cdc.Event{Type: cdc.EventPRUpdated, ProjectID: testProject})
+	b.enqueue(cdc.Event{Type: cdc.EventSessionCreated, ProjectID: testProject})
+
+	if got := len(b.queue); got != 0 {
+		t.Fatalf("queued = %d, want 0 for non session_updated events", got)
+	}
+}
+
+func TestSessionEnqueueDropsWhenQueueFull(t *testing.T) {
+	log, buf := logSink()
+	b := NewSessionBridge(SessionConfig{
+		Broadcaster: cdc.NewBroadcaster(),
+		Defs:        &fakeDefs{},
+		Engines:     fakeProvider{eng: &fakeEngine{}},
+		Spawned:     openGuard(),
+		Logger:      log,
+	})
+
+	for i := 0; i < queueCap+5; i++ {
+		b.enqueue(sessionEventCDC(testSession, domain.ActivityIdle))
+	}
+
+	if got := len(b.queue); got != queueCap {
+		t.Fatalf("queued = %d, want %d (buffer cap)", got, queueCap)
+	}
+	if !strings.Contains(buf.String(), "dropping") {
+		t.Fatalf("overflow was not logged: %s", buf.String())
+	}
+}
+
+func TestSessionBridgeDeliversThroughBroadcaster(t *testing.T) {
+	bcast := cdc.NewBroadcaster()
+	eng := &fakeEngine{}
+	b := NewSessionBridge(SessionConfig{
+		Broadcaster: bcast,
+		Defs:        &fakeDefs{byProject: map[domain.ProjectID][]pipeline.Definition{testProject: {sessionDefOn("onIdle", pipeline.SessionEventIdle)}}},
+		Engines:     fakeProvider{eng: eng},
+		Spawned:     openGuard(),
+	})
+	b.Start(context.Background())
+	t.Cleanup(b.Stop)
+
+	bcast.Publish(sessionEventCDC(testSession, domain.ActivityActive))
+	bcast.Publish(sessionEventCDC(testSession, domain.ActivityIdle))
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if eng.count(string(pipeline.SessionEventIdle)) == 1 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("idle trigger not observed within the deadline (async delivery failed)")
+}
+
+func TestSessionProcessIgnoresIncompleteEvents(t *testing.T) {
+	ctx := context.Background()
+	b, eng := newSessionBridge([]pipeline.Definition{sessionDefOn("onIdle", pipeline.SessionEventIdle)}, openGuard())
+
+	noProject := sessionEventCDC(testSession, domain.ActivityIdle)
+	noProject.ProjectID = ""
+	b.process(ctx, noProject)
+
+	badPayload := sessionEventCDC(testSession, domain.ActivityIdle)
+	badPayload.Payload = []byte("not json")
+	b.process(ctx, badPayload)
+
+	noID := cdc.Event{Seq: 2, ProjectID: testProject, Type: cdc.EventSessionUpdated, Payload: []byte(`{"activity":"idle"}`)}
+	b.process(ctx, noID)
+
+	// None of the above may have seeded prev either, so a real transition still
+	// needs its own first sighting.
+	b.process(ctx, sessionEventCDC(testSession, domain.ActivityIdle))
+
+	if got := len(eng.all()); got != 0 {
+		t.Fatalf("triggers = %d, want 0", got)
+	}
+}
+
+func TestSessionStopWithoutStartIsSafe(t *testing.T) {
+	b, _ := newSessionBridge([]pipeline.Definition{sessionDefOn("onIdle", pipeline.SessionEventIdle)}, openGuard())
+	b.Stop()
+}


### PR DESCRIPTION
Closes #306

Pipelines v2 Task 13: rewrites the v1 PR trigger bridge onto the v2 vocabulary and adds the session trigger bridge alongside it.

## Shared shape (ported from v1, it is proven)

Both bridges: a synchronous `Broadcaster.Subscribe` callback that only filters and enqueues onto a buffered channel (cap 256, drop-and-log on overflow), plus one owned worker goroutine doing every store read and every blocking engine call. The CDC poller goroutine is never blocked, and engine methods are only ever called from the worker, so the engine actor mailbox cannot deadlock against a bridge.

Both detect **transitions**, not states, in a `prev` map owned exclusively by the worker (no lock): a PR holding at merge-ready fires once, and so does a session holding at idle.

## PR bridge (`prbridge.go`)

- Consumes `EventPRCreated` / `EventPRUpdated`, re-reads PR facts, maps onto the spec's `created | updated | merge-ready | merged` (decision D14; v1's `pr.opened` is gone).
- `isMergeReady` ported as-is; `merge-ready` and `merged` fire on the transition into the state, and a PR first seen already in the state counts as a transition.
- Builds `Subject{Kind: pr, PR: &PRRef{...}, SessionID: <local tracking session if any>}` and fires each definition whose `on.pr` contains the event.
- No session required: sessionless PR subjects are first-class (spec section 4).
- Unknown fork provenance (`IsFromFork == nil`) resolves to `FromFork: true`, the fail-safe direction for the identity-only rule (D17): credentials withheld rather than handed to a PR whose provenance nobody established.
- v1's new-SHA cancel-and-rearm dispatch is gone from the bridge. In v2 that is `concurrency.cancel-in-progress` on the `updated` trigger, decided by the engine's concurrency table, so `prSnapshot` no longer tracks head SHA.
- Two store reads per event (`GetPRFactsByURL` + `GetPR`) because neither query is complete alone: facts carry fork provenance and the merge-readiness inputs, the PR row carries repo, branches, and the tracking session. Both are primary-key reads at PR-event rates.

## Session bridge (`sessionbridge.go`)

- Consumes `EventSessionUpdated` and fires on the transition into `idle` / `exited` / `blocked`. `session_updated` also fires on renames and `ao preview`, so the same idle reading arrives repeatedly; only the transition triggers.
- **Loop guard:** sessions that are themselves pipeline-spawned are skipped, or a pipeline agent going idle starts another run forever. The marker (`PipelineRunID` session metadata) does not exist on this branch yet, so the guard is a narrow port, `SessionSpawnCheck.IsPipelineSpawned`. **Task 16 wires the real marker behind it.** Until then, a bridge constructed with no guard logs an error and does not subscribe at all: inert beats looping. A guard read that errors skips the session.
- The guard runs only after a definition has matched the event, so it costs nothing in projects with no session pipelines.
- A first sighting never fires: the bridge saw a state, not a transition. After a daemon restart the first update for an already-idle session is usually a rename or a preview change, and firing there would start a run nothing asked for. The cost is that a session already idle when the bridge starts waits for its next real transition.
- `waiting_input` deliberately has no trigger event (spec section 4 names three states), so an agent parked at an empty prompt does not start pipelines behind the user.

## Engine seam for Task 15

\`\`\`go
type TriggerRequest struct {
    Definition pipeline.Definition
    Event      string
    Subject    pipeline.Subject
}
type Engine interface { TriggerRun(req TriggerRequest) (pipeline.RunID, error) }
type EngineProvider interface { For(ctx context.Context, projectID domain.ProjectID) (Engine, error) }
\`\`\`

Declared in `triggers` next to its callers, so the engine actor implements it and the dependency points one way. `Event` is a plain string because both trigger families ride the one seam. Tested against a fake engine; **Task 15 implements it** (its `pendingTrigger` in `engine/concurrency.go` is already this shape plus the run id).

## Tests (34 in the package, all the plan's cases)

PR: event mapping for created and updated, non-subscribing definition ignored, subject and `PRRef` contents, sessionless PR, unknown fork provenance, merge-ready transition-only across a hold, first-seen-already-ready fires, re-fires after leaving and returning, merged transition-only, transitions tracked per PR (stacked PRs), fan-out across definitions, non-PR events not queued, overflow drop logged, async delivery through a real broadcaster, incomplete and unknown events ignored.

Session: idle fires once per transition and not on repeats, re-fires after going active, first sighting does not fire, exited and blocked map correctly, `waiting_input` and `active` do not fire, subject contents, fan-out across definitions, pipeline-spawned sessions ignored, guard error skips the session, no-guard bridge does not subscribe, guard not consulted when no definition subscribes, overflow drop logged, async delivery, incomplete events ignored.

Transition detectors were mutation-checked (fire-on-state instead of fire-on-transition) to confirm the tests are the ones catching it.

## Verification

- \`go build ./...\`, \`go test ./...\` (2673 pass), \`gofmt -l .\` empty, \`golangci-lint run ./...\` 0 issues, all from \`backend/\`.
- The 4 \`internal/cli\` spawn failures seen locally are an environment leak (\`AO_PROJECT_ID\` / \`AO_SESSION_ID\` set in the worker shell); \`env -u AO_PROJECT_ID -u AO_SESSION_ID -u AO_ISSUE_ID go test ./internal/cli/\` is green, and nothing imports this new package yet.

## Risks and follow-ups

- Neither bridge is wired yet (no engine to wire to). Task 15 wires both; Task 16 supplies the real loop-guard marker.
- Terminated sessions are not filtered: an activity transition into `exited` fires whether or not the session was explicitly killed. That is the literal reading of the spec's trigger table; if dogfooding says a deliberate kill should not trigger, the filter is one condition in `process`.