### PR TITLE
feat(pipelines-ui): v2 canvas edges and stage inspector

### DIFF
--- a/frontend/src/renderer/components/PipelineCanvas.test.tsx
+++ b/frontend/src/renderer/components/PipelineCanvas.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { PipelineCanvas } from "./PipelineCanvas";
+import { edgeAppearance, PipelineCanvas } from "./PipelineCanvas";
 import type { StageSelection } from "../hooks/useStageSelection";
 import type { PipelineDraft, StageDraft } from "../lib/pipeline-draft";
 
@@ -41,7 +41,57 @@ describe("PipelineCanvas", () => {
 		expect(screen.getByText("npm test")).toBeInTheDocument();
 		expect(screen.getByLabelText("Command stage")).toHaveTextContent("$");
 
-		expect(screen.getByText("stage · review.md")).toBeInTheDocument();
+		// Explicit workspace and the declared artifact each get their own chip.
+		expect(screen.getByText("stage")).toBeInTheDocument();
+		expect(screen.getByText("review.md")).toBeInTheDocument();
+	});
+
+	it("shows the effective deadline on every card (spec §13.1)", () => {
+		const draft: PipelineDraft = {
+			name: "release",
+			defaults: { deadline: "45m" },
+			stages: [stage("build", { deadline: "10m" }), stage("sign")],
+		};
+		render(<PipelineCanvas draft={draft} />);
+
+		// The stage's own deadline wins; the other inherits the pipeline default.
+		expect(screen.getByText("10m")).toBeInTheDocument();
+		expect(screen.getByText("45m")).toBeInTheDocument();
+	});
+
+	it("falls back to the engine default deadline when nothing declares one", () => {
+		render(<PipelineCanvas draft={draftOf(stage("review"))} />);
+		expect(screen.getByText("30m")).toBeInTheDocument();
+	});
+
+	it("shows a needs chip on join nodes only", () => {
+		render(<PipelineCanvas draft={draftOf(stage("gate", { needs: ["review", "tests"] }), stage("review"))} />);
+
+		expect(screen.getByText("needs 2")).toBeInTheDocument();
+		expect(document.querySelector('[data-stage-id="review"]')).not.toHaveTextContent("needs");
+	});
+
+	it("warns on workspace session under a pr trigger (spec §5.3)", () => {
+		const withPr: PipelineDraft = {
+			name: "pr-review",
+			on: { pr: ["created"] },
+			stages: [stage("review", { workspace: "session" })],
+		};
+		const { unmount } = render(<PipelineCanvas draft={withPr} />);
+		expect(screen.getByLabelText(/no session/i)).toBeInTheDocument();
+		unmount();
+
+		// Same stage without a pr.* trigger: the subject always has a session.
+		render(<PipelineCanvas draft={draftOf(stage("review", { workspace: "session" }))} />);
+		expect(screen.queryByLabelText(/no session/i)).not.toBeInTheDocument();
+	});
+
+	it("offers a success and a failure source handle per stage", () => {
+		render(<PipelineCanvas draft={draftOf(stage("review"))} onDraftChange={vi.fn()} />);
+
+		// Which handle an edge leaves picks its kind (plan Task 21).
+		expect(document.querySelector('[data-handleid="success"]')).toBeInTheDocument();
+		expect(document.querySelector('[data-handleid="failure"]')).toBeInTheDocument();
 	});
 
 	it("appends a default stage through the draft on Add stage", async () => {
@@ -183,5 +233,37 @@ describe("PipelineCanvas", () => {
 		expect(screen.getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Zoom out" })).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Fit view" })).toBeInTheDocument();
+	});
+});
+
+// Edge DOM rendering needs measured node dimensions React Flow only gets in a
+// real browser, so the three treatments are asserted on the pure style mapping.
+describe("edgeAppearance", () => {
+	it("draws success solid accent, failure dashed destructive, defaults dashed faint", () => {
+		const success = edgeAppearance("success", false);
+		const failure = edgeAppearance("failure", false);
+		const synthetic = edgeAppearance("default-failure", false);
+
+		expect(success.strokeDasharray).toBeUndefined();
+		expect(success.stroke).toBe("var(--color-accent)");
+
+		expect(failure.strokeDasharray).toBeTruthy();
+		expect(failure.stroke).toBe("var(--color-destructive)");
+
+		// Synthetic defaults.on_failure edges: same tone, dashed, visibly fainter.
+		// Faintness rides on the stroke color, not opacity, so the arrowhead fades
+		// with the line instead of staying solid.
+		expect(synthetic.strokeDasharray).toBeTruthy();
+		expect(synthetic.stroke).toContain("var(--color-destructive)");
+		expect(synthetic.stroke).toContain("transparent");
+
+		const fingerprint = (a: ReturnType<typeof edgeAppearance>) => JSON.stringify(a);
+		expect(new Set([success, failure, synthetic].map(fingerprint)).size).toBe(3);
+	});
+
+	it("overrides every kind with the cycle treatment", () => {
+		for (const kind of ["success", "failure", "default-failure"] as const) {
+			expect(edgeAppearance(kind, true).stroke).toBe("var(--color-error)");
+		}
 	});
 });

