### PR TITLE
feat(pipelines): v2 agent executor, signal-or-activity polling, session-preserving interrupt

### DIFF
--- a/backend/internal/pipeline/executors/agent.go
+++ b/backend/internal/pipeline/executors/agent.go
@@ -1,0 +1,242 @@
+package executors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// SpawnRequest is the narrow spawn payload the agent executor hands the session
+// manager. It carries only what a stage needs; the engine's adapter maps it
+// onto ports.SpawnConfig.
+type SpawnRequest struct {
+	ProjectID string
+	// Harness is the stage's `agent:` key. Empty lets the project default pick.
+	Harness string
+	// Prompt is the v2 preamble followed by the stage's own prompt.
+	Prompt string
+	// WorkspacePath is the tree the driver already provisioned for this stage
+	// (spec section 5). The session runs there instead of resolving one of its
+	// own, which is what makes `workspace: run` and `inherit` mean anything.
+	WorkspacePath string
+	// Env is the ambient variable set (spec section 12.2), passed straight into
+	// ports.SpawnConfig.Env. AO_RUN_ID and AO_STAGE ride in here, which is how
+	// `ao pipeline done` resolves the stage it is settling.
+	Env map[string]string
+	// DisplayName labels the session in the sidebar.
+	DisplayName string
+}
+
+// SpawnedSession is what the session manager returns for a fresh spawn. The
+// path comes back because the adapter, not this executor, has the last word on
+// where the session actually landed.
+type SpawnedSession struct {
+	SessionID     string
+	WorkspacePath string
+}
+
+// SessionSnapshot is the subset of session state the executor polls: how busy
+// the agent is, and whether the session row went terminal.
+type SessionSnapshot struct {
+	Activity   domain.ActivityState
+	Terminated bool
+}
+
+// SessionSpawner is the session-manager seam the agent executor needs. The
+// concrete Manager never enters this package; the engine wires an adapter
+// (Task 15).
+type SessionSpawner interface {
+	Spawn(ctx context.Context, req SpawnRequest) (SpawnedSession, error)
+	// Get returns a snapshot and whether the session still exists.
+	Get(ctx context.Context, sessionID string) (SessionSnapshot, bool, error)
+	// Interrupt stops the agent's work while leaving the session record and its
+	// scrollback alive. This is the timed_out path (spec section 7.2).
+	Interrupt(ctx context.Context, sessionID string) error
+	// Kill tears the session down. Idempotent; a missing session is not an error.
+	Kill(ctx context.Context, sessionID string) error
+}
+
+// SessionMessenger is the nudge delivery seam. It is the driver's, not this
+// executor's: the reducer emits NudgeStage, the engine sends the message and
+// feeds NudgeDelivered back (spec section 7.1). It lives here with the other
+// session seams so the engine's adapters implement one vocabulary.
+type SessionMessenger interface {
+	Alive(ctx context.Context, sessionID string) (bool, error)
+	Send(ctx context.Context, sessionID, message string) error
+}
+
+// SignalReader reads the latest `ao pipeline done|fail` a stage recorded.
+// Task 11's Manager implements it over the signal registry.
+type SignalReader interface {
+	LatestSignal(runID pipeline.RunID, stageID string) (pipeline.StageSignal, bool)
+}
+
+// SessionHolder is implemented by handles backed by an agent session, so the
+// driver can name the session in StageLaunched and in the kill-on decision
+// without knowing which executor produced the handle.
+type SessionHolder interface{ SessionID() string }
+
+// agentHandle is the running-stage token for an agent stage.
+type agentHandle struct {
+	stageIdentity
+	sessionID string
+
+	// mu guards reportedAt, the CreatedAt of the last signal Poll turned into a
+	// terminal state. A nudged stage keeps the same session and the same signal
+	// row, so re-reporting the stale signal would settle the stage before the
+	// agent had a chance to answer the nudge. Only a strictly newer signal is
+	// reported again.
+	mu         sync.Mutex
+	reportedAt time.Time
+}
+
+// SessionID implements SessionHolder.
+func (h *agentHandle) SessionID() string { return h.sessionID }
+
+var _ SessionHolder = (*agentHandle)(nil)
+
+// AgentExecutor runs an agent stage as a real, visible AO session: spawn it
+// with the ambient env and a pointer-style preamble, then watch for the
+// agent's own settlement signal. It harvests nothing: the whole contract is the
+// signal plus, when `produces:` is declared, the file the driver verifies
+// (spec section 6.2).
+type AgentExecutor struct {
+	sessions SessionSpawner
+	signals  SignalReader
+}
+
+// NewAgentExecutor builds the agent executor over the session and signal seams.
+func NewAgentExecutor(sessions SessionSpawner, signals SignalReader) *AgentExecutor {
+	return &AgentExecutor{sessions: sessions, signals: signals}
+}
+
+var _ StageExecutor = (*AgentExecutor)(nil)
+
+// Start spawns the stage's session. There is no log file for an agent stage:
+// its record is the session's own scrollback, which outlives the stage on every
+// outcome that keeps the session.
+func (e *AgentExecutor) Start(ctx context.Context, in StartInput) (Handle, error) {
+	if in.Stage.Executor != pipeline.ExecutorAgent {
+		return nil, fmt.Errorf("agent executor cannot start stage %q with executor %q", in.Stage.ID, in.Stage.Executor)
+	}
+	// The schema forbids `credentials:` on an agent stage (spec section 8). This
+	// is the runtime half of that rule: a tier separation enforced only by
+	// validation is one bad call site away from being gone.
+	if len(in.Credentials) > 0 {
+		return nil, fmt.Errorf("agent stage %q must not receive credentials", in.Stage.ID)
+	}
+
+	session, err := e.sessions.Spawn(ctx, SpawnRequest{
+		ProjectID:     in.ProjectID,
+		Harness:       in.Stage.Agent,
+		Prompt:        buildAgentPrompt(in),
+		WorkspacePath: in.WorkspacePath,
+		Env:           in.Env,
+		DisplayName:   fmt.Sprintf("%s/%s", in.RunID, in.Stage.ID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("agent stage %q: spawn session: %w", in.Stage.ID, err)
+	}
+	if session.SessionID == "" {
+		return nil, fmt.Errorf("agent stage %q: spawn returned no session id", in.Stage.ID)
+	}
+
+	return &agentHandle{
+		stageIdentity: stageIdentity{runID: in.RunID, stageID: in.Stage.ID, attempt: in.Attempt},
+		sessionID:     session.SessionID,
+	}, nil
+}
+
+// Poll reports the signal if there is a new one, and otherwise what the session
+// is doing. Signal always beats activity: an agent that signalled and then went
+// idle has settled, and reading that as "idle without a signal" would nudge a
+// stage that is already done.
+func (e *AgentExecutor) Poll(ctx context.Context, h Handle) (Poll, error) {
+	handle, ok := h.(*agentHandle)
+	if !ok {
+		return Poll{}, fmt.Errorf("agent executor: unexpected handle type %T", h)
+	}
+
+	if out, signalled := e.pollSignal(handle); signalled {
+		return out, nil
+	}
+
+	snap, exists, err := e.sessions.Get(ctx, handle.sessionID)
+	if err != nil {
+		return Poll{}, fmt.Errorf("agent stage %q: get session %s: %w", handle.stageID, handle.sessionID, err)
+	}
+	switch {
+	case !exists:
+		return Poll{State: PollGone, Reason: fmt.Sprintf("session %s no longer exists", handle.sessionID)}, nil
+	case snap.Terminated || snap.Activity == domain.ActivityExited:
+		return Poll{State: PollGone, Reason: fmt.Sprintf("session %s ended without signalling", handle.sessionID)}, nil
+	case snap.Activity == domain.ActivityIdle,
+		snap.Activity == domain.ActivityWaitingInput,
+		snap.Activity == domain.ActivityBlocked:
+		// Alive but not working, so the missing signal will not arrive on its
+		// own. Whether that earns a nudge or a settlement is the reducer's call.
+		return Poll{State: PollIdle}, nil
+	default:
+		// Active, or an activity state this executor does not know about. An
+		// unrecognized state is not evidence the agent stopped; the stage's
+		// deadline still bounds it.
+		return Poll{State: PollRunning}, nil
+	}
+}
+
+// pollSignal reports a settlement signal at most once. The nudge keeps the
+// stage running against the same registry row, so a signal already turned into
+// a poll state must not settle the stage a second time.
+func (e *AgentExecutor) pollSignal(handle *agentHandle) (Poll, bool) {
+	if e.signals == nil {
+		return Poll{}, false
+	}
+	sig, ok := e.signals.LatestSignal(handle.runID, handle.stageID)
+	if !ok || !sig.Kind.IsKnown() {
+		return Poll{}, false
+	}
+
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	if !sig.CreatedAt.After(handle.reportedAt) {
+		return Poll{}, false
+	}
+	handle.reportedAt = sig.CreatedAt
+
+	if sig.Kind == pipeline.SignalFail {
+		return Poll{State: PollSignaledFail, Reason: sig.Reason}, true
+	}
+	return Poll{State: PollSignaledDone}, true
+}
+
+// Interrupt stops the agent's work and keeps the session. This is what a
+// timed-out stage gets: killing a runaway agent is the point, losing its
+// scrollback is not (spec section 7.2).
+func (e *AgentExecutor) Interrupt(ctx context.Context, h Handle) error {
+	handle, ok := h.(*agentHandle)
+	if !ok {
+		return fmt.Errorf("agent executor: unexpected handle type %T", h)
+	}
+	if err := e.sessions.Interrupt(ctx, handle.sessionID); err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("agent stage %q: interrupt session %s: %w", handle.stageID, handle.sessionID, err)
+	}
+	return nil
+}
+
+// Cancel kills the session. Run cancellation, not the deadline path.
+// Idempotent: the reducer can cancel a stage that has already settled.
+func (e *AgentExecutor) Cancel(ctx context.Context, h Handle) error {
+	handle, ok := h.(*agentHandle)
+	if !ok {
+		return fmt.Errorf("agent executor: unexpected handle type %T", h)
+	}
+	if err := e.sessions.Kill(ctx, handle.sessionID); err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("agent stage %q: kill session %s: %w", handle.stageID, handle.sessionID, err)
+	}
+	return nil
+}

