### PR TITLE
feat(pipelines): engine-held credentials, resolver validation, fork identity-only rule

### DIFF
--- a/backend/internal/pipeline/credentials.go
+++ b/backend/internal/pipeline/credentials.go
@@ -1,0 +1,111 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+)
+
+// CredentialResolver is the daemon's view of a project's engine-held
+// credentials (decision D13, spec section 8).
+//
+// Values live only in the daemon and only ever reach a command stage's process
+// env at exec time. Nothing here echoes a value back to a user, a log line or
+// an agent: Exists answers by name, and Resolve's result goes straight into a
+// process environment.
+type CredentialResolver interface {
+	// Resolve returns the flattened environment of every named credential, in
+	// order, so a later name wins a key collision. An unknown name is an
+	// error: a stage that asked for a credential must never run without it.
+	Resolve(ctx context.Context, projectID string, names []string) (map[string]string, error)
+	// Exists reports whether the project declares a credential by that name.
+	Exists(ctx context.Context, projectID, name string) (bool, error)
+}
+
+// ValidateCredentials is the resolver-dependent second validation pass: it
+// rejects a credential name the project does not declare (spec section 13),
+// pointing at "stages[i].credentials[j]".
+//
+// It is deliberately not part of Validate. Validate stays dependency-free so
+// the parser and the canvas editor can call it without a store; the save path
+// runs this pass after it, with the project's resolver in hand. A nil resolver
+// is a no-op, which is what makes the pass optional.
+//
+// A store failure comes back as an ordinary error, not a *ValidationError:
+// "unknown credential" on a failed read would tell the author to fix a name
+// that is fine.
+func ValidateCredentials(ctx context.Context, p *Pipeline, projectID string, r CredentialResolver) error {
+	if r == nil || p == nil {
+		return nil
+	}
+	var issues []Issue
+	for i := range p.Stages {
+		s := &p.Stages[i]
+		for j, name := range s.Credentials {
+			ok, err := r.Exists(ctx, projectID, name)
+			if err != nil {
+				return fmt.Errorf("check credential %q for project %s: %w", name, projectID, err)
+			}
+			if ok {
+				continue
+			}
+			issues = append(issues, Issue{
+				Path:    fmt.Sprintf("stages[%d].credentials[%d]", i, j),
+				Message: fmt.Sprintf("unknown credential %q: set it with `ao pipeline credential set %s KEY=VALUE`", name, name),
+			})
+		}
+	}
+	if len(issues) > 0 {
+		return &ValidationError{Issues: issues}
+	}
+	return nil
+}
+
+// KnownCredentialSet turns the project's declared credential names into the
+// predicate ComputePlan takes.
+//
+// A nil slice returns a nil predicate, which tells ComputePlan to skip the
+// check: "the caller has no credential store" is not the same answer as "the
+// project declares nothing", and only the second one may fail a run.
+func KnownCredentialSet(names []string) func(string) bool {
+	if names == nil {
+		return nil
+	}
+	set := make(map[string]bool, len(names))
+	for _, name := range names {
+		set[name] = true
+	}
+	return func(name string) bool { return set[name] }
+}
+
+// checkCredentials applies both plan-time credential rules to one reachable
+// stage. Reachability is the caller's business: a stage that never runs can
+// never fail the plan.
+//
+// The rules are written executor-agnostic on purpose. Only a command stage can
+// legitimately declare credentials (Validate rejects them on an agent stage and
+// the schema forbids them), so an agent stage carrying one here means the
+// definition is already invalid, and failing the run is the safe answer.
+func checkCredentials(s *Stage, subject Subject, knownCreds func(string) bool) error {
+	if len(s.Credentials) == 0 {
+		return nil
+	}
+
+	// D17, spec section 8: a fork PR never blocks the run, but it forces
+	// identity-only env, because PR contents are untrusted input to an LLM
+	// with shell access. A stage that declared credentials would run without
+	// them, so state the reason and fail instead of quietly dropping them.
+	if subject.FromForkPR() {
+		return fmt.Errorf("stage '%s' declares credentials %v, and %s is from a fork: fork PRs run identity-only, so no credential is injected anywhere in the run",
+			s.ID, s.Credentials, subject.describe())
+	}
+
+	if knownCreds == nil {
+		return nil
+	}
+	for _, name := range s.Credentials {
+		if !knownCreds(name) {
+			return fmt.Errorf("stage '%s' declares credential %q, which this project does not define", s.ID, name)
+		}
+	}
+	return nil
+}

