### PR TITLE
feat(pipelines-ui): v2 outcome palette and run-status Kanban

### DIFF
--- a/frontend/src/renderer/components/PipelineRunCard.tsx
+++ b/frontend/src/renderer/components/PipelineRunCard.tsx
@@ -1,23 +1,32 @@
 import { cn } from "../lib/utils";
 import { formatTimeCompact } from "../lib/format-time";
-import { loopStateTone, shortSha, stageStatusDotTone } from "../lib/pipeline-display";
+import {
+	runStatusOf,
+	runStatusTone,
+	shortSha,
+	stageOutcomeDotTone,
+	stageOutcomeLabel,
+	stageOutcomesOf,
+} from "../lib/pipeline-display";
 import type { PipelineRunSummary } from "../hooks/usePipelineRuns";
 import { Badge } from "./ui/badge";
 
-// Card view of a single pipeline run in a Kanban column: pipeline name, run id,
-// session, loop rounds, per-stage status dots, artifact/findings hint, and a
+// Card view of a single pipeline run in a Kanban column: pipeline name, run
+// status, session, per-stage outcome dots, an unverified-success hint, and a
 // relative timestamp. The whole card opens the read-only run detail.
 export function PipelineRunCard({ run, onOpen }: { run: PipelineRunSummary; onOpen: () => void }) {
-	const stageNames = Object.keys(run.stageStatuses ?? {}).sort();
+	const status = runStatusOf(run);
+	const outcomes = stageOutcomesOf(run);
+	const stageNames = Object.keys(outcomes).sort();
+	const unverified = Object.values(outcomes).filter((outcome) => outcome === "succeeded_unverified").length;
+
 	return (
 		<button
 			type="button"
 			onClick={onOpen}
 			data-run-id={run.runId}
-			className={cn(
-				"flex w-full flex-col gap-1.5 rounded-md border bg-card p-2.5 text-left shadow-sm transition-colors hover:border-border-strong",
-				run.hasOpenFindings ? "border-warning/40" : "border-border",
-			)}
+			data-run-status={status}
+			className="flex w-full flex-col gap-1.5 rounded-md border border-border bg-card p-2.5 text-left shadow-sm transition-colors hover:border-border-strong"
 		>
 			<div className="flex items-baseline gap-2">
 				<span className="truncate font-mono text-caption font-semibold text-foreground">{run.pipelineName}</span>
@@ -26,25 +35,21 @@ export function PipelineRunCard({ run, onOpen }: { run: PipelineRunSummary; onOp
 						Blocks merge
 					</Badge>
 				)}
-				<span className={cn("ml-auto text-micro font-medium", loopStateTone(run.loopState))}>
-					rounds {run.loopRounds}
-				</span>
+				<span className={cn("ml-auto text-micro font-medium", runStatusTone(status))}>{status}</span>
 			</div>
 			<div className="flex items-center gap-2 font-mono text-micro text-passive">
 				<span className="truncate">{run.sessionId || run.runId}</span>
 				{run.headSha && <span className="shrink-0">· {shortSha(run.headSha)}</span>}
 			</div>
 			{stageNames.length > 0 && (
-				<ul className="flex flex-wrap items-center gap-1.5" aria-label="stage statuses">
+				<ul className="flex flex-wrap items-center gap-1.5" aria-label="stage outcomes">
 					{stageNames.map((name) => (
 						<li
 							key={name}
 							className="inline-flex items-center gap-1 font-mono text-micro text-muted-foreground"
-							title={`${name}: ${run.stageStatuses?.[name] ?? "pending"}`}
+							title={`${name}: ${stageOutcomeLabel(outcomes[name])}`}
 						>
-							<span
-								className={cn("h-1.5 w-1.5 rounded-full", stageStatusDotTone(run.stageStatuses?.[name] ?? "pending"))}
-							/>
+							<span className={cn("h-1.5 w-1.5 rounded-full", stageOutcomeDotTone(outcomes[name]))} />
 							<span className="truncate">{name}</span>
 						</li>
 					))}
@@ -54,7 +59,7 @@ export function PipelineRunCard({ run, onOpen }: { run: PipelineRunSummary; onOp
 				<span>
 					{run.stageCount} stage{run.stageCount === 1 ? "" : "s"}
 				</span>
-				{run.hasOpenFindings && <span className="text-warning">· open findings</span>}
+				{unverified > 0 && <span className="text-muted-foreground">· {unverified} unverified</span>}
 				<span className="ml-auto">{formatTimeCompact(run.updatedAt)}</span>
 			</div>
 		</button>

--- a/frontend/src/renderer/components/PipelineWorkbench.test.tsx
+++ b/frontend/src/renderer/components/PipelineWorkbench.test.tsx
@@ -43,7 +43,7 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("PipelineWorkbench", () => {
-	it("groups runs into the five loopState columns", () => {
+	it("groups runs into the five run-status columns", () => {
 		setRuns([
 			run({ runId: "r1", pipelineName: "review", loopState: "running" }),
 			run({ runId: "r2", pipelineName: "audit", loopState: "done" }),
@@ -52,20 +52,42 @@ describe("PipelineWorkbench", () => {
 		render(<PipelineWorkbench />);
 
 		expect(within(screen.getByLabelText("Running column")).getByText("review")).toBeInTheDocument();
-		expect(within(screen.getByLabelText("Done column")).getByText("audit")).toBeInTheDocument();
-		expect(within(screen.getByLabelText("Stalled column")).getByText("audit")).toBeInTheDocument();
+		expect(within(screen.getByLabelText("Succeeded column")).getByText("audit")).toBeInTheDocument();
+		expect(within(screen.getByLabelText("Failed column")).getByText("audit")).toBeInTheDocument();
 		// Empty columns render the placeholder.
-		expect(within(screen.getByLabelText("Terminated column")).getByText("Empty")).toBeInTheDocument();
+		expect(within(screen.getByLabelText("Queued column")).getByText("Empty")).toBeInTheDocument();
+		expect(within(screen.getByLabelText("Cancelled column")).getByText("Empty")).toBeInTheDocument();
 	});
 
-	it("renders card fields: pipeline name, rounds, and stage count", () => {
-		setRuns([run({ runId: "r1", pipelineName: "review", loopRounds: 3, stageCount: 2 })]);
+	it("renders card fields: pipeline name, run status, and stage count", () => {
+		setRuns([run({ runId: "r1", pipelineName: "review", loopState: "running", stageCount: 2 })]);
 		const { container } = render(<PipelineWorkbench />);
 
 		const card = container.querySelector('[data-run-id="r1"]') as HTMLElement;
 		expect(within(card).getByText("review")).toBeInTheDocument();
-		expect(within(card).getByText("rounds 3")).toBeInTheDocument();
+		expect(within(card).getByText("running")).toBeInTheDocument();
 		expect(within(card).getByText("2 stages")).toBeInTheDocument();
+	});
+
+	it("hints at unverified successes on the card and tones each stage dot by outcome", () => {
+		setRuns([
+			run({
+				runId: "r1",
+				stageCount: 3,
+				stageStatuses: { lint: "succeeded", review: "succeeded_unverified", test: "timed_out" },
+			}),
+		]);
+		const { container } = render(<PipelineWorkbench />);
+
+		const card = container.querySelector('[data-run-id="r1"]') as HTMLElement;
+		expect(within(card).getByText("· 1 unverified")).toBeInTheDocument();
+		expect(within(card).getByTitle("review: succeeded (unverified)")).toBeInTheDocument();
+		const dots = card.querySelectorAll('ul[aria-label="stage outcomes"] li span:first-child');
+		// lint solid success, review hollow success, test error: three distinct looks.
+		expect(dots[0].className).toContain("bg-success");
+		expect(dots[1].className).toContain("border-success");
+		expect(dots[1].className).not.toContain("bg-success");
+		expect(dots[2].className).toContain("bg-error");
 	});
 
 	it("filters the board to the selected pipeline names", async () => {

--- a/frontend/src/renderer/components/PipelineWorkbench.tsx
+++ b/frontend/src/renderer/components/PipelineWorkbench.tsx
@@ -1,13 +1,14 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { cn } from "../lib/utils";
-import { KANBAN_COLUMNS, type LoopStateName } from "../lib/pipeline-display";
+import { KANBAN_COLUMNS, runStatusOf } from "../lib/pipeline-display";
+import type { RunStatus } from "../lib/pipeline-draft";
 import { usePipelineRuns, type PipelineRunSummary } from "../hooks/usePipelineRuns";
 import { DashboardSubhead } from "./DashboardSubhead";
 import { PipelineFilterBar } from "./PipelineFilterBar";
 import { PipelineRunCard } from "./PipelineRunCard";
 
-// Runs workbench: a 5-column Kanban grouped by loopState across all projects.
+// Runs workbench: a 5-column Kanban grouped by run status across all projects.
 // Runs stay live through the CDC event transport (pipeline_* → query
 // invalidation); the filter bar narrows to a subset of pipeline names.
 export function PipelineWorkbench() {
@@ -28,21 +29,21 @@ export function PipelineWorkbench() {
 	}, [runs, selectedPipelines]);
 
 	const columns = useMemo(() => {
-		const grouped = new Map<LoopStateName, PipelineRunSummary[]>();
-		for (const col of KANBAN_COLUMNS) grouped.set(col.state, []);
-		for (const run of filteredRuns) grouped.get(run.loopState as LoopStateName)?.push(run);
+		const grouped = new Map<RunStatus, PipelineRunSummary[]>();
+		for (const col of KANBAN_COLUMNS) grouped.set(col.status, []);
+		for (const run of filteredRuns) grouped.get(runStatusOf(run))?.push(run);
 		// Newest first within a column.
 		for (const list of grouped.values()) {
 			list.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : a.updatedAt > b.updatedAt ? -1 : 0));
 		}
-		return KANBAN_COLUMNS.map((col) => ({ ...col, runs: grouped.get(col.state) ?? [] }));
+		return KANBAN_COLUMNS.map((col) => ({ ...col, runs: grouped.get(col.status) ?? [] }));
 	}, [filteredRuns]);
 
 	return (
 		<div className="flex h-full min-h-0 flex-col bg-background text-foreground">
 			<DashboardSubhead
 				title="Pipeline runs"
-				subtitle="Live pipeline runs grouped by loop state across every project."
+				subtitle="Live pipeline runs grouped by run status across every project."
 				count={filteredRuns.length}
 			/>
 
@@ -60,9 +61,9 @@ export function PipelineWorkbench() {
 				<div className="grid min-h-0 flex-1 grid-cols-1 gap-3 overflow-auto p-4.5 md:grid-cols-5">
 					{columns.map((col) => (
 						<section
-							key={col.state}
+							key={col.status}
 							aria-label={`${col.title} column`}
-							data-loop-state={col.state}
+							data-run-status={col.status}
 							className={cn("flex min-h-40 flex-col rounded-md border-l-2 bg-surface p-2", col.borderClass)}
 						>
 							<header className="px-1 pb-2">

--- a/frontend/src/renderer/lib/pipeline-display.test.ts
+++ b/frontend/src/renderer/lib/pipeline-display.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { SETTLED_OUTCOMES, type StageOutcome } from "./pipeline-draft";
+import {
+	KANBAN_COLUMNS,
+	runStatusOf,
+	runStatusTone,
+	stageOutcomeDotTone,
+	stageOutcomeLabel,
+	stageOutcomesOf,
+	shortSha,
+} from "./pipeline-display";
+
+const ALL_OUTCOMES: StageOutcome[] = ["pending", "running", ...SETTLED_OUTCOMES];
+
+describe("KANBAN_COLUMNS", () => {
+	it("is the five D11 run statuses in lifecycle order, with pending labelled Queued", () => {
+		expect(KANBAN_COLUMNS.map((col) => col.status)).toEqual(["pending", "running", "succeeded", "failed", "cancelled"]);
+		expect(KANBAN_COLUMNS[0].title).toBe("Queued");
+	});
+
+	it("gives every column a title, a description and a left-border tone", () => {
+		for (const col of KANBAN_COLUMNS) {
+			expect(col.title).not.toBe("");
+			expect(col.description).not.toBe("");
+			expect(col.borderClass).toMatch(/^border-l-/);
+		}
+	});
+});
+
+describe("runStatusTone", () => {
+	it("tones each status apart: accent running, success, error, muted cancelled, neutral pending", () => {
+		expect(runStatusTone("running")).toContain("text-accent");
+		expect(runStatusTone("succeeded")).toContain("text-success");
+		expect(runStatusTone("failed")).toContain("text-error");
+		expect(runStatusTone("cancelled")).toContain("text-passive");
+		expect(runStatusTone("pending")).toContain("text-muted-foreground");
+	});
+});
+
+describe("stageOutcomeDotTone", () => {
+	it("keeps succeeded_unverified in the success family but hollow, not filled", () => {
+		expect(stageOutcomeDotTone("succeeded")).toContain("bg-success");
+		const unverified = stageOutcomeDotTone("succeeded_unverified");
+		expect(unverified).toContain("border-success");
+		expect(unverified).not.toContain("bg-success");
+		expect(unverified).not.toBe(stageOutcomeDotTone("succeeded"));
+	});
+
+	it("groups failed with timed_out, no_output with no_signal, cancelled with skipped", () => {
+		expect(stageOutcomeDotTone("timed_out")).toBe(stageOutcomeDotTone("failed"));
+		expect(stageOutcomeDotTone("failed")).toContain("bg-error");
+		expect(stageOutcomeDotTone("no_signal")).toBe(stageOutcomeDotTone("no_output"));
+		expect(stageOutcomeDotTone("no_output")).toContain("bg-warning");
+		expect(stageOutcomeDotTone("skipped")).toBe(stageOutcomeDotTone("cancelled"));
+		expect(stageOutcomeDotTone("cancelled")).toContain("bg-passive");
+	});
+
+	it("pulses running on the accent and leaves pending neutral", () => {
+		expect(stageOutcomeDotTone("running")).toContain("bg-accent");
+		expect(stageOutcomeDotTone("running")).toContain("animate-pulse");
+		expect(stageOutcomeDotTone("pending")).toContain("bg-muted-foreground");
+	});
+
+	it("does not collapse the eight settled outcomes into pass/fail", () => {
+		const tones = new Set(SETTLED_OUTCOMES.map(stageOutcomeDotTone));
+		// succeeded, succeeded_unverified, failed/timed_out, no_output/no_signal,
+		// cancelled/skipped: five looks for eight outcomes, not two.
+		expect(tones.size).toBe(5);
+	});
+
+	it("has a tone and a label for every outcome in the union", () => {
+		for (const outcome of ALL_OUTCOMES) {
+			expect(stageOutcomeDotTone(outcome)).not.toBe("");
+			expect(stageOutcomeLabel(outcome)).not.toBe("");
+		}
+		expect(stageOutcomeLabel("succeeded_unverified")).toBe("succeeded (unverified)");
+	});
+});
+
+describe("runStatusOf", () => {
+	it("prefers the v2 status field", () => {
+		expect(runStatusOf({ status: "succeeded", loopState: "stalled" })).toBe("succeeded");
+	});
+
+	it("falls back to the v1 loop state until the API regen lands", () => {
+		expect(runStatusOf({ loopState: "running" })).toBe("running");
+		expect(runStatusOf({ loopState: "awaiting_context" })).toBe("running");
+		expect(runStatusOf({ loopState: "done" })).toBe("succeeded");
+		expect(runStatusOf({ loopState: "stalled" })).toBe("failed");
+		expect(runStatusOf({ loopState: "terminated" })).toBe("cancelled");
+	});
+
+	it("reads an unknown or missing status as pending rather than dropping the run", () => {
+		expect(runStatusOf({})).toBe("pending");
+		expect(runStatusOf({ status: "exploded" })).toBe("pending");
+		expect(runStatusOf({ loopState: "who_knows" })).toBe("pending");
+	});
+});
+
+describe("stageOutcomesOf", () => {
+	it("prefers stageOutcomes and falls back to the v1 stageStatuses map", () => {
+		expect(stageOutcomesOf({ stageOutcomes: { lint: "succeeded_unverified" } })).toEqual({
+			lint: "succeeded_unverified",
+		});
+		expect(stageOutcomesOf({ stageStatuses: { lint: "running" } })).toEqual({ lint: "running" });
+		expect(stageOutcomesOf({ stageStatuses: null })).toEqual({});
+		expect(stageOutcomesOf({})).toEqual({});
+	});
+});
+
+describe("shortSha", () => {
+	it("clips to twelve characters", () => {
+		expect(shortSha("abcdef1234567890")).toBe("abcdef123456");
+		expect(shortSha("abcdef")).toBe("abcdef");
+	});
+});

--- a/frontend/src/renderer/lib/pipeline-display.ts
+++ b/frontend/src/renderer/lib/pipeline-display.ts
@@ -1,12 +1,19 @@
-// Shared presentation helpers for the pipeline Runs UI: the fixed 5-column
-// Kanban layout (grouped by loopState), plus status/severity → tone maps used by
-// the workbench cards and the read-only run detail. Ported from the old
-// PipelineWorkbench/PipelineRunCard information design, restyled to AO tokens.
+// Shared presentation vocabulary for the pipelines Runs UI: the fixed five-column
+// Kanban keyed on the v2 `RunStatus` (decision D11), plus the tone maps for run
+// statuses and the eight settled stage outcomes (spec §7).
+//
+// The palette's job is to keep the eight outcomes distinguishable at a glance
+// rather than collapsing them into pass/fail. Two pairs share a tone because
+// they mean the same thing to the eye (failed/timed_out, no_output/no_signal;
+// cancelled/skipped are both "nothing happened here"), and
+// `succeeded_unverified` stays in the success family but renders hollow, since
+// spec §7 makes unverified success deliberately visible. Colors are AO design
+// tokens only (DESIGN.md, refined-blue accent); nothing new is invented here.
 
-export type LoopStateName = "running" | "awaiting_context" | "done" | "stalled" | "terminated";
+import type { RunStatus, StageOutcome } from "./pipeline-draft";
 
 export type KanbanColumn = {
-	state: LoopStateName;
+	status: RunStatus;
 	title: string;
 	description: string;
 	// Tailwind class for the column's 2px left accent border.
@@ -14,21 +21,120 @@ export type KanbanColumn = {
 };
 
 // Column order and copy are fixed; the board renders exactly these five in this
-// order regardless of which states currently have runs.
+// order regardless of which statuses currently have runs.
 export const KANBAN_COLUMNS: readonly KanbanColumn[] = [
-	{ state: "running", title: "Running", description: "Stage executing", borderClass: "border-l-working" },
+	{ status: "pending", title: "Queued", description: "Waiting to start", borderClass: "border-l-border" },
+	{ status: "running", title: "Running", description: "Stages executing", borderClass: "border-l-accent" },
 	{
-		state: "awaiting_context",
-		title: "Awaiting context",
-		description: "Stage paused for input",
-		borderClass: "border-l-warning",
+		status: "succeeded",
+		title: "Succeeded",
+		description: "Every stage settled successfully",
+		borderClass: "border-l-success",
 	},
-	{ state: "done", title: "Done", description: "All stages succeeded", borderClass: "border-l-success" },
-	{ state: "stalled", title: "Stalled", description: "Failed stages — resume to retry", borderClass: "border-l-error" },
-	{ state: "terminated", title: "Terminated", description: "Cancelled or superseded", borderClass: "border-l-border" },
+	{
+		status: "failed",
+		title: "Failed",
+		description: "A stage failed, timed out, or produced nothing",
+		borderClass: "border-l-error",
+	},
+	{ status: "cancelled", title: "Cancelled", description: "Superseded or killed", borderClass: "border-l-passive" },
 ] as const;
 
-// A run's loopState → the dot/text tone used on its card header.
+// A run's status → the text tone used for it on a card or in the run detail.
+export function runStatusTone(status: RunStatus): string {
+	switch (status) {
+		case "running":
+			return "text-accent";
+		case "succeeded":
+			return "text-success";
+		case "failed":
+			return "text-error";
+		case "cancelled":
+			return "text-passive";
+		case "pending":
+		default:
+			return "text-muted-foreground";
+	}
+}
+
+// A stage outcome → the classes for its small status dot. `succeeded_unverified`
+// is the one hollow dot: same success hue, no fill, so "it said done but nothing
+// was verified" reads differently from a real success without shouting.
+export function stageOutcomeDotTone(outcome: StageOutcome): string {
+	switch (outcome) {
+		case "succeeded":
+			return "bg-success";
+		case "succeeded_unverified":
+			return "border border-success bg-transparent";
+		case "failed":
+		case "timed_out":
+			return "bg-error";
+		case "no_output":
+		case "no_signal":
+			return "bg-warning";
+		case "cancelled":
+		case "skipped":
+			return "bg-passive";
+		case "running":
+			return "bg-accent animate-pulse";
+		case "pending":
+		default:
+			return "bg-muted-foreground";
+	}
+}
+
+// Human copy for an outcome, matching the spec's own wording.
+export function stageOutcomeLabel(outcome: StageOutcome): string {
+	return outcome === "succeeded_unverified" ? "succeeded (unverified)" : outcome.replace(/_/g, " ");
+}
+
+// The run fields this module reads. Task 18 regenerates `api/schema.ts` with the
+// v2 DTO (`status`, `stageOutcomes`); until then the runs list still serves the
+// v1 `loopState`/`stageStatuses`, so both readers below prefer the v2 field and
+// fall back to the v1 one. The board therefore keys on RunStatus today and keeps
+// working the day the regen lands.
+// ponytail: drop the v1 fallbacks (and this type) once Task 18 has merged.
+export type RunDisplayFields = {
+	status?: string;
+	loopState?: string;
+	stageOutcomes?: { [key: string]: string } | null;
+	stageStatuses?: { [key: string]: string } | null;
+};
+
+const RUN_STATUSES: readonly string[] = KANBAN_COLUMNS.map((col) => col.status);
+
+// v1 loop states → the v2 run status they stood for.
+const LOOP_STATE_STATUS: Record<string, RunStatus> = {
+	running: "running",
+	awaiting_context: "running",
+	done: "succeeded",
+	stalled: "failed",
+	terminated: "cancelled",
+};
+
+// An unknown status reads as "pending" so an unrecognised run still lands in a
+// column instead of vanishing off the board.
+export function runStatusOf(run: RunDisplayFields): RunStatus {
+	if (run.status && RUN_STATUSES.includes(run.status)) return run.status as RunStatus;
+	return LOOP_STATE_STATUS[run.loopState ?? ""] ?? "pending";
+}
+
+// v1 statuses that are not v2 outcomes (e.g. "outdated") fall through to the
+// neutral branch of stageOutcomeDotTone, which is why this cast is safe.
+export function stageOutcomesOf(run: RunDisplayFields): Record<string, StageOutcome> {
+	return (run.stageOutcomes ?? run.stageStatuses ?? {}) as Record<string, StageOutcome>;
+}
+
+// A short commit reference for a run header.
+export function shortSha(sha: string): string {
+	return sha.length > 12 ? sha.slice(0, 12) : sha;
+}
+
+// --- v1 leftovers -----------------------------------------------------------
+// PipelineRunDetail still renders the v1 loop/findings vocabulary; Task 24
+// rewrites it onto the outcome palette above. These three exist only to keep it
+// compiling until then, and go with it.
+
 export function loopStateTone(state: string): string {
 	switch (state) {
 		case "running":
@@ -45,26 +151,10 @@ export function loopStateTone(state: string): string {
 	}
 }
 
-// Per-stage status → the small status dot's background tone.
 export function stageStatusDotTone(status: string): string {
-	switch (status) {
-		case "succeeded":
-			return "bg-success";
-		case "running":
-			return "bg-working";
-		case "failed":
-			return "bg-error";
-		case "skipped":
-			return "bg-passive";
-		case "outdated":
-			return "bg-muted-foreground";
-		case "pending":
-		default:
-			return "bg-muted-foreground";
-	}
+	return stageOutcomeDotTone(status as StageOutcome);
 }
 
-// Finding severity → a Badge variant. Unknown/empty severities read as neutral.
 export function severityBadgeVariant(severity: string | undefined): "error" | "warning" | "neutral" {
 	switch ((severity ?? "").toLowerCase()) {
 		case "critical":
@@ -75,9 +165,4 @@ export function severityBadgeVariant(severity: string | undefined): "error" | "w
 		default:
 			return "neutral";
 	}
-}
-
-// A short commit reference for a run header.
-export function shortSha(sha: string): string {
-	return sha.length > 12 ? sha.slice(0, 12) : sha;
 }


### PR DESCRIPTION
Closes #313

## What

Task 23 of the pipelines v2 plan: the display vocabulary the run board speaks.

- **`lib/pipeline-display.ts` rewritten** on the v2 unions from `lib/pipeline-draft.ts` (imported, not redeclared):
  - `KANBAN_COLUMNS` keyed on `RunStatus`, five columns per decision D11: `pending` ("Queued"), `running`, `succeeded`, `failed`, `cancelled`.
  - `runStatusTone(status)`: running accent, succeeded success, failed error, cancelled muted, pending neutral.
  - `stageOutcomeDotTone(outcome)` covers all eight settled outcomes plus pending/running. `succeeded` is a filled success dot and **`succeeded_unverified` is the same success hue but hollow** (`border border-success bg-transparent`), because spec §7 makes unverified success deliberately visible. failed/timed_out share error, no_output/no_signal share warning, cancelled/skipped share muted, running is an accent pulse, pending is neutral. Eight outcomes, five distinct looks, no pass/fail collapse (there is a test that asserts exactly that).
  - `stageOutcomeLabel` renders the spec's own wording ("succeeded (unverified)").
- **`PipelineRunCard.tsx`**: stage dots use the outcome tones, the header's v1 "rounds N" is replaced by the run status in its tone, and the v1 findings hint is replaced by a subtle "n unverified" hint.
- **`PipelineWorkbench.tsx`**: column keying only (`col.status`, `runStatusOf(run)`, `data-run-status`), plus the subhead copy that said "loop state". Shell logic untouched.
- **`PipelineFilterBar.tsx`**: untouched, it compiled as is.

Colors are existing AO tokens only (`success`, `error`, `warning`, `accent`, `passive`, `muted-foreground`); nothing new invented, per DESIGN.md.

## DTO note (Task 18 not landed yet)

`api/schema.ts` still carries the v1 run DTO (`loopState`, `stageStatuses`); the v2 `status` / `stageOutcomes` fields arrive with Task 18's regen, and I did not regenerate the schema. So `runStatusOf` / `stageOutcomesOf` read the v2 field when present and fall back to the v1 field otherwise (`done` to `succeeded`, `stalled` to `failed`, `terminated` to `cancelled`, `awaiting_context` to `running`, unknown to `pending` so no run falls off the board). Both fallbacks are marked `ponytail:` for deletion once Task 18 merges.

`PipelineRunDetail.tsx` is Task 24's file and I did not touch it, so `loopStateTone`, `stageStatusDotTone` and `severityBadgeVariant` survive in a clearly marked "v1 leftovers" block purely to keep it compiling; they go with the run detail rewrite.

## Verification

- `npm run typecheck` clean, `vitest run` green (1093 tests, includes 13 new `pipeline-display` tests plus the reworked workbench/card tests), `vite build --config vite.renderer.config.ts` green, prettier clean on the changed files. Written test-first: the display tests were red for missing exports before the rewrite.
- `ao preview`: the real `/pipelines/runs` route has nothing to show. In `dev:web` there is no daemon behind the renderer (the sidebar reads "daemon stopped"), the `AO_PIPELINES` probe therefore resolves false, and the v2 engine is not wired until Task 15, so **there are no runs to look at**. I am not claiming I saw seeded data.
- To actually look at the palette I rendered `PipelineRunCard` and the `KANBAN_COLUMNS` chrome against the real stylesheet in a local throwaway harness (not committed) and read the result: five columns in D11 order with Queued first and its neutral hairline left border, running blue, succeeded green, failed red, cancelled muted; the card header status picks up the same tone; on a succeeded run the `succeeded_unverified` stage reads as a hollow green ring next to filled green dots with "· 1 unverified" in the footer; on a failed run `failed`/`timed_out` are red, `no_output`/`no_signal` amber and `skipped` grey, all four distinguishable side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