--- a/backend/internal/pipeline/executors/agent_test.go
+++ b/backend/internal/pipeline/executors/agent_test.go
@@ -1,0 +1,417 @@
+package executors
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// fakeSpawner is the session seam under test control: it records the spawn
+// request, hands back whatever snapshot the test set, and counts kills and
+// interrupts separately so the session-preserving interrupt is observable.
+type fakeSpawner struct {
+	mu sync.Mutex
+
+	req      SpawnRequest
+	spawns   int
+	spawned  SpawnedSession
+	spawnErr error
+
+	snap   SessionSnapshot
+	exists bool
+	getErr error
+
+	kills      int
+	interrupts int
+}
+
+func newFakeSpawner() *fakeSpawner {
+	return &fakeSpawner{
+		spawned: SpawnedSession{SessionID: "sess-1", WorkspacePath: "/tmp/tree"},
+		snap:    SessionSnapshot{Activity: domain.ActivityActive},
+		exists:  true,
+	}
+}
+
+func (s *fakeSpawner) Spawn(_ context.Context, req SpawnRequest) (SpawnedSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.req = req
+	s.spawns++
+	if s.spawnErr != nil {
+		return SpawnedSession{}, s.spawnErr
+	}
+	return s.spawned, nil
+}
+
+func (s *fakeSpawner) Get(_ context.Context, _ string) (SessionSnapshot, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.snap, s.exists, s.getErr
+}
+
+func (s *fakeSpawner) Interrupt(_ context.Context, _ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.interrupts++
+	return nil
+}
+
+func (s *fakeSpawner) Kill(_ context.Context, _ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.kills++
+	return nil
+}
+
+// activity sets what the next Get reports.
+func (s *fakeSpawner) activity(state domain.ActivityState, exists bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.snap = SessionSnapshot{Activity: state}
+	s.exists = exists
+}
+
+func (s *fakeSpawner) request() SpawnRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.req
+}
+
+func (s *fakeSpawner) counts() (kills, interrupts int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.kills, s.interrupts
+}
+
+// fakeSignals is the registry Task 11 implements on the Manager.
+type fakeSignals struct {
+	mu  sync.Mutex
+	sig pipeline.StageSignal
+	ok  bool
+}
+
+func (r *fakeSignals) LatestSignal(_ pipeline.RunID, _ string) (pipeline.StageSignal, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.sig, r.ok
+}
+
+func (r *fakeSignals) set(kind pipeline.SignalKind, reason string, at time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sig = pipeline.StageSignal{RunID: "run-1", StageID: "review", Kind: kind, Reason: reason, CreatedAt: at}
+	r.ok = true
+}
+
+// fakeMessenger stands in for the driver's nudge seam. The executor never
+// nudges (the engine executes NudgeStage effects), so nothing here is wired
+// into the executor; this only pins the interface shape Task 15 adapts.
+type fakeMessenger struct{ sent []string }
+
+func (m *fakeMessenger) Alive(context.Context, string) (bool, error) { return true, nil }
+
+func (m *fakeMessenger) Send(_ context.Context, _, message string) error {
+	m.sent = append(m.sent, message)
+	return nil
+}
+
+var _ SessionMessenger = (*fakeMessenger)(nil)
+
+// agentInput builds an agent stage rooted in a real run folder, with an
+// upstream pointer line already in Context.md.
+func agentInput(t *testing.T) StartInput {
+	t.Helper()
+	folder, err := pipeline.CreateRunFolder(t.TempDir(), "proj-1", "run-1", []byte("stages: []\n"))
+	if err != nil {
+		t.Fatalf("CreateRunFolder: %v", err)
+	}
+	if err := folder.AppendContext("stage `build` finished, its output is at agent-outputs/build.md"); err != nil {
+		t.Fatalf("AppendContext: %v", err)
+	}
+	stage := pipeline.Stage{
+		ID:       "review",
+		Executor: pipeline.ExecutorAgent,
+		Agent:    "claude-code",
+		Produces: "review.md",
+		Prompt:   "Review the diff.",
+	}
+	return StartInput{
+		ProjectID:     "proj-1",
+		RunID:         "run-1",
+		RunDir:        folder.Dir,
+		Stage:         stage,
+		Attempt:       1,
+		Subject:       pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: "proj-1"},
+		WorkspacePath: "/tmp/tree",
+		Env: map[string]string{
+			"AO_RUN_ID": "run-1",
+			"AO_STAGE":  "review",
+			"AO_OUTPUT": folder.OutputPath(&stage),
+		},
+		LogPath: folder.LogPath("review"),
+	}
+}
+
+// startAgent spawns the stage and returns the executor, its fakes and handle.
+func startAgent(t *testing.T, in StartInput) (*AgentExecutor, *fakeSpawner, *fakeSignals, Handle) {
+	t.Helper()
+	spawner, signals := newFakeSpawner(), &fakeSignals{}
+	exec := NewAgentExecutor(spawner, signals)
+	h, err := exec.Start(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	return exec, spawner, signals, h
+}
+
+func TestAgentStartSpawnsWithEnvAndPreamble(t *testing.T) {
+	in := agentInput(t)
+	_, spawner, _, h := startAgent(t, in)
+
+	req := spawner.request()
+	if req.ProjectID != "proj-1" {
+		t.Errorf("project = %q, want proj-1", req.ProjectID)
+	}
+	if req.Harness != "claude-code" {
+		t.Errorf("harness = %q, want claude-code", req.Harness)
+	}
+	if req.WorkspacePath != in.WorkspacePath {
+		t.Errorf("workspace = %q, want %q", req.WorkspacePath, in.WorkspacePath)
+	}
+	if got := req.Env["AO_STAGE"]; got != "review" {
+		t.Errorf("AO_STAGE = %q, want review", got)
+	}
+	if got := req.Env["AO_RUN_ID"]; got != "run-1" {
+		t.Errorf("AO_RUN_ID = %q, want run-1", got)
+	}
+	if h.StageID() != "review" || h.RunID() != "run-1" || h.Attempt() != 1 {
+		t.Errorf("handle identity = %s/%s/%d, want run-1/review/1", h.RunID(), h.StageID(), h.Attempt())
+	}
+	if holder, ok := h.(SessionHolder); !ok || holder.SessionID() != "sess-1" {
+		t.Errorf("handle does not carry session id sess-1: %#v", h)
+	}
+
+	prompt := req.Prompt
+	for _, want := range []string{
+		"review",
+		// Context.md is pasted verbatim, not referenced by path alone.
+		"stage `build` finished, its output is at agent-outputs/build.md",
+		"$AO_CONTEXT",
+		"$AO_OUTPUT",
+		"ao pipeline done",
+		`ao pipeline fail --reason "..."`,
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	if !strings.HasSuffix(prompt, in.Stage.Prompt) {
+		t.Errorf("prompt does not end with the stage prompt:\n%s", prompt)
+	}
+	// v1's findings machinery is deleted and must not come back.
+	if strings.Contains(prompt, "findings") {
+		t.Errorf("prompt still mentions findings:\n%s", prompt)
+	}
+}
+
+func TestAgentStartWithoutProducesOmitsOutputPath(t *testing.T) {
+	in := agentInput(t)
+	in.Stage.Produces = ""
+	_, spawner, _, _ := startAgent(t, in)
+
+	if strings.Contains(spawner.request().Prompt, "$AO_OUTPUT") {
+		t.Errorf("prompt promises an artifact the stage does not declare:\n%s", spawner.request().Prompt)
+	}
+}
+
+func TestAgentStartRejectsNonAgentStage(t *testing.T) {
+	in := agentInput(t)
+	in.Stage.Executor = pipeline.ExecutorCommand
+	exec := NewAgentExecutor(newFakeSpawner(), &fakeSignals{})
+
+	if _, err := exec.Start(context.Background(), in); err == nil {
+		t.Fatal("Start accepted a command stage")
+	}
+}
+
+func TestAgentStartRejectsCredentials(t *testing.T) {
+	in := agentInput(t)
+	in.Credentials = map[string]string{"GH_TOKEN": "secret"}
+	spawner := newFakeSpawner()
+	exec := NewAgentExecutor(spawner, &fakeSignals{})
+
+	if _, err := exec.Start(context.Background(), in); err == nil {
+		t.Fatal("Start injected credentials into an agent session")
+	}
+	if spawner.spawns != 0 {
+		t.Errorf("spawns = %d, want 0", spawner.spawns)
+	}
+}
+
+func TestAgentPollRunningWhileActiveAndUnsignalled(t *testing.T) {
+	exec, _, _, h := startAgent(t, agentInput(t))
+
+	got, err := exec.Poll(context.Background(), h)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if got.State != PollRunning {
+		t.Errorf("state = %q, want %q", got.State, PollRunning)
+	}
+}
+
+func TestAgentPollSignaledDoneBeatsIdle(t *testing.T) {
+	exec, spawner, signals, h := startAgent(t, agentInput(t))
+	// An agent that signalled and then went idle has settled: the signal wins.
+	spawner.activity(domain.ActivityIdle, true)
+	signals.set(pipeline.SignalDone, "", time.Now())
+
+	got, err := exec.Poll(context.Background(), h)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if got.State != PollSignaledDone {
+		t.Errorf("state = %q, want %q", got.State, PollSignaledDone)
+	}
+}
+
+func TestAgentPollSignaledFailBeatsGoneAndCarriesReason(t *testing.T) {
+	exec, spawner, signals, h := startAgent(t, agentInput(t))
+	spawner.activity(domain.ActivityExited, false)
+	signals.set(pipeline.SignalFail, "the migration cannot be written", time.Now())
+
+	got, err := exec.Poll(context.Background(), h)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if got.State != PollSignaledFail {
+		t.Errorf("state = %q, want %q", got.State, PollSignaledFail)
+	}
+	if got.Reason != "the migration cannot be written" {
+		t.Errorf("reason = %q, want the fail signal's reason", got.Reason)
+	}
+}
+
+func TestAgentPollSignalReportedOnce(t *testing.T) {
+	exec, spawner, signals, h := startAgent(t, agentInput(t))
+	spawner.activity(domain.ActivityIdle, true)
+	signals.set(pipeline.SignalDone, "", time.Now())
+
+	if got, _ := exec.Poll(context.Background(), h); got.State != PollSignaledDone {
+		t.Fatalf("first poll = %q, want %q", got.State, PollSignaledDone)
+	}
+	// The nudge leaves the same session running against the same signal row.
+	// Reporting it twice would settle the stage before the agent could answer.
+	got, err := exec.Poll(context.Background(), h)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if got.State != PollIdle {
+		t.Errorf("second poll = %q, want %q", got.State, PollIdle)
+	}
+
+	// A fresh signal after the nudge is reported.
+	signals.set(pipeline.SignalDone, "", time.Now().Add(time.Minute))
+	if got, _ := exec.Poll(context.Background(), h); got.State != PollSignaledDone {
+		t.Errorf("poll after re-signal = %q, want %q", got.State, PollSignaledDone)
+	}
+}
+
+func TestAgentPollIdleAndGone(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		activity domain.ActivityState
+		exists   bool
+		want     PollState
+	}{
+		{"idle", domain.ActivityIdle, true, PollIdle},
+		{"waiting for input", domain.ActivityWaitingInput, true, PollIdle},
+		{"blocked", domain.ActivityBlocked, true, PollIdle},
+		{"exited", domain.ActivityExited, true, PollGone},
+		{"session vanished", domain.ActivityActive, false, PollGone},
+		// An activity state the executor does not know about is not evidence
+		// the agent stopped working; the deadline still bounds the stage.
+		{"unreported activity", domain.ActivityState(""), true, PollRunning},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			exec, spawner, _, h := startAgent(t, agentInput(t))
+			spawner.activity(tc.activity, tc.exists)
+
+			got, err := exec.Poll(context.Background(), h)
+			if err != nil {
+				t.Fatalf("Poll: %v", err)
+			}
+			if got.State != tc.want {
+				t.Errorf("state = %q, want %q", got.State, tc.want)
+			}
+		})
+	}
+}
+
+func TestAgentPollTerminatedSessionIsGone(t *testing.T) {
+	exec, spawner, _, h := startAgent(t, agentInput(t))
+	spawner.mu.Lock()
+	spawner.snap = SessionSnapshot{Activity: domain.ActivityIdle, Terminated: true}
+	spawner.mu.Unlock()
+
+	got, err := exec.Poll(context.Background(), h)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if got.State != PollGone {
+		t.Errorf("state = %q, want %q", got.State, PollGone)
+	}
+}
+
+func TestAgentPollPropagatesLookupError(t *testing.T) {
+	exec, spawner, _, h := startAgent(t, agentInput(t))
+	spawner.mu.Lock()
+	spawner.getErr = errors.New("boom")
+	spawner.mu.Unlock()
+
+	if _, err := exec.Poll(context.Background(), h); err == nil {
+		t.Fatal("Poll swallowed the lookup error")
+	}
+}
+
+func TestAgentInterruptKeepsTheSession(t *testing.T) {
+	exec, spawner, _, h := startAgent(t, agentInput(t))
+
+	if err := exec.Interrupt(context.Background(), h); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+	kills, interrupts := spawner.counts()
+	if interrupts != 1 {
+		t.Errorf("interrupts = %d, want 1", interrupts)
+	}
+	// timed_out keeps the session record: a human wants the scrollback.
+	if kills != 0 {
+		t.Errorf("kills = %d, want 0: Interrupt must not kill the session", kills)
+	}
+}
+
+func TestAgentCancelKillsTheSession(t *testing.T) {
+	exec, spawner, _, h := startAgent(t, agentInput(t))
+
+	if err := exec.Cancel(context.Background(), h); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	kills, interrupts := spawner.counts()
+	if kills != 1 {
+		t.Errorf("kills = %d, want 1", kills)
+	}
+	if interrupts != 0 {
+		t.Errorf("interrupts = %d, want 0", interrupts)
+	}
+	// Cancel is idempotent: the reducer can cancel an already settled stage.
+	if err := exec.Cancel(context.Background(), h); err != nil {
+		t.Fatalf("second Cancel: %v", err)
+	}
+}