--- a/backend/internal/pipeline/credentials_test.go
+++ b/backend/internal/pipeline/credentials_test.go
@@ -1,0 +1,258 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// memResolver is the in-memory CredentialResolver the tests run against: the
+// real one reads the project's credential table (Task 15 wires it).
+type memResolver struct {
+	creds map[string]map[string]string
+	err   error
+}
+
+func newMemResolver(creds map[string]map[string]string) *memResolver {
+	return &memResolver{creds: creds}
+}
+
+func (r *memResolver) Resolve(_ context.Context, _ string, names []string) (map[string]string, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	env := map[string]string{}
+	for _, name := range names {
+		got, ok := r.creds[name]
+		if !ok {
+			return nil, errors.New("unknown credential " + name)
+		}
+		for k, v := range got {
+			env[k] = v
+		}
+	}
+	return env, nil
+}
+
+func (r *memResolver) Exists(_ context.Context, _ string, name string) (bool, error) {
+	if r.err != nil {
+		return false, r.err
+	}
+	_, ok := r.creds[name]
+	return ok, nil
+}
+
+func knownCredentials(names ...string) func(string) bool { return KnownCredentialSet(names) }
+
+func credsPipeline(t *testing.T) *Pipeline {
+	t.Helper()
+	return mustParse(t, []byte(`
+name: p
+stages:
+  - id: build
+    executor: command
+    run: make
+    on_success: sign
+  - id: sign
+    executor: command
+    run: make sign
+    credentials: [apple-signing, notary]
+`))
+}
+
+func TestValidateCredentials_UnknownNameFlagsTheExactPath(t *testing.T) {
+	def := credsPipeline(t)
+	resolver := newMemResolver(map[string]map[string]string{
+		"apple-signing": {"AC_USER": "someone"},
+	})
+
+	err := ValidateCredentials(context.Background(), def, "proj", resolver)
+	if err == nil {
+		t.Fatal("expected an error for the unknown credential, got nil")
+	}
+	var verr *ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("error = %T (%v), want *ValidationError", err, err)
+	}
+	if len(verr.Issues) != 1 {
+		t.Fatalf("issues = %v, want exactly one", verr.Issues)
+	}
+	// stages[1] is sign, credentials[1] is notary: the index pair is what the
+	// editor highlights, so it has to point at the offending entry itself.
+	if got, want := verr.Issues[0].Path, "stages[1].credentials[1]"; got != want {
+		t.Errorf("path = %q, want %q", got, want)
+	}
+	if !strings.Contains(verr.Issues[0].Message, "notary") {
+		t.Errorf("message = %q, want it to name the credential", verr.Issues[0].Message)
+	}
+}
+
+func TestValidateCredentials_EveryNameKnownIsClean(t *testing.T) {
+	def := credsPipeline(t)
+	resolver := newMemResolver(map[string]map[string]string{
+		"apple-signing": {"AC_USER": "someone"},
+		"notary":        {"AC_PASSWORD": "shh"},
+	})
+
+	if err := ValidateCredentials(context.Background(), def, "proj", resolver); err != nil {
+		t.Fatalf("ValidateCredentials: %v", err)
+	}
+}
+
+// The second pass is optional: the parser and the canvas editor validate
+// without a store, and pure Validate stays dependency-free.
+func TestValidateCredentials_NilResolverIsANoOp(t *testing.T) {
+	if err := ValidateCredentials(context.Background(), credsPipeline(t), "proj", nil); err != nil {
+		t.Fatalf("ValidateCredentials with no resolver: %v", err)
+	}
+}
+
+// A store that cannot answer is not a validation finding: reporting "unknown
+// credential" on a read failure would tell the author to fix a name that is
+// fine.
+func TestValidateCredentials_StoreErrorIsNotAValidationIssue(t *testing.T) {
+	resolver := newMemResolver(nil)
+	resolver.err = errors.New("database is locked")
+
+	err := ValidateCredentials(context.Background(), credsPipeline(t), "proj", resolver)
+	if err == nil {
+		t.Fatal("expected the store error to surface, got nil")
+	}
+	var verr *ValidationError
+	if errors.As(err, &verr) {
+		t.Fatalf("store failure reported as a validation error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "database is locked") {
+		t.Errorf("error = %v, want it to wrap the store failure", err)
+	}
+}
+
+func forkSubject(number int) Subject {
+	s := prSubject(number)
+	s.PR.FromFork = true
+	return s
+}
+
+// D17, spec section 8: a fork PR never blocks the run, but it forces
+// identity-only env. A stage that declared credentials would run without them,
+// so the run fails at plan time with the reason stated instead.
+func TestComputePlan_ForkPRWithACredentialsStageFails(t *testing.T) {
+	def := credsPipeline(t)
+
+	_, err := ComputePlan(def, forkSubject(412), nil)
+	if err == nil {
+		t.Fatal("expected ComputePlan to fail for a fork PR with a credentials stage, got nil")
+	}
+	for _, want := range []string{"sign", "fork", "identity-only", "PR #412"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want it to mention %q", err.Error(), want)
+		}
+	}
+}
+
+func TestComputePlan_ForkPRWithoutCredentialsPlansFine(t *testing.T) {
+	def := mustParse(t, []byte(`
+name: p
+stages:
+  - id: build
+    executor: command
+    run: make
+    on_success: review
+  - id: review
+    executor: agent
+    agent: claude-code
+    prompt: look at the diff
+`))
+	plan, err := ComputePlan(def, forkSubject(412), nil)
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if len(plan.Reachable) != 2 {
+		t.Errorf("reachable = %v, want both stages", plan.Reachable)
+	}
+}
+
+// The rule is about the fork, not about credentials: the same pipeline on an
+// in-repo PR runs with its credentials injected.
+func TestComputePlan_SameRepoPRWithCredentialsPlansFine(t *testing.T) {
+	def := credsPipeline(t)
+
+	if _, err := ComputePlan(def, prSubject(412), knownCredentials("apple-signing", "notary")); err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+}
+
+// An unreachable stage never runs, so it cannot make the plan fail.
+func TestComputePlan_ForkPRIgnoresUnreachableCredentialsStages(t *testing.T) {
+	def := mustParse(t, []byte(`
+name: p
+stages:
+  - id: build
+    executor: command
+    run: make
+  - id: orphan
+    executor: command
+    run: make sign
+    credentials: [apple-signing]
+`))
+	if _, err := ComputePlan(def, forkSubject(412), nil); err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+}
+
+// The name was known when the pipeline was saved and the credential was
+// deleted since. Fail the run rather than run the stage with the variable
+// missing from its environment.
+func TestComputePlan_CredentialDeletedSinceSaveFails(t *testing.T) {
+	def := credsPipeline(t)
+
+	_, err := ComputePlan(def, prSubject(412), knownCredentials("apple-signing"))
+	if err == nil {
+		t.Fatal("expected ComputePlan to fail for the deleted credential, got nil")
+	}
+	for _, want := range []string{"sign", "notary"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want it to mention %q", err.Error(), want)
+		}
+	}
+}
+
+func TestKnownCredentialSet(t *testing.T) {
+	if KnownCredentialSet(nil) != nil {
+		t.Error("KnownCredentialSet(nil) must stay nil: unknown is not the same as none")
+	}
+	known := KnownCredentialSet([]string{})
+	if known == nil {
+		t.Fatal("KnownCredentialSet of an empty slice must answer, not skip the check")
+	}
+	if known("apple-signing") {
+		t.Error("a project with no credentials must know no names")
+	}
+	if known = KnownCredentialSet([]string{"apple-signing"}); !known("apple-signing") || known("notary") {
+		t.Error("KnownCredentialSet does not answer its own set")
+	}
+}
+
+// Resolve flattens every named credential's environment into one map, which is
+// what a command stage's process env needs.
+func TestResolverFlattensNamedEnvironments(t *testing.T) {
+	resolver := newMemResolver(map[string]map[string]string{
+		"apple-signing": {"AC_USER": "someone", "AC_TEAM": "J432"},
+		"notary":        {"AC_PASSWORD": "shh"},
+	})
+
+	env, err := resolver.Resolve(context.Background(), "proj", []string{"apple-signing", "notary"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if strings.Join(keys, ",") != "AC_PASSWORD,AC_TEAM,AC_USER" {
+		t.Errorf("flattened keys = %v, want every variable from both credentials", keys)
+	}
+}

--- a/backend/internal/pipeline/events.go
+++ b/backend/internal/pipeline/events.go
@@ -29,7 +29,12 @@ type TriggerFired struct {
 	Subject Subject
 	RunID   RunID
 	RunDir  string
-	Now     time.Time
+	// KnownCredentials names the credentials the project defines, stamped by
+	// the driver the same way Now is, so the pure reducer can plan without
+	// reaching for the credential store. Nil means the driver did not supply
+	// them and the plan-time unknown-credential check is skipped.
+	KnownCredentials []string
+	Now              time.Time
 }
 
 // When implements Event.

--- a/backend/internal/pipeline/plan.go
+++ b/backend/internal/pipeline/plan.go
@@ -29,8 +29,15 @@ type Plan struct {
 // plan for this subject.
 //
 // It returns an error when a reachable stage requires a session workspace the
-// subject cannot supply. Fail the run; never silently fall back.
-func ComputePlan(def *Pipeline, subject Subject) (*Plan, error) {
+// subject cannot supply, or when a reachable stage's credentials cannot be
+// injected: the subject is a fork PR (identity-only, decision D17), or the
+// project no longer defines a name the definition asks for. Fail the run;
+// never silently fall back.
+//
+// knownCreds answers whether the project defines a credential name; a nil
+// predicate skips that check, for callers with no credential store in hand
+// (see KnownCredentialSet).
+func ComputePlan(def *Pipeline, subject Subject, knownCreds func(string) bool) (*Plan, error) {
 	entry := def.EntryStage()
 	if entry == nil {
 		return nil, errors.New("pipeline declares no stages")
@@ -55,6 +62,9 @@ func ComputePlan(def *Pipeline, subject Subject) (*Plan, error) {
 		kind := resolveWorkspace(s.Workspace, viaSuccess[s.ID], subject)
 		if kind == WorkspaceSession && !subject.HasSession() {
 			return nil, fmt.Errorf("stage '%s' requires workspace 'session'; %s has no local session", s.ID, subject.describe())
+		}
+		if err := checkCredentials(s, subject, knownCreds); err != nil {
+			return nil, err
 		}
 		plan.Workspaces[s.ID] = kind
 	}

--- a/backend/internal/pipeline/plan_test.go
+++ b/backend/internal/pipeline/plan_test.go
@@ -18,7 +18,7 @@ func prSubject(number int) Subject {
 func TestComputePlan_ReleaseExampleReachesEveryStage(t *testing.T) {
 	def := mustParse(t, releaseYAML(t))
 
-	plan, err := ComputePlan(def, prSubject(412))
+	plan, err := ComputePlan(def, prSubject(412), nil)
 	if err != nil {
 		t.Fatalf("ComputePlan: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestComputePlan_ReleaseExampleReachesEveryStage(t *testing.T) {
 func TestComputePlan_EffectiveDeadlines(t *testing.T) {
 	def := mustParse(t, releaseYAML(t))
 
-	plan, err := ComputePlan(def, prSubject(412))
+	plan, err := ComputePlan(def, prSubject(412), nil)
 	if err != nil {
 		t.Fatalf("ComputePlan: %v", err)
 	}
@@ -73,7 +73,7 @@ stages:
     run: "true"
     deadline: 5m
 `))
-	plan, err := ComputePlan(def, Subject{Kind: SubjectProject, ProjectID: "proj"})
+	plan, err := ComputePlan(def, Subject{Kind: SubjectProject, ProjectID: "proj"}, nil)
 	if err != nil {
 		t.Fatalf("ComputePlan: %v", err)
 	}
@@ -88,7 +88,7 @@ stages:
 func TestComputePlan_ReleaseExampleWorkspaces(t *testing.T) {
 	def := mustParse(t, releaseYAML(t))
 
-	plan, err := ComputePlan(def, prSubject(412))
+	plan, err := ComputePlan(def, prSubject(412), nil)
 	if err != nil {
 		t.Fatalf("ComputePlan: %v", err)
 	}
@@ -131,7 +131,7 @@ stages:
 `))
 
 	t.Run("subject with a session", func(t *testing.T) {
-		plan, err := ComputePlan(def, Subject{Kind: SubjectSession, ProjectID: "proj", SessionID: "sess-1"})
+		plan, err := ComputePlan(def, Subject{Kind: SubjectSession, ProjectID: "proj", SessionID: "sess-1"}, nil)
 		if err != nil {
 			t.Fatalf("ComputePlan: %v", err)
 		}
@@ -144,7 +144,7 @@ stages:
 	})
 
 	t.Run("subject without a session", func(t *testing.T) {
-		plan, err := ComputePlan(def, prSubject(412))
+		plan, err := ComputePlan(def, prSubject(412), nil)
 		if err != nil {
 			t.Fatalf("ComputePlan: %v", err)
 		}
@@ -168,7 +168,7 @@ stages:
     prompt: hi
     workspace: session
 `))
-	_, err := ComputePlan(def, prSubject(412))
+	_, err := ComputePlan(def, prSubject(412), nil)
 	if err == nil {
 		t.Fatal("expected ComputePlan to fail, got nil")
 	}
@@ -190,7 +190,7 @@ stages:
 `))
 	subject := prSubject(412)
 	subject.SessionID = "sess-1"
-	plan, err := ComputePlan(def, subject)
+	plan, err := ComputePlan(def, subject, nil)
 	if err != nil {
 		t.Fatalf("ComputePlan: %v", err)
 	}
@@ -212,7 +212,7 @@ stages:
     run: "true"
     workspace: session
 `))
-	plan, err := ComputePlan(def, prSubject(412))
+	plan, err := ComputePlan(def, prSubject(412), nil)
 	if err != nil {
 		t.Fatalf("ComputePlan: %v", err)
 	}
@@ -225,7 +225,7 @@ stages:
 }
 
 func TestComputePlan_NoStages(t *testing.T) {
-	_, err := ComputePlan(&Pipeline{Name: "p"}, prSubject(1))
+	_, err := ComputePlan(&Pipeline{Name: "p"}, prSubject(1), nil)
 	if err == nil || !strings.Contains(err.Error(), "no stages") {
 		t.Fatalf("error = %v, want a no-stages error", err)
 	}
@@ -247,7 +247,7 @@ stages:
     executor: command
     run: "true"
 `))
-	plan, err := ComputePlan(def, prSubject(412))
+	plan, err := ComputePlan(def, prSubject(412), nil)
 	if err != nil {
 		t.Fatalf("ComputePlan: %v", err)
 	}

--- a/backend/internal/pipeline/reducer.go
+++ b/backend/internal/pipeline/reducer.go
@@ -97,7 +97,7 @@ func reduceTriggerFired(run RunState, e TriggerFired) (RunState, []Effect) {
 	next.UpdatedAt = e.Now
 	next.Stages = map[string]*StageState{}
 
-	plan, err := ComputePlan(&next.Def, e.Subject)
+	plan, err := ComputePlan(&next.Def, e.Subject, KnownCredentialSet(e.KnownCredentials))
 	if err != nil {
 		return failAtPlanTime(next, err, e.Now)
 	}

--- a/backend/internal/pipeline/subject.go
+++ b/backend/internal/pipeline/subject.go
@@ -47,6 +47,11 @@ type PRRef struct {
 // the one thing that decides whether `workspace: session` is possible.
 func (s Subject) HasSession() bool { return s.SessionID != "" }
 
+// FromForkPR reports whether the subject is a pull request from a fork, the
+// one condition that forces identity-only env for the whole run (spec section
+// 8, decision D17).
+func (s Subject) FromForkPR() bool { return s.PR != nil && s.PR.FromFork }
+
 // DefaultScope is the subject's natural concurrency scope, used when the
 // pipeline declares none (spec section 10).
 func (s Subject) DefaultScope() ConcurrencyScope {


### PR DESCRIPTION
Pipelines v2 Task 12: the credential seam the engine plans and injects through.

Closes #315

## What lands

- `CredentialResolver` (`backend/internal/pipeline/credentials.go`) exactly as the plan writes it: `Resolve(ctx, projectID, names)` returning flattened env, `Exists(ctx, projectID, name)`. Values live only in the daemon; every read path here answers by name, nothing echoes a secret back.
- `ValidateCredentials(ctx, def, projectID, resolver)`: the resolver-dependent second pass. An unknown credential name is an error at `stages[i].credentials[j]` (spec §13). A nil resolver is a no-op, which is what makes the pass optional. A store read failure comes back as a plain error, not a `*ValidationError`, so a locked database never tells an author to fix a name that is fine.
- Pure `Validate` is untouched and stays dependency-free: the parser and the canvas editor still call it without a store.
- Fork identity-only rule (D17, spec §8): `ComputePlan` gains the known-credentials predicate, `ComputePlan(def, subject, knownCreds)`. A reachable stage declaring `credentials:` under a fork-PR subject fails the plan with the reason stated (fork PRs run identity-only), instead of dropping the credentials and running anyway. A fork PR with no credentials stage plans normally; an unreachable credentials stage never fails a plan.
- Second plan-time rule off the same predicate: a name that was known at save time and has been deleted since fails the run rather than running the stage with the variable missing. `KnownCredentialSet(nil)` returns a nil predicate, so "caller has no store" stays distinct from "project defines nothing".
- `Subject.FromForkPR()` and `TriggerFired.KnownCredentials` (driver-stamped, like `Now`) so the pure reducer plans the same plan the engine did.

The credential check is written executor-agnostic on purpose: only a command stage can legitimately declare `credentials:` (`Validate` rejects them on an agent stage, the schema forbids it), so an agent stage carrying one means the definition is already invalid, and failing closed is the safe answer.

## Not in scope

- Injection at exec time is Task 15's driver, through Task 8's `StartInput.Credentials`.
- `ao pipeline credential set|ls|rm` is Task 19's.
- The save/validate service path does not exist yet: every `/pipelines` route is still 501 and `pipelinesvc.Manager` is a stub with only `PRBlocksMerge`. `ValidateCredentials` is the seam Task 15's Manager calls after `Validate`; its doc comment says so.

## Tests

`backend/internal/pipeline/credentials_test.go`, with an in-memory resolver: unknown name flags the exact path; all names known is clean; nil resolver is a no-op; a store error is not a validation issue; fork + credentials stage fails `ComputePlan` with a stated reason; fork without credentials plans fine; same-repo PR with credentials plans fine; unreachable credentials stage ignored under a fork; deleted-since-save name fails; `KnownCredentialSet` nil-versus-empty; `Resolve` flattening.

## Verification

- `go build ./...`, `go test ./...`, `gofmt -l .` (empty), `~/go/bin/golangci-lint run ./...` (0 issues).
- 4 pre-existing failures in `internal/cli` (`TestSpawn*`, daemon HTTP 404) reproduce identically on `origin/pipelines` in a clean worktree; unrelated to this change.

## Risks

Widening `ComputePlan` touches the reducer's `TriggerFired` path. `TriggerFired.KnownCredentials` is nil-safe: unset means the unknown-name check is skipped, and the fork rule still applies because it reads only the subject.