### PR TITLE
feat(pipelines): v2 command executor, exit-code outcomes, stage log files

### DIFF
--- a/backend/internal/pipeline/executors/command.go
+++ b/backend/internal/pipeline/executors/command.go
@@ -1,0 +1,219 @@
+package executors
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// stageTailCapBytes bounds the in-memory copy of a stage's output (64 KiB) that
+// the run-detail DTO shows. The full stream is on disk in the stage log, so
+// nothing is lost by keeping this small.
+const stageTailCapBytes = 64 << 10
+
+// stageLogFilePerm matches the run folder's file mode: run output can contain
+// whatever the command printed, so it stays owner-only.
+const stageLogFilePerm os.FileMode = 0o600
+
+// stageLogDirPerm matches the run folder's directory mode.
+const stageLogDirPerm os.FileMode = 0o750
+
+// RunnerFactory builds a CommandRunner bound to one stage's log sink. It exists
+// because the sink is per stage while the executor is per project: NewOSRunner
+// satisfies this signature as-is, and tests pass a fake.
+type RunnerFactory func(sink LogSink) CommandRunner
+
+// CommandExecutor runs a command stage's `run:` block in the stage's workspace.
+// Exit status is the outcome (spec section 6.1): there is no stdout envelope to
+// parse, and this executor never decides whether a code means success.
+type CommandExecutor struct {
+	runners RunnerFactory
+}
+
+// NewCommandExecutor builds the command executor over a runner factory. Pass
+// NewOSRunner in production.
+func NewCommandExecutor(runners RunnerFactory) *CommandExecutor {
+	return &CommandExecutor{runners: runners}
+}
+
+var _ StageExecutor = (*CommandExecutor)(nil)
+
+// commandHandle is the running-stage token for a command stage.
+type commandHandle struct {
+	stageIdentity
+	child CommandProcess
+	log   *stageLog
+}
+
+// OutputTail returns the capped copy of the stage's output.
+func (h *commandHandle) OutputTail() (string, bool) {
+	if h.log == nil {
+		return "", false
+	}
+	return h.log.tail()
+}
+
+// Start opens the stage log and spawns the command. The `run:` block is handed
+// to a shell so environment variables interpolate, which is the whole of v2's
+// templating story (spec section 12.3).
+func (e *CommandExecutor) Start(ctx context.Context, in StartInput) (Handle, error) {
+	if in.Stage.Executor != pipeline.ExecutorCommand {
+		return nil, fmt.Errorf("command executor cannot start stage %q with executor %q", in.Stage.ID, in.Stage.Executor)
+	}
+	if in.WorkspacePath == "" {
+		return nil, fmt.Errorf("command stage %q has no workspace to run in", in.Stage.ID)
+	}
+	log, err := openStageLog(in.LogPath)
+	if err != nil {
+		return nil, fmt.Errorf("command stage %q: %w", in.Stage.ID, err)
+	}
+
+	child, err := e.runners(log).Start(ctx, CommandSpec{
+		// ponytail: sh everywhere, matching how session_manager runs a
+		// configured command. A Windows shell selection lands the day a
+		// pipeline has to run there.
+		Command: "sh",
+		Args:    []string{"-c", in.Stage.Run},
+		Env:     commandEnv(in),
+		Dir:     in.WorkspacePath,
+		// The runner's own capture is bounded to the same size as the tail: the
+		// stage log on disk is the complete record, so buffering more in the
+		// engine buys nothing.
+		OutputCap: stageTailCapBytes,
+	})
+	if err != nil {
+		log.close()
+		return nil, fmt.Errorf("spawn command stage %q: %w", in.Stage.ID, err)
+	}
+
+	return &commandHandle{
+		stageIdentity: stageIdentity{runID: in.RunID, stageID: in.Stage.ID, attempt: in.Attempt},
+		child:         child,
+		log:           log,
+	}, nil
+}
+
+// Poll reports running until the process exits, then reports the exit status
+// verbatim. Mapping a code onto an outcome is the driver's job.
+func (e *CommandExecutor) Poll(_ context.Context, h Handle) (Poll, error) {
+	handle, ok := h.(*commandHandle)
+	if !ok {
+		return Poll{}, fmt.Errorf("command executor: unexpected handle type %T", h)
+	}
+	select {
+	case <-handle.child.Done():
+		handle.log.close()
+		res := handle.child.Result()
+		out := Poll{State: PollExited, ExitCode: res.ExitCode}
+		switch {
+		case res.Err != nil:
+			// A spawn or wait failure is not a clean exit. Never let it read as
+			// success just because no status was collected.
+			if out.ExitCode == 0 {
+				out.ExitCode = -1
+			}
+			out.Reason = res.Err.Error()
+		case res.Signal != "":
+			out.Reason = "killed by signal " + res.Signal
+		}
+		return out, nil
+	default:
+		return Poll{State: PollRunning}, nil
+	}
+}
+
+// Cancel kills the process group (the runner owns the SIGTERM to SIGKILL
+// escalation, so a shell's children die with it) and closes the log.
+// Idempotent.
+func (e *CommandExecutor) Cancel(_ context.Context, h Handle) error {
+	handle, ok := h.(*commandHandle)
+	if !ok {
+		return fmt.Errorf("command executor: unexpected handle type %T", h)
+	}
+	handle.child.Kill()
+	return nil
+}
+
+// Interrupt is Cancel for a command stage. The interrupt/cancel distinction only
+// buys anything for agent stages, where the session must survive the kill (spec
+// section 7.2); a process has nothing to preserve.
+func (e *CommandExecutor) Interrupt(ctx context.Context, h Handle) error {
+	return e.Cancel(ctx, h)
+}
+
+// commandEnv layers the resolved credentials over the ambient set. The process
+// environment is added underneath by the runner, so the effective order is
+// process env, then ambient, then credentials. Credentials win a collision:
+// they are the authority the stage was granted, and ambient identity must not
+// be able to mask them.
+func commandEnv(in StartInput) map[string]string {
+	env := make(map[string]string, len(in.Env)+len(in.Credentials))
+	for k, v := range in.Env {
+		env[k] = v
+	}
+	for k, v := range in.Credentials {
+		env[k] = v
+	}
+	return env
+}
+
+// stageLog is the LogSink for one stage: it writes the full stream to
+// <run>/stage-logs/<stage>.log and keeps a capped copy in memory for the
+// run-detail DTO. Both streams land in one file, raw and interleaved, because
+// tagging each chunk would split partial lines mid-write.
+type stageLog struct {
+	mu     sync.Mutex
+	file   *os.File
+	capped *capBuffer
+	closed bool
+}
+
+// openStageLog creates or appends to the stage's log file. Appending means a
+// second attempt after a nudge adds to the record instead of erasing the first.
+func openStageLog(path string) (*stageLog, error) {
+	if path == "" {
+		return nil, fmt.Errorf("stage log: no log path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), stageLogDirPerm); err != nil {
+		return nil, fmt.Errorf("stage log dir %s: %w", filepath.Dir(path), err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, stageLogFilePerm)
+	if err != nil {
+		return nil, fmt.Errorf("open stage log %s: %w", path, err)
+	}
+	return &stageLog{file: file, capped: &capBuffer{limit: stageTailCapBytes}}, nil
+}
+
+// Write implements LogSink. Failures are swallowed: a stage must not die
+// because logging did, and the exit status is still the outcome.
+func (l *stageLog) Write(_ string, chunk []byte) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return
+	}
+	_, _ = l.file.Write(chunk)
+	_, _ = l.capped.Write(chunk)
+}
+
+// tail returns the in-memory copy and whether output past the cap was dropped.
+func (l *stageLog) tail() (string, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.capped.String(), l.capped.capped
+}
+
+// close releases the file. Idempotent, and safe to race with a pump goroutine.
+func (l *stageLog) close() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return
+	}
+	l.closed = true
+	_ = l.file.Close()
+}

