### PR TITLE
feat(pipelines): stage signal endpoint and ao pipeline done/fail

### DIFF
--- a/backend/internal/cli/pipeline.go
+++ b/backend/internal/cli/pipeline.go
@@ -132,6 +132,8 @@ func newPipelineCommand(ctx *commandContext) *cobra.Command {
 	cmd.AddCommand(newPipelineRunCommand(ctx))
 	cmd.AddCommand(newPipelineCancelCommand(ctx))
 	cmd.AddCommand(newPipelineResumeCommand(ctx))
+	cmd.AddCommand(newPipelineDoneCommand(ctx))
+	cmd.AddCommand(newPipelineFailCommand(ctx))
 	return cmd
 }
 
@@ -229,6 +231,36 @@ func newPipelineResumeCommand(ctx *commandContext) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&project, "project", "p", "", "Project id to scope to")
+	return cmd
+}
+
+func newPipelineDoneCommand(ctx *commandContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "done",
+		Short: "Settle the current pipeline stage as done (run from inside an agent stage)",
+		Args:  noArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return ctx.pipelineSignal(cmd, "done", "")
+		},
+	}
+}
+
+func newPipelineFailCommand(ctx *commandContext) *cobra.Command {
+	var reason string
+	cmd := &cobra.Command{
+		Use:   "fail",
+		Short: "Settle the current pipeline stage as failed (run from inside an agent stage)",
+		Args:  noArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// The reason is the whole point of the failure channel: it is what
+			// the run detail and the failure edge's AO_FAILED_* variables show.
+			if strings.TrimSpace(reason) == "" {
+				return usageError{fmt.Errorf("--reason is required: say why the stage failed")}
+			}
+			return ctx.pipelineSignal(cmd, "fail", reason)
+		},
+	}
+	cmd.Flags().StringVar(&reason, "reason", "", "Why the stage failed")
 	return cmd
 }
 
@@ -387,6 +419,46 @@ func (c *commandContext) pipelineLifecycle(cmd *cobra.Command, runID, project, a
 	}
 	_, err = fmt.Fprintln(cmd.OutOrStdout(), line)
 	return err
+}
+
+// pipelineSignal settles the stage the caller is running inside, by posting to
+// the signal endpoint. The target comes from the ambient stage environment
+// alone.
+func (c *commandContext) pipelineSignal(cmd *cobra.Command, status, reason string) error {
+	runID, stageID, err := stageSignalTarget()
+	if err != nil {
+		return err
+	}
+	body := map[string]string{"status": status}
+	if r := strings.TrimSpace(reason); r != "" {
+		body["reason"] = r
+	}
+	path := "pipelines/runs/" + url.PathEscape(runID) + "/stages/" + url.PathEscape(stageID) + "/signal"
+	if err := c.postJSON(cmd.Context(), path, body, nil); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "stage %s in run %s → %s\n", stageID, runID, status)
+	return err
+}
+
+// stageSignalTarget reads which stage is being settled from AO_RUN_ID and
+// AO_STAGE (spec section 6.3). A missing variable is an error naming it, never
+// a guess: an agent that shelled into another tree, or a nested session that
+// did not inherit the stage environment, must fail loudly instead of silently
+// settling somebody else's stage.
+func stageSignalTarget() (runID, stageID string, err error) {
+	runID = strings.TrimSpace(os.Getenv("AO_RUN_ID"))
+	stageID = strings.TrimSpace(os.Getenv("AO_STAGE"))
+	const hint = "run `ao pipeline done|fail` from inside the pipeline stage that set it"
+	switch {
+	case runID == "" && stageID == "":
+		return "", "", fmt.Errorf("AO_RUN_ID and AO_STAGE are not set: %s", hint)
+	case runID == "":
+		return "", "", fmt.Errorf("AO_RUN_ID is not set: %s", hint)
+	case stageID == "":
+		return "", "", fmt.Errorf("AO_STAGE is not set: %s", hint)
+	}
+	return runID, stageID, nil
 }
 
 // getPipelineRaw fetches a GET endpoint and returns the raw JSON body so --json

--- a/backend/internal/cli/pipeline_test.go
+++ b/backend/internal/cli/pipeline_test.go
@@ -290,6 +290,125 @@ func TestPipelineResume_Human(t *testing.T) {
 	}
 }
 
