### PR TITLE
feat(pipelines-ui): v2 settings modal and starter templates

### DIFF
--- a/backend/internal/pipeline/templates_test.go
+++ b/backend/internal/pipeline/templates_test.go
@@ -1,0 +1,77 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The renderer's three "New pipeline" starter templates, checked against the
+// real parser and the real validator.
+//
+// The templates themselves live in TypeScript
+// (frontend/src/renderer/lib/pipeline-templates.ts), because they are static
+// config baked into the renderer with no template API behind them. The YAML in
+// testdata/templates is the serializer's output for each one, and
+// pipeline-templates.test.ts asserts serializeToYaml(template.draft()) is
+// byte-identical to these files. So a template edited on the TS side that stops
+// satisfying a Go rule fails here, and a template edited without regenerating
+// the fixture fails there. Neither side can drift quietly.
+//
+// A template that fails validation the moment a user clicks it is the worst
+// possible first impression, and mirrored TS rules are a copy of the rules, not
+// the rules.
+func TestStarterTemplatesValidate(t *testing.T) {
+	// Warnings are asserted, not just errors: the point is to know exactly what
+	// the editor's problems panel shows on a freshly created template. Only the
+	// single-stage triage template warns, and spec section 13 says that case
+	// legitimately needs no failure route.
+	cases := []struct {
+		file         string
+		stages       int
+		wantWarnings []Issue
+	}{
+		{file: "pr-review.yaml", stages: 3},
+		{
+			file:   "session-idle-triage.yaml",
+			stages: 1,
+			wantWarnings: []Issue{{
+				Path:    "defaults.on_failure",
+				Message: `stage "triage" declares no on_failure and the pipeline declares no defaults.on_failure, so its failure ends the branch silently`,
+			}},
+		},
+		{file: "release-gate.yaml", stages: 6},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.file, func(t *testing.T) {
+			src, err := os.ReadFile(filepath.Join("testdata", "templates", tc.file))
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+
+			// ParseDefinition is the exact path POST /pipelines/validate takes:
+			// strict decode (so an unknown key is an error too) then Validate.
+			p, err := ParseDefinition(src)
+			if err != nil {
+				t.Fatalf("template does not validate:\n%v", err)
+			}
+			if len(p.Stages) != tc.stages {
+				t.Errorf("stage count = %d, want %d", len(p.Stages), tc.stages)
+			}
+
+			warnings, err := Validate(p)
+			if err != nil {
+				t.Fatalf("Validate after ParseDefinition: %v", err)
+			}
+			if len(warnings) != len(tc.wantWarnings) {
+				t.Fatalf("warnings = %+v, want %+v", warnings, tc.wantWarnings)
+			}
+			for i, want := range tc.wantWarnings {
+				if warnings[i] != want {
+					t.Errorf("warning[%d] = %+v, want %+v", i, warnings[i], want)
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/pipeline/testdata/templates/pr-review.yaml
+++ b/backend/internal/pipeline/testdata/templates/pr-review.yaml
@@ -1,0 +1,35 @@
+name: pr-review
+'on':
+  pr:
+    - created
+    - updated
+concurrency:
+  scope: pr
+  cancel-in-progress: true
+defaults:
+  on_failure: notify-failure
+stages:
+  - id: review
+    executor: agent
+    agent: claude-code
+    produces: review.md
+    deadline: 20m
+    session:
+      kill-on:
+        - succeeded
+        - failed
+    prompt: |-
+      Review the diff for correctness, security, and convention drift.
+      Write the review to $AO_OUTPUT, then `ao pipeline done`.
+      If the change cannot be reviewed, `ao pipeline fail --reason "..."`.
+    on_success: post-review
+  - id: post-review
+    executor: command
+    workspace: run
+    credentials:
+      - github-review
+    run: gh pr comment "$AO_PR_NUMBER" --body-file "$AO_RUN_DIR/agent-outputs/review.md"
+  - id: notify-failure
+    executor: command
+    workspace: run
+    run: echo "pr-review failed at $AO_FAILED_STAGE ($AO_FAILED_OUTCOME)"

--- a/backend/internal/pipeline/testdata/templates/release-gate.yaml
+++ b/backend/internal/pipeline/testdata/templates/release-gate.yaml
@@ -1,0 +1,64 @@
+name: release-gate
+'on':
+  pr:
+    - merged
+concurrency:
+  scope: project
+  group: release
+  cancel-in-progress: false
+defaults:
+  deadline: 45m
+  on_failure: notify-failure
+stages:
+  - id: prepare
+    executor: command
+    workspace: run
+    run: |-
+      mkdir -p "$AO_RUN_DIR/artifacts"
+      ao release resolve-version > "$AO_RUN_DIR/version"
+    on_success:
+      - build
+      - release-notes
+  - id: build
+    executor: command
+    workspace: stage
+    deadline: 60m
+    run: |-
+      npm ci
+      npm run build -- --version "$(cat "$AO_RUN_DIR/version")"
+      cp -R dist/. "$AO_RUN_DIR/artifacts/"
+    on_success: verify
+  - id: release-notes
+    executor: agent
+    agent: claude-code
+    workspace: stage
+    produces: release-notes.md
+    deadline: 15m
+    session:
+      kill-on:
+        - succeeded
+        - failed
+    prompt: |-
+      Write release notes for version $(cat "$AO_RUN_DIR/version").
+      Group by user-visible change, not by commit.
+      Write them to $AO_OUTPUT, then `ao pipeline done`.
+      If there are no user-visible changes, `ao pipeline fail --reason "..."`.
+    on_success: publish
+  - id: verify
+    executor: command
+    workspace: run
+    run: ao release verify-artifacts "$AO_RUN_DIR/artifacts"
+    on_success: publish
+  - id: publish
+    executor: command
+    needs:
+      - release-notes
+      - verify
+    workspace: run
+    credentials:
+      - github-release
+    run: gh release create "v$(cat "$AO_RUN_DIR/version")" "$AO_RUN_DIR/artifacts/"* --notes-file "$AO_RUN_DIR/agent-outputs/release-notes.md"
+  - id: notify-failure
+    executor: command
+    workspace: run
+    run: echo "release failed at $AO_FAILED_STAGE ($AO_FAILED_OUTCOME)"

--- a/backend/internal/pipeline/testdata/templates/session-idle-triage.yaml
+++ b/backend/internal/pipeline/testdata/templates/session-idle-triage.yaml
@@ -1,0 +1,19 @@
+name: session-idle-triage
+'on':
+  session:
+    - idle
+concurrency:
+  cancel-in-progress: true
+stages:
+  - id: triage
+    executor: agent
+    agent: claude-code
+    workspace: session
+    produces: triage.md
+    deadline: 10m
+    session:
+      kill-on: []
+    prompt: |-
+      The session has gone idle. Summarize where the work stands,
+      what is blocked, and the single next action.
+      Write it to $AO_OUTPUT, then `ao pipeline done`.

--- a/frontend/src/renderer/components/PipelineSettingsModal.test.tsx
+++ b/frontend/src/renderer/components/PipelineSettingsModal.test.tsx
@@ -111,6 +111,76 @@ describe("PipelineSettingsModal", () => {
 		expect(committed).toEqual(baseDraft());
 	});
 
+	// The §10 guidance copy: the modal has to state what "Subject default"
+	// resolves to and steer cancel-in-progress, because both are decisions a
+	// user gets exactly one shot at before a run misbehaves.
+	describe("concurrency guidance (spec §10)", () => {
+		it("names what the subject default resolves to, per trigger kind", async () => {
+			const user = userEvent.setup();
+			render(<Harness initial={{ ...baseDraft(), on: { pr: ["created"] } }} />);
+			expect(screen.getByText(/serializes per PR number/)).toBeInTheDocument();
+
+			await user.click(screen.getByRole("button", { name: "idle" }));
+			expect(screen.getByText(/a session event per session/)).toBeInTheDocument();
+
+			await user.click(screen.getByRole("button", { name: "created" }));
+			expect(screen.getByText(/serializes per session/)).toBeInTheDocument();
+		});
+
+		it("falls back to per-project for a manual-only pipeline", () => {
+			render(<Harness initial={baseDraft()} />);
+			expect(screen.getByText(/hand-started run serializes per project/)).toBeInTheDocument();
+		});
+
+		it("describes an explicitly chosen scope instead of the default", async () => {
+			render(<Harness initial={baseDraft()} />);
+			await chooseOption(screen.getByRole("combobox", { name: "Concurrency scope" }), "project");
+			expect(screen.getByText(/One bucket for the whole project/)).toBeInTheDocument();
+			expect(screen.queryByText(/Subject default/)).not.toBeInTheDocument();
+		});
+
+		it("warns that pr.merged would serialize per PR, not per project", async () => {
+			render(<Harness initial={{ ...baseDraft(), on: { pr: ["merged"] } }} />);
+			expect(screen.getByText(/two merges publish at the same time/)).toBeInTheDocument();
+
+			await chooseOption(screen.getByRole("combobox", { name: "Concurrency scope" }), "project");
+			expect(screen.queryByText(/two merges publish at the same time/)).not.toBeInTheDocument();
+		});
+
+		it("pushes cancel-in-progress on for a pr.updated review pipeline", async () => {
+			const user = userEvent.setup();
+			render(<Harness initial={{ ...baseDraft(), on: { pr: ["created", "updated"] } }} />);
+
+			expect(screen.getByText(/reviewing a commit nobody is looking at/)).toBeInTheDocument();
+			await user.click(screen.getByRole("switch", { name: "Cancel in progress" }));
+			expect(screen.queryByText(/reviewing a commit nobody is looking at/)).not.toBeInTheDocument();
+			expect(screen.getByText(/Recommended for pr.updated/)).toBeInTheDocument();
+		});
+
+		it("pushes cancel-in-progress off for a release-shaped pipeline", async () => {
+			const user = userEvent.setup();
+			render(
+				<Harness
+					initial={{
+						...baseDraft(),
+						on: { pr: ["merged"] },
+						concurrency: { scope: "project", cancelInProgress: true },
+					}}
+				/>,
+			);
+
+			expect(screen.getByText(/partial release with no rollback/)).toBeInTheDocument();
+			await user.click(screen.getByRole("switch", { name: "Cancel in progress" }));
+			expect(screen.queryByText(/partial release with no rollback/)).not.toBeInTheDocument();
+			expect(screen.getByText(/an in-flight release finishes/)).toBeInTheDocument();
+		});
+
+		it("explains the queue behaviour whatever the setting", () => {
+			render(<Harness initial={baseDraft()} />);
+			expect(screen.getByText(/queue depth is 1/)).toBeInTheDocument();
+		});
+	});
+
 	it("discards edits on Cancel and reseeds on reopen", async () => {
 		const user = userEvent.setup();
 		render(<Harness initial={baseDraft()} />);

--- a/frontend/src/renderer/components/PipelineSettingsModal.tsx
+++ b/frontend/src/renderer/components/PipelineSettingsModal.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
+import { AlertTriangle } from "lucide-react";
 import {
 	ALL_CONCURRENCY_SCOPES,
 	ALL_PR_EVENTS,
 	ALL_SESSION_EVENTS,
 	type ConcurrencyScope,
+	DEFAULT_STAGE_DEADLINE,
 	type PipelineDraft,
 	type PREvent,
 	type SessionEvent,
@@ -21,16 +23,41 @@ import { Switch } from "./ui/switch";
 // commit through usePipelineDraft's setDraft; Cancel (or dismissing) discards
 // them.
 //
-// ponytail: this is the v2 stub, not the v2 settings modal. It edits every v2
-// key but carries none of the §10 guidance copy (cancel-in-progress for
-// pr.updated vs release pipelines, the subject-default scope hint). Task 22
-// owns the real rewrite.
+// The concurrency block carries the spec §10 guidance inline, because both of
+// its decisions are ones a user gets exactly one shot at: an unset scope
+// resolves from the subject (invisible unless the modal says so), and
+// cancel-in-progress is right for a `pr.updated` review pipeline and actively
+// destructive on a release. So the copy is derived from the draft rather than
+// static: it names what the default resolves to given the declared triggers,
+// and it warns when the current setting contradicts the pipeline's shape.
 
 export interface PipelineSettingsModalProps {
 	open: boolean;
 	value: PipelineDraft;
 	onCancel: () => void;
 	onDone: (value: PipelineDraft) => void;
+}
+
+// scopeHint states the effective bucket. With no explicit scope the engine
+// resolves it per run from the subject (Subject.DefaultScope: pr -> pr,
+// session -> session, anything else -> project), so the hint enumerates what
+// the declared triggers can produce instead of naming one scope.
+function scopeHint(scope: ConcurrencyScope | undefined, hasPR: boolean, hasSession: boolean): string {
+	switch (scope) {
+		case "pr":
+			return "One bucket per PR number, so two different PRs never collide.";
+		case "session":
+			return "One bucket per session.";
+		case "project":
+			return "One bucket for the whole project. Every run in this group serializes, whichever PR or session triggered it.";
+		default:
+			if (hasPR && hasSession) {
+				return "Subject default: a pr event serializes per PR number, a session event per session.";
+			}
+			if (hasPR) return "Subject default: a pr event serializes per PR number, so two different PRs never collide.";
+			if (hasSession) return "Subject default: a session event serializes per session.";
+			return "Subject default: a hand-started run serializes per project.";
+	}
 }
 
 export function PipelineSettingsModal({ open, value, onCancel, onDone }: PipelineSettingsModalProps) {
@@ -67,6 +94,25 @@ export function PipelineSettingsModal({ open, value, onCancel, onDone }: Pipelin
 		patchBlock("on", { session: on.includes(event) ? on.filter((e) => e !== event) : [...on, event] });
 	};
 
+	const prEvents = draft.on?.pr ?? [];
+	const sessionEvents = draft.on?.session ?? [];
+	const scope = draft.concurrency?.scope;
+	const cancelInProgress = draft.concurrency?.cancelInProgress ?? false;
+
+	// The §11 forcing function: `pr.merged` defaults to per-PR scope, which lets
+	// two merges release concurrently. Only worth saying when the effective scope
+	// really is `pr`.
+	const mergedUnderPRScope =
+		prEvents.includes("merged") && (scope === "pr" || (scope === undefined && prEvents.length > 0));
+
+	// Release shaped means "an in-flight run must be allowed to finish": either
+	// the author already said `scope: project` (the thing being protected is
+	// project-wide), or the trigger is a merge and nothing that re-fires on a
+	// push. A pipeline declaring both `merged` and `updated` is review shaped,
+	// because the push case is the one that recurs.
+	const releaseShaped = scope === "project" || (prEvents.includes("merged") && !prEvents.includes("updated"));
+	const reviewShaped = !releaseShaped && prEvents.includes("updated");
+
 	return (
 		<Dialog open={open} onOpenChange={(next) => !next && onCancel()}>
 			<DialogContent showCloseButton={false} aria-describedby={undefined} className="max-w-3xl">
@@ -87,7 +133,7 @@ export function PipelineSettingsModal({ open, value, onCancel, onDone }: Pipelin
 					</div>
 				</DialogHeader>
 
-				<div className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto">
+				<div className="flex max-h-[70vh] flex-col gap-5 overflow-y-auto">
 					<label className="flex flex-col gap-1.5">
 						<FieldLabel>Name</FieldLabel>
 						<Input
@@ -97,110 +143,158 @@ export function PipelineSettingsModal({ open, value, onCancel, onDone }: Pipelin
 						/>
 					</label>
 
-					<div className="flex flex-col gap-2">
-						<FieldLabel>Triggers</FieldLabel>
+					<Section label="Triggers">
+						<p className="mb-2 text-caption text-passive">
+							A trigger names the subject a run works on, which decides its workspace and its default concurrency scope.
+						</p>
 						<div className="flex flex-col gap-2">
 							<EventRow
 								caption="on.pr"
 								events={ALL_PR_EVENTS}
-								active={draft.on?.pr ?? []}
+								active={prEvents}
 								onToggle={(e) => togglePREvent(e as PREvent)}
 							/>
 							<EventRow
 								caption="on.session"
 								events={ALL_SESSION_EVENTS}
-								active={draft.on?.session ?? []}
+								active={sessionEvents}
 								onToggle={(e) => toggleSessionEvent(e as SessionEvent)}
 							/>
 						</div>
-						{!draft.on?.pr?.length && !draft.on?.session?.length && (
-							<span className="text-caption text-passive">
-								No triggers: the pipeline runs only when started by hand.
-							</span>
+						{prEvents.length === 0 && sessionEvents.length === 0 && (
+							<Hint>No triggers: the pipeline runs only when started by hand.</Hint>
 						)}
-					</div>
+					</Section>
 
-					<div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-						<div className="flex flex-col gap-1.5">
-							<FieldLabel>Concurrency scope</FieldLabel>
-							<Select
-								value={draft.concurrency?.scope ?? "__subject"}
-								onValueChange={(scope) =>
-									patchBlock("concurrency", {
-										scope: scope === "__subject" ? undefined : (scope as ConcurrencyScope),
-									})
-								}
-							>
-								<SelectTrigger size="sm" aria-label="Concurrency scope" className="w-full">
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value="__subject">Subject default</SelectItem>
-									{ALL_CONCURRENCY_SCOPES.map((scope) => (
-										<SelectItem key={scope} value={scope}>
-											{scope}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
+					<Section label="Concurrency">
+						<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+							<div className="flex flex-col gap-1.5">
+								<SubLabel>Scope</SubLabel>
+								<Select
+									value={scope ?? "__subject"}
+									onValueChange={(next) =>
+										patchBlock("concurrency", {
+											scope: next === "__subject" ? undefined : (next as ConcurrencyScope),
+										})
+									}
+								>
+									<SelectTrigger size="sm" aria-label="Concurrency scope" className="w-full">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="__subject">Subject default</SelectItem>
+										{ALL_CONCURRENCY_SCOPES.map((s) => (
+											<SelectItem key={s} value={s}>
+												{s}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<Hint>{scopeHint(scope, prEvents.length > 0, sessionEvents.length > 0)}</Hint>
+							</div>
+
+							<label className="flex flex-col gap-1.5">
+								<SubLabel>Group</SubLabel>
+								<Input
+									aria-label="Concurrency group"
+									value={draft.concurrency?.group ?? ""}
+									onChange={(e) => patchBlock("concurrency", { group: e.target.value || undefined })}
+									placeholder={draft.name || "(pipeline name)"}
+								/>
+								<Hint>
+									Defaults to the pipeline name. Runs sharing a scope identity and a group serialize, so two pipelines
+									with the same group share one bucket.
+								</Hint>
+							</label>
 						</div>
 
-						<label className="flex flex-col gap-1.5">
-							<FieldLabel>Concurrency group</FieldLabel>
-							<Input
-								aria-label="Concurrency group"
-								value={draft.concurrency?.group ?? ""}
-								onChange={(e) => patchBlock("concurrency", { group: e.target.value || undefined })}
-								placeholder={draft.name || "(pipeline name)"}
-							/>
-						</label>
+						{mergedUnderPRScope && (
+							<Warning>
+								<code className="font-mono">on.pr: merged</code> under per-PR scope lets two merges publish at the same
+								time. A release pipeline wants <code className="font-mono">scope: project</code>, because what needs
+								serializing is the project, not the PR.
+							</Warning>
+						)}
 
-						<div className="flex flex-col gap-1.5">
-							<FieldLabel>Cancel in progress</FieldLabel>
-							<div className="flex h-control-form items-center gap-2 rounded-md border border-border bg-surface px-2.5">
-								<Switch
-									aria-label="Cancel in progress"
-									checked={draft.concurrency?.cancelInProgress ?? false}
-									onCheckedChange={(checked) => patchBlock("concurrency", { cancelInProgress: checked })}
+						<div className="mt-3 flex flex-col gap-1.5">
+							<div className="flex items-center justify-between gap-3">
+								<SubLabel>Cancel in progress</SubLabel>
+								<div className="flex items-center gap-2">
+									<span className="text-caption text-muted-foreground">{cancelInProgress ? "On" : "Off"}</span>
+									<Switch
+										aria-label="Cancel in progress"
+										checked={cancelInProgress}
+										onCheckedChange={(checked) => patchBlock("concurrency", { cancelInProgress: checked })}
+									/>
+								</div>
+							</div>
+							<Hint>
+								On, a new run cancels the one in flight. Off, it queues behind, and queue depth is 1, so a third arrival
+								evicts the queued run.
+							</Hint>
+							{reviewShaped &&
+								(cancelInProgress ? (
+									<Hint>Recommended for pr.updated: the new push cancels the review of the old head.</Hint>
+								) : (
+									<Warning>
+										<code className="font-mono">on.pr: updated</code> is declared and this is off, so a push leaves the
+										in-flight run reviewing a commit nobody is looking at. Review pipelines want it on.
+									</Warning>
+								))}
+							{releaseShaped &&
+								(cancelInProgress ? (
+									<Warning>
+										This pipeline is release shaped ({scope === "project" ? "scope: project" : "on.pr: merged"}).
+										Cancelling mid-publish or mid-notarization leaves a partial release with no rollback, so release
+										pipelines want this off.
+									</Warning>
+								) : (
+									<Hint>
+										Recommended for release pipelines: an in-flight release finishes even when the next one arrives.
+									</Hint>
+								))}
+						</div>
+					</Section>
+
+					<Section label="Stage defaults">
+						<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+							<label className="flex flex-col gap-1.5">
+								<SubLabel>Deadline</SubLabel>
+								<Input
+									aria-label="Default deadline"
+									value={draft.defaults?.deadline ?? ""}
+									onChange={(e) => patchBlock("defaults", { deadline: e.target.value || undefined })}
+									placeholder={DEFAULT_STAGE_DEADLINE}
 								/>
-								<span className="text-xs text-muted-foreground">
-									{draft.concurrency?.cancelInProgress ? "On" : "Off"}
-								</span>
+								<Hint>
+									Applies to every stage that names none. Empty means the engine default, {DEFAULT_STAGE_DEADLINE}.
+								</Hint>
+							</label>
+
+							<div className="flex flex-col gap-1.5">
+								<SubLabel>On failure</SubLabel>
+								<Select
+									value={draft.defaults?.onFailure ?? "__none"}
+									onValueChange={(id) => patchBlock("defaults", { onFailure: id === "__none" ? undefined : id })}
+								>
+									<SelectTrigger size="sm" aria-label="Default on failure" className="w-full">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="__none">None</SelectItem>
+										{stageIds.map((id) => (
+											<SelectItem key={id} value={id}>
+												{id}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<Hint>
+									Every stage that names no failure route lands here. Without it, a failed branch ends in silence.
+								</Hint>
 							</div>
 						</div>
-					</div>
-
-					<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-						<label className="flex flex-col gap-1.5">
-							<FieldLabel>Default deadline</FieldLabel>
-							<Input
-								aria-label="Default deadline"
-								value={draft.defaults?.deadline ?? ""}
-								onChange={(e) => patchBlock("defaults", { deadline: e.target.value || undefined })}
-								placeholder="30m"
-							/>
-						</label>
-
-						<div className="flex flex-col gap-1.5">
-							<FieldLabel>Default on failure</FieldLabel>
-							<Select
-								value={draft.defaults?.onFailure ?? "__none"}
-								onValueChange={(id) => patchBlock("defaults", { onFailure: id === "__none" ? undefined : id })}
-							>
-								<SelectTrigger size="sm" aria-label="Default on failure" className="w-full">
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value="__none">None</SelectItem>
-									{stageIds.map((id) => (
-										<SelectItem key={id} value={id}>
-											{id}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</div>
-					</div>
+					</Section>
 				</div>
 			</DialogContent>
 		</Dialog>
@@ -244,6 +338,32 @@ function EventRow({
 	);
 }
 
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+	return (
+		<section>
+			<h3 className="mb-1.5 font-mono text-micro font-medium uppercase tracking-wide text-passive">{label}</h3>
+			{children}
+		</section>
+	);
+}
+
+function SubLabel({ children }: { children: React.ReactNode }) {
+	return <span className="text-caption text-muted-foreground">{children}</span>;
+}
+
 function FieldLabel({ children }: { children: React.ReactNode }) {
 	return <span className="font-mono text-micro font-medium uppercase tracking-wide text-passive">{children}</span>;
+}
+
+function Hint({ children }: { children: React.ReactNode }) {
+	return <p className="text-caption text-passive">{children}</p>;
+}
+
+function Warning({ children }: { children: React.ReactNode }) {
+	return (
+		<p className="mt-1.5 flex items-start gap-1.5 text-caption text-warning">
+			<AlertTriangle className="mt-0.5 size-icon-xs shrink-0" aria-hidden="true" />
+			<span>{children}</span>
+		</p>
+	);
 }

--- a/frontend/src/renderer/lib/pipeline-templates.test.ts
+++ b/frontend/src/renderer/lib/pipeline-templates.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	ALL_CONCURRENCY_SCOPES,
@@ -17,6 +19,28 @@ import { PIPELINE_TEMPLATES } from "./pipeline-templates";
 // sees them until a user hits Save. This suite mirrors the edit-time rules of
 // backend/internal/pipeline (spec §13) closely enough that a template violating
 // them fails here instead of at /validate in front of a user.
+//
+// The mirror is a copy of the rules, not the rules, so it is backed by the real
+// thing: every template's serialized YAML is committed as
+// backend/internal/pipeline/testdata/templates/<id>.yaml, and
+// TestStarterTemplatesValidate over there runs the actual ParseDefinition +
+// Validate against each file. This suite pins the two sides together by
+// asserting the fixture is byte-identical to what the serializer emits today,
+// so editing a template without regenerating its fixture fails here and a
+// template that stops satisfying a Go rule fails there.
+
+// Vitest's root is frontend/ (vite.renderer.config.ts), which is also where
+// `npm test` runs from.
+const TEMPLATE_FIXTURE_DIR = resolve(process.cwd(), "../backend/internal/pipeline/testdata/templates");
+
+function fixtureYaml(id: string): string {
+	const path = resolve(TEMPLATE_FIXTURE_DIR, `${id}.yaml`);
+	try {
+		return readFileSync(path, "utf8");
+	} catch {
+		throw new Error(`missing template fixture ${path}; regenerate it from serializeToYaml(template.draft())`);
+	}
+}
 
 const KNOWN_EXECUTORS = new Set<string>(ALL_EXECUTOR_KINDS);
 const KNOWN_WORKSPACES = new Set<string>(ALL_WORKSPACE_KINDS);
@@ -119,6 +143,10 @@ describe("PIPELINE_TEMPLATES", () => {
 				expect(a).toEqual(b);
 			});
 
+			it("matches the YAML fixture the Go validator runs against", () => {
+				expect(serializeToYaml(template.draft())).toBe(fixtureYaml(template.id));
+			});
+
 			it("round-trips through the codec unchanged", () => {
 				const draft = template.draft();
 				const parsed = parseYamlToDraft(serializeToYaml(draft));
@@ -135,4 +163,59 @@ describe("PIPELINE_TEMPLATES", () => {
 			});
 		});
 	}
+
+	// The shape of each starter, pinned. These are the properties that make the
+	// template worth shipping rather than incidental details of the YAML.
+	function byId(id: string) {
+		return PIPELINE_TEMPLATES.find((t) => t.id === id)!.draft();
+	}
+
+	it("pr-review reviews with an agent and posts with a command", () => {
+		const draft = byId("pr-review");
+		expect(draft.on).toEqual({ pr: ["created", "updated"] });
+		expect(draft.concurrency).toEqual({ scope: "pr", cancelInProgress: true });
+
+		const review = draft.stages.find((s) => s.executor === "agent");
+		expect(review?.produces).toBe("review.md");
+		expect(review?.credentials).toBeUndefined();
+
+		// The §6.4 split: the agent produces the file, a command performs the
+		// unverifiable action with the credential.
+		const post = draft.stages.find((s) => s.id === "post-review");
+		expect(post?.executor).toBe("command");
+		expect(post?.run).toContain("agent-outputs/review.md");
+		expect(post?.credentials).toEqual(["github-review"]);
+		expect(review?.onSuccess).toEqual(["post-review"]);
+	});
+
+	it("session-idle-triage is one agent stage that never kills the session", () => {
+		const draft = byId("session-idle-triage");
+		expect(draft.on).toEqual({ session: ["idle"] });
+		expect(draft.stages).toHaveLength(1);
+		expect(draft.stages[0].executor).toBe("agent");
+		// An explicit empty list, not an absent block: the engine default would
+		// kill the human's own session (§7.2).
+		expect(draft.stages[0].session).toEqual({ killOn: [] });
+	});
+
+	it("release-gate fans out, joins on needs, and routes failure through defaults", () => {
+		const draft = byId("release-gate");
+		expect(draft.stages).toHaveLength(6);
+		expect(draft.concurrency).toEqual({ scope: "project", group: "release", cancelInProgress: false });
+		expect(draft.defaults?.onFailure).toBe("notify-failure");
+
+		const prepare = draft.stages.find((s) => s.id === "prepare");
+		expect(prepare?.onSuccess).toEqual(["build", "release-notes"]);
+		// Concurrent stages get a tree each; three parallel npm ci in one tree is
+		// a corrupt node_modules (§5.2).
+		expect(draft.stages.find((s) => s.id === "build")?.workspace).toBe("stage");
+		expect(draft.stages.find((s) => s.id === "release-notes")?.workspace).toBe("stage");
+
+		const publish = draft.stages.find((s) => s.id === "publish");
+		expect(publish?.needs).toEqual(["release-notes", "verify"]);
+		expect(publish?.credentials).toEqual(["github-release"]);
+
+		// Every stage relies on defaults.on_failure; none repeats the key.
+		expect(draft.stages.filter((s) => s.onFailure)).toEqual([]);
+	});
 });

--- a/frontend/src/renderer/lib/pipeline-templates.ts
+++ b/frontend/src/renderer/lib/pipeline-templates.ts
@@ -23,8 +23,9 @@ function prReview(): PipelineDraft {
 	return {
 		name: "pr-review",
 		on: { pr: ["created", "updated"] },
-		// The head moved, so an in-flight review is reading stale code (§10).
-		concurrency: { scope: "pr", group: "pr-review", cancelInProgress: true },
+		// The head moved, so an in-flight review is reading stale code (§10). The
+		// group is left implicit: it defaults to the pipeline name.
+		concurrency: { scope: "pr", cancelInProgress: true },
 		defaults: { onFailure: "notify-failure" },
 		stages: [
 			{
@@ -63,7 +64,10 @@ function sessionIdleTriage(): PipelineDraft {
 	return {
 		name: "session-idle-triage",
 		on: { session: ["idle"] },
-		concurrency: { scope: "session", group: "session-idle-triage", cancelInProgress: true },
+		// No scope: a session trigger already defaults to per-session, so the only
+		// thing worth declaring is that a fresh idle event replaces a stale triage
+		// rather than queueing behind it (§10).
+		concurrency: { cancelInProgress: true },
 		stages: [
 			{
 				id: "triage",
@@ -84,32 +88,43 @@ function sessionIdleTriage(): PipelineDraft {
 	};
 }
 
-// A trimmed version of the spec §11 release pipeline: fan-out, one join, an
-// agent on the failure path, and the pipeline-level failure default.
+// A six-stage trim of the spec §11 release pipeline, keeping the four things
+// that example exists to teach: the fan-out onto `workspace: stage`, the join
+// declaring `needs`, credentials on the command stage that performs (never on
+// the agent that produces), and one failure route reached by
+// `defaults.on_failure` instead of six copies of the same key.
+//
+// Trimmed away, all of it recoverable by hand: the three per-OS builds collapse
+// to one, signing and notarization collapse into `verify`, and §11's
+// diagnose-build agent is gone (session-idle-triage already shows
+// `kill-on: []`).
 function releaseGate(): PipelineDraft {
 	return {
 		name: "release-gate",
 		on: { pr: ["merged"] },
 		// Nothing is worse than killing a run mid-release, so no cancellation, and
-		// the scope is the project rather than the merged PR (§10).
+		// the scope is the project rather than the merged PR: pr.merged would
+		// otherwise default to per-PR scope and let two merges release at once
+		// (§10).
 		concurrency: { scope: "project", group: "release", cancelInProgress: false },
-		defaults: { deadline: "30m", onFailure: "notify-failure" },
+		defaults: { deadline: "45m", onFailure: "notify-failure" },
 		stages: [
 			{
 				id: "prepare",
 				executor: "command",
 				workspace: "run",
-				run: 'ao release resolve-version > "$AO_RUN_DIR/version"',
+				run: 'mkdir -p "$AO_RUN_DIR/artifacts"\nao release resolve-version > "$AO_RUN_DIR/version"',
 				onSuccess: ["build", "release-notes"],
 			},
 			{
 				id: "build",
 				executor: "command",
+				// A fresh tree per entry, so a second concurrent build could never
+				// share this one's node_modules (§5.2).
 				workspace: "stage",
-				deadline: "40m",
-				run: "npm ci\nnpm run build",
-				onSuccess: ["publish"],
-				onFailure: "diagnose-build",
+				deadline: "60m",
+				run: 'npm ci\nnpm run build -- --version "$(cat "$AO_RUN_DIR/version")"\ncp -R dist/. "$AO_RUN_DIR/artifacts/"',
+				onSuccess: ["verify"],
 			},
 			{
 				id: "release-notes",
@@ -123,36 +138,35 @@ function releaseGate(): PipelineDraft {
 					'Write release notes for version $(cat "$AO_RUN_DIR/version").',
 					"Group by user-visible change, not by commit.",
 					"Write them to $AO_OUTPUT, then `ao pipeline done`.",
+					'If there are no user-visible changes, `ao pipeline fail --reason "..."`.',
 				].join("\n"),
+				onSuccess: ["publish"],
+			},
+			{
+				id: "verify",
+				executor: "command",
+				// The run tree, so publish sees the artifacts this stage checked.
+				workspace: "run",
+				run: 'ao release verify-artifacts "$AO_RUN_DIR/artifacts"',
 				onSuccess: ["publish"],
 			},
 			{
 				id: "publish",
 				executor: "command",
-				needs: ["build", "release-notes"],
+				// Two inbound success edges, so `needs` is required and must name
+				// exactly them (§13).
+				needs: ["release-notes", "verify"],
 				workspace: "run",
+				// Credentials are engine-held and injected here, at the stage that
+				// performs; the agent above cannot express the key at all (§8).
 				credentials: ["github-release"],
-				run: 'gh release create "v$(cat "$AO_RUN_DIR/version")" --notes-file "$AO_RUN_DIR/agent-outputs/release-notes.md"',
-			},
-			{
-				id: "diagnose-build",
-				executor: "agent",
-				agent: "claude-code",
-				produces: "diagnosis.md",
-				deadline: "15m",
-				// Kept alive on every outcome: this is the stage a human opens.
-				session: { killOn: [] },
-				prompt: [
-					"Build stage `$AO_FAILED_STAGE` failed. Its log is at",
-					"$AO_RUN_DIR/stage-logs/$AO_FAILED_STAGE.log and you are in its",
-					"working tree with the failure state intact.",
-					"Diagnose the root cause, write to $AO_OUTPUT, then `ao pipeline done`.",
-				].join("\n"),
-				onSuccess: ["notify-failure"],
+				run: 'gh release create "v$(cat "$AO_RUN_DIR/version")" "$AO_RUN_DIR/artifacts/"* --notes-file "$AO_RUN_DIR/agent-outputs/release-notes.md"',
 			},
 			{
 				id: "notify-failure",
 				executor: "command",
+				// Reached from every stage above through defaults.on_failure, so a
+				// post-publication failure is never silent (§13.3).
 				workspace: "run",
 				run: 'echo "release failed at $AO_FAILED_STAGE ($AO_FAILED_OUTCOME)"',
 			},


### PR DESCRIPTION
Closes #316

Finishes Task 22: the two v2 stubs PR #298 left behind, `PipelineSettingsModal.tsx` and `lib/pipeline-templates.ts`. `NewPipelineModal.tsx` was verify-only and needed no change.

## Settings modal: the spec section 10 guidance copy

The stub edited every v2 key but said nothing about the two decisions a user gets one shot at. Both are now stated inline, and the copy is derived from the draft rather than static, so a wrong choice is unlikely rather than merely avoidable:

- **Scope.** "Subject default" is invisible unless the modal names what it resolves to, so it does: with `on.pr` declared it says a pr event serializes per PR number, with `on.session` per session, with both it names both, and with no trigger at all it says a hand-started run serializes per project. That mirrors `Subject.DefaultScope` in `backend/internal/pipeline/subject.go` (pr to pr, session to session, otherwise project), which is resolved per run, not per definition, hence the enumeration. An explicitly chosen scope gets its own line instead.
- **The section 11 forcing function.** `on.pr: merged` with an effective scope of `pr` warns that two merges would publish at the same time and that a release pipeline wants `scope: project`.
- **Cancel in progress.** A neutral line always states both directions plus the queue rule (depth 1, a third arrival evicts the queued run). On top of that the modal infers the pipeline's shape and warns when the setting contradicts it: review shaped (`on.pr: updated`) with it **off** warns that a push leaves the in-flight run reviewing a commit nobody is looking at; release shaped (`scope: project`, or `pr.merged` without `updated`) with it **on** warns that cancelling mid-publish leaves a partial release with no rollback. When the setting already agrees, the same line reads as a "Recommended for ..." confirmation instead of a warning.
- Group, default deadline and default on-failure gained hints too (the bucket rule, the 30m engine default, and that a stage with no failure route ends its branch in silence).

Layout moved from a flat 3-column grid to Triggers / Concurrency / Stage defaults sections, because the guidance lines do not fit under grid cells. shadcn primitives and existing tokens only (`text-warning` + `AlertTriangle`, same `Warning` treatment `StageInspector` uses); no new components.

## Templates: three v2 starters

- **pr-review** (3 stages): `on.pr: [created, updated]`, agent review producing `review.md`, command stage posting it with `credentials: [github-review]`, `concurrency: {scope: pr, cancel-in-progress: true}`. Redundant `group` dropped (it defaults to the pipeline name).
- **session-idle-triage** (1 stage): `on.session: [idle]`, one agent stage, `kill-on: []`. Scope left unset so the template exercises the subject default; the only concurrency key it declares is `cancel-in-progress: true`.
- **release-gate** (6 stages): reshaped. The stub was missing section 11's `verify`, so `verify` is in and `diagnose-build` is out (session-idle-triage already demonstrates `kill-on: []`), which lands it on the plan's six stages. The join therefore moved to `publish` with `needs: [release-notes, verify]`, matching section 11's `publish-github`, and `defaults` carries both keys (`deadline: 45m`, `on_failure: notify-failure`) with no stage repeating `on_failure`.

## Validated against the real Go validator

`/pipelines/validate` still answers 501 on this branch, so an HTTP integration test is not available yet. Instead each template's serialized YAML is committed as `backend/internal/pipeline/testdata/templates/<id>.yaml`, and `backend/internal/pipeline/templates_test.go` runs the **real** `ParseDefinition` (strict decode, so an unknown key fails too) plus `Validate` over each file, asserting no errors, the stage count, and the exact warning set. Only `session-idle-triage` warns, the single-stage no-failure-route case spec section 13 says is legitimate.

The two sides are pinned together: `pipeline-templates.test.ts` asserts each fixture is byte-identical to `serializeToYaml(template.draft())`. Edit a template without regenerating its fixture and vitest fails; break a Go rule and `go test` fails. Same anti-drift pattern #298 used for `testdata/release.yaml`. The mirrored-rules suite stays as the fast local check, and gained per-template shape assertions (the section 6.4 produce/perform split, `kill-on: []`, the join's `needs`, no repeated `on_failure`).

**Deliberate scope deviation, flagged:** this adds two test-only paths under `backend/` (a `_test.go` file and three `testdata` fixtures) against the task's "no backend changes" guard. With `/validate` at 501 there is no other way to reach the real validator, and a mirror of the rules is not the rules. No production Go code is touched. Raised with the orchestrator before pushing; drop the two paths if you would rather keep the guard absolute, and the frontend suite still stands on its own.

## Verification

- `tsc --noEmit`: clean. **Full renderer build** (`vite build --config vite.renderer.config.ts`): green, not just a typecheck.
- Full vitest suite: **1092 passed, 90 files** (13 in `PipelineSettingsModal.test.tsx`, 25 across the template + entry-modal suites). Tests were written first and watched fail: 7 red on the guidance copy, 4 red on the Go side before the fixtures existed.
- `cd backend && go test ./internal/pipeline/`: 159 passed. `gofmt -l`: clean. `golangci-lint run ./internal/pipeline/...`: 0 issues.
- Prettier clean on every changed frontend file.

## What `ao preview` actually showed

Run from inside the session against `dev:web` (the renderer's browser mode, mock workspace fixtures), all three templates loaded through New pipeline into the visual editor:

- **pr-review**: three nodes, solid accent edge `review -> post-review`, two dashed synthetic default-failure edges into `notify-failure`, `20m` explicit and `30m` inherited deadline chips, the `review.md` produces chip on the agent node.
- **session-idle-triage**: single node, and the settings modal reads "Subject default: a session event serializes per session." with the scope select left on Subject default, which is the path that copy exists for.
- **release-gate**: `prepare` fans out to `build` and `release-notes`, `build -> verify`, `verify` and `release-notes` join into `publish` with its `needs 2` chip, dashed failure edges into `notify-failure`, `60m` on build against the `45m` default. The settings modal shows "One bucket for the whole project..." and, with cancel-in-progress flipped on, the amber release warning naming `scope: project`.
- Flipping cancel-in-progress the wrong way on pr-review raises the amber `on.pr: updated` warning, and flipping it back turns the same line into the "Recommended for pr.updated" confirmation.

**Could not be verified, and why:** nothing on this branch can be saved or validated through the daemon. Every `/api/v1/pipelines/*` route is still 501 (`controllers/pipelines.go`), including `GET /pipelines/schema`, which is what `usePipelinesEnabled` probes, so the Pipelines section renders its "Pipelines are off" panel against a real daemon. Reaching the editor at all required forcing that probe true locally; that edit is **not committed** (`git status` clean on the pushed branch). So: no live `/validate` response, no save round-trip, no run. The Go test over the committed fixtures is the substitute for the first of those, and Task 26 owns the end-to-end drill.

## Note for whoever wires the save path

`ValidateCredentials` landed on `pipelines` while this was in flight and has no production caller yet. When the save path calls it, `pr-review` and `release-gate` will report unknown-credential on a project where nobody has run `ao pipeline credential set github-review ...` / `github-release ...`. That is the right behaviour (spec section 8, decision D13: names are declared in the definition, values are engine-held, no UI editor this pass) and the message already names the exact command to run, but it means the two credential-bearing templates are not click-then-save on a fresh project. Worth deciding whether the problems panel presents that differently from a real mistake. The Go fixture test asserts `Validate`, the dependency-free pass the editor uses; a resolver-backed pass needs a project store and belongs with the save path.