--- a/backend/internal/pipeline/executors/command_test.go
+++ b/backend/internal/pipeline/executors/command_test.go
@@ -1,0 +1,444 @@
+package executors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// fakeProcess is a subprocess that never runs: the test decides when it exits,
+// what it wrote, and observes whether it was killed.
+type fakeProcess struct {
+	done chan struct{}
+
+	mu     sync.Mutex
+	result CommandResult
+	kills  int
+}
+
+func newFakeProcess() *fakeProcess { return &fakeProcess{done: make(chan struct{})} }
+
+func (p *fakeProcess) Done() <-chan struct{} { return p.done }
+
+func (p *fakeProcess) Result() CommandResult {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.result
+}
+
+func (p *fakeProcess) Kill() {
+	p.mu.Lock()
+	p.kills++
+	p.mu.Unlock()
+}
+
+func (p *fakeProcess) killCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.kills
+}
+
+// exit settles the process with the given result and closes Done.
+func (p *fakeProcess) exit(res CommandResult) {
+	p.mu.Lock()
+	p.result = res
+	p.mu.Unlock()
+	close(p.done)
+}
+
+// fakeRunner records the spec it was started with and hands the test the log
+// sink the executor bound to it, so the test can push output through the same
+// path a real subprocess would.
+type fakeRunner struct {
+	sink  LogSink
+	spec  CommandSpec
+	child *fakeProcess
+	err   error
+}
+
+func (r *fakeRunner) Start(_ context.Context, spec CommandSpec) (CommandProcess, error) {
+	r.spec = spec
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.child, nil
+}
+
+// newFakeExecutor wires a CommandExecutor onto a single fake runner.
+func newFakeExecutor(t *testing.T) (*CommandExecutor, *fakeRunner) {
+	t.Helper()
+	runner := &fakeRunner{child: newFakeProcess()}
+	exec := NewCommandExecutor(func(sink LogSink) CommandRunner {
+		runner.sink = sink
+		return runner
+	})
+	return exec, runner
+}
+
+// startInput builds a minimal command-stage start input rooted in a temp dir.
+func startInput(t *testing.T) StartInput {
+	t.Helper()
+	dir := t.TempDir()
+	folder, err := pipeline.CreateRunFolder(dir, "proj-1", "run-1", []byte("stages: []\n"))
+	if err != nil {
+		t.Fatalf("CreateRunFolder: %v", err)
+	}
+	return StartInput{
+		ProjectID:     "proj-1",
+		RunID:         "run-1",
+		RunDir:        folder.Dir,
+		Stage:         pipeline.Stage{ID: "publish", Executor: pipeline.ExecutorCommand, Run: "echo hi"},
+		Attempt:       1,
+		Subject:       pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: "proj-1"},
+		WorkspacePath: filepath.Join(dir, "tree"),
+		Env:           map[string]string{"AO_RUN_ID": "run-1", "AO_STAGE": "publish", "GH_TOKEN": "ambient"},
+		LogPath:       folder.LogPath("publish"),
+	}
+}
+
+func TestCommandStartSpec(t *testing.T) {
+	exec, runner := newFakeExecutor(t)
+	in := startInput(t)
+
+	if _, err := exec.Start(context.Background(), in); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if runner.spec.Dir != in.WorkspacePath {
+		t.Errorf("cwd = %q, want the stage workspace %q", runner.spec.Dir, in.WorkspacePath)
+	}
+	if got := runner.spec.Env["AO_RUN_ID"]; got != "run-1" {
+		t.Errorf("AO_RUN_ID = %q, want run-1", got)
+	}
+	if got := runner.spec.Env["AO_STAGE"]; got != "publish" {
+		t.Errorf("AO_STAGE = %q, want publish", got)
+	}
+	// The whole `run:` block is handed to a shell so env interpolation works
+	// without an expression language (spec section 12.3).
+	if want := "echo hi"; runner.spec.Args[len(runner.spec.Args)-1] != want {
+		t.Errorf("args = %v, want the run block %q last", runner.spec.Args, want)
+	}
+}
+
+func TestCommandCredentialsOnlyWhenProvidedAndWin(t *testing.T) {
+	exec, runner := newFakeExecutor(t)
+	in := startInput(t)
+
+	if _, err := exec.Start(context.Background(), in); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if got, ok := runner.spec.Env["APPLE_KEY"]; ok {
+		t.Errorf("APPLE_KEY = %q, want absent when no credentials are provided", got)
+	}
+	if got := runner.spec.Env["GH_TOKEN"]; got != "ambient" {
+		t.Errorf("GH_TOKEN = %q, want the ambient value untouched", got)
+	}
+
+	exec, runner = newFakeExecutor(t)
+	in = startInput(t)
+	in.Credentials = map[string]string{"APPLE_KEY": "secret", "GH_TOKEN": "credential"}
+	if _, err := exec.Start(context.Background(), in); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if got := runner.spec.Env["APPLE_KEY"]; got != "secret" {
+		t.Errorf("APPLE_KEY = %q, want secret", got)
+	}
+	if got := runner.spec.Env["GH_TOKEN"]; got != "credential" {
+		t.Errorf("GH_TOKEN = %q, want the credential to win the collision", got)
+	}
+}
+
+func TestCommandTeesBothStreamsToLogFile(t *testing.T) {
+	exec, runner := newFakeExecutor(t)
+	in := startInput(t)
+
+	h, err := exec.Start(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	runner.sink.Write("stdout", []byte("out line\n"))
+	runner.sink.Write("stderr", []byte("err line\n"))
+	runner.child.exit(CommandResult{ExitCode: 0})
+	if _, err := exec.Poll(context.Background(), h); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	raw, err := os.ReadFile(in.LogPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	for _, want := range []string{"out line", "err line"} {
+		if !strings.Contains(string(raw), want) {
+			t.Errorf("log %q missing %q", raw, want)
+		}
+	}
+
+	tailer, ok := h.(OutputTailer)
+	if !ok {
+		t.Fatalf("handle %T does not expose an output tail", h)
+	}
+	text, truncated := tailer.OutputTail()
+	if !strings.Contains(text, "out line") || !strings.Contains(text, "err line") {
+		t.Errorf("tail = %q, want both streams", text)
+	}
+	if truncated {
+		t.Error("tail reported truncated for a two-line stage")
+	}
+}
+
+func TestCommandOutputTailIsCapped(t *testing.T) {
+	exec, runner := newFakeExecutor(t)
+	in := startInput(t)
+
+	h, err := exec.Start(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	chunk := strings.Repeat("x", 8<<10)
+	total := 0
+	for i := 0; i < 12; i++ { // 96 KiB, past the 64 KiB tail cap
+		runner.sink.Write("stdout", []byte(chunk))
+		total += len(chunk)
+	}
+	runner.child.exit(CommandResult{ExitCode: 0})
+	if _, err := exec.Poll(context.Background(), h); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	text, truncated := h.(OutputTailer).OutputTail()
+	if len(text) != stageTailCapBytes {
+		t.Errorf("tail is %d bytes, want the %d byte cap", len(text), stageTailCapBytes)
+	}
+	if !truncated {
+		t.Error("tail did not report truncation past the cap")
+	}
+	info, err := os.Stat(in.LogPath)
+	if err != nil {
+		t.Fatalf("stat log: %v", err)
+	}
+	if info.Size() != int64(total) {
+		t.Errorf("log file is %d bytes, want the full %d byte stream", info.Size(), total)
+	}
+}
+
+func TestCommandPollRunningThenExit(t *testing.T) {
+	exec, runner := newFakeExecutor(t)
+	in := startInput(t)
+
+	h, err := exec.Start(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	got, err := exec.Poll(context.Background(), h)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if got.State != PollRunning {
+		t.Fatalf("state = %q, want running", got.State)
+	}
+
+	runner.child.exit(CommandResult{ExitCode: 3})
+	got, err = exec.Poll(context.Background(), h)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	// Exit status is the outcome: the executor reports the code, the driver maps
+	// it (spec section 6.1). No stdout envelope is parsed.
+	if got.State != PollExited || got.ExitCode != 3 {
+		t.Errorf("poll = %+v, want exited with code 3", got)
+	}
+}
+
+func TestCommandPollReportsSpawnFailureAsNonZero(t *testing.T) {
+	exec, runner := newFakeExecutor(t)
+	in := startInput(t)
+
+	h, err := exec.Start(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	runner.child.exit(CommandResult{ExitCode: 0, Err: os.ErrPermission})
+	got, err := exec.Poll(context.Background(), h)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if got.State != PollExited {
+		t.Fatalf("state = %q, want exited", got.State)
+	}
+	if got.ExitCode == 0 {
+		t.Error("a wait failure reported exit code 0, which the driver would read as success")
+	}
+	if got.Reason == "" {
+		t.Error("a wait failure carried no reason")
+	}
+}
+
+func TestCommandCancelAndInterruptKillTheProcessGroup(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(*CommandExecutor, Handle) error
+	}{
+		// Interrupt is Cancel for a command stage: there is no session to keep
+		// alive, so a deadline kill and a run cancellation do the same thing.
+		{"cancel", func(e *CommandExecutor, h Handle) error { return e.Cancel(context.Background(), h) }},
+		{"interrupt", func(e *CommandExecutor, h Handle) error { return e.Interrupt(context.Background(), h) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			exec, runner := newFakeExecutor(t)
+			h, err := exec.Start(context.Background(), startInput(t))
+			if err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			if err := tc.call(exec, h); err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if got := runner.child.killCount(); got != 1 {
+				t.Fatalf("kills = %d, want 1", got)
+			}
+			// Idempotent: the reducer can cancel a stage that already settled.
+			runner.child.exit(CommandResult{Signal: "killed"})
+			if _, err := exec.Poll(context.Background(), h); err != nil {
+				t.Fatalf("Poll after %s: %v", tc.name, err)
+			}
+			if err := tc.call(exec, h); err != nil {
+				t.Fatalf("second %s: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestCommandRejectsAgentStage(t *testing.T) {
+	exec, _ := newFakeExecutor(t)
+	in := startInput(t)
+	in.Stage.Executor = pipeline.ExecutorAgent
+	if _, err := exec.Start(context.Background(), in); err == nil {
+		t.Fatal("Start accepted an agent stage")
+	}
+}
+
+func TestCommandRequiresWorkspaceAndLogPath(t *testing.T) {
+	exec, _ := newFakeExecutor(t)
+	in := startInput(t)
+	in.WorkspacePath = ""
+	if _, err := exec.Start(context.Background(), in); err == nil {
+		t.Error("Start accepted an empty workspace path")
+	}
+
+	exec, _ = newFakeExecutor(t)
+	in = startInput(t)
+	in.LogPath = ""
+	if _, err := exec.Start(context.Background(), in); err == nil {
+		t.Error("Start accepted an empty log path")
+	}
+}
+
+// TestCommandThroughRealRunner covers what a fake runner cannot: the process
+// environment survives the merge, the real log file gets both streams, and a
+// non-zero exit arrives faithfully.
+func TestCommandThroughRealRunner(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the run block is executed through sh")
+	}
+	t.Setenv("AO_TEST_PROCESS_ENV", "inherited")
+
+	in := startInput(t)
+	if err := os.MkdirAll(in.WorkspacePath, 0o750); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	in.Stage.Run = "printf '%s %s %s\\n' \"$AO_TEST_PROCESS_ENV\" \"$AO_RUN_ID\" \"$PWD\"; echo boom >&2; exit 7"
+
+	exec := NewCommandExecutor(NewOSRunner)
+	h, err := exec.Start(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	var got Poll
+	for {
+		got, err = exec.Poll(context.Background(), h)
+		if err != nil {
+			t.Fatalf("Poll: %v", err)
+		}
+		if got.State != PollRunning {
+			break
+		}
+	}
+	if got.State != PollExited || got.ExitCode != 7 {
+		t.Fatalf("poll = %+v, want exited with code 7", got)
+	}
+
+	raw, err := os.ReadFile(in.LogPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	log := string(raw)
+	for _, want := range []string{"inherited", "run-1", in.WorkspacePath, "boom"} {
+		if !strings.Contains(log, want) {
+			t.Errorf("log %q missing %q", log, want)
+		}
+	}
+}
+
+// stubExecutor records which of its methods the Set routed to it.
+type stubExecutor struct {
+	handle  Handle
+	polls   int
+	cancels int
+}
+
+func (s *stubExecutor) Start(context.Context, StartInput) (Handle, error) { return s.handle, nil }
+
+func (s *stubExecutor) Poll(context.Context, Handle) (Poll, error) {
+	s.polls++
+	return Poll{State: PollRunning}, nil
+}
+
+func (s *stubExecutor) Cancel(context.Context, Handle) error {
+	s.cancels++
+	return nil
+}
+
+func (s *stubExecutor) Interrupt(ctx context.Context, h Handle) error { return s.Cancel(ctx, h) }
+
+func TestSetRoutesHandleBackToItsOwner(t *testing.T) {
+	command := &stubExecutor{handle: &commandHandle{}}
+	agent := &stubExecutor{handle: &commandHandle{}}
+	set := &Set{Agent: agent, Command: command}
+
+	in := startInput(t)
+	h, err := set.Start(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := set.Poll(context.Background(), h); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if err := set.Cancel(context.Background(), h); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if command.polls != 1 || command.cancels != 1 {
+		t.Errorf("command executor saw %d polls and %d cancels, want 1 each", command.polls, command.cancels)
+	}
+	if agent.polls != 0 || agent.cancels != 0 {
+		t.Errorf("agent executor was routed a command stage's handle")
+	}
+
+	in.Stage.Executor = pipeline.ExecutorAgent
+	if _, err := set.Start(context.Background(), in); err != nil {
+		t.Fatalf("agent Start: %v", err)
+	}
+
+	// A kind with no executor wired is an error, not a nil-handle panic.
+	if _, err := (&Set{Command: command}).Start(context.Background(), in); err == nil {
+		t.Error("Set started an agent stage with no agent executor")
+	}
+	// A foreign handle is rejected rather than dereferenced.
+	if _, err := set.Poll(context.Background(), &commandHandle{}); err == nil {
+		t.Error("Set polled a handle it did not create")
+	}
+}

--- a/backend/internal/pipeline/executors/executor.go
+++ b/backend/internal/pipeline/executors/executor.go
@@ -1,0 +1,203 @@
+package executors
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// PollState is what one poll of a running stage observed. It is deliberately
+// smaller than the outcome taxonomy (spec section 7): an executor reports what
+// it saw, and the driver decides what that means for the stage. `succeeded`,
+// `no_output`, `timed_out`, `cancelled` and `skipped` are all driver verdicts,
+// never executor observations.
+type PollState string
+
+// Every poll state.
+const (
+	// PollRunning means the process or session is still working.
+	PollRunning PollState = "running"
+	// PollSignaledDone means the agent ran `ao pipeline done`.
+	PollSignaledDone PollState = "signaled_done"
+	// PollSignaledFail means the agent ran `ao pipeline fail`.
+	PollSignaledFail PollState = "signaled_fail"
+	// PollExited means a command stage's process finished; ExitCode carries the
+	// status, which for a command stage IS the outcome (spec section 6.1).
+	PollExited PollState = "exited"
+	// PollIdle means an agent session is alive but has stopped working, so a
+	// missing signal will not arrive on its own.
+	PollIdle PollState = "idle"
+	// PollGone means the agent session no longer exists.
+	PollGone PollState = "gone"
+)
+
+// Poll is one observation of a running stage. ExitCode is meaningful only for
+// PollExited. Reason is a short human-readable note (a fail signal's reason, a
+// killing signal, a wait failure) surfaced in run detail; empty is normal.
+type Poll struct {
+	State    PollState
+	ExitCode int
+	Reason   string
+}
+
+// StartInput is everything an executor needs to begin a stage. The driver has
+// already resolved every field: the stage is the frozen copy from the run
+// folder, the workspace exists, and Env is the fully built ambient set (spec
+// section 12.2). No executor reads configuration of its own.
+type StartInput struct {
+	ProjectID string
+	RunID     pipeline.RunID
+	// RunDir is the run folder, <AO_DATA_DIR>/pipelines/<project>/<run>.
+	RunDir string
+	// Stage is the frozen definition's copy of the stage, so editing the
+	// pipeline mid-run cannot change what runs.
+	Stage pipeline.Stage
+	// Attempt is 1, or 2 for the one nudge a stage may get (spec section 7.1).
+	Attempt int
+	Subject pipeline.Subject
+	// WorkspacePath is the resolved tree the stage runs in, already provisioned.
+	WorkspacePath string
+	// Env is the ambient variable set, built by the driver.
+	Env map[string]string
+	// Credentials are resolved credential values. Command stages only: they
+	// never enter an agent's environment (spec section 8), and the schema
+	// rejects `credentials:` on an agent stage so the tier cannot be regressed
+	// by convention alone.
+	Credentials map[string]string
+	// LogPath is <run>/stage-logs/<stage>.log, from RunFolder.LogPath. Both
+	// executors capture one; a failed stage's reason is otherwise gone by the
+	// time anyone opens run detail (spec section 6.1).
+	LogPath string
+}
+
+// Handle is an opaque running-stage token returned by Start and threaded back
+// into Poll, Cancel and Interrupt. Each executor kind returns its own concrete
+// type; the driver treats it as opaque and only reads the identity accessors.
+type Handle interface {
+	RunID() pipeline.RunID
+	StageID() string
+	Attempt() int
+}
+
+// OutputTailer is implemented by handles that kept a capped copy of the stage's
+// output in memory for the run-detail DTO. The complete stream always lives on
+// disk at StartInput.LogPath; this is only what can be shown without reading a
+// file. truncated reports that output past the cap was dropped from the copy.
+type OutputTailer interface {
+	OutputTail() (text string, truncated bool)
+}
+
+// stageIdentity is embedded in every concrete handle to satisfy the Handle
+// accessors without repetition.
+type stageIdentity struct {
+	runID   pipeline.RunID
+	stageID string
+	attempt int
+}
+
+func (s stageIdentity) RunID() pipeline.RunID { return s.runID }
+func (s stageIdentity) StageID() string       { return s.stageID }
+func (s stageIdentity) Attempt() int          { return s.attempt }
+
+// StageExecutor is the contract the engine drives. Start begins the work and
+// returns a handle; Poll reports what the stage is doing; Cancel tears it down;
+// Interrupt stops the work but preserves anything worth keeping.
+//
+// Poll, Cancel and Interrupt must be safe to call after a terminal Poll, and
+// safe to call twice: the reducer can cancel a stage that has already settled.
+type StageExecutor interface {
+	Start(ctx context.Context, in StartInput) (Handle, error)
+	Poll(ctx context.Context, h Handle) (Poll, error)
+	Cancel(ctx context.Context, h Handle) error
+	// Interrupt stops the stage's work on a deadline while leaving an agent's
+	// session alive so a human can see what it was doing (spec section 7.2).
+	// For a command stage there is no session, so it is Cancel.
+	Interrupt(ctx context.Context, h Handle) error
+}
+
+// Set routes a stage to the executor for its kind and presents both as a single
+// StageExecutor the engine drives uniformly. Start tags the returned handle with
+// its owner so Poll, Cancel and Interrupt route back to the executor that made
+// it.
+//
+// The fields are exported so wiring reads as `Set{Agent: ..., Command: ...}`.
+type Set struct{ Agent, Command StageExecutor }
+
+var _ StageExecutor = (*Set)(nil)
+
+// setHandle wraps a kind executor's handle with the executor that owns it.
+type setHandle struct {
+	owner StageExecutor
+	inner Handle
+}
+
+func (h setHandle) RunID() pipeline.RunID { return h.inner.RunID() }
+func (h setHandle) StageID() string       { return h.inner.StageID() }
+func (h setHandle) Attempt() int          { return h.inner.Attempt() }
+
+// OutputTail forwards to the wrapped handle when it kept one, so the DTO does
+// not have to unwrap the routing layer.
+func (h setHandle) OutputTail() (string, bool) {
+	if tailer, ok := h.inner.(OutputTailer); ok {
+		return tailer.OutputTail()
+	}
+	return "", false
+}
+
+func (s *Set) executorFor(kind pipeline.ExecutorKind) (StageExecutor, error) {
+	switch kind {
+	case pipeline.ExecutorAgent:
+		if s.Agent == nil {
+			return nil, fmt.Errorf("executor set: no agent executor wired")
+		}
+		return s.Agent, nil
+	case pipeline.ExecutorCommand:
+		if s.Command == nil {
+			return nil, fmt.Errorf("executor set: no command executor wired")
+		}
+		return s.Command, nil
+	default:
+		return nil, fmt.Errorf("executor set: no executor for kind %q", kind)
+	}
+}
+
+// Start dispatches to the executor for the stage's kind.
+func (s *Set) Start(ctx context.Context, in StartInput) (Handle, error) {
+	owner, err := s.executorFor(in.Stage.Executor)
+	if err != nil {
+		return nil, err
+	}
+	h, err := owner.Start(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return setHandle{owner: owner, inner: h}, nil
+}
+
+// Poll routes to the executor that started the stage.
+func (s *Set) Poll(ctx context.Context, h Handle) (Poll, error) {
+	sh, ok := h.(setHandle)
+	if !ok {
+		return Poll{}, fmt.Errorf("executor set: unexpected handle type %T", h)
+	}
+	return sh.owner.Poll(ctx, sh.inner)
+}
+
+// Cancel routes to the executor that started the stage.
+func (s *Set) Cancel(ctx context.Context, h Handle) error {
+	sh, ok := h.(setHandle)
+	if !ok {
+		return fmt.Errorf("executor set: unexpected handle type %T", h)
+	}
+	return sh.owner.Cancel(ctx, sh.inner)
+}
+
+// Interrupt routes to the executor that started the stage.
+func (s *Set) Interrupt(ctx context.Context, h Handle) error {
+	sh, ok := h.(setHandle)
+	if !ok {
+		return fmt.Errorf("executor set: unexpected handle type %T", h)
+	}
+	return sh.owner.Interrupt(ctx, sh.inner)
+}


### PR DESCRIPTION
Pipelines v2 Task 8. Adds the v2 executor contract and the command executor.

Closes #309

## What lands

`executors/executor.go`, the contract Tasks 10 and 15 are written against, verbatim from the plan:

- `StageExecutor{Start, Poll, Cancel, Interrupt}`, `StartInput`, `Poll`/`PollState`, `Set{Agent, Command}`.
- `Handle` keeps v1's shape (opaque token, identity accessors `RunID`/`StageID`/`Attempt`) and `Set` keeps v1's owner-tagged handle, so a handle routes back to the executor that made it. Task 10 fills in `Set.Agent`.
- `PollState` stays smaller than the outcome taxonomy on purpose: `running | signaled_done | signaled_fail | exited | idle | gone`. `succeeded`, `no_output`, `timed_out`, `cancelled`, `skipped` are driver verdicts, never executor observations.

`executors/command.go`:

- **Exit status is the outcome** (spec 6.1). v1's `{outcome, verdict, artifacts}` JSON stdout envelope is gone and is not parsed anywhere. Exit 0 gives `Poll{State: exited, ExitCode: 0}`; the driver maps codes.
- Env order is process env, then the ambient set from `StartInput.Env`, then `StartInput.Credentials` last, so a credential wins a collision. The process-env layer comes from the runner's existing `mergeEnv`. cwd is `StartInput.WorkspacePath`.
- The `run:` block goes to `sh -c`, which is v2's whole templating story (spec 12.3) and matches how `session_manager` runs a configured command.
- stdout and stderr both tee to `RunFolder.LogPath(stageID)`: the full interleaved stream to the file, a 64KiB `capBuffer` copy in memory for the run-detail DTO via the `OutputTailer` interface (forwarded through `setHandle`). Nothing buffers the whole stream; the runner's own capture is bounded to the same 64KiB since the file is the complete record.
- `Cancel` kills the process group through the runner's existing SIGTERM to SIGKILL escalation. `Interrupt` is `Cancel` for a command stage: there is no session to preserve.
- A spawn or wait failure with no collected status reports exit code -1, never 0, so a broken wait cannot read as success.

Deadlines are not enforced here: the reducer owns them and calls `Interrupt`, which is why v1's per-stage timeout context is gone.

## Deviations from the plan's interface block

None. Two additions the plan left unspecified: `Handle`'s accessor set, and `OutputTailer` for the DTO tail (kept off `Poll` so the plan's `Poll` struct is untouched).

## Tests

`command_test.go`, fake runner plus one real-runner pass:

- Start: cwd is the workspace, `AO_RUN_ID`/`AO_STAGE` pass through, the run block reaches the shell.
- Credentials absent unless provided; present values override the ambient set on collision.
- Both streams reach the log file; the in-memory tail carries both and is exactly 64KiB with `truncated` set once output passes the cap, while the file holds the full 96KiB.
- Poll reports running, then a non-zero exit faithfully; a wait failure never reports 0.
- Cancel and Interrupt each kill the process group once, and both are safe to call again after a terminal Poll.
- Agent stage, empty workspace and empty log path are rejected at Start.
- Real runner through `NewOSRunner`: process env survives the merge, both streams land in the real log file, exit 7 arrives as 7.
- `Set` routes Poll and Cancel back to the owning executor, errors on an unwired kind, and rejects a foreign handle instead of dereferencing it.

## Verification

- `go build ./...`, `gofmt -l .` empty, `golangci-lint run ./internal/pipeline/...` 0 issues.
- `go test -race ./internal/pipeline/executors/` green (33 tests).
- Full `go test ./...`: 2672 pass, 4 pre-existing failures in `internal/cli` (`TestSpawn*`, `daemon returned HTTP 404`). Confirmed identical on untouched `origin/pipelines` in a scratch worktree; unrelated to this change.

## Risks

- `sh -c` on Windows: marked with a `ponytail:` comment, same posture as the rest of the codebase.
- The log file is opened `O_APPEND`, so a nudged second attempt adds to the record rather than erasing the first.