+// stageEnv sets (or clears, with "") the ambient stage variables the signal
+// verbs read.
+func stageEnv(t *testing.T, runID, stageID string) {
+	t.Helper()
+	t.Setenv("AO_RUN_ID", runID)
+	t.Setenv("AO_STAGE", stageID)
+}
+
+func TestPipelineDone_PostsSignal(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineServer(t, http.StatusAccepted, `{"accepted":true}`)
+	writeRunFileFor(t, cfg, srv)
+	stageEnv(t, "run-1", "review")
+
+	out, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "done")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodPost || capture.path != "/api/v1/pipelines/runs/run-1/stages/review/signal" {
+		t.Fatalf("request = %s %s", capture.method, capture.path)
+	}
+	var body map[string]string
+	if err := json.Unmarshal([]byte(capture.body), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["status"] != "done" || len(body) != 1 {
+		t.Fatalf("body = %+v", body)
+	}
+	if !strings.Contains(out, "review") || !strings.Contains(out, "run-1") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestPipelineFail_PostsReason(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineServer(t, http.StatusAccepted, `{"accepted":true}`)
+	writeRunFileFor(t, cfg, srv)
+	stageEnv(t, "run-1", "review")
+
+	_, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "fail", "--reason", "upstream API is down")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.path != "/api/v1/pipelines/runs/run-1/stages/review/signal" {
+		t.Fatalf("path = %q", capture.path)
+	}
+	var body map[string]string
+	if err := json.Unmarshal([]byte(capture.body), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["status"] != "fail" || body["reason"] != "upstream API is down" {
+		t.Fatalf("body = %+v", body)
+	}
+}
+
+// Spec section 6.3: a missing stage variable errors by name, never guesses.
+func TestPipelineSignal_MissingEnvErrorsByName(t *testing.T) {
+	tests := []struct {
+		name    string
+		runID   string
+		stageID string
+		args    []string
+		want    []string
+	}{
+		{"done without run id", "", "review", []string{"pipeline", "done"}, []string{"AO_RUN_ID"}},
+		{"done without stage", "run-1", "", []string{"pipeline", "done"}, []string{"AO_STAGE"}},
+		{"fail without run id", "", "review", []string{"pipeline", "fail", "--reason", "x"}, []string{"AO_RUN_ID"}},
+		{"fail without stage", "run-1", "", []string{"pipeline", "fail", "--reason", "x"}, []string{"AO_STAGE"}},
+		{"neither set", "", "", []string{"pipeline", "done"}, []string{"AO_RUN_ID", "AO_STAGE"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := setConfigEnv(t)
+			srv, capture := pipelineServer(t, http.StatusAccepted, `{"accepted":true}`)
+			writeRunFileFor(t, cfg, srv)
+			stageEnv(t, tc.runID, tc.stageID)
+
+			_, _, err := executeCLI(t, aliveDeps(), tc.args...)
+			if err == nil {
+				t.Fatal("expected an error when the stage environment is incomplete")
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error %q does not name %s", err, want)
+				}
+			}
+			// The telemetry ping is the only call an aborted verb may make.
+			if strings.Contains(capture.path, "/signal") {
+				t.Fatalf("CLI signalled anyway: %s %s", capture.method, capture.path)
+			}
+		})
+	}
+}
+
+func TestPipelineFail_MissingReasonIsUsageError(t *testing.T) {
+	setConfigEnv(t)
+	stageEnv(t, "run-1", "review")
+	_, _, err := executeCLI(t, aliveDeps(), "pipeline", "fail")
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+}
+
+func TestPipelineDone_StageNotRunningSurfacesConflict(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := pipelineServer(t, http.StatusConflict,
+		`{"message":"Pipeline stage is not running","code":"PIPELINE_STAGE_NOT_RUNNING"}`)
+	writeRunFileFor(t, cfg, srv)
+	stageEnv(t, "run-1", "review")
+
+	_, _, err := executeCLI(t, aliveDeps(), "pipeline", "done")
+	if err == nil {
+		t.Fatal("expected error for 409")
+	}
+	if !strings.Contains(err.Error(), "PIPELINE_STAGE_NOT_RUNNING") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestPipelineShow_MissingRunIDIsUsageError(t *testing.T) {
 	setConfigEnv(t)
 	_, _, err := executeCLI(t, aliveDeps(), "pipeline", "show")

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -162,7 +162,7 @@ func Run() error {
 	var pipelinesSvc pipelinesvc.Manager
 	if resolvePipelinesEnabled(ctx, cfg, store, log) {
 		pipelineStk = startPipelineEngine(ctx, log)
-		pipelinesSvc = pipelinesvc.New()
+		pipelinesSvc = pipelinesvc.New(store)
 		// Let the lifecycle merge-readiness path veto a ready-to-merge PR whose
 		// latest settled pipeline run blocks merge. Only wired when pipelines are
 		// enabled, so the gate stays a no-op otherwise.

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -1136,6 +1136,71 @@ paths:
       summary: Resume a stalled or failed pipeline run
       tags:
       - pipelines
+  /api/v1/pipelines/runs/{runId}/stages/{stageId}/signal:
+    post:
+      operationId: signalPipelineStage
+      parameters:
+      - description: Pipeline run identifier.
+        in: path
+        name: runId
+        required: true
+        schema:
+          description: Pipeline run identifier.
+          type: string
+      - description: Stage id as declared in the pipeline definition.
+        in: path
+        name: stageId
+        required: true
+        schema:
+          description: Stage id as declared in the pipeline definition.
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ControllersSignalPipelineStageRequest'
+        required: true
+      responses:
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControllersSignalPipelineStageResponse'
+          description: Accepted
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Bad Request
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Conflict
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: 'Settle a running agent stage: `ao pipeline done` or `ao pipeline fail
+        --reason`'
+      tags:
+      - pipelines
   /api/v1/pipelines/schema:
     get:
       operationId: getPipelineConfigSchema
@@ -2864,6 +2929,28 @@ components:
       - updatedAt
       - status
       - prs
+      type: object
+    ControllersSignalPipelineStageRequest:
+      properties:
+        reason:
+          description: Why the stage failed. Carried on the failure edge and shown
+            in run detail.
+          type: string
+        status:
+          description: 'How the stage settled: done | fail.'
+          enum:
+          - done
+          - fail
+          type: string
+      required:
+      - status
+      type: object
+    ControllersSignalPipelineStageResponse:
+      properties:
+        accepted:
+          type: boolean
+      required:
+      - accepted
       type: object
     ControllersUpdatePipelineArtifactStatusRequest:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -570,6 +570,20 @@ func pipelineOperations() []operation {
 			},
 		},
 		{
+			method: http.MethodPost, path: "/api/v1/pipelines/runs/{runId}/stages/{stageId}/signal", id: "signalPipelineStage", tag: "pipelines",
+			summary:    "Settle a running agent stage: `ao pipeline done` or `ao pipeline fail --reason`",
+			pathParams: []any{controllers.PipelineStageIDParam{}},
+			reqBody:    controllers.SignalPipelineStageRequest{},
+			resps: []respUnit{
+				{http.StatusAccepted, controllers.SignalPipelineStageResponse{}},
+				{http.StatusBadRequest, envelope.APIError{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusConflict, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+		{
 			method: http.MethodPut, path: "/api/v1/pipelines/{id}", id: "updatePipelineDefinition", tag: "pipelines",
 			summary:    "Update a pipeline definition's YAML",
 			pathParams: []any{controllers.PipelineIDParam{}},

--- a/backend/internal/httpd/controllers/pipelines.go
+++ b/backend/internal/httpd/controllers/pipelines.go
@@ -1,12 +1,16 @@
 package controllers
 
 import (
+	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apispec"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
 	pipelinesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/pipeline"
 )
 
@@ -33,6 +37,12 @@ type PipelineRunIDParam struct {
 type PipelineArtifactIDParam struct {
 	RunID      string `path:"runId" description:"Pipeline run identifier."`
 	ArtifactID string `path:"artifactId" description:"Artifact identifier."`
+}
+
+// PipelineStageIDParam carries both path segments of the stage signal route.
+type PipelineStageIDParam struct {
+	RunID   string `path:"runId" description:"Pipeline run identifier."`
+	StageID string `path:"stageId" description:"Stage id as declared in the pipeline definition."`
 }
 
 // PipelineProjectQuery is the shared `project` scoping query for the collection
@@ -222,6 +232,20 @@ type UpdatePipelineArtifactStatusRequest struct {
 	Status string `json:"status" description:"New artifact status: open | resolved | dismissed."`
 }
 
+// SignalPipelineStageRequest is the body of the stage signal route: how an
+// agent settles its own stage, sent by `ao pipeline done|fail`.
+type SignalPipelineStageRequest struct {
+	Status string `json:"status" enum:"done,fail" description:"How the stage settled: done | fail."`
+	Reason string `json:"reason,omitempty" description:"Why the stage failed. Carried on the failure edge and shown in run detail."`
+}
+
+// SignalPipelineStageResponse acknowledges a recorded signal. The stage does
+// not settle here: the engine reads the signal on its next poll, so this is an
+// acceptance receipt rather than an outcome.
+type SignalPipelineStageResponse struct {
+	Accepted bool `json:"accepted"`
+}
+
 // ---------------------------------------------------------------------------
 // Controller
 // ---------------------------------------------------------------------------
@@ -247,9 +271,60 @@ func (c *PipelinesController) Register(r chi.Router) {
 	r.Post("/pipelines/runs/{runId}/resume", notImplementedHandler("POST", "/api/v1/pipelines/runs/{runId}/resume"))
 	r.Get("/pipelines/runs/{runId}/artifacts/{artifactId}", notImplementedHandler("GET", "/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}"))
 	r.Post("/pipelines/runs/{runId}/artifacts/{artifactId}/status", notImplementedHandler("POST", "/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status"))
+	r.Post("/pipelines/runs/{runId}/stages/{stageId}/signal", c.signalStage)
 
 	r.Put("/pipelines/{id}", notImplementedHandler("PUT", "/api/v1/pipelines/{id}"))
 	r.Delete("/pipelines/{id}", notImplementedHandler("DELETE", "/api/v1/pipelines/{id}"))
+}
+
+// signalStagePath is the one route this controller really serves, spelled the
+// way the OpenAPI document spells it.
+const signalStagePath = "/api/v1/pipelines/runs/{runId}/stages/{stageId}/signal"
+
+// signalStage records how an agent settled its own stage (spec section 6.3).
+// The signal is only recorded here; the engine reads it on its next poll and
+// decides the outcome, so the answer is 202 rather than the settled stage.
+func (c *PipelinesController) signalStage(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "POST", signalStagePath)
+		return
+	}
+	var in SignalPipelineStageRequest
+	if err := decodeJSON(r, &in); err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
+		return
+	}
+	kind := pipeline.SignalKind(strings.TrimSpace(in.Status))
+	if !kind.IsKnown() {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_SIGNAL_STATUS",
+			`status must be "done" or "fail"`, nil)
+		return
+	}
+
+	runID := pipeline.RunID(chi.URLParam(r, "runId"))
+	stageID := chi.URLParam(r, "stageId")
+	if err := c.Svc.SignalStage(r.Context(), runID, stageID, kind, strings.TrimSpace(in.Reason)); err != nil {
+		writePipelineSignalError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusAccepted, SignalPipelineStageResponse{Accepted: true})
+}
+
+// writePipelineSignalError maps the signal service's sentinels onto the wire
+// contract, falling back to 500 for unexpected failures.
+func writePipelineSignalError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, pipelinesvc.ErrRunNotFound):
+		envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "PIPELINE_RUN_NOT_FOUND", "Unknown pipeline run", nil)
+	case errors.Is(err, pipelinesvc.ErrStageNotFound):
+		envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "PIPELINE_STAGE_NOT_FOUND", "Unknown pipeline stage", nil)
+	case errors.Is(err, pipelinesvc.ErrStageNotRunning):
+		envelope.WriteAPIError(w, r, http.StatusConflict, "conflict", "PIPELINE_STAGE_NOT_RUNNING", "Pipeline stage is not running", nil)
+	case errors.Is(err, pipelinesvc.ErrUnknownSignalKind):
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_SIGNAL_STATUS", `status must be "done" or "fail"`, nil)
+	default:
+		envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "PIPELINE_SIGNAL_FAILED", "Recording the stage signal failed", nil)
+	}
 }
 
 // notImplementedHandler answers the locked 501 envelope for one operation.

--- a/backend/internal/httpd/controllers/pipelines_test.go
+++ b/backend/internal/httpd/controllers/pipelines_test.go
@@ -34,10 +34,6 @@ func (f *fakePipelineService) SignalStage(_ context.Context, runID pipeline.RunI
 	return f.signalErr
 }
 
-func (f *fakePipelineService) LatestStageSignal(context.Context, pipeline.RunID, string) (pipeline.StageSignal, bool, error) {
-	return pipeline.StageSignal{}, false, nil
-}
-
 func newPipelineTestServer(t *testing.T, svc pipelinesvc.Manager) *httptest.Server {
 	t.Helper()
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))

--- a/backend/internal/httpd/controllers/pipelines_test.go
+++ b/backend/internal/httpd/controllers/pipelines_test.go
@@ -1,0 +1,137 @@
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	pipelinesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/pipeline"
+)
+
+// fakePipelineService records the last signal it was handed and answers with a
+// canned error, so the handler's status mapping is what is under test.
+type fakePipelineService struct {
+	signalErr error
+	got       pipeline.StageSignal
+	calls     int
+}
+
+func (f *fakePipelineService) PRBlocksMerge(context.Context, domain.ProjectID, string, string) (bool, error) {
+	return false, nil
+}
+
+func (f *fakePipelineService) SignalStage(_ context.Context, runID pipeline.RunID, stageID string, kind pipeline.SignalKind, reason string) error {
+	f.calls++
+	f.got = pipeline.StageSignal{RunID: runID, StageID: stageID, Kind: kind, Reason: reason}
+	return f.signalErr
+}
+
+func (f *fakePipelineService) LatestStageSignal(context.Context, pipeline.RunID, string) (pipeline.StageSignal, bool, error) {
+	return pipeline.StageSignal{}, false, nil
+}
+
+func newPipelineTestServer(t *testing.T, svc pipelinesvc.Manager) *httptest.Server {
+	t.Helper()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := httptest.NewServer(httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{Pipelines: svc}, httpd.ControlDeps{}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+const signalPath = "/api/v1/pipelines/runs/run-1/stages/review/signal"
+
+func TestPipelineSignal_NilServiceReturns501(t *testing.T) {
+	srv := newPipelineTestServer(t, nil)
+	body, status, headers := doRequest(t, srv, "POST", signalPath, `{"status":"done"}`)
+	assertJSON(t, headers)
+	assertErrorCode(t, body, status, http.StatusNotImplemented, "NOT_IMPLEMENTED")
+}
+
+func TestPipelineSignal_DoneAccepted(t *testing.T) {
+	svc := &fakePipelineService{}
+	srv := newPipelineTestServer(t, svc)
+
+	body, status, headers := doRequest(t, srv, "POST", signalPath, `{"status":"done"}`)
+	assertJSON(t, headers)
+	if status != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", status, body)
+	}
+	var res struct {
+		Accepted bool `json:"accepted"`
+	}
+	mustJSON(t, body, &res)
+	if !res.Accepted {
+		t.Fatalf("body = %s", body)
+	}
+	if svc.got.RunID != "run-1" || svc.got.StageID != "review" || svc.got.Kind != pipeline.SignalDone {
+		t.Fatalf("signal = %+v", svc.got)
+	}
+}
+
+func TestPipelineSignal_FailCarriesReason(t *testing.T) {
+	svc := &fakePipelineService{}
+	srv := newPipelineTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, "POST", signalPath, `{"status":"fail","reason":"upstream API is down"}`)
+	if status != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", status, body)
+	}
+	if svc.got.Kind != pipeline.SignalFail || svc.got.Reason != "upstream API is down" {
+		t.Fatalf("signal = %+v", svc.got)
+	}
+}
+
+func TestPipelineSignal_ErrorMapping(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{"unknown run", fmt.Errorf("%w: run-1", pipelinesvc.ErrRunNotFound), http.StatusNotFound, "PIPELINE_RUN_NOT_FOUND"},
+		{"unknown stage", fmt.Errorf("%w: run-1/review", pipelinesvc.ErrStageNotFound), http.StatusNotFound, "PIPELINE_STAGE_NOT_FOUND"},
+		{"stage not running", fmt.Errorf("%w: run-1/review is succeeded", pipelinesvc.ErrStageNotRunning), http.StatusConflict, "PIPELINE_STAGE_NOT_RUNNING"},
+		{"store unavailable", pipelinesvc.ErrStoreUnavailable, http.StatusInternalServerError, "PIPELINE_SIGNAL_FAILED"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newPipelineTestServer(t, &fakePipelineService{signalErr: tc.err})
+			body, status, headers := doRequest(t, srv, "POST", signalPath, `{"status":"done"}`)
+			assertJSON(t, headers)
+			assertErrorCode(t, body, status, tc.wantStatus, tc.wantCode)
+		})
+	}
+}
+
+func TestPipelineSignal_BadRequests(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		wantCode string
+	}{
+		{"unknown status", `{"status":"maybe"}`, "INVALID_SIGNAL_STATUS"},
+		{"missing status", `{}`, "INVALID_SIGNAL_STATUS"},
+		{"malformed json", `{"status":`, "INVALID_JSON"},
+		{"empty body", ``, "INVALID_JSON"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &fakePipelineService{}
+			srv := newPipelineTestServer(t, svc)
+			body, status, headers := doRequest(t, srv, "POST", signalPath, tc.body)
+			assertJSON(t, headers)
+			assertErrorCode(t, body, status, http.StatusBadRequest, tc.wantCode)
+			if svc.calls != 0 {
+				t.Fatalf("service was called %d times for a rejected body", svc.calls)
+			}
+		})
+	}
+}

--- a/backend/internal/service/pipeline/pipeline.go
+++ b/backend/internal/service/pipeline/pipeline.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
 )
 
 // Manager is the pipelines service the HTTP controller and the lifecycle merge
@@ -16,13 +17,20 @@ type Manager interface {
 	// PRBlocksMerge reports whether the most recent settled pipeline run for a
 	// PR blocks it from merging.
 	PRBlocksMerge(ctx context.Context, projectID domain.ProjectID, prURL, headSHA string) (bool, error)
+	// SignalStage records one `ao pipeline done|fail` against a running stage.
+	SignalStage(ctx context.Context, runID pipeline.RunID, stageID string, kind pipeline.SignalKind, reason string) error
+	// LatestStageSignal returns the newest signal for a (run, stage), which is
+	// what the agent executor polls to decide whether a stage settled itself.
+	LatestStageSignal(ctx context.Context, runID pipeline.RunID, stageID string) (pipeline.StageSignal, bool, error)
 }
 
 // Service is the concrete Manager.
-type Service struct{}
+type Service struct {
+	store SignalStore
+}
 
-// New builds a Service.
-func New() *Service { return &Service{} }
+// New builds a Service over the run and signal store.
+func New(store SignalStore) *Service { return &Service{store: store} }
 
 var _ Manager = (*Service)(nil)
 

--- a/backend/internal/service/pipeline/pipeline.go
+++ b/backend/internal/service/pipeline/pipeline.go
@@ -18,10 +18,9 @@ type Manager interface {
 	// PR blocks it from merging.
 	PRBlocksMerge(ctx context.Context, projectID domain.ProjectID, prURL, headSHA string) (bool, error)
 	// SignalStage records one `ao pipeline done|fail` against a running stage.
+	// The read side is not here: the agent executor polls the concrete Service
+	// through executors.SignalReader, not through this HTTP-facing seam.
 	SignalStage(ctx context.Context, runID pipeline.RunID, stageID string, kind pipeline.SignalKind, reason string) error
-	// LatestStageSignal returns the newest signal for a (run, stage), which is
-	// what the agent executor polls to decide whether a stage settled itself.
-	LatestStageSignal(ctx context.Context, runID pipeline.RunID, stageID string) (pipeline.StageSignal, bool, error)
 }
 
 // Service is the concrete Manager.

--- a/backend/internal/service/pipeline/signal.go
+++ b/backend/internal/service/pipeline/signal.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
 )
 
 // Signal path errors. The controller maps them onto the wire contract for
@@ -78,4 +79,19 @@ func (s *Service) LatestStageSignal(ctx context.Context, runID pipeline.RunID, s
 		return pipeline.StageSignal{}, false, ErrStoreUnavailable
 	}
 	return s.store.LatestPipelineStageSignal(ctx, runID, stageID)
+}
+
+// The agent executor polls the Service for signals.
+var _ executors.SignalReader = (*Service)(nil)
+
+// LatestSignal is LatestStageSignal in the shape the agent executor's poll
+// loop wants. That contract has no error channel, so a failed read is reported
+// as "not signalled yet": the stage then settles on idle, exit or its deadline
+// rather than on a read that did not happen.
+func (s *Service) LatestSignal(runID pipeline.RunID, stageID string) (pipeline.StageSignal, bool) {
+	sig, ok, err := s.LatestStageSignal(context.Background(), runID, stageID)
+	if err != nil {
+		return pipeline.StageSignal{}, false
+	}
+	return sig, ok
 }

--- a/backend/internal/service/pipeline/signal.go
+++ b/backend/internal/service/pipeline/signal.go
@@ -1,0 +1,81 @@
+package pipelinesvc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// Signal path errors. The controller maps them onto the wire contract for
+// POST /pipelines/runs/{runId}/stages/{stageId}/signal: 404, 404, 409, 400.
+var (
+	// ErrRunNotFound means no run carries the requested id.
+	ErrRunNotFound = errors.New("pipeline run not found")
+	// ErrStageNotFound means the run exists but declares no such stage.
+	ErrStageNotFound = errors.New("pipeline stage not found")
+	// ErrStageNotRunning means the stage is pending or already settled, so a
+	// signal for it would settle nothing. A stage that signals twice while
+	// running is fine (the latest wins); a stage that signals after settling
+	// is a mistake worth reporting.
+	ErrStageNotRunning = errors.New("pipeline stage is not running")
+	// ErrUnknownSignalKind means the caller sent something other than done or
+	// fail.
+	ErrUnknownSignalKind = errors.New("unknown signal kind")
+	// ErrStoreUnavailable means the service was built without a store, so
+	// nothing can be persisted or read.
+	ErrStoreUnavailable = errors.New("pipeline store unavailable")
+)
+
+// SignalStore is the persistence the signal path needs: the run to validate
+// the target against, plus the append-only signal log.
+type SignalStore interface {
+	GetPipelineRun(ctx context.Context, id pipeline.RunID) (pipeline.RunState, bool, error)
+	AppendPipelineStageSignal(ctx context.Context, sig pipeline.StageSignal) error
+	LatestPipelineStageSignal(ctx context.Context, runID pipeline.RunID, stageID string) (pipeline.StageSignal, bool, error)
+}
+
+// SignalStage records one `ao pipeline done|fail` for a running stage. The
+// signal is appended, never updated: the executor reads the latest row, so a
+// second signal after a nudge supersedes the first without losing history.
+func (s *Service) SignalStage(ctx context.Context, runID pipeline.RunID, stageID string, kind pipeline.SignalKind, reason string) error {
+	if s.store == nil {
+		return ErrStoreUnavailable
+	}
+	if !kind.IsKnown() {
+		return fmt.Errorf("%w: %q", ErrUnknownSignalKind, kind)
+	}
+	run, ok, err := s.store.GetPipelineRun(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrRunNotFound, runID)
+	}
+	stage, ok := run.Stages[stageID]
+	if !ok || stage == nil {
+		return fmt.Errorf("%w: %s/%s", ErrStageNotFound, runID, stageID)
+	}
+	if stage.Outcome != pipeline.OutcomeRunning {
+		return fmt.Errorf("%w: %s/%s is %s", ErrStageNotRunning, runID, stageID, stage.Outcome)
+	}
+	return s.store.AppendPipelineStageSignal(ctx, pipeline.StageSignal{
+		RunID:     runID,
+		StageID:   stageID,
+		Kind:      kind,
+		Reason:    reason,
+		CreatedAt: time.Now().UTC(),
+	})
+}
+
+// LatestStageSignal returns the newest signal for a (run, stage), ok=false
+// when the stage has not signalled. This is the read side the agent executor
+// polls to tell "the agent said it is done" from "the agent went quiet".
+func (s *Service) LatestStageSignal(ctx context.Context, runID pipeline.RunID, stageID string) (pipeline.StageSignal, bool, error) {
+	if s.store == nil {
+		return pipeline.StageSignal{}, false, ErrStoreUnavailable
+	}
+	return s.store.LatestPipelineStageSignal(ctx, runID, stageID)
+}

--- a/backend/internal/service/pipeline/signal_test.go
+++ b/backend/internal/service/pipeline/signal_test.go
@@ -1,0 +1,150 @@
+package pipelinesvc_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	pipelinesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+// newSignalService stands up a real store with one project and one run whose
+// stages carry the outcomes the caller asked for, keyed by stage id.
+func newSignalService(t *testing.T, outcomes map[string]pipeline.Outcome) *pipelinesvc.Service {
+	t.Helper()
+	s, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := s.UpsertProject(ctx, domain.ProjectRecord{ID: "proj", Path: t.TempDir(), RegisteredAt: now}); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	stages := make(map[string]*pipeline.StageState, len(outcomes))
+	for id, outcome := range outcomes {
+		stages[id] = &pipeline.StageState{ID: id, Outcome: outcome, Attempt: 1, EnteredVia: pipeline.EntryTrigger, StartedAt: now}
+	}
+	run := pipeline.RunState{
+		RunID:        "run-1",
+		ProjectID:    "proj",
+		PipelineID:   "pl-1",
+		PipelineName: "review",
+		Subject:      pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: "proj"},
+		Status:       pipeline.RunRunning,
+		Stages:       stages,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := s.SavePipelineRun(ctx, run); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	return pipelinesvc.New(s)
+}
+
+func TestSignalStage_DoneIsAppendedAndReadBack(t *testing.T) {
+	svc := newSignalService(t, map[string]pipeline.Outcome{"review": pipeline.OutcomeRunning})
+	ctx := context.Background()
+
+	if err := svc.SignalStage(ctx, "run-1", "review", pipeline.SignalDone, ""); err != nil {
+		t.Fatalf("SignalStage: %v", err)
+	}
+
+	got, ok, err := svc.LatestStageSignal(ctx, "run-1", "review")
+	if err != nil || !ok {
+		t.Fatalf("LatestStageSignal ok=%v err=%v", ok, err)
+	}
+	if got.Kind != pipeline.SignalDone || got.RunID != "run-1" || got.StageID != "review" {
+		t.Fatalf("signal = %+v", got)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Fatal("signal createdAt is zero")
+	}
+}
+
+func TestSignalStage_FailPersistsReason(t *testing.T) {
+	svc := newSignalService(t, map[string]pipeline.Outcome{"review": pipeline.OutcomeRunning})
+	ctx := context.Background()
+
+	if err := svc.SignalStage(ctx, "run-1", "review", pipeline.SignalFail, "cannot reach the API"); err != nil {
+		t.Fatalf("SignalStage: %v", err)
+	}
+
+	got, ok, err := svc.LatestStageSignal(ctx, "run-1", "review")
+	if err != nil || !ok {
+		t.Fatalf("LatestStageSignal ok=%v err=%v", ok, err)
+	}
+	if got.Kind != pipeline.SignalFail || got.Reason != "cannot reach the API" {
+		t.Fatalf("signal = %+v", got)
+	}
+}
+
+// The latest signal wins: a stage nudged after signalling fail can settle done.
+func TestSignalStage_LatestSignalWins(t *testing.T) {
+	svc := newSignalService(t, map[string]pipeline.Outcome{"review": pipeline.OutcomeRunning})
+	ctx := context.Background()
+
+	if err := svc.SignalStage(ctx, "run-1", "review", pipeline.SignalFail, "first"); err != nil {
+		t.Fatalf("first SignalStage: %v", err)
+	}
+	if err := svc.SignalStage(ctx, "run-1", "review", pipeline.SignalDone, ""); err != nil {
+		t.Fatalf("second SignalStage: %v", err)
+	}
+
+	got, _, err := svc.LatestStageSignal(ctx, "run-1", "review")
+	if err != nil {
+		t.Fatalf("LatestStageSignal: %v", err)
+	}
+	if got.Kind != pipeline.SignalDone {
+		t.Fatalf("kind = %q, want done", got.Kind)
+	}
+}
+
+func TestSignalStage_Rejections(t *testing.T) {
+	tests := []struct {
+		name    string
+		runID   pipeline.RunID
+		stageID string
+		kind    pipeline.SignalKind
+		want    error
+	}{
+		{"unknown run", "run-nope", "review", pipeline.SignalDone, pipelinesvc.ErrRunNotFound},
+		{"unknown stage", "run-1", "nope", pipeline.SignalDone, pipelinesvc.ErrStageNotFound},
+		{"pending stage", "run-1", "publish", pipeline.SignalDone, pipelinesvc.ErrStageNotRunning},
+		{"settled stage", "run-1", "lint", pipeline.SignalDone, pipelinesvc.ErrStageNotRunning},
+		{"unknown kind", "run-1", "review", pipeline.SignalKind("maybe"), pipelinesvc.ErrUnknownSignalKind},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newSignalService(t, map[string]pipeline.Outcome{
+				"review":  pipeline.OutcomeRunning,
+				"publish": pipeline.OutcomePending,
+				"lint":    pipeline.OutcomeSucceeded,
+			})
+			err := svc.SignalStage(context.Background(), tc.runID, tc.stageID, tc.kind, "")
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("err = %v, want %v", err, tc.want)
+			}
+			if _, ok, _ := svc.LatestStageSignal(context.Background(), tc.runID, tc.stageID); ok {
+				t.Fatal("rejected signal was persisted anyway")
+			}
+		})
+	}
+}
+
+func TestLatestStageSignal_NoSignalYet(t *testing.T) {
+	svc := newSignalService(t, map[string]pipeline.Outcome{"review": pipeline.OutcomeRunning})
+	_, ok, err := svc.LatestStageSignal(context.Background(), "run-1", "review")
+	if err != nil {
+		t.Fatalf("LatestStageSignal: %v", err)
+	}
+	if ok {
+		t.Fatal("ok = true for a stage that never signalled")
+	}
+}

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -417,6 +417,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/pipelines/runs/{runId}/stages/{stageId}/signal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Settle a running agent stage: `ao pipeline done` or `ao pipeline fail --reason` */
+        post: operations["signalPipelineStage"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/pipelines/schema": {
         parameters: {
             query?: never;
@@ -1030,6 +1047,18 @@ export interface components {
             terminalHandleId?: string;
             /** Format: date-time */
             updatedAt: string;
+        };
+        ControllersSignalPipelineStageRequest: {
+            /** @description Why the stage failed. Carried on the failure edge and shown in run detail. */
+            reason?: string;
+            /**
+             * @description How the stage settled: done | fail.
+             * @enum {string}
+             */
+            status: "done" | "fail";
+        };
+        ControllersSignalPipelineStageResponse: {
+            accepted: boolean;
         };
         ControllersUpdatePipelineArtifactStatusRequest: {
             /** @description New artifact status: open | resolved | dismissed. */
@@ -3133,6 +3162,80 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    signalPipelineStage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Pipeline run identifier. */
+                runId: string;
+                /** @description Stage id as declared in the pipeline definition. */
+                stageId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllersSignalPipelineStageRequest"];
+            };
+        };
+        responses: {
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllersSignalPipelineStageResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Conflict */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Pipelines v2, Task 11: the path an agent stage uses to settle itself (spec section 6.3, plan decision D12).

## What lands

- **Service** (`internal/service/pipeline/signal.go`): `SignalStage` validates the target against the persisted run (404 unknown run, 404 unknown stage, 409 stage not running, 400 unknown kind) and appends to `pipeline_stage_signals`. Signals are append-only; reads take the latest row, so a stage that signals again after a nudge supersedes its earlier signal without losing history.
- **Read side**: `LatestStageSignal(ctx, ...)` is the honest ctx/error method; `LatestSignal(runID, stageID)` adapts it to Task 10's `executors.SignalReader` (that contract has no error channel, so a failed read reads as "not signalled yet" and the stage settles on idle, exit or deadline instead of on a read that did not happen). Compile-time assertion keeps the two in step.
- **Endpoint**: `POST /api/v1/pipelines/runs/{runId}/stages/{stageId}/signal`, body `{"status":"done"}` or `{"status":"fail","reason":"..."}`, answering 202. Registered in specgen, so `openapi.yaml` and `frontend/src/api/schema.ts` are regenerated in this PR. Nil Manager (pipelines off) still answers the locked 501.
- **CLI**: `ao pipeline done` and `ao pipeline fail --reason "..."`. Both read `AO_RUN_ID` and `AO_STAGE` from their own environment and error naming the missing variable, never guessing and never falling back to a recent run. `--reason` is required on `fail`: it is what the failure edge and run detail show.

The plan's in-memory signal registry is obsolete (Task 17's table already merged), so this wires straight to the store. `pipelinesvc.New` now takes the store; the daemon passes it.

## Tests

- Service: done and fail persisted, reason persisted, latest signal wins, and every rejection path (unknown run, unknown stage, pending stage, settled stage, unknown kind) with a check that nothing was persisted.
- Handler: 202 for done and fail, sentinel-to-status mapping (404/404/409/500), 400 for a bad or missing status, 501 with no Manager.
- CLI: happy path POSTs the right path and body, each missing variable errors by name without calling the daemon, missing `--reason` is a usage error, 409 surfaces to the user.

Verified: `go build ./...`, full `go test ./...`, `gofmt -l .` clean, `golangci-lint run ./...` 0 issues.

Closes #320