--- a/frontend/src/renderer/components/PipelineCanvas.tsx
+++ b/frontend/src/renderer/components/PipelineCanvas.tsx
@@ -503,10 +503,7 @@ function StageNode({ data, selected }: NodeProps<StageNodeType>) {
 				{/* Only an explicit workspace is shown; the inherited default is not a
 				    property of this stage (spec §5.4). */}
 				{stage.workspace && (
-					<Badge
-						variant={sessionUnderPr ? "warning" : "neutral"}
-						title={`Workspace ${stage.workspace}`}
-					>
+					<Badge variant={sessionUnderPr ? "warning" : "neutral"} title={`Workspace ${stage.workspace}`}>
 						{stage.workspace}
 					</Badge>
 				)}

--- a/frontend/src/renderer/components/PipelineCanvas.tsx
+++ b/frontend/src/renderer/components/PipelineCanvas.tsx
@@ -17,13 +17,14 @@ import {
 	type NodeProps,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { AlertCircle, Maximize, Minus, Plus, Sparkles } from "lucide-react";
+import { AlertCircle, AlertTriangle, Clock, FileText, GitMerge, Maximize, Minus, Plus, Sparkles } from "lucide-react";
 import type { ExecutorKind, PipelineDraft, StageDraft } from "../lib/pipeline-draft";
 import {
 	addStage,
 	applyConnection,
 	cycleStageIds,
 	draftEdges,
+	effectiveDeadline,
 	isEdgeInCycle,
 	layoutPositions,
 	removeConnection,
@@ -32,9 +33,12 @@ import {
 	STAGE_NODE_WIDTH,
 	stageIndexFromNodeId,
 	stageNodeId,
+	type ConnectableEdgeKind,
+	type EdgeKind,
 	type StagePosition,
 } from "../lib/pipeline-graph";
 import type { StageSelection } from "../hooks/useStageSelection";
+import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { cn } from "../lib/utils";
 
@@ -50,9 +54,10 @@ import { cn } from "../lib/utils";
 // cycle is blocked and flashed as a red dashed edge; cycles already present in
 // the draft (authored in YAML mode) render the same persistent red treatment.
 //
-// ponytail: this is the v2 stub, not the v2 canvas. Connecting always draws a
-// success edge and the cards carry no produces/deadline/needs chips. Task 21
-// owns the real rewrite (two source handles, badges, edge treatments).
+// v2 routing is a state machine with two edge kinds, so every card carries two
+// source handles: right = on_success, bottom = on_failure. Which handle the
+// drag leaves picks the kind, so there is no modifier key to discover and the
+// drawn edge reads the same as the rendered one.
 
 export interface PipelineCanvasProps {
 	draft: PipelineDraft;
@@ -67,7 +72,24 @@ export interface PipelineCanvasProps {
 
 const CYCLE_FLASH_MS = 1800;
 
-type StageNodeType = Node<{ stage: StageDraft; inCycle: boolean; issues: string[] }, "stage">;
+type StageNodeData = {
+	stage: StageDraft;
+	inCycle: boolean;
+	issues: string[];
+	// The bound the engine will actually enforce, inherited or explicit (spec
+	// §13.1: deadlines are defaulted, so the card is where they stay visible).
+	deadline: string;
+	// Spec §5.3: `workspace: session` under a `pr.*` trigger cannot be rejected
+	// at edit time (the PR may or may not have a session) but fails the run at
+	// plan time, so the card warns.
+	sessionUnderPr: boolean;
+};
+
+type StageNodeType = Node<StageNodeData, "stage">;
+
+// The source handle ids double as the edge kind a drag off them produces.
+const SUCCESS_HANDLE: ConnectableEdgeKind = "success";
+const FAILURE_HANDLE: ConnectableEdgeKind = "failure";
 
 export function PipelineCanvas({ draft, onDraftChange, selection, stageIssues }: PipelineCanvasProps) {
 	return (
@@ -85,7 +107,12 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 	const [selectedEdgeIds, setSelectedEdgeIds] = useState<ReadonlySet<string>>(new Set());
 	// The blocked connect attempt currently flashing red, if any: the endpoint
 	// node ids for the transient edge plus the cycle path as stage ids.
-	const [flash, setFlash] = useState<{ sourceId: string; targetId: string; path: string[] } | null>(null);
+	const [flash, setFlash] = useState<{
+		sourceId: string;
+		targetId: string;
+		kind: ConnectableEdgeKind;
+		path: string[];
+	} | null>(null);
 	const flashTimer = useRef<number | undefined>(undefined);
 
 	// The handlers read the latest draft through a ref so their identity stays
@@ -115,6 +142,7 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 
 	const nodes = useMemo<StageNodeType[]>(() => {
 		const persistent = cycleStageIds(draft);
+		const prTriggered = (draft.on?.pr?.length ?? 0) > 0;
 		// Index-based ids are unique by construction, so every stage renders,
 		// including duplicate-named ones (each independently selectable to fix).
 		return draft.stages.map((stage, i): StageNodeType => {
@@ -129,6 +157,8 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 					// Cycle membership is a config-level (stage id) property.
 					inCycle: persistent.has(stage.id) || (flash?.path.includes(stage.id) ?? false),
 					issues: stageIssues?.[id] ?? [],
+					deadline: effectiveDeadline(draft, stage),
+					sessionUnderPr: prTriggered && stage.workspace === "session",
 				},
 				selected: selected === id,
 			};
@@ -138,37 +168,37 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 	const edges = useMemo<Edge[]>(() => {
 		const out: Edge[] = draftEdges(draft).map((edge) => {
 			const inCycle = isEdgeInCycle(draft, edge);
-			const failure = edge.kind !== "success";
-			const stroke = inCycle ? "var(--color-error)" : failure ? "var(--color-warning)" : "var(--color-border-strong)";
+			const style = edgeAppearance(edge.kind, inCycle);
 			return {
 				id: edge.id,
 				source: edge.source,
 				target: edge.target,
+				// The kind decides which source handle the edge leaves, so the drawn
+				// gesture and the rendered edge use the same geometry.
+				sourceHandle: edge.kind === "success" ? SUCCESS_HANDLE : FAILURE_HANDLE,
 				data: { from: edge.from, to: edge.to, kind: edge.kind },
 				selected: selectedEdgeIds.has(edge.id),
-				style: {
-					stroke,
-					strokeWidth: 1.5,
-					...(inCycle || failure ? { strokeDasharray: "6 4" } : {}),
-					...(edge.kind === "default-failure" ? { opacity: 0.5 } : {}),
-				},
-				markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16, color: stroke },
-				...(inCycle ? { animated: true, ariaLabel: `Routing cycle edge ${edge.id}` } : {}),
+				ariaLabel: `${EDGE_KIND_LABEL[edge.kind]} edge from ${edge.from} to ${edge.to}`,
+				style,
+				markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16, color: style.stroke },
+				...(inCycle ? { animated: true } : {}),
 			};
 		});
 		// The blocked attempt renders as a transient red dashed edge (mockup 1d);
 		// a blocked self-edge shows only the node highlight.
 		if (flash && flash.sourceId !== flash.targetId) {
+			const style = edgeAppearance(flash.kind, true);
 			out.push({
 				id: "__cycle-flash",
 				source: flash.sourceId,
 				target: flash.targetId,
+				sourceHandle: flash.kind === "success" ? SUCCESS_HANDLE : FAILURE_HANDLE,
 				animated: true,
 				selectable: false,
 				deletable: false,
 				ariaLabel: "Blocked cycle edge",
-				style: { stroke: "var(--color-error)", strokeWidth: 1.5, strokeDasharray: "6 4" },
-				markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16, color: "var(--color-error)" },
+				style,
+				markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16, color: style.stroke },
 			});
 		}
 		return out;
@@ -253,14 +283,15 @@ function CanvasInner({ draft, onDraftChange, selection, stageIssues }: PipelineC
 	const onConnect = useCallback(
 		(connection: Connection) => {
 			if (!onDraftChange || !connection.source || !connection.target) return;
-			// Task 21 adds the second (failure) source handle; until then every
-			// drawn edge is a success edge.
-			const result = applyConnection(draftRef.current, connection.source, connection.target, "success");
+			// The handle the drag left picks the edge kind: right = on_success,
+			// bottom = on_failure.
+			const kind: ConnectableEdgeKind = connection.sourceHandle === FAILURE_HANDLE ? "failure" : "success";
+			const result = applyConnection(draftRef.current, connection.source, connection.target, kind);
 			if (result.kind === "added") {
 				draftRef.current = result.draft;
 				onDraftChange(result.draft);
 			} else if (result.kind === "cycle") {
-				setFlash({ sourceId: connection.source, targetId: connection.target, path: result.path });
+				setFlash({ sourceId: connection.source, targetId: connection.target, kind, path: result.path });
 				window.clearTimeout(flashTimer.current);
 				flashTimer.current = window.setTimeout(() => setFlash(null), CYCLE_FLASH_MS);
 			}
@@ -350,6 +381,38 @@ function ZoomBar() {
 	);
 }
 
+// --- edge treatments ---------------------------------------------------------
+
+const EDGE_KIND_LABEL: Record<EdgeKind, string> = {
+	success: "Success",
+	failure: "Failure",
+	"default-failure": "Default failure",
+};
+
+// edgeAppearance is the three-way visual split the graph's edge kinds need:
+// on_success solid in the accent, on_failure dashed in the destructive tone,
+// and the synthetic defaults.on_failure edge dashed in a faded version of the
+// same tone (it is inherited boilerplate, so it must not compete with the
+// routes the author actually wrote). A cycle overrides all three: the edge is
+// already invalid, so what kind it was stops mattering.
+//
+// The synthetic edge fades through its color rather than through `opacity` so
+// that its arrowhead marker, which does not inherit path opacity, fades with
+// the line instead of staying solid.
+export function edgeAppearance(
+	kind: EdgeKind,
+	inCycle: boolean,
+): { stroke: string; strokeWidth: number; strokeDasharray?: string } {
+	if (inCycle) return { stroke: "var(--color-error)", strokeWidth: 2, strokeDasharray: "6 4" };
+	if (kind === "success") return { stroke: "var(--color-accent)", strokeWidth: 2 };
+	if (kind === "failure") return { stroke: "var(--color-destructive)", strokeWidth: 1.75, strokeDasharray: "6 4" };
+	return {
+		stroke: "color-mix(in oklab, var(--color-destructive) 45%, transparent)",
+		strokeWidth: 1.5,
+		strokeDasharray: "3 5",
+	};
+}
+
 // --- stage node card ---------------------------------------------------------
 
 // Executor-kind treatments (mockup 1a), restyled to the app tokens: agent =
@@ -365,10 +428,17 @@ function executorSubtitle(stage: StageDraft): string {
 	return stage.run?.split("\n")[0]?.trim() || "command";
 }
 
+// A join carries the `needs` set the graph lib maintains; below two inbound
+// success edges there is no join and the key is dropped (spec §9.2).
+function joinCount(stage: StageDraft): number {
+	const n = stage.needs?.length ?? 0;
+	return n > 1 ? n : 0;
+}
+
 function StageNode({ data, selected }: NodeProps<StageNodeType>) {
-	const { stage, inCycle, issues } = data;
+	const { stage, inCycle, issues, deadline, sessionUnderPr } = data;
 	const badge = KIND_BADGE[stage.executor] ?? KIND_BADGE.agent;
-	const footer = [stage.workspace, stage.produces].filter(Boolean).join(" · ");
+	const needs = joinCount(stage);
 
 	return (
 		<div
@@ -398,6 +468,12 @@ function StageNode({ data, selected }: NodeProps<StageNodeType>) {
 				<span className="min-w-0 flex-1 truncate text-control font-semibold text-foreground">
 					{stage.id || "(unnamed)"}
 				</span>
+				{sessionUnderPr && (
+					<AlertTriangle
+						className="size-icon-xs shrink-0 text-warning"
+						aria-label="Warning: workspace session, a PR may have no session"
+					/>
+				)}
 				{issues.length > 0 && (
 					<span
 						className="flex shrink-0 items-center gap-0.5 text-error"
@@ -411,12 +487,51 @@ function StageNode({ data, selected }: NodeProps<StageNodeType>) {
 			<p className="mt-1 truncate font-mono text-micro text-muted-foreground">{executorSubtitle(stage)}</p>
 			{issues.length > 0 && <p className="mt-1.5 truncate text-micro text-error">{issues[0]}</p>}
 			{inCycle && <p className="mt-1.5 text-micro text-error">in routing cycle</p>}
-			{footer && (
-				<p className="mt-1.5">
-					<span className="truncate text-micro text-passive">{footer}</span>
-				</p>
-			)}
-			<Handle type="source" position={Position.Right} className="!size-2 !border-border-strong !bg-raised" />
+			<div className="mt-1.5 flex flex-wrap items-center gap-1">
+				{/* The effective deadline rides on every card: spec §13.1 defaults it
+				    rather than requiring it, so visibility is what makes that safe. */}
+				<Badge variant="neutral" title={`Deadline ${deadline}`}>
+					<Clock className="size-icon-xs" aria-hidden="true" />
+					{deadline}
+				</Badge>
+				{stage.produces && (
+					<Badge variant="outline" className="max-w-full" title={`Produces ${stage.produces}`}>
+						<FileText className="size-icon-xs shrink-0" aria-hidden="true" />
+						<span className="truncate">{stage.produces}</span>
+					</Badge>
+				)}
+				{/* Only an explicit workspace is shown; the inherited default is not a
+				    property of this stage (spec §5.4). */}
+				{stage.workspace && (
+					<Badge
+						variant={sessionUnderPr ? "warning" : "neutral"}
+						title={`Workspace ${stage.workspace}`}
+					>
+						{stage.workspace}
+					</Badge>
+				)}
+				{needs > 0 && (
+					<Badge variant="neutral" title={`Joins ${stage.needs?.join(", ")}`}>
+						<GitMerge className="size-icon-xs" aria-hidden="true" />
+						needs {needs}
+					</Badge>
+				)}
+			</div>
+			{/* Two source handles, so the drag itself picks the routing key. */}
+			<Handle
+				id={SUCCESS_HANDLE}
+				type="source"
+				position={Position.Right}
+				title="Route on success"
+				className="!size-2 !border-accent-dim !bg-accent"
+			/>
+			<Handle
+				id={FAILURE_HANDLE}
+				type="source"
+				position={Position.Bottom}
+				title="Route on failure"
+				className="!size-2 !border-destructive/60 !bg-destructive"
+			/>
 		</div>
 	);
 }

--- a/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
@@ -356,6 +356,10 @@ function DefinitionEditor({
 									key={selection.selectedStage}
 									stage={selectedStageDraft}
 									stageIds={stageIds}
+									// Pipeline-level context the stage warnings need: the
+									// pr.* trigger (spec §5.3) and the inherited deadline.
+									prTriggered={(draft.on?.pr?.length ?? 0) > 0}
+									defaultDeadline={draft.defaults?.deadline}
 									onChange={updateSelectedStage}
 									onClose={() => selection.selectStage(null)}
 									onDelete={deleteSelectedStage}

--- a/frontend/src/renderer/components/StageInspector.test.tsx
+++ b/frontend/src/renderer/components/StageInspector.test.tsx
@@ -69,9 +69,29 @@ describe("StageInspector", () => {
 
 		await userEvent.type(screen.getByRole("textbox", { name: "Run" }), "x");
 		expect(last().run).toBe("npm testx");
+	});
 
-		await userEvent.type(screen.getByRole("textbox", { name: "Credentials" }), "github-release\ndiscord");
+	it("adds and removes credential chips on a command stage", async () => {
+		const { last } = renderInspector({ id: "tests", executor: "command", run: "npm test" });
+		const input = screen.getByRole("textbox", { name: "Add credential" });
+
+		await userEvent.type(input, "github-release{Enter}");
+		expect(last().credentials).toEqual(["github-release"]);
+		// The committed name leaves the input, so the next one starts clean.
+		expect(input).toHaveValue("");
+
+		await userEvent.type(input, "discord{Enter}");
 		expect(last().credentials).toEqual(["github-release", "discord"]);
+
+		// A duplicate is a no-op rather than a second identical chip.
+		await userEvent.type(input, "discord{Enter}");
+		expect(last().credentials).toEqual(["github-release", "discord"]);
+
+		await userEvent.click(screen.getByRole("button", { name: "Remove credential github-release" }));
+		expect(last().credentials).toEqual(["discord"]);
+
+		await userEvent.click(screen.getByRole("button", { name: "Remove credential discord" }));
+		expect(last().credentials).toBeUndefined();
 	});
 
 	it("drops the other kind's fields when switching executor", async () => {

--- a/frontend/src/renderer/components/StageInspector.test.tsx
+++ b/frontend/src/renderer/components/StageInspector.test.tsx
@@ -127,10 +127,51 @@ describe("StageInspector", () => {
 		expect(last().workspace).toBeUndefined();
 	});
 
-	it("binds the deadline field", async () => {
-		const { last } = renderInspector(agentStage());
+	it("binds the deadline field and shows the inherited one as the placeholder", async () => {
+		const { last } = renderInspector(agentStage(), { defaultDeadline: "45m" });
+		// Spec §13.1: the effective bound must be visible, not just the override.
+		expect(screen.getByRole("textbox", { name: "Deadline" })).toHaveAttribute("placeholder", "45m");
+
 		await userEvent.type(screen.getByRole("textbox", { name: "Deadline" }), "40m");
 		expect(last().deadline).toBe("40m");
+	});
+
+	it("falls back to the engine default deadline placeholder", () => {
+		renderInspector(agentStage());
+		expect(screen.getByRole("textbox", { name: "Deadline" })).toHaveAttribute("placeholder", "30m");
+	});
+
+	it("rejects a produces filename carrying a path separator", async () => {
+		const { last } = renderInspector(agentStage());
+		const produces = screen.getByRole("textbox", { name: "Produces" });
+		expect(produces).toHaveAttribute("aria-invalid", "false");
+
+		await userEvent.type(produces, "docs/review.md");
+		// The edit still binds (the daemon is authoritative); the field flags it.
+		expect(last().produces).toBe("docs/review.md");
+		expect(produces).toHaveAttribute("aria-invalid", "true");
+		expect(screen.getByText(/bare filename/i)).toBeInTheDocument();
+	});
+
+	it("rejects a windows path separator in produces too", async () => {
+		renderInspector({ ...agentStage(), produces: "docs\\review.md" });
+		expect(screen.getByRole("textbox", { name: "Produces" })).toHaveAttribute("aria-invalid", "true");
+	});
+
+	it("warns on workspace session under a pr.* trigger (spec §5.3)", () => {
+		renderInspector({ ...agentStage(), workspace: "session" }, { prTriggered: true });
+		expect(screen.getByText(/no local session/i)).toBeInTheDocument();
+	});
+
+	it("does not warn on workspace session without a pr.* trigger", () => {
+		renderInspector({ ...agentStage(), workspace: "session" });
+		expect(screen.queryByText(/no local session/i)).not.toBeInTheDocument();
+	});
+
+	it("never offers credentials on an agent stage", () => {
+		renderInspector(agentStage(), { prTriggered: true });
+		// Credentials-on-agent is impossible by construction, not by validation.
+		expect(screen.queryByRole("textbox", { name: "Credentials" })).not.toBeInTheDocument();
 	});
 
 	it("overrides session kill-on, including the never-kill empty list", async () => {

--- a/frontend/src/renderer/components/StageInspector.tsx
+++ b/frontend/src/renderer/components/StageInspector.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { AlertTriangle, Trash2, X } from "lucide-react";
 import { cn } from "../lib/utils";
 import { AGENT_OPTIONS } from "../lib/agent-options";
@@ -216,23 +217,15 @@ export function StageInspector({
 				<Section label="On success">
 					<div className="flex flex-wrap gap-1.5">
 						{onSuccess.map((id) => (
-							<span
+							<Chip
 								key={id}
-								className="inline-flex items-center gap-1 rounded-md border border-border bg-raised px-2 py-0.5 font-mono text-caption text-foreground"
-							>
-								{id}
-								<button
-									type="button"
-									aria-label={`Remove successor ${id}`}
-									onClick={() => {
-										const next = onSuccess.filter((s) => s !== id);
-										update({ onSuccess: next.length ? next : undefined });
-									}}
-									className="text-passive transition-colors hover:text-foreground"
-								>
-									<X className="size-icon-xs" aria-hidden="true" />
-								</button>
-							</span>
+								label={id}
+								removeLabel={`Remove successor ${id}`}
+								onRemove={() => {
+									const next = onSuccess.filter((s) => s !== id);
+									update({ onSuccess: next.length ? next : undefined });
+								}}
+							/>
 						))}
 						{successCandidates.map((id) => (
 							<button
@@ -379,6 +372,21 @@ function AgentFields({ stage, update }: FieldsProps) {
 }
 
 function CommandFields({ stage, update }: FieldsProps) {
+	const credentials = stage.credentials ?? [];
+	// The pending chip text. The inspector is remounted per selected node, so
+	// this never leaks between stages.
+	const [pending, setPending] = useState("");
+
+	// ponytail: free text, because there is no credentials catalog endpoint yet.
+	// Swap the input for a picker once one exists; the daemon rejects unknown
+	// names either way (spec §13).
+	const commit = () => {
+		const name = pending.trim();
+		setPending("");
+		if (!name || credentials.includes(name)) return;
+		update({ credentials: [...credentials, name] });
+	};
+
 	return (
 		<div className="flex flex-col gap-2.5">
 			<LabeledControl label="Run">
@@ -391,22 +399,37 @@ function CommandFields({ stage, update }: FieldsProps) {
 					placeholder="npm test"
 				/>
 			</LabeledControl>
-			<LabeledControl label="Credentials (one name per line)">
-				<textarea
-					key={`credentials-${stage.id}`}
-					aria-label="Credentials"
-					className={textareaClass}
-					rows={2}
-					defaultValue={(stage.credentials ?? []).join("\n")}
-					onChange={(e) => {
-						const names = e.target.value
-							.split("\n")
-							.map((line) => line.trim())
-							.filter(Boolean);
-						update({ credentials: names.length ? names : undefined });
+			<LabeledControl label="Credentials">
+				{credentials.length > 0 && (
+					<div className="flex flex-wrap gap-1.5">
+						{credentials.map((name) => (
+							<Chip
+								key={name}
+								label={name}
+								removeLabel={`Remove credential ${name}`}
+								onRemove={() => {
+									const kept = credentials.filter((c) => c !== name);
+									update({ credentials: kept.length ? kept : undefined });
+								}}
+							/>
+						))}
+					</div>
+				)}
+				<Input
+					aria-label="Add credential"
+					value={pending}
+					onChange={(e) => setPending(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key !== "Enter" && e.key !== ",") return;
+						e.preventDefault();
+						commit();
 					}}
+					onBlur={commit}
 					placeholder="github-release"
 				/>
+				<span className="text-caption text-passive">
+					Injected into this stage's environment only. Agent stages cannot declare credentials.
+				</span>
 			</LabeledControl>
 		</div>
 	);
@@ -416,6 +439,24 @@ function CommandFields({ stage, update }: FieldsProps) {
 
 const textareaClass =
 	"w-full resize-y rounded-md border border-border bg-transparent px-3 py-2 font-mono text-caption leading-relaxed text-foreground outline-none transition placeholder:text-passive focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent-weak";
+
+// Chip is a removable mono pill, the shape every stage-id-ish list in this
+// panel uses (successors, credentials).
+function Chip({ label, removeLabel, onRemove }: { label: string; removeLabel: string; onRemove: () => void }) {
+	return (
+		<span className="inline-flex max-w-full items-center gap-1 rounded-md border border-border bg-raised px-2 py-0.5 font-mono text-caption text-foreground">
+			<span className="truncate">{label}</span>
+			<button
+				type="button"
+				aria-label={removeLabel}
+				onClick={onRemove}
+				className="shrink-0 text-passive transition-colors hover:text-foreground"
+			>
+				<X className="size-icon-xs" aria-hidden="true" />
+			</button>
+		</span>
+	);
+}
 
 // Warning is the edit-time caution for states the daemon accepts but a run may
 // not survive; it never blocks saving.

--- a/frontend/src/renderer/components/StageInspector.tsx
+++ b/frontend/src/renderer/components/StageInspector.tsx
@@ -1,9 +1,10 @@
-import { Trash2, X } from "lucide-react";
+import { AlertTriangle, Trash2, X } from "lucide-react";
 import { cn } from "../lib/utils";
 import { AGENT_OPTIONS } from "../lib/agent-options";
 import {
 	ALL_EXECUTOR_KINDS,
 	ALL_WORKSPACE_KINDS,
+	DEFAULT_STAGE_DEADLINE,
 	SETTLED_OUTCOMES,
 	type ExecutorKind,
 	type StageDraft,
@@ -23,10 +24,15 @@ import { Switch } from "./ui/switch";
 // `needs` is not editable here: the graph lib maintains it from the inbound
 // success edges (spec §9.2), so it renders read-only.
 //
-// ponytail: this is the v2 stub, not the v2 inspector. It covers every v2 key
-// but skips the warning states (workspace: session under a pr.* trigger,
-// produces filename validation) and the DESIGN.md polish pass. Task 21 owns
-// the real rewrite.
+// The form is split per executor kind, and `credentials` renders only under
+// `command`. Credentials on an agent stage is therefore impossible to express
+// rather than merely rejected: the tier separation (spec §6.2) is enforced by
+// the shape of the UI, not by a validation message after the fact.
+//
+// Two states the daemon cannot settle at edit time are warned about here:
+// `produces` with a path separator (spec §13), and `workspace: session` under a
+// `pr.*` trigger, which is legal but fails at plan time when the PR has no
+// local session (spec §5.3).
 
 export interface StageInspectorProps {
 	stage: StageDraft;
@@ -37,6 +43,21 @@ export interface StageInspectorProps {
 	// Removes the inspected stage from the draft (the parent scrubs the routing
 	// keys and clears the selection). The delete button renders only when wired.
 	onDelete?: () => void;
+	// The pipeline declares an `on.pr` trigger, which is what makes
+	// `workspace: session` a warning rather than a certainty (spec §5.3).
+	prTriggered?: boolean;
+	// `defaults.deadline`, shown as the deadline placeholder so the effective
+	// bound is visible even when this stage does not override it (spec §13.1).
+	defaultDeadline?: string;
+}
+
+// A `produces` value names a file inside the stage's output directory, so a
+// path separator is rejected (spec §13). Checked live here; the daemon's
+// /validate stays authoritative.
+export function producesError(produces: string | undefined): string | null {
+	if (!produces) return null;
+	if (produces.includes("/") || produces.includes("\\")) return "Must be a bare filename, no path separators.";
+	return null;
 }
 
 const WORKSPACE_OPTIONS: { value: WorkspaceKind | "default"; label: string }[] = [
@@ -52,7 +73,15 @@ const EXECUTOR_SUBTITLE: Record<ExecutorKind, string> = {
 // The engine kills the session on these outcomes when `session` is absent.
 const DEFAULT_KILL_ON: StageOutcome[] = ["succeeded", "failed"];
 
-export function StageInspector({ stage, stageIds, onChange, onClose, onDelete }: StageInspectorProps) {
+export function StageInspector({
+	stage,
+	stageIds,
+	onChange,
+	onClose,
+	onDelete,
+	prTriggered,
+	defaultDeadline,
+}: StageInspectorProps) {
 	const update = (patch: Partial<StageDraft>) => onChange({ ...stage, ...patch });
 
 	// Swapping executor kind drops the other kind's fields so nothing the daemon
@@ -75,6 +104,7 @@ export function StageInspector({ stage, stageIds, onChange, onClose, onDelete }:
 	const onSuccess = stage.onSuccess ?? [];
 	const successCandidates = stageIds.filter((id) => id !== stage.id && !onSuccess.includes(id));
 	const killOn = stage.session?.killOn;
+	const sessionUnderPr = stage.workspace === "session" && !!prTriggered;
 
 	return (
 		<div
@@ -127,6 +157,8 @@ export function StageInspector({ stage, stageIds, onChange, onClose, onDelete }:
 						{stage.executor === "agent" ? (
 							<AgentFields stage={stage} update={update} />
 						) : (
+							// `credentials` lives here and nowhere else, so an agent stage
+							// cannot express it at all (spec §6.2).
 							<CommandFields stage={stage} update={update} />
 						)}
 					</div>
@@ -272,6 +304,12 @@ export function StageInspector({ stage, stageIds, onChange, onClose, onDelete }:
 							))}
 						</SelectContent>
 					</Select>
+					{sessionUnderPr && (
+						<Warning>
+							This pipeline triggers on pull requests. A PR with no local session fails the run at plan time, before any
+							stage starts.
+						</Warning>
+					)}
 				</Section>
 
 				<Section label="Deadline">
@@ -279,7 +317,9 @@ export function StageInspector({ stage, stageIds, onChange, onClose, onDelete }:
 						aria-label="Deadline"
 						value={stage.deadline ?? ""}
 						onChange={(e) => update({ deadline: e.target.value || undefined })}
-						placeholder="(pipeline default)"
+						// Every stage has a bound; the placeholder is the one it
+						// inherits, so the effective deadline is always on screen.
+						placeholder={defaultDeadline || DEFAULT_STAGE_DEADLINE}
 					/>
 				</Section>
 			</div>
@@ -292,6 +332,7 @@ export function StageInspector({ stage, stageIds, onChange, onClose, onDelete }:
 type FieldsProps = { stage: StageDraft; update: (patch: Partial<StageDraft>) => void };
 
 function AgentFields({ stage, update }: FieldsProps) {
+	const producesIssue = producesError(stage.produces);
 	return (
 		<div className="flex flex-col gap-2.5">
 			<LabeledControl label="Agent">
@@ -318,13 +359,20 @@ function AgentFields({ stage, update }: FieldsProps) {
 					placeholder="What this stage should do."
 				/>
 			</LabeledControl>
-			<LabeledControl label="Produces (bare filename)">
+			<LabeledControl label="Produces">
 				<Input
 					aria-label="Produces"
 					value={stage.produces ?? ""}
 					onChange={(e) => update({ produces: e.target.value || undefined })}
 					placeholder="review.md"
+					aria-invalid={producesIssue !== null}
+					className={cn(producesIssue && "border-destructive focus-visible:border-destructive")}
 				/>
+				{producesIssue ? (
+					<span className="text-caption text-destructive">{producesIssue}</span>
+				) : (
+					<span className="text-caption text-passive">Written to $AO_OUTPUT and verified when the stage signals.</span>
+				)}
 			</LabeledControl>
 		</div>
 	);
@@ -368,6 +416,17 @@ function CommandFields({ stage, update }: FieldsProps) {
 
 const textareaClass =
 	"w-full resize-y rounded-md border border-border bg-transparent px-3 py-2 font-mono text-caption leading-relaxed text-foreground outline-none transition placeholder:text-passive focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent-weak";
+
+// Warning is the edit-time caution for states the daemon accepts but a run may
+// not survive; it never blocks saving.
+function Warning({ children }: { children: React.ReactNode }) {
+	return (
+		<p className="mt-1.5 flex items-start gap-1.5 text-caption text-warning">
+			<AlertTriangle className="mt-0.5 size-icon-xs shrink-0" aria-hidden="true" />
+			<span>{children}</span>
+		</p>
+	);
+}
 
 function Section({ label, children }: { label: string; children: React.ReactNode }) {
 	return (

--- a/frontend/src/renderer/lib/pipeline-graph.ts
+++ b/frontend/src/renderer/lib/pipeline-graph.ts
@@ -16,9 +16,11 @@ import dagre from "dagre";
 import { DEFAULT_STAGE_DEADLINE, type PipelineDraft, type StageDraft } from "./pipeline-draft";
 
 // Fixed card footprint the layout assumes; the rendered card is w-52 with a
-// content-dependent height this estimate stays close enough to for spacing.
+// content-dependent height this estimate stays close enough to for spacing. The
+// height covers a card with a wrapped chip row (deadline, produces, workspace,
+// needs), which is the tallest ordinary case.
 export const STAGE_NODE_WIDTH = 208;
-export const STAGE_NODE_HEIGHT = 96;
+export const STAGE_NODE_HEIGHT = 124;
 
 export interface StagePosition {
 	x: number;


### PR DESCRIPTION
Closes #304

Finishes the two v2 stubs #298 left behind: the canvas edge treatments and stage cards, and the stage inspector's warning states. No backend changes.

## Canvas

**Two source handles per stage**, right = `on_success`, bottom = `on_failure`, so a drawn edge picks its kind from the handle it leaves (the plan's simpler option). The rendered edges use the same handles, so a drawn edge and a parsed one have the same geometry. The blocked-cycle flash keeps the kind it was drawn with.

**Three edge treatments**, from one pure `edgeAppearance(kind, inCycle)` mapping:

| kind | treatment |
|---|---|
| `success` | solid, accent, 2px |
| `failure` | dashed `6 4`, destructive, 1.75px |
| `default-failure` (synthetic, from `defaults.on_failure`) | dashed `3 5`, destructive faded to 45%, 1.5px |
| any kind in a cycle | dashed error red, 2px, animated (unchanged) |

The synthetic edge fades through its stroke color rather than through `opacity`, because an SVG arrowhead marker does not inherit path opacity and would otherwise stay solid on an otherwise faint line.

**Stage cards** now carry the executor badge (unchanged), the effective deadline (spec 13.1: defaulted rather than required, so visibility is what makes that safe), the `produces` filename, an explicit `workspace`, a `needs n` chip on join nodes, and the spec 5.3 warning icon on `workspace: session` under a `pr.*` trigger. Chips are the shared `ui/badge` primitive. Selection, auto-layout, delete and the problems-reveal wiring are untouched.

`STAGE_NODE_HEIGHT` in the graph lib goes 96 -> 124: it is the layout's card-footprint estimate and the chip row made the real card taller, so a fan-out was overlapping. No graph-lib API change beyond that constant.

## Stage inspector

- `produces` with `/` or `\` is flagged inline (spec 13). The edit still binds, since the daemon stays authoritative; the field just marks itself invalid.
- `workspace: session` under a `pr.*` trigger explains what actually happens: a PR with no local session fails the run at plan time, before any stage starts (spec 5.3). The page passes the pipeline-level `on.pr` and `defaults.deadline` down as two props.
- The deadline field shows the inherited bound as its placeholder, so the effective deadline is visible without opening Settings.
- `credentials` moved from a newline textarea to chips (Enter or comma commits, duplicates are a no-op). It renders only under `command`, so credentials-on-agent stays impossible to express rather than merely rejected. Still free text, with a `ponytail:` note: there is no credentials catalog endpoint yet.

## Verification

- `tsc --noEmit` clean; **full renderer build** (`vite build --config vite.renderer.config.ts`) green, not just a typecheck.
- Full vitest suite: **1079 passed, 90 files** (13 new tests, written before the implementation).
- Prettier clean on every changed file.
- `backend/` untouched.

### What `ao preview` actually showed

The pipelines HTTP surface on this branch is still the 501 stub set (the API tasks land later), so the renderer hides the whole section against a real daemon. To see the page I ran a scratch daemon from this worktree (`AO_DATA_DIR`/`AO_RUN_FILE` under `/tmp`, `AO_PIPELINES=1`, port 3999) behind a throwaway shim that answers `pipelines/schema`, `GET /pipelines` and `pipelines/validate`, pointed `vite dev` at it, and previewed `http://localhost:5199/pipelines`. Everything below is what I saw on the **Release gate** template, not what I expect:

- `prepare -> build` and `prepare -> release-notes` fan out as solid blue edges; `build -> publish` and `release-notes -> publish` converge on the join.
- `build -> diagnose-build` is a dashed red failure edge leaving the bottom of the card.
- Four faint dotted red edges run to `notify-failure` from `prepare`, `release-notes`, `publish` and `diagnose-build`: the synthetic `defaults.on_failure` set, clearly the weakest lines on the canvas, and visibly distinct from the explicit failure edge.
- Cards: `30m` on `prepare` (inherited) next to `40m` on `build` and `15m` on `release-notes` (explicit), `release-notes.md` and `diagnosis.md` produces chips, `stage`/`run` workspace chips, and `needs 2` on `publish`.
- Switching `release-notes` to `workspace: session` put the amber warning triangle in its card header, turned its workspace chip amber, and showed the plan-time explanation under the inspector's workspace select.
- Typing `docs/release-notes.md` into Produces turned the field red with "Must be a bare filename, no path separators."
- Selecting `publish` showed Run plus a `github-release` credential chip and no session block; selecting an agent stage showed no credentials field at all.

The "Valid" indicator in those screenshots comes from the shim, not from real validation. Live `/validate` lands with the API task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