--- a/backend/internal/pipeline/executors/executor.go
+++ b/backend/internal/pipeline/executors/executor.go
@@ -145,6 +145,16 @@ func (h setHandle) OutputTail() (string, bool) {
 	return "", false
 }
 
+// SessionID forwards to the wrapped handle when the stage runs in a session, so
+// the driver can name it in StageLaunched and in the kill-on decision without
+// unwrapping the routing layer. A command stage has no session and returns "".
+func (h setHandle) SessionID() string {
+	if holder, ok := h.inner.(SessionHolder); ok {
+		return holder.SessionID()
+	}
+	return ""
+}
+
 func (s *Set) executorFor(kind pipeline.ExecutorKind) (StageExecutor, error) {
 	switch kind {
 	case pipeline.ExecutorAgent:

--- a/backend/internal/pipeline/executors/prompt.go
+++ b/backend/internal/pipeline/executors/prompt.go
@@ -1,0 +1,55 @@
+package executors
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// buildAgentPrompt puts the v2 preamble in front of the stage's own prompt.
+//
+// The preamble is pointer-style on purpose (spec section 12.1): it names the
+// stage, pastes the current Context.md verbatim, names $AO_OUTPUT when the
+// stage declares an artifact, and states the settlement contract. Upstream
+// output files are never pasted, so prompt size stays bounded no matter how
+// much the run has produced.
+func buildAgentPrompt(in StartInput) string {
+	folder := pipeline.RunFolder{Dir: in.RunDir}
+	attempt := in.Attempt
+	if attempt < 1 {
+		attempt = 1
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "You are running stage `%s` of pipeline run %s (attempt %d of 2 at most).\n\n", in.Stage.ID, in.RunID, attempt)
+
+	contextPath := folder.ContextPath()
+	if text := strings.TrimRight(readContextFile(contextPath), "\n"); text != "" {
+		fmt.Fprintf(&b, "$AO_CONTEXT (%s) indexes what earlier stages produced. It currently reads:\n\n%s\n\nRead those files off disk if you need the detail.\n\n", contextPath, text)
+	} else {
+		fmt.Fprintf(&b, "$AO_CONTEXT (%s) indexes what earlier stages produced. It is empty: nothing ran before you.\n\n", contextPath)
+	}
+
+	if out := folder.OutputPath(&in.Stage); out != "" {
+		fmt.Fprintf(&b, "Write your output to $AO_OUTPUT (%s). The stage only succeeds if that file exists and is not empty.\n\n", out)
+	}
+
+	b.WriteString("When you are finished run `ao pipeline done`. " +
+		"If the task cannot be completed run `ao pipeline fail --reason \"...\"` instead of stopping. " +
+		"Nothing else settles this stage.\n\n---\n\n")
+	b.WriteString(in.Stage.Prompt)
+	return b.String()
+}
+
+// readContextFile returns Context.md's current text, or "" when the run has not
+// written one yet. A read failure is not worth failing a stage over: the file
+// is an index, and the prompt says so either way.
+func readContextFile(path string) string {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}


### PR DESCRIPTION
Pipelines v2, Task 10. The v2 agent executor over Task 8's `StageExecutor` contract (signatures unchanged).

## What lands

- `executors/agent.go`: `AgentExecutor` plus the session seams it needs.
  - `Start` spawns a worker session through `SessionSpawner` with the stage's ambient env (`SpawnRequest.Env`, Task 9's `ports.SpawnConfig.Env`) and `preamble + stage.Prompt`. It rejects a non-agent stage, and rejects any resolved credential: the schema forbids `credentials:` on agent stages (spec 8) and this is the runtime half of that rule.
  - `Poll` consults the signal registry through a new `SignalReader` (`LatestSignal(runID, stageID) (pipeline.StageSignal, bool)`, implemented by the Manager in Task 11) and then session activity. Signal always beats activity: an agent that signalled and then went idle has settled. Maps to `signaled_done | signaled_fail | idle | gone | running`. `waiting_input` and `blocked` read as idle (alive, not working); an unrecognized or unreported activity state reads as running, because it is not evidence the agent stopped and the deadline still bounds the stage.
  - A signal is reported at most once per handle (latched on `CreatedAt`). A nudged stage keeps the same session and the same registry row, so re-reporting the stale signal would settle the stage before the agent could answer the nudge.
  - `Interrupt` interrupts the harness and leaves the session record alive (the `timed_out` path, spec 7.2). `Cancel` kills it.
  - Nudging stays with the driver: `SessionMessenger` is defined here with the other session seams, but the executor never sends.
- `executors/prompt.go`: the v2 preamble. Short and pointer-style: stage id and attempt, `Context.md` pasted verbatim as `$AO_CONTEXT` (spec 12.1), `$AO_OUTPUT` only when `produces:` is declared, and the settlement contract (`ao pipeline done` / `ao pipeline fail --reason \"...\"`). No findings machinery, and a test asserts the word never reappears in a prompt.
- `executors/executor.go`: one additive method. `setHandle` forwards a new `SessionHolder` accessor the same way it already forwards `OutputTailer`, so the driver can read the session id through the routing layer for `StageLaunched` and the kill-on decision. No existing signature changed.

## Tests

`agent_test.go` with fake spawner, messenger and signal reader: spawn carries env, harness, workspace and the preamble; running while active and unsignalled; `signaled_done` beats idle; `signaled_fail` beats gone and carries the reason; a signal is reported once and a fresh one after a nudge is reported again; idle / waiting_input / blocked / exited / vanished / terminated mappings; lookup errors propagate; Interrupt does not kill the session record and Cancel does.

## Verification

- `go build ./...`, `go test ./internal/pipeline/...` green (254 tests), `gofmt -l .` empty.
- `~/go/bin/golangci-lint run ./internal/pipeline/...`: 0 issues.
- Full `go test ./...`: 2750 pass, 4 fail in `internal/cli` (`TestSpawn*`). Those fail identically on a clean `origin/pipelines` snapshot on this machine (they reach a local daemon and get HTTP 404), so they are pre-existing and unrelated: `internal/cli` does not depend on `pipeline/executors`.

Closes #314