### PR TITLE
feat(pipelines): v2 engine actor, effect driver, ambient env, wiring

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -154,19 +154,26 @@ func Run() error {
 
 	// Pipelines: enablement resolves from the AO_PIPELINES env override (dev/CI)
 	// falling through to the persisted "pipelines.enabled" app-setting the
-	// Settings UI writes: see resolvePipelinesEnabled. The v1 engine was
-	// stripped ahead of the v2 rebuild, so starting the stack is currently a
-	// no-op and every /api/v1/pipelines route answers 501 either way.
+	// Settings UI writes: see resolvePipelinesEnabled. With the flag off, the
+	// stack is never built and every /api/v1/pipelines route answers 501.
 	// pipelineStk.Stop is nil-safe, so teardown needs no extra guard.
 	var pipelineStk *pipelineStack
 	var pipelinesSvc pipelinesvc.Manager
 	if resolvePipelinesEnabled(ctx, cfg, store, log) {
-		pipelineStk = startPipelineEngine(ctx, log)
-		pipelinesSvc = pipelinesvc.New(store)
-		// Let the lifecycle merge-readiness path veto a ready-to-merge PR whose
-		// latest settled pipeline run blocks merge. Only wired when pipelines are
-		// enabled, so the gate stays a no-op otherwise.
-		lcStack.LCM.SetPipelineMergeGate(pipelinesSvc)
+		pipelineStk = startPipelineEngine(ctx, pipelineDeps{
+			Store:       store,
+			Sessions:    sessionSvc,
+			Runtime:     runtimeAdapter,
+			Broadcaster: cdcPipe.Broadcaster,
+			DataDir:     cfg.DataDir,
+		}, log)
+		pipelinesSvc = pipelineStk.Manager()
+		if pipelinesSvc != nil {
+			// Let the lifecycle merge-readiness path consult pipelines before it
+			// calls a PR ready to merge. Only wired when pipelines are enabled,
+			// so the gate stays absent otherwise.
+			lcStack.LCM.SetPipelineMergeGate(pipelinesSvc)
+		}
 	}
 
 	agentSvc := agentsvc.New()

--- a/backend/internal/daemon/pipeline_wiring.go
+++ b/backend/internal/daemon/pipeline_wiring.go
@@ -2,20 +2,136 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"path/filepath"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/gitworktree"
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/engine"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/triggers"
+	pipelinesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
 
-// pipelineStack is the single wiring seam for the pipelines subsystem. The v1
-// engine supervisor and CDC trigger bridge were stripped ahead of the v2
-// rebuild, so the stack is currently empty and its lifecycle is a no-op.
-type pipelineStack struct{}
-
-// startPipelineEngine is a no-op until the v2 engine is wired back in. It still
-// runs behind the AO_PIPELINES flag so the enablement path stays exercised.
-func startPipelineEngine(_ context.Context, log *slog.Logger) *pipelineStack {
-	log.Info("pipelines v2: engine not yet wired")
-	return &pipelineStack{}
+// pipelineStack is the single wiring seam for the pipelines subsystem: the
+// per-project engine supervisor plus the CDC trigger bridges. It is built only
+// when AO_PIPELINES resolves on, so everything below it stays inert otherwise.
+type pipelineStack struct {
+	supervisor *engine.Supervisor
+	prBridge   *triggers.PRBridge
+	svc        *pipelinesvc.Service
 }
 
-// Stop tears the stack down. Nil-safe, so callers need no extra guard.
-func (p *pipelineStack) Stop(context.Context) {}
+// pipelineDeps is what the pipelines stack needs from the rest of the daemon.
+type pipelineDeps struct {
+	Store       *sqlite.Store
+	Sessions    engine.SessionCommander
+	Runtime     engine.RuntimeInterrupter
+	Broadcaster *cdc.Broadcaster
+	DataDir     string
+}
+
+// startPipelineEngine wires and starts the pipelines subsystem. A failure to
+// build it is logged and the stack comes back nil, which leaves every
+// /api/v1/pipelines route answering 501: an experimental subsystem must never
+// be able to sink daemon boot.
+func startPipelineEngine(ctx context.Context, deps pipelineDeps, log *slog.Logger) *pipelineStack {
+	stack, err := buildPipelineStack(ctx, deps, log)
+	if err != nil {
+		log.Error("pipelines: engine not started", "err", err)
+		return nil
+	}
+	log.Info("pipelines v2: engine started")
+	return stack
+}
+
+// buildPipelineStack assembles the run folder root, the pipeline-scoped
+// worktree adapter, the executor set over the session seams, the supervisor and
+// the PR trigger bridge.
+func buildPipelineStack(ctx context.Context, deps pipelineDeps, log *slog.Logger) (*pipelineStack, error) {
+	// Run folders, and the worktrees inside them, live under the data dir, so a
+	// single AO_DATA_DIR override moves all durable state together and nothing
+	// lands in an OS-default application-data location.
+	baseDir := filepath.Join(deps.DataDir, "pipelines")
+
+	// The worktree adapter is rooted at the pipelines base dir because run and
+	// stage trees live inside the run folder, and the adapter refuses any path
+	// outside its managed root.
+	trees, err := gitworktree.New(gitworktree.Options{
+		ManagedRoot:  baseDir,
+		RepoResolver: projectRepoResolver{store: deps.Store},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pipeline workspaces: %w", err)
+	}
+
+	sessions := engine.NewSessionAdapter(deps.Sessions, deps.Store, deps.Runtime, log)
+	workspaces := executors.NewWorkspaceResolver(trees, sessions.SessionWorkspaces(), engine.NewCheckoutAdapter(deps.Store))
+	credentials := engine.NewCredentialAdapter(deps.Store)
+
+	// The service is built first because it is the agent executor's signal
+	// reader, and it gets its engines last, once the supervisor those executors
+	// feed exists. That is the whole cycle, broken at the one seam where late
+	// binding is harmless: nothing serves a request until wiring returns.
+	svc := pipelinesvc.New(deps.Store, pipelinesvc.WithCredentials(credentials))
+	execs := engine.BuildExecutorSet(sessions, svc)
+
+	supervisor := engine.NewSupervisor(engine.SupervisorConfig{
+		Store:       deps.Store,
+		Executors:   execs,
+		Workspaces:  workspaces,
+		Sessions:    sessions,
+		Messenger:   sessions,
+		Credentials: credentials,
+		Projects:    deps.Store,
+		BaseDir:     baseDir,
+		Logger:      log,
+	})
+	if err := supervisor.Start(ctx); err != nil {
+		return nil, fmt.Errorf("pipeline supervisor: %w", err)
+	}
+
+	// The PR bridge turns CDC pull-request events into runs with a PR subject.
+	//
+	// The session bridge is deliberately not started yet: its loop guard is the
+	// pipeline-spawned marker on session metadata, and without that marker a
+	// pipeline agent going idle would fire the session pipelines, whose agents
+	// go idle, forever. It is wired the moment the marker lands.
+	prBridge := triggers.NewPRBridge(triggers.PRConfig{
+		Broadcaster: deps.Broadcaster,
+		Defs:        deps.Store,
+		PRs:         deps.Store,
+		Engines:     supervisor.Engines(),
+		Logger:      log,
+	})
+	prBridge.Start(ctx)
+
+	svc.SetEngines(pipelinesvc.SupervisorEngines(supervisor))
+
+	return &pipelineStack{supervisor: supervisor, prBridge: prBridge, svc: svc}, nil
+}
+
+// Manager is the service the HTTP API and the lifecycle merge gate mount. A nil
+// stack yields a nil Manager, which is the 501 path.
+func (p *pipelineStack) Manager() pipelinesvc.Manager {
+	if p == nil || p.svc == nil {
+		return nil
+	}
+	return p.svc
+}
+
+// Stop tears the stack down: bridges first, so no new trigger arrives while the
+// engines are stopping. Nil-safe, so callers need no extra guard.
+func (p *pipelineStack) Stop(ctx context.Context) {
+	if p == nil {
+		return
+	}
+	if p.prBridge != nil {
+		p.prBridge.Stop()
+	}
+	if p.supervisor != nil {
+		_ = p.supervisor.Stop(ctx)
+	}
+}

--- a/backend/internal/httpd/controllers/pipelines.go
+++ b/backend/internal/httpd/controllers/pipelines.go
@@ -3,21 +3,24 @@ package controllers
 import (
 	"errors"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apispec"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
 	pipelinesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/pipeline"
 )
 
-// The v1 pipelines semantics layer has been stripped ahead of the v2 rebuild.
-// Routes and wire shapes stay frozen so the OpenAPI document and the generated
-// frontend client do not churn, but every handler answers 501 until the v2
-// engine is wired back in.
+// The wire shapes below are v1's, kept frozen so the OpenAPI document and the
+// generated frontend client do not churn while the v2 engine lands. The v2 DTO
+// pass renames them (run status, stage outcomes) and adds the signal, log and
+// output routes.
 
 // ---------------------------------------------------------------------------
 // Path / query params (reflected into the OpenAPI spec by apispec.Build)
@@ -250,8 +253,13 @@ type SignalPipelineStageResponse struct {
 // Controller
 // ---------------------------------------------------------------------------
 
-// PipelinesController owns the /pipelines routes. Every handler returns 501
-// while the v2 engine is being rebuilt.
+// PipelinesController owns the /pipelines routes. A nil Svc (the AO_PIPELINES
+// flag off) answers 501 on every one of them.
+//
+// The wire shapes here are still v1's. The v2 DTO pass (run status, stage
+// outcomes, the signal, log and output routes, and the OpenAPI regen) is its
+// own task; this controller maps v2 state onto the frozen fields so the routes
+// stop returning 501 without churning the generated client.
 type PipelinesController struct {
 	Svc pipelinesvc.Manager
 }
@@ -259,26 +267,28 @@ type PipelinesController struct {
 // Register mounts the pipeline routes. Static run/schema segments are declared
 // before the {id} definition routes so chi matches them ahead of the param.
 func (c *PipelinesController) Register(r chi.Router) {
-	r.Get("/pipelines", notImplementedHandler("GET", "/api/v1/pipelines"))
-	r.Post("/pipelines", notImplementedHandler("POST", "/api/v1/pipelines"))
-	r.Post("/pipelines/validate", notImplementedHandler("POST", "/api/v1/pipelines/validate"))
-	r.Get("/pipelines/schema", notImplementedHandler("GET", "/api/v1/pipelines/schema"))
+	r.Get("/pipelines", c.listDefinitions)
+	r.Post("/pipelines", c.createDefinition)
+	r.Post("/pipelines/validate", c.validateDefinition)
+	r.Get("/pipelines/schema", c.schema)
 
-	r.Get("/pipelines/runs", notImplementedHandler("GET", "/api/v1/pipelines/runs"))
-	r.Post("/pipelines/runs", notImplementedHandler("POST", "/api/v1/pipelines/runs"))
-	r.Get("/pipelines/runs/{runId}", notImplementedHandler("GET", "/api/v1/pipelines/runs/{runId}"))
-	r.Post("/pipelines/runs/{runId}/cancel", notImplementedHandler("POST", "/api/v1/pipelines/runs/{runId}/cancel"))
+	r.Get("/pipelines/runs", c.listRuns)
+	r.Post("/pipelines/runs", c.triggerRun)
+	r.Get("/pipelines/runs/{runId}", c.getRun)
+	r.Post("/pipelines/runs/{runId}/cancel", c.cancelRun)
+	// Resume is gone in v2 (there is no resume, spec section 14.1) and the
+	// artifact subsystem is deleted, but the routes stay mounted at 501 until
+	// the API pass removes them from the OpenAPI document too.
 	r.Post("/pipelines/runs/{runId}/resume", notImplementedHandler("POST", "/api/v1/pipelines/runs/{runId}/resume"))
 	r.Get("/pipelines/runs/{runId}/artifacts/{artifactId}", notImplementedHandler("GET", "/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}"))
 	r.Post("/pipelines/runs/{runId}/artifacts/{artifactId}/status", notImplementedHandler("POST", "/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status"))
 	r.Post("/pipelines/runs/{runId}/stages/{stageId}/signal", c.signalStage)
 
-	r.Put("/pipelines/{id}", notImplementedHandler("PUT", "/api/v1/pipelines/{id}"))
-	r.Delete("/pipelines/{id}", notImplementedHandler("DELETE", "/api/v1/pipelines/{id}"))
+	r.Put("/pipelines/{id}", c.updateDefinition)
+	r.Delete("/pipelines/{id}", c.deleteDefinition)
 }
 
-// signalStagePath is the one route this controller really serves, spelled the
-// way the OpenAPI document spells it.
+// signalStagePath spells the signal route the way the OpenAPI document does.
 const signalStagePath = "/api/v1/pipelines/runs/{runId}/stages/{stageId}/signal"
 
 // signalStage records how an agent settled its own stage (spec section 6.3).
@@ -331,5 +341,321 @@ func writePipelineSignalError(w http.ResponseWriter, r *http.Request, err error)
 func notImplementedHandler(method, path string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		apispec.NotImplemented(w, r, method, path)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Definitions
+// ---------------------------------------------------------------------------
+
+func (c *PipelinesController) listDefinitions(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "GET", "/api/v1/pipelines")
+		return
+	}
+	projectID, ok := requirePipelineProject(w, r)
+	if !ok {
+		return
+	}
+	defs, err := c.Svc.ListDefinitions(r.Context(), projectID)
+	if err != nil {
+		writePipelineError(w, r, err)
+		return
+	}
+	out := make([]PipelineDefinitionSummary, 0, len(defs))
+	for _, d := range defs {
+		out = append(out, definitionSummary(d))
+	}
+	envelope.WriteJSON(w, http.StatusOK, ListPipelineDefinitionsResponse{Definitions: out})
+}
+
+func (c *PipelinesController) createDefinition(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "POST", "/api/v1/pipelines")
+		return
+	}
+	projectID, ok := requirePipelineProject(w, r)
+	if !ok {
+		return
+	}
+	var in SavePipelineDefinitionRequest
+	if err := decodeJSONStrict(r, &in); err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
+		return
+	}
+	def, err := c.Svc.CreateDefinition(r.Context(), projectID, in.YAMLSource)
+	if err != nil {
+		writePipelineError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusCreated, PipelineDefinitionResponse{Definition: definitionSummary(def)})
+}
+
+func (c *PipelinesController) updateDefinition(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "PUT", "/api/v1/pipelines/{id}")
+		return
+	}
+	var in SavePipelineDefinitionRequest
+	if err := decodeJSONStrict(r, &in); err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
+		return
+	}
+	def, err := c.Svc.UpdateDefinition(r.Context(), pipeline.ID(chi.URLParam(r, "id")), in.YAMLSource)
+	if err != nil {
+		writePipelineError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, PipelineDefinitionResponse{Definition: definitionSummary(def)})
+}
+
+func (c *PipelinesController) deleteDefinition(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "DELETE", "/api/v1/pipelines/{id}")
+		return
+	}
+	id := chi.URLParam(r, "id")
+	if err := c.Svc.DeleteDefinition(r.Context(), pipeline.ID(id)); err != nil {
+		writePipelineError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, DeletePipelineDefinitionResponse{ID: id, Deleted: true})
+}
+
+// validateDefinition dry-runs the YAML and returns the outcome as data: 200
+// {valid, issues}. A validation failure is not a 4xx, because the editor wants
+// the issue list as a result rather than an error envelope. Persists nothing.
+func (c *PipelinesController) validateDefinition(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "POST", "/api/v1/pipelines/validate")
+		return
+	}
+	projectID, ok := requirePipelineProject(w, r)
+	if !ok {
+		return
+	}
+	var in ValidatePipelineDefinitionRequest
+	if err := decodeJSONStrict(r, &in); err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
+		return
+	}
+	valid, issues, err := c.Svc.ValidateDefinition(r.Context(), projectID, in.YAMLSource)
+	if err != nil {
+		writePipelineError(w, r, err)
+		return
+	}
+	out := make([]PipelineValidationIssue, 0, len(issues))
+	for _, is := range issues {
+		out = append(out, PipelineValidationIssue{Path: is.Path, Message: is.Message})
+	}
+	envelope.WriteJSON(w, http.StatusOK, ValidatePipelineDefinitionResponse{Valid: valid, Issues: out})
+}
+
+func (c *PipelinesController) schema(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "GET", "/api/v1/pipelines/schema")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(c.Svc.ConfigSchema())
+}
+
+// ---------------------------------------------------------------------------
+// Runs
+// ---------------------------------------------------------------------------
+
+func (c *PipelinesController) listRuns(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "GET", "/api/v1/pipelines/runs")
+		return
+	}
+	projectID, ok := requirePipelineProject(w, r)
+	if !ok {
+		return
+	}
+	filter := pipeline.RunFilter{
+		PipelineName: r.URL.Query().Get("pipeline"),
+		Status:       r.URL.Query().Get("status"),
+	}
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 0 {
+			envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_LIMIT", "limit must be a non-negative integer", nil)
+			return
+		}
+		filter.Limit = n
+	}
+	runs, err := c.Svc.ListRuns(r.Context(), projectID, filter)
+	if err != nil {
+		writePipelineError(w, r, err)
+		return
+	}
+	out := make([]PipelineRunSummary, 0, len(runs))
+	for _, run := range runs {
+		out = append(out, runSummary(run))
+	}
+	envelope.WriteJSON(w, http.StatusOK, ListPipelineRunsResponse{Runs: out})
+}
+
+func (c *PipelinesController) getRun(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "GET", "/api/v1/pipelines/runs/{runId}")
+		return
+	}
+	run, err := c.Svc.GetRun(r.Context(), pipeline.RunID(chi.URLParam(r, "runId")))
+	if err != nil {
+		writePipelineError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, PipelineRunDetailResponse{Run: runDetail(run)})
+}
+
+// triggerRun starts a manual run. headSha in the body is ignored: v2 pins a run
+// to its subject, not to a commit, and a manual PR subject arrives with the
+// run API pass.
+func (c *PipelinesController) triggerRun(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "POST", "/api/v1/pipelines/runs")
+		return
+	}
+	projectID, ok := requirePipelineProject(w, r)
+	if !ok {
+		return
+	}
+	var in TriggerPipelineRunRequest
+	if err := decodeJSONStrict(r, &in); err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
+		return
+	}
+	runID, err := c.Svc.TriggerRun(r.Context(), projectID, pipelinesvc.TriggerInput{
+		Ref:       in.Pipeline,
+		SessionID: in.SessionID,
+	})
+	if err != nil {
+		writePipelineError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusCreated, TriggerPipelineRunResponse{RunID: string(runID)})
+}
+
+func (c *PipelinesController) cancelRun(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "POST", "/api/v1/pipelines/runs/{runId}/cancel")
+		return
+	}
+	projectID, ok := requirePipelineProject(w, r)
+	if !ok {
+		return
+	}
+	run, err := c.Svc.CancelRun(r.Context(), projectID, pipeline.RunID(chi.URLParam(r, "runId")))
+	if err != nil {
+		writePipelineError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, PipelineRunDetailResponse{Run: runDetail(run)})
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// requirePipelineProject reads the mandatory `project` query parameter, writing
+// a 400 and returning ok=false when it is absent.
+func requirePipelineProject(w http.ResponseWriter, r *http.Request) (domain.ProjectID, bool) {
+	project := r.URL.Query().Get("project")
+	if project == "" {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "PROJECT_REQUIRED", "project query parameter is required", nil)
+		return "", false
+	}
+	return domain.ProjectID(project), true
+}
+
+// writePipelineError renders a service error. A *pipeline.ValidationError is
+// unpacked into the envelope's details as the full issue list, so the editor
+// surfaces every problem at once.
+func writePipelineError(w http.ResponseWriter, r *http.Request, err error) {
+	var verr *pipeline.ValidationError
+	if errors.As(err, &verr) {
+		issues := make([]map[string]string, 0, len(verr.Issues))
+		for _, issue := range verr.Issues {
+			issues = append(issues, map[string]string{"path": issue.Path, "message": issue.Message})
+		}
+		envelope.WriteAPIError(w, r, http.StatusUnprocessableEntity, "unprocessable", "PIPELINE_VALIDATION_FAILED",
+			"pipeline definition is invalid", map[string]any{"issues": issues})
+		return
+	}
+	envelope.WriteError(w, r, err)
+}
+
+func definitionSummary(d pipeline.Definition) PipelineDefinitionSummary {
+	return PipelineDefinitionSummary{
+		ID:         string(d.ID),
+		ProjectID:  d.ProjectID,
+		Name:       d.Name,
+		YAMLSource: d.YAMLSource,
+		CreatedAt:  d.CreatedAt,
+		UpdatedAt:  d.UpdatedAt,
+	}
+}
+
+// runSummary maps a v2 run onto the frozen wire shape. loopState carries the v2
+// run status and stageStatuses the v2 stage outcomes; the fields keep their
+// names until the DTO pass renames them along with the OpenAPI document.
+func runSummary(run pipeline.RunState) PipelineRunSummary {
+	outcomes := make(map[string]string, len(run.Stages))
+	for id, st := range run.Stages {
+		outcomes[id] = string(st.Outcome)
+	}
+	headSHA := ""
+	if run.Subject.PR != nil {
+		headSHA = run.Subject.PR.HeadSHA
+	}
+	return PipelineRunSummary{
+		RunID:             string(run.RunID),
+		PipelineID:        string(run.PipelineID),
+		PipelineName:      run.PipelineName,
+		SessionID:         run.Subject.SessionID,
+		LoopState:         string(run.Status),
+		TerminationReason: run.CancelReason,
+		HeadSHA:           headSHA,
+		StageCount:        len(run.Stages),
+		StageStatuses:     outcomes,
+		CreatedAt:         run.CreatedAt,
+		UpdatedAt:         run.UpdatedAt,
+	}
+}
+
+func runDetail(run pipeline.RunState) PipelineRunDetail {
+	stages := make([]PipelineStageView, 0, len(run.Stages))
+	for id, st := range run.Stages {
+		view := PipelineStageView{
+			StageName:    id,
+			Status:       string(st.Outcome),
+			Attempt:      st.Attempt,
+			Verdict:      string(st.EnteredVia),
+			ErrorMessage: st.Reason,
+			Output:       st.OutputTail,
+			SessionID:    st.SessionID,
+			ArtifactIDs:  []string{},
+		}
+		if !st.StartedAt.IsZero() {
+			started := st.StartedAt
+			view.StartedAt = &started
+		}
+		if !st.SettledAt.IsZero() {
+			settled := st.SettledAt
+			view.CompletedAt = &settled
+		}
+		stages = append(stages, view)
+	}
+	sort.Slice(stages, func(i, j int) bool { return stages[i].StageName < stages[j].StageName })
+
+	return PipelineRunDetail{
+		PipelineRunSummary: runSummary(run),
+		Stages:             stages,
+		// The findings subsystem is deleted in v2; the field stays until the
+		// DTO pass removes it from the OpenAPI document.
+		Findings: []PipelineArtifact{},
 	}
 }

--- a/backend/internal/httpd/controllers/pipelines_test.go
+++ b/backend/internal/httpd/controllers/pipelines_test.go
@@ -18,7 +18,13 @@ import (
 
 // fakePipelineService records the last signal it was handed and answers with a
 // canned error, so the handler's status mapping is what is under test.
+//
+// The embedded Manager supplies the rest of the interface: those methods are
+// not exercised here and panic on a nil embed if a test ever reaches one, which
+// is louder than a silent zero value.
 type fakePipelineService struct {
+	pipelinesvc.Manager
+
 	signalErr error
 	got       pipeline.StageSignal
 	calls     int

--- a/backend/internal/pipeline/engine/adapters.go
+++ b/backend/internal/pipeline/engine/adapters.go
@@ -37,12 +37,6 @@ type RuntimeInterrupter interface {
 	Interrupt(ctx context.Context, handle ports.RuntimeHandle) error
 }
 
-// SignalStore reads the latest `ao pipeline done|fail` a stage recorded.
-// Satisfied by *storage/sqlite/store.Store.
-type SignalStore interface {
-	LatestPipelineStageSignal(ctx context.Context, runID pipeline.RunID, stageID string) (pipeline.StageSignal, bool, error)
-}
-
 // CredentialStore is the persistence half of the engine-held credentials.
 // Satisfied by *storage/sqlite/store.Store.
 type CredentialStore interface {
@@ -177,38 +171,6 @@ func (a *SessionAdapter) GetPath(ctx context.Context, sessionID string) (string,
 // ---------------------------------------------------------------------------
 // Store-backed seams
 // ---------------------------------------------------------------------------
-
-// SignalAdapter serves the agent executor's SignalReader over the store.
-//
-// The executor's port is context-free (it is polled from the actor loop, which
-// has its own base context), so the adapter carries one.
-type SignalAdapter struct {
-	ctx    context.Context
-	store  SignalStore
-	logger *slog.Logger
-}
-
-// NewSignalAdapter builds the signal reader. ctx bounds the store reads.
-func NewSignalAdapter(ctx context.Context, store SignalStore, log *slog.Logger) *SignalAdapter {
-	if log == nil {
-		log = slog.Default()
-	}
-	return &SignalAdapter{ctx: ctx, store: store, logger: log}
-}
-
-var _ executors.SignalReader = (*SignalAdapter)(nil)
-
-// LatestSignal returns the newest signal for a stage, if any. A read failure is
-// reported as "no signal": the stage's deadline still bounds it, and settling a
-// stage on a database hiccup would be worse.
-func (a *SignalAdapter) LatestSignal(runID pipeline.RunID, stageID string) (pipeline.StageSignal, bool) {
-	sig, ok, err := a.store.LatestPipelineStageSignal(a.ctx, runID, stageID)
-	if err != nil {
-		a.logger.Warn("pipeline read stage signal", "run", runID, "stage", stageID, "err", err)
-		return pipeline.StageSignal{}, false
-	}
-	return sig, ok
-}
 
 // CredentialAdapter serves both the engine's Credentials seam and the service
 // layer's pipeline.CredentialResolver over the store.

--- a/backend/internal/pipeline/engine/adapters.go
+++ b/backend/internal/pipeline/engine/adapters.go
@@ -1,0 +1,310 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// This file is the only place the executors' narrow seams meet real infra. The
+// executors never learn about the session service, the runtime adapter or the
+// store; these adapters translate their vocabulary to and from domain types.
+
+// SessionCommander is the session-manager surface the pipeline stages need.
+// Satisfied by *internal/service/session.Service, which spawns the same visible
+// sidebar sessions a human gets.
+type SessionCommander interface {
+	Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Session, error)
+	Kill(ctx context.Context, id domain.SessionID) (bool, error)
+	Send(ctx context.Context, id domain.SessionID, message string) error
+}
+
+// SessionReader reads session rows. Satisfied by *storage/sqlite/store.Store.
+type SessionReader interface {
+	GetSession(ctx context.Context, id domain.SessionID) (domain.SessionRecord, bool, error)
+}
+
+// RuntimeInterrupter sends the terminal interrupt to a session's runtime pane.
+// It is what makes timed_out different from cancelled: the agent's work stops,
+// the session and its scrollback survive (spec section 7.2). Satisfied by the
+// selected runtime adapter.
+type RuntimeInterrupter interface {
+	Interrupt(ctx context.Context, handle ports.RuntimeHandle) error
+}
+
+// SignalStore reads the latest `ao pipeline done|fail` a stage recorded.
+// Satisfied by *storage/sqlite/store.Store.
+type SignalStore interface {
+	LatestPipelineStageSignal(ctx context.Context, runID pipeline.RunID, stageID string) (pipeline.StageSignal, bool, error)
+}
+
+// CredentialStore is the persistence half of the engine-held credentials.
+// Satisfied by *storage/sqlite/store.Store.
+type CredentialStore interface {
+	GetPipelineCredential(ctx context.Context, projectID domain.ProjectID, name string) (map[string]string, bool, error)
+	ListPipelineCredentialNames(ctx context.Context, projectID domain.ProjectID) ([]string, error)
+}
+
+// ProjectReader resolves a project's primary checkout, the tree a `workspace:
+// checkout` stage runs in. Satisfied by *storage/sqlite/store.Store.
+type ProjectReader interface {
+	GetProject(ctx context.Context, id string) (domain.ProjectRecord, bool, error)
+}
+
+// ---------------------------------------------------------------------------
+// Session seams (agent executor, nudges, kill-on)
+// ---------------------------------------------------------------------------
+
+// SessionAdapter implements the agent executor's session seam, the driver's
+// nudge messenger, and the kill-on disposer, all over one pair of dependencies.
+type SessionAdapter struct {
+	cmd     SessionCommander
+	reader  SessionReader
+	runtime RuntimeInterrupter
+	log     *slog.Logger
+}
+
+// NewSessionAdapter builds the session seam. runtime may be nil, in which case
+// an interrupt degrades to a log line rather than killing the session, which is
+// the safe direction: losing the scrollback is the thing the timed_out rule
+// exists to prevent.
+func NewSessionAdapter(cmd SessionCommander, reader SessionReader, runtime RuntimeInterrupter, log *slog.Logger) *SessionAdapter {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &SessionAdapter{cmd: cmd, reader: reader, runtime: runtime, log: log}
+}
+
+var (
+	_ executors.SessionSpawner   = (*SessionAdapter)(nil)
+	_ executors.SessionMessenger = (*SessionAdapter)(nil)
+	_ SessionDisposer            = (*SessionAdapter)(nil)
+)
+
+// Spawn starts the stage's worker session.
+//
+// ponytail: the driver-provisioned workspace is not handed to the session.
+// ports.SpawnConfig has no path to adopt an existing tree, so the session
+// manager creates its own worktree and the stage runs there; the workspace
+// kinds still govern command stages, `inherit` and teardown. Closing this needs
+// a SpawnConfig.WorkspacePath plus a session teardown that never destroys a
+// pipeline-owned tree, which is a session-lifecycle change, not an engine one.
+func (a *SessionAdapter) Spawn(ctx context.Context, req executors.SpawnRequest) (executors.SpawnedSession, error) {
+	sess, err := a.cmd.Spawn(ctx, ports.SpawnConfig{
+		ProjectID:   domain.ProjectID(req.ProjectID),
+		Kind:        domain.KindWorker,
+		Harness:     domain.AgentHarness(req.Harness),
+		Prompt:      req.Prompt,
+		DisplayName: req.DisplayName,
+		Env:         req.Env,
+	})
+	if err != nil {
+		return executors.SpawnedSession{}, err
+	}
+	return executors.SpawnedSession{
+		SessionID:     string(sess.ID),
+		WorkspacePath: sess.Metadata.WorkspacePath,
+	}, nil
+}
+
+// Get reports how busy the session is and whether its row went terminal.
+func (a *SessionAdapter) Get(ctx context.Context, sessionID string) (executors.SessionSnapshot, bool, error) {
+	rec, ok, err := a.reader.GetSession(ctx, domain.SessionID(sessionID))
+	if err != nil || !ok {
+		return executors.SessionSnapshot{}, false, err
+	}
+	return executors.SessionSnapshot{
+		Activity:   rec.Activity.State,
+		Terminated: rec.IsTerminated,
+	}, true, nil
+}
+
+// Interrupt stops the agent's work and keeps the session.
+func (a *SessionAdapter) Interrupt(ctx context.Context, sessionID string) error {
+	if a.runtime == nil {
+		a.log.Warn("pipeline stage interrupt skipped: no runtime wired", "session", sessionID)
+		return nil
+	}
+	rec, ok, err := a.reader.GetSession(ctx, domain.SessionID(sessionID))
+	if err != nil {
+		return err
+	}
+	if !ok || rec.Metadata.RuntimeHandleID == "" {
+		// Nothing to interrupt is not an error: the session is already gone or
+		// never had a live pane.
+		return nil
+	}
+	return a.runtime.Interrupt(ctx, ports.RuntimeHandle{ID: rec.Metadata.RuntimeHandleID})
+}
+
+// Kill tears the session down. Best-effort and idempotent: a missing or
+// already-dead session is not an error, which the executor contract requires.
+func (a *SessionAdapter) Kill(ctx context.Context, sessionID string) error {
+	_, _ = a.cmd.Kill(ctx, domain.SessionID(sessionID))
+	return nil
+}
+
+// Alive implements the messenger seam: a nudge is only worth sending into a
+// session that is still there.
+func (a *SessionAdapter) Alive(ctx context.Context, sessionID string) (bool, error) {
+	rec, ok, err := a.reader.GetSession(ctx, domain.SessionID(sessionID))
+	if err != nil || !ok {
+		return false, err
+	}
+	return !rec.IsTerminated && rec.Activity.State != domain.ActivityExited, nil
+}
+
+// Send delivers the nudge into the live session.
+func (a *SessionAdapter) Send(ctx context.Context, sessionID, message string) error {
+	return a.cmd.Send(ctx, domain.SessionID(sessionID), message)
+}
+
+// GetPath implements the workspace resolver's session seam: where the subject
+// session's own worktree lives.
+func (a *SessionAdapter) GetPath(ctx context.Context, sessionID string) (string, bool, error) {
+	rec, ok, err := a.reader.GetSession(ctx, domain.SessionID(sessionID))
+	if err != nil || !ok {
+		return "", false, err
+	}
+	return rec.Metadata.WorkspacePath, rec.Metadata.WorkspacePath != "", nil
+}
+
+// ---------------------------------------------------------------------------
+// Store-backed seams
+// ---------------------------------------------------------------------------
+
+// SignalAdapter serves the agent executor's SignalReader over the store.
+//
+// The executor's port is context-free (it is polled from the actor loop, which
+// has its own base context), so the adapter carries one.
+type SignalAdapter struct {
+	ctx    context.Context
+	store  SignalStore
+	logger *slog.Logger
+}
+
+// NewSignalAdapter builds the signal reader. ctx bounds the store reads.
+func NewSignalAdapter(ctx context.Context, store SignalStore, log *slog.Logger) *SignalAdapter {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &SignalAdapter{ctx: ctx, store: store, logger: log}
+}
+
+var _ executors.SignalReader = (*SignalAdapter)(nil)
+
+// LatestSignal returns the newest signal for a stage, if any. A read failure is
+// reported as "no signal": the stage's deadline still bounds it, and settling a
+// stage on a database hiccup would be worse.
+func (a *SignalAdapter) LatestSignal(runID pipeline.RunID, stageID string) (pipeline.StageSignal, bool) {
+	sig, ok, err := a.store.LatestPipelineStageSignal(a.ctx, runID, stageID)
+	if err != nil {
+		a.logger.Warn("pipeline read stage signal", "run", runID, "stage", stageID, "err", err)
+		return pipeline.StageSignal{}, false
+	}
+	return sig, ok
+}
+
+// CredentialAdapter serves both the engine's Credentials seam and the service
+// layer's pipeline.CredentialResolver over the store.
+type CredentialAdapter struct{ store CredentialStore }
+
+// NewCredentialAdapter builds the credential seam.
+func NewCredentialAdapter(store CredentialStore) *CredentialAdapter {
+	return &CredentialAdapter{store: store}
+}
+
+var (
+	_ Credentials                 = (*CredentialAdapter)(nil)
+	_ pipeline.CredentialResolver = (*CredentialAdapter)(nil)
+)
+
+// Resolve flattens the named credentials into one environment, in order, so a
+// later name wins a key collision. An unknown name is an error: a stage that
+// asked for a credential must never run without it.
+func (a *CredentialAdapter) Resolve(ctx context.Context, projectID string, names []string) (map[string]string, error) {
+	out := make(map[string]string)
+	for _, name := range names {
+		env, ok, err := a.store.GetPipelineCredential(ctx, domain.ProjectID(projectID), name)
+		if err != nil {
+			return nil, fmt.Errorf("read credential %q: %w", name, err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("project %s does not define credential %q", projectID, name)
+		}
+		for k, v := range env {
+			out[k] = v
+		}
+	}
+	return out, nil
+}
+
+// Exists reports whether the project declares a credential by that name.
+func (a *CredentialAdapter) Exists(ctx context.Context, projectID, name string) (bool, error) {
+	_, ok, err := a.store.GetPipelineCredential(ctx, domain.ProjectID(projectID), name)
+	return ok, err
+}
+
+// Names lists the project's declared credential names, which is what the
+// plan-time check needs. Names only, never values.
+func (a *CredentialAdapter) Names(ctx context.Context, projectID string) ([]string, error) {
+	return a.store.ListPipelineCredentialNames(ctx, domain.ProjectID(projectID))
+}
+
+// CheckoutAdapter resolves a project's primary local checkout for a
+// `workspace: checkout` stage: the tree the user is actually coding in, which
+// is why the kind is explicit and never a default.
+type CheckoutAdapter struct{ projects ProjectReader }
+
+// NewCheckoutAdapter builds the checkout seam.
+func NewCheckoutAdapter(projects ProjectReader) *CheckoutAdapter {
+	return &CheckoutAdapter{projects: projects}
+}
+
+var _ executors.Checkouts = (*CheckoutAdapter)(nil)
+
+// CheckoutPath returns the project's registered repo path.
+func (a *CheckoutAdapter) CheckoutPath(projectID string) (string, error) {
+	rec, ok, err := a.projects.GetProject(context.Background(), projectID)
+	if err != nil {
+		return "", fmt.Errorf("resolve project %q: %w", projectID, err)
+	}
+	if !ok || rec.Path == "" {
+		return "", fmt.Errorf("project %q has no registered checkout", projectID)
+	}
+	return rec.Path, nil
+}
+
+// sessionWorkspaces adapts SessionAdapter.GetPath onto the resolver's seam,
+// whose Get name would otherwise collide with the spawner's.
+type sessionWorkspaces struct{ sessions *SessionAdapter }
+
+var _ executors.SessionWorkspaces = sessionWorkspaces{}
+
+func (s sessionWorkspaces) Get(ctx context.Context, sessionID string) (string, bool, error) {
+	return s.sessions.GetPath(ctx, sessionID)
+}
+
+// SessionWorkspaces returns the adapter's view for the workspace resolver.
+func (a *SessionAdapter) SessionWorkspaces() executors.SessionWorkspaces {
+	return sessionWorkspaces{sessions: a}
+}
+
+// ---------------------------------------------------------------------------
+// Executor set
+// ---------------------------------------------------------------------------
+
+// BuildExecutorSet assembles the two kind executors over the real seams and
+// returns the routing facade the engine drives. This is the single place the
+// executors are wired to infra.
+func BuildExecutorSet(sessions *SessionAdapter, signals executors.SignalReader) *executors.Set {
+	return &executors.Set{
+		Agent:   executors.NewAgentExecutor(sessions, signals),
+		Command: executors.NewCommandExecutor(executors.NewOSRunner),
+	}
+}

--- a/backend/internal/pipeline/engine/adapters_test.go
+++ b/backend/internal/pipeline/engine/adapters_test.go
@@ -1,0 +1,245 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// fakeCommander records what the adapter asked the session service to do.
+type fakeCommander struct {
+	spawned  ports.SpawnConfig
+	spawnErr error
+	killed   []domain.SessionID
+	sent     map[domain.SessionID]string
+}
+
+func newFakeCommander() *fakeCommander {
+	return &fakeCommander{sent: map[domain.SessionID]string{}}
+}
+
+func (c *fakeCommander) Spawn(_ context.Context, cfg ports.SpawnConfig) (domain.Session, error) {
+	c.spawned = cfg
+	if c.spawnErr != nil {
+		return domain.Session{}, c.spawnErr
+	}
+	return domain.Session{SessionRecord: domain.SessionRecord{
+		ID:       "sess-new",
+		Metadata: domain.SessionMetadata{WorkspacePath: "/trees/sess-new"},
+	}}, nil
+}
+
+func (c *fakeCommander) Kill(_ context.Context, id domain.SessionID) (bool, error) {
+	c.killed = append(c.killed, id)
+	return true, nil
+}
+
+func (c *fakeCommander) Send(_ context.Context, id domain.SessionID, message string) error {
+	c.sent[id] = message
+	return nil
+}
+
+// fakeSessionRows is the store half of the session seam.
+type fakeSessionRows struct {
+	rows map[domain.SessionID]domain.SessionRecord
+	err  error
+}
+
+func (s fakeSessionRows) GetSession(_ context.Context, id domain.SessionID) (domain.SessionRecord, bool, error) {
+	if s.err != nil {
+		return domain.SessionRecord{}, false, s.err
+	}
+	rec, ok := s.rows[id]
+	return rec, ok, nil
+}
+
+// fakeRuntime records the interrupts the adapter sent.
+type fakeRuntime struct{ interrupted []string }
+
+func (r *fakeRuntime) Interrupt(_ context.Context, handle ports.RuntimeHandle) error {
+	r.interrupted = append(r.interrupted, handle.ID)
+	return nil
+}
+
+func liveSession() domain.SessionRecord {
+	return domain.SessionRecord{
+		ID:       "sess-1",
+		Activity: domain.Activity{State: domain.ActivityActive},
+		Metadata: domain.SessionMetadata{WorkspacePath: "/trees/sess-1", RuntimeHandleID: "pane-1"},
+	}
+}
+
+func TestSessionAdapterSpawnCarriesEnvAndPrompt(t *testing.T) {
+	cmd := newFakeCommander()
+	adapter := NewSessionAdapter(cmd, fakeSessionRows{}, nil, nil)
+
+	out, err := adapter.Spawn(context.Background(), executors.SpawnRequest{
+		ProjectID:   "proj-1",
+		Harness:     "claude-code",
+		Prompt:      "do the thing",
+		Env:         map[string]string{"AO_RUN_ID": "run-a", "AO_STAGE": "review"},
+		DisplayName: "run-a/review",
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if out.SessionID != "sess-new" {
+		t.Fatalf("session id = %q", out.SessionID)
+	}
+	if cmd.spawned.Env["AO_RUN_ID"] != "run-a" || cmd.spawned.Env["AO_STAGE"] != "review" {
+		t.Fatalf("spawn env = %v, want the ambient identity `ao pipeline done` resolves itself from", cmd.spawned.Env)
+	}
+	if cmd.spawned.Prompt != "do the thing" || cmd.spawned.Kind != domain.KindWorker {
+		t.Fatalf("spawn config = %+v", cmd.spawned)
+	}
+}
+
+func TestSessionAdapterInterruptKeepsTheSession(t *testing.T) {
+	cmd := newFakeCommander()
+	runtime := &fakeRuntime{}
+	rows := fakeSessionRows{rows: map[domain.SessionID]domain.SessionRecord{"sess-1": liveSession()}}
+	adapter := NewSessionAdapter(cmd, rows, runtime, nil)
+
+	if err := adapter.Interrupt(context.Background(), "sess-1"); err != nil {
+		t.Fatalf("interrupt: %v", err)
+	}
+	if len(runtime.interrupted) != 1 || runtime.interrupted[0] != "pane-1" {
+		t.Fatalf("interrupted %v, want the session's runtime pane", runtime.interrupted)
+	}
+	if len(cmd.killed) != 0 {
+		t.Fatalf("killed %v, want the session and its scrollback kept", cmd.killed)
+	}
+}
+
+func TestSessionAdapterInterruptWithoutAPaneIsNotAnError(t *testing.T) {
+	rows := fakeSessionRows{rows: map[domain.SessionID]domain.SessionRecord{"sess-1": {ID: "sess-1"}}}
+	adapter := NewSessionAdapter(newFakeCommander(), rows, &fakeRuntime{}, nil)
+	if err := adapter.Interrupt(context.Background(), "sess-1"); err != nil {
+		t.Fatalf("interrupt: %v", err)
+	}
+}
+
+func TestSessionAdapterKillIsIdempotent(t *testing.T) {
+	cmd := newFakeCommander()
+	adapter := NewSessionAdapter(cmd, fakeSessionRows{}, nil, nil)
+	for range 2 {
+		if err := adapter.Kill(context.Background(), "sess-gone"); err != nil {
+			t.Fatalf("kill: %v", err)
+		}
+	}
+	if len(cmd.killed) != 2 {
+		t.Fatalf("killed %v", cmd.killed)
+	}
+}
+
+func TestSessionAdapterAliveAndWorkspace(t *testing.T) {
+	dead := liveSession()
+	dead.ID = "sess-dead"
+	dead.IsTerminated = true
+	rows := fakeSessionRows{rows: map[domain.SessionID]domain.SessionRecord{
+		"sess-1":    liveSession(),
+		"sess-dead": dead,
+	}}
+	adapter := NewSessionAdapter(newFakeCommander(), rows, nil, nil)
+
+	if alive, err := adapter.Alive(context.Background(), "sess-1"); err != nil || !alive {
+		t.Fatalf("alive = %v, %v; want true", alive, err)
+	}
+	if alive, err := adapter.Alive(context.Background(), "sess-dead"); err != nil || alive {
+		t.Fatalf("alive = %v, %v; want false for a terminated session", alive, err)
+	}
+	if alive, err := adapter.Alive(context.Background(), "sess-missing"); err != nil || alive {
+		t.Fatalf("alive = %v, %v; want false for a missing session", alive, err)
+	}
+
+	path, ok, err := adapter.SessionWorkspaces().Get(context.Background(), "sess-1")
+	if err != nil || !ok || path != "/trees/sess-1" {
+		t.Fatalf("session workspace = %q, %v, %v", path, ok, err)
+	}
+}
+
+// fakeCredentialStore is the store half of the credential seam.
+type fakeCredentialStore struct {
+	creds map[string]map[string]string
+	err   error
+}
+
+func (s fakeCredentialStore) GetPipelineCredential(_ context.Context, _ domain.ProjectID, name string) (map[string]string, bool, error) {
+	if s.err != nil {
+		return nil, false, s.err
+	}
+	env, ok := s.creds[name]
+	return env, ok, nil
+}
+
+func (s fakeCredentialStore) ListPipelineCredentialNames(_ context.Context, _ domain.ProjectID) ([]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	names := make([]string, 0, len(s.creds))
+	for name := range s.creds {
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func TestCredentialAdapterResolvesInOrder(t *testing.T) {
+	store := fakeCredentialStore{creds: map[string]map[string]string{
+		"base":     {"TOKEN": "old", "OTHER": "keep"},
+		"override": {"TOKEN": "new"},
+	}}
+	adapter := NewCredentialAdapter(store)
+
+	env, err := adapter.Resolve(context.Background(), "proj-1", []string{"base", "override"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	// A later name wins a key collision, and everything else survives.
+	if env["TOKEN"] != "new" || env["OTHER"] != "keep" {
+		t.Fatalf("env = %v", env)
+	}
+}
+
+func TestCredentialAdapterUnknownNameIsAnError(t *testing.T) {
+	adapter := NewCredentialAdapter(fakeCredentialStore{creds: map[string]map[string]string{}})
+	if _, err := adapter.Resolve(context.Background(), "proj-1", []string{"missing"}); err == nil {
+		t.Fatal("resolve succeeded, want an error: a stage that asked for a credential must never run without it")
+	}
+	ok, err := adapter.Exists(context.Background(), "proj-1", "missing")
+	if err != nil || ok {
+		t.Fatalf("exists = %v, %v; want false", ok, err)
+	}
+}
+
+func TestCredentialAdapterReadFailurePropagates(t *testing.T) {
+	adapter := NewCredentialAdapter(fakeCredentialStore{err: errors.New("db down")})
+	if _, err := adapter.Names(context.Background(), "proj-1"); err == nil {
+		t.Fatal("names succeeded, want the store error")
+	}
+}
+
+// fakeProjects is the store half of the checkout seam.
+type fakeProjects struct{ path string }
+
+func (p fakeProjects) GetProject(_ context.Context, id string) (domain.ProjectRecord, bool, error) {
+	if p.path == "" {
+		return domain.ProjectRecord{}, false, nil
+	}
+	return domain.ProjectRecord{ID: id, Path: p.path}, true, nil
+}
+
+func TestCheckoutAdapter(t *testing.T) {
+	adapter := NewCheckoutAdapter(fakeProjects{path: "/repos/app"})
+	path, err := adapter.CheckoutPath("proj-1")
+	if err != nil || path != "/repos/app" {
+		t.Fatalf("checkout = %q, %v", path, err)
+	}
+
+	if _, err := NewCheckoutAdapter(fakeProjects{}).CheckoutPath("proj-1"); err == nil {
+		t.Fatal("unregistered project resolved a checkout")
+	}
+}

--- a/backend/internal/pipeline/engine/engine.go
+++ b/backend/internal/pipeline/engine/engine.go
@@ -1,0 +1,1000 @@
+// Package engine runs pipelines. This file is the per-project actor: one
+// goroutine owns every run's state, feeds events into the pure reducer, and
+// executes the effects it hands back.
+//
+// The single-writer invariant is the correctness property the whole design
+// rests on: nothing outside the actor goroutine reads or writes the run map or
+// the inflight handle map. Public entry points post a closure onto the mailbox
+// and block until it runs; effect execution feeds follow-up events back through
+// the reducer synchronously on the same goroutine, so there is no re-entrancy
+// deadlock and no interleaving.
+//
+// The actor shape (mailbox, 2s ticker, inflight handles, hydrate on boot) is
+// ported from the v1 engine because it was proven; everything inside it is v2.
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/triggers"
+)
+
+// defaultTickInterval is how often the engine polls inflight stages and feeds a
+// Tick for deadline enforcement. Stages settle asynchronously, so the loop needs
+// a heartbeat to make progress; 2s balances latency against churn.
+const defaultTickInterval = 2 * time.Second
+
+// Store is the persistence surface the engine drives. It is a subset of the
+// sqlite store so the engine unit-tests against a fake; *store.Store satisfies
+// it. SQLite stays the store of record (decision D2); run.json in the run
+// folder is a projection written alongside every save.
+type Store interface {
+	SavePipelineRun(ctx context.Context, run pipeline.RunState) error
+	HydratePipelineEngineState(ctx context.Context, projectID domain.ProjectID) ([]pipeline.RunState, error)
+}
+
+// Credentials is the engine's view of a project's engine-held credentials
+// (decision D13). Names feeds the plan-time unknown-credential check; Resolve
+// produces the values a command stage's process env gets at exec time. Nothing
+// here ever reaches an agent.
+type Credentials interface {
+	Resolve(ctx context.Context, projectID string, names []string) (map[string]string, error)
+	Names(ctx context.Context, projectID string) ([]string, error)
+}
+
+// SessionDisposer kills a stage's session when the stage's kill-on rule says so
+// (spec section 7.2). executors.SessionSpawner satisfies it.
+type SessionDisposer interface {
+	Kill(ctx context.Context, sessionID string) error
+}
+
+// Config constructs an Engine. ProjectID, Store, Executors, Workspaces and
+// BaseDir are required; everything else defaults.
+type Config struct {
+	ProjectID domain.ProjectID
+	Store     Store
+	// Executors routes a stage to the executor for its kind. Production wires
+	// an *executors.Set.
+	Executors executors.StageExecutor
+	// Workspaces provisions a stage's tree lazily, when its StartStage effect
+	// executes (decision D8).
+	Workspaces executors.WorkspaceProvisioner
+	// Sessions applies the kill half of the kill-on rule. Optional: without it
+	// a session is always kept.
+	Sessions SessionDisposer
+	// Messenger delivers the one nudge a stage may get. Optional: without it a
+	// nudge cannot be delivered and the stage settles on its next poll.
+	Messenger executors.SessionMessenger
+	// Credentials resolves engine-held credentials. Optional: without it the
+	// plan-time unknown-name check is skipped and a stage declaring
+	// credentials fails to launch.
+	Credentials Credentials
+	// BaseDir is the run-folder root, <AO_DATA_DIR>/pipelines. No app state
+	// ever lands anywhere else.
+	BaseDir string
+	// Concurrency is the table the supervisor shares across its engines. A nil
+	// table gets a private one, which is what a single-engine test wants.
+	Concurrency *ConcurrencyTable
+	// StartQueued starts a trigger that was waiting on a concurrency key and
+	// just got it. The supervisor routes it to the right project's engine; a
+	// nil value starts it on this engine.
+	StartQueued func(pendingTrigger)
+
+	Logger *slog.Logger
+	// Clock is the driver clock stamped onto every event. The reducer never
+	// reads a clock of its own, which is what makes it testable.
+	Clock        func() time.Time
+	NewRunID     func() pipeline.RunID
+	TickInterval time.Duration
+}
+
+// stageKey identifies one running stage across the runs the engine holds.
+type stageKey struct {
+	RunID pipeline.RunID
+	Stage string
+}
+
+// Engine is one project's pipeline runtime. Every exported method is safe to
+// call from any goroutine; each serializes onto the actor loop.
+type Engine struct {
+	projectID   domain.ProjectID
+	store       Store
+	execs       executors.StageExecutor
+	workspaces  executors.WorkspaceProvisioner
+	sessions    SessionDisposer
+	messenger   executors.SessionMessenger
+	creds       Credentials
+	baseDir     string
+	concurrency *ConcurrencyTable
+	startQueued func(pendingTrigger)
+
+	log          *slog.Logger
+	now          func() time.Time
+	newRunID     func() pipeline.RunID
+	tickInterval time.Duration
+
+	mailbox  chan func()
+	quit     chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+	baseCtx  context.Context
+	cancel   context.CancelFunc
+
+	// The fields below are owned exclusively by the actor goroutine and need no
+	// lock: only mailbox closures touch them.
+	runs     map[pipeline.RunID]pipeline.RunState
+	inflight map[stageKey]executors.Handle
+	// keys remembers which concurrency key a run holds, so the run can release
+	// exactly what it took when it settles.
+	keys map[pipeline.RunID]groupKey
+	// owned lists the workspaces a run created and may therefore destroy.
+	owned map[pipeline.RunID][]string
+}
+
+// New builds an Engine. It touches neither the store nor any goroutine; call
+// Start.
+func New(cfg Config) *Engine {
+	e := &Engine{
+		projectID:    cfg.ProjectID,
+		store:        cfg.Store,
+		execs:        cfg.Executors,
+		workspaces:   cfg.Workspaces,
+		sessions:     cfg.Sessions,
+		messenger:    cfg.Messenger,
+		creds:        cfg.Credentials,
+		baseDir:      cfg.BaseDir,
+		concurrency:  cfg.Concurrency,
+		startQueued:  cfg.StartQueued,
+		log:          cfg.Logger,
+		now:          cfg.Clock,
+		newRunID:     cfg.NewRunID,
+		tickInterval: cfg.TickInterval,
+		mailbox:      make(chan func()),
+		quit:         make(chan struct{}),
+		runs:         map[pipeline.RunID]pipeline.RunState{},
+		inflight:     map[stageKey]executors.Handle{},
+		keys:         map[pipeline.RunID]groupKey{},
+		owned:        map[pipeline.RunID][]string{},
+	}
+	if e.log == nil {
+		e.log = slog.Default()
+	}
+	if e.now == nil {
+		e.now = func() time.Time { return time.Now().UTC() }
+	}
+	if e.newRunID == nil {
+		e.newRunID = func() pipeline.RunID { return pipeline.RunID("run-" + uuid.NewString()) }
+	}
+	if e.concurrency == nil {
+		e.concurrency = &ConcurrencyTable{}
+	}
+	if e.tickInterval <= 0 {
+		e.tickInterval = defaultTickInterval
+	}
+	return e
+}
+
+var _ triggers.Engine = (*Engine)(nil)
+
+// Start hydrates unsettled runs from the store, launches the actor loop, and
+// reconciles the stages a previous process left running. It fails only when
+// hydration does.
+func (e *Engine) Start(ctx context.Context) error {
+	e.baseCtx, e.cancel = context.WithCancel(context.Background())
+
+	// Hydrate before the actor serves: nothing else touches e.runs yet, so the
+	// direct assignment is race-free.
+	runs, err := e.store.HydratePipelineEngineState(ctx, e.projectID)
+	if err != nil {
+		e.cancel()
+		return fmt.Errorf("pipeline engine %s: hydrate: %w", e.projectID, err)
+	}
+	for _, run := range runs {
+		e.runs[run.RunID] = run
+	}
+
+	e.wg.Add(1)
+	go e.runLoop()
+
+	// A daemon restart cannot resume a Poll loop, so a stage persisted running
+	// has no handle anywhere and can never settle on its own (decision D16).
+	e.do(e.reconcileLostStages)
+	return nil
+}
+
+// Stop halts the actor loop and cancels in-flight I/O. Idempotent. Runs are
+// left as they are: sessions and worktrees outlive the daemon, and the next
+// Start reconciles whatever was running.
+func (e *Engine) Stop(context.Context) error {
+	e.stopOnce.Do(func() {
+		close(e.quit)
+		if e.cancel != nil {
+			e.cancel()
+		}
+	})
+	e.wg.Wait()
+	return nil
+}
+
+// runLoop is the single actor goroutine: the only place e.runs and e.inflight
+// are read or written after Start.
+func (e *Engine) runLoop() {
+	defer e.wg.Done()
+	ticker := time.NewTicker(e.tickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-e.quit:
+			return
+		case fn := <-e.mailbox:
+			fn()
+		case <-ticker.C:
+			e.tick()
+		}
+	}
+}
+
+// do runs fn on the actor goroutine and blocks until it completes. A stopped
+// engine drops fn and returns.
+func (e *Engine) do(fn func()) {
+	done := make(chan struct{})
+	select {
+	case e.mailbox <- func() { defer close(done); fn() }:
+		<-done
+	case <-e.quit:
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Entry points (each serialized onto the actor)
+// ---------------------------------------------------------------------------
+
+// TriggerRun admits a trigger against the concurrency table and, when it holds
+// the key, starts the run: allocate the id, create the run folder, freeze the
+// definition, plan, then feed TriggerFired.
+//
+// The returned run id is allocated before admission, so a queued trigger still
+// names the run it will become. A queued trigger has no run in the store yet:
+// the id is a promise, not a row.
+func (e *Engine) TriggerRun(req triggers.TriggerRequest) (pipeline.RunID, error) {
+	if req.Definition.Config.EntryStage() == nil {
+		return "", fmt.Errorf("pipeline engine %s: pipeline %q declares no stages", e.projectID, req.Definition.Name)
+	}
+
+	trigger := pendingTrigger{
+		Definition: req.Definition,
+		Event:      req.Event,
+		Subject:    req.Subject,
+		RunID:      e.newRunID(),
+	}
+	key := keyFor(req.Definition, req.Subject)
+	admission := e.concurrency.Admit(key, req.Definition.Config.Concurrency.CancelInProgress, trigger)
+
+	switch admission.Kind {
+	case Queued:
+		e.log.Info("pipeline run queued behind its concurrency key",
+			"project", e.projectID, "pipeline", req.Definition.Name, "group", key.Group, "scope", key.ScopeIdentity)
+		return trigger.RunID, nil
+	case CancelThenStart:
+		// cancel-in-progress: the newcomer already holds the key, so the victim
+		// is torn down and its release is a no-op.
+		e.Cancel(admission.Victim, fmt.Sprintf("superseded by a newer run of %q", req.Definition.Name))
+	case StartNow:
+	}
+
+	e.do(func() { e.startTrigger(trigger, key) })
+	return trigger.RunID, nil
+}
+
+// Cancel tears an in-flight run down. Unknown or settled runs are a no-op.
+func (e *Engine) Cancel(runID pipeline.RunID, reason string) {
+	if reason == "" {
+		reason = "cancelled"
+	}
+	e.do(func() {
+		run, ok := e.runs[runID]
+		if !ok || runSettled(run.Status) {
+			return
+		}
+		e.dispatch(runID, pipeline.CancelRequested{Reason: reason, Now: e.now()})
+	})
+}
+
+// Tick polls every inflight stage once and enforces deadlines, synchronously.
+// Production drives this on the heartbeat; tests call it for determinism.
+func (e *Engine) Tick() { e.do(e.tick) }
+
+// Run returns one run's current state. The reducer is copy-on-write, so the
+// returned value is safe to read off the actor.
+func (e *Engine) Run(id pipeline.RunID) (pipeline.RunState, bool) {
+	var (
+		run pipeline.RunState
+		ok  bool
+	)
+	e.do(func() { run, ok = e.runs[id] })
+	return run, ok
+}
+
+// Runs returns every run the engine holds, oldest id first.
+func (e *Engine) Runs() []pipeline.RunState {
+	var out []pipeline.RunState
+	e.do(func() {
+		out = make([]pipeline.RunState, 0, len(e.runs))
+		for _, run := range e.runs {
+			out = append(out, run)
+		}
+	})
+	sort.Slice(out, func(i, j int) bool { return out[i].RunID < out[j].RunID })
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Actor internals (never call these off the actor goroutine)
+// ---------------------------------------------------------------------------
+
+// startTrigger materialises a run: the folder first (so the frozen definition
+// exists before anything reads it), then the reducer's TriggerFired, which
+// plans and either starts the entry stage or settles the run failed with the
+// plan's reason.
+func (e *Engine) startTrigger(trigger pendingTrigger, key groupKey) {
+	now := e.now()
+	def := trigger.Definition
+	subject := trigger.Subject
+	if subject.ProjectID == "" {
+		subject.ProjectID = string(e.projectID)
+	}
+
+	folder, err := pipeline.CreateRunFolder(e.baseDir, subject.ProjectID, trigger.RunID, []byte(def.YAMLSource))
+	if err != nil {
+		// Without a folder the run has nowhere to write, so it never starts. It
+		// is still recorded as failed: a trigger that vanished silently is worse
+		// than a red card with a reason.
+		e.log.Error("pipeline run folder", "project", e.projectID, "run", trigger.RunID, "err", err)
+		e.persistFolderlessFailure(trigger, subject, err, now)
+		e.releaseKey(trigger.RunID, key)
+		return
+	}
+
+	e.runs[trigger.RunID] = pipeline.RunState{
+		RunID:        trigger.RunID,
+		ProjectID:    subject.ProjectID,
+		PipelineID:   def.ID,
+		PipelineName: def.Config.Name,
+		Subject:      subject,
+		Status:       pipeline.RunPending,
+		RunDir:       folder.Dir,
+		Def:          def.Config,
+		Stages:       map[string]*pipeline.StageState{},
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	e.keys[trigger.RunID] = key
+
+	e.dispatch(trigger.RunID, pipeline.TriggerFired{
+		Def:              def.Config,
+		Subject:          subject,
+		RunID:            trigger.RunID,
+		RunDir:           folder.Dir,
+		KnownCredentials: e.knownCredentials(subject.ProjectID),
+		Now:              now,
+	})
+}
+
+// persistFolderlessFailure records a run that could not even be created. There
+// is no run folder, so this writes the store row directly rather than going
+// through the reducer, whose every effect wants a folder to write into.
+func (e *Engine) persistFolderlessFailure(trigger pendingTrigger, subject pipeline.Subject, cause error, now time.Time) {
+	run := pipeline.RunState{
+		RunID:        trigger.RunID,
+		ProjectID:    subject.ProjectID,
+		PipelineID:   trigger.Definition.ID,
+		PipelineName: trigger.Definition.Config.Name,
+		Subject:      subject,
+		Status:       pipeline.RunFailed,
+		Stages:       map[string]*pipeline.StageState{},
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		SettledAt:    now,
+	}
+	if entry := trigger.Definition.Config.EntryStage(); entry != nil {
+		run.Stages[entry.ID] = &pipeline.StageState{
+			ID:         entry.ID,
+			Outcome:    pipeline.OutcomeFailed,
+			EnteredVia: pipeline.EntryTrigger,
+			SettledAt:  now,
+			Reason:     fmt.Sprintf("create run folder: %v", cause),
+		}
+	}
+	if err := e.store.SavePipelineRun(e.baseCtx, run); err != nil {
+		e.log.Error("pipeline persist run", "run", run.RunID, "err", err)
+	}
+}
+
+// knownCredentials stamps the project's declared credential names onto
+// TriggerFired the same way the clock is stamped, so the pure reducer can plan
+// without a credential store.
+//
+// A read failure yields nil, which tells ComputePlan to skip the unknown-name
+// check: a store hiccup must not fail a run for a credential that is fine. A
+// name that really is missing still fails the stage at resolve time.
+func (e *Engine) knownCredentials(projectID string) []string {
+	if e.creds == nil {
+		return nil
+	}
+	names, err := e.creds.Names(e.baseCtx, projectID)
+	if err != nil {
+		e.log.Warn("pipeline credential names", "project", projectID, "err", err)
+		return nil
+	}
+	return names
+}
+
+// dispatch is the reduce-then-execute cycle. Effect execution can feed further
+// events back through here, synchronously, on this goroutine.
+func (e *Engine) dispatch(runID pipeline.RunID, ev pipeline.Event) {
+	run, ok := e.runs[runID]
+	if !ok {
+		return
+	}
+	next, effects := pipeline.Reduce(run, ev)
+	e.runs[runID] = next
+	for _, eff := range effects {
+		e.execute(runID, eff)
+	}
+	e.pruneInflight(runID)
+}
+
+func (e *Engine) execute(runID pipeline.RunID, eff pipeline.Effect) {
+	switch ef := eff.(type) {
+	case pipeline.PersistRun:
+		e.persist(runID)
+	case pipeline.AppendContext:
+		e.appendContext(runID, ef.Line)
+	case pipeline.StartStage:
+		e.startStage(runID, ef)
+	case pipeline.NudgeStage:
+		e.nudge(runID, ef)
+	case pipeline.InterruptStage:
+		e.teardownStage(runID, ef.Stage, false)
+	case pipeline.CancelStageExec:
+		e.teardownStage(runID, ef.Stage, true)
+	case pipeline.SettleSession:
+		e.settleSession(runID, ef)
+	case pipeline.RunSettled:
+		e.runSettled(runID, ef)
+	default:
+		e.log.Warn("pipeline effect not handled", "run", runID, "effect", fmt.Sprintf("%T", eff))
+	}
+}
+
+// persist writes the run to the store of record and rewrites run.json, the
+// projection humans read (decision D2).
+func (e *Engine) persist(runID pipeline.RunID) {
+	run, ok := e.runs[runID]
+	if !ok {
+		return
+	}
+	if err := e.store.SavePipelineRun(e.baseCtx, run); err != nil {
+		e.log.Error("pipeline persist run", "run", runID, "err", err)
+	}
+	if run.RunDir == "" {
+		return
+	}
+	if err := (pipeline.RunFolder{Dir: run.RunDir}).WriteRunJSON(run); err != nil {
+		e.log.Warn("pipeline write run.json", "run", runID, "err", err)
+	}
+}
+
+func (e *Engine) appendContext(runID pipeline.RunID, line string) {
+	run, ok := e.runs[runID]
+	if !ok || run.RunDir == "" {
+		return
+	}
+	if err := (pipeline.RunFolder{Dir: run.RunDir}).AppendContext(line); err != nil {
+		e.log.Warn("pipeline append Context.md", "run", runID, "err", err)
+	}
+}
+
+// startStage provisions the stage's tree, builds the ambient environment,
+// resolves credentials for a command stage, and launches the executor. Any
+// failure before the stage is actually running comes back as StageLaunchFailed,
+// which settles the stage and routes it like any other failure.
+func (e *Engine) startStage(runID pipeline.RunID, eff pipeline.StartStage) {
+	run, ok := e.runs[runID]
+	if !ok {
+		return
+	}
+	st := run.Stages[eff.Stage]
+	def := run.Def.StageByID(eff.Stage)
+	if st == nil || def == nil {
+		return
+	}
+
+	path, owned, err := e.provision(run, st, def)
+	if err != nil {
+		e.dispatch(runID, pipeline.StageLaunchFailed{Stage: eff.Stage, Reason: err.Error(), Now: e.now()})
+		return
+	}
+	if owned {
+		e.owned[runID] = appendUnique(e.owned[runID], path)
+	}
+
+	creds, err := e.resolveCredentials(run, def)
+	if err != nil {
+		e.dispatch(runID, pipeline.StageLaunchFailed{Stage: eff.Stage, Reason: err.Error(), Now: e.now()})
+		return
+	}
+
+	attempt := eff.Attempt
+	if attempt < 1 {
+		attempt = 1
+	}
+	folder := pipeline.RunFolder{Dir: run.RunDir}
+	handle, err := e.execs.Start(e.baseCtx, executors.StartInput{
+		ProjectID:     run.ProjectID,
+		RunID:         run.RunID,
+		RunDir:        run.RunDir,
+		Stage:         *def,
+		Attempt:       attempt,
+		Subject:       run.Subject,
+		WorkspacePath: path,
+		Env:           ambientEnv(run, st, def, path, attempt),
+		Credentials:   creds,
+		LogPath:       folder.LogPath(def.ID),
+	})
+	if err != nil {
+		e.dispatch(runID, pipeline.StageLaunchFailed{Stage: eff.Stage, Reason: err.Error(), Now: e.now()})
+		return
+	}
+
+	e.inflight[stageKey{RunID: runID, Stage: eff.Stage}] = handle
+	sessionID := ""
+	if holder, ok := handle.(executors.SessionHolder); ok {
+		sessionID = holder.SessionID()
+	}
+	e.dispatch(runID, pipeline.StageLaunched{
+		Stage:         eff.Stage,
+		SessionID:     sessionID,
+		WorkspacePath: path,
+		Now:           e.now(),
+	})
+}
+
+// provision resolves the stage's tree. `inherit` is handed the tree of the
+// stage that routed here, which is the whole point of the failure-entry default
+// (spec section 5.4).
+func (e *Engine) provision(run pipeline.RunState, st *pipeline.StageState, def *pipeline.Stage) (string, bool, error) {
+	inherit := ""
+	if st.FailedStage != "" {
+		if from := run.Stages[st.FailedStage]; from != nil {
+			inherit = from.WorkspacePath
+		}
+	}
+	return e.workspaces.Provision(e.baseCtx, executors.WorkspaceRequest{
+		Kind:        st.WorkspaceKind,
+		ProjectID:   run.ProjectID,
+		RunID:       run.RunID,
+		StageID:     def.ID,
+		Subject:     run.Subject,
+		InheritPath: inherit,
+		BaseRef:     baseRef(run.Subject),
+		RunDir:      run.RunDir,
+	})
+}
+
+// baseRef is the ref a run or stage worktree starts from: the PR's head branch
+// for a PR subject, and otherwise nothing, which lets the workspace adapter
+// fall back to the project's default branch.
+func baseRef(subject pipeline.Subject) string {
+	if subject.PR != nil {
+		return subject.PR.HeadBranch
+	}
+	return ""
+}
+
+// resolveCredentials resolves the stage's engine-held credentials. Command
+// stages only: values never enter an agent's environment, and the schema
+// forbids `credentials:` on an agent stage so the two rules enforce each other
+// (spec section 8).
+func (e *Engine) resolveCredentials(run pipeline.RunState, def *pipeline.Stage) (map[string]string, error) {
+	if len(def.Credentials) == 0 || def.Executor != pipeline.ExecutorCommand {
+		return nil, nil
+	}
+	if e.creds == nil {
+		return nil, fmt.Errorf("stage %q declares credentials %v but this daemon has no credential store wired", def.ID, def.Credentials)
+	}
+	env, err := e.creds.Resolve(e.baseCtx, run.ProjectID, def.Credentials)
+	if err != nil {
+		return nil, fmt.Errorf("resolve credentials for stage %q: %w", def.ID, err)
+	}
+	return env, nil
+}
+
+// ambientEnv is the spec section 12.2 table, built here because the driver is
+// the only place that knows all of it: the resolved tree, the attempt, and the
+// stage's entry edge.
+//
+// AO_RUN_ID and AO_STAGE are the two that must never be absent: they are what
+// `ao pipeline done|fail` resolves itself from (spec section 6.3).
+//
+// AO_ATTEMPT is stamped at launch. A nudge does not relaunch the stage, so a
+// nudged agent reads 1 from its environment and learns it is on the second
+// attempt from the nudge message itself.
+func ambientEnv(run pipeline.RunState, st *pipeline.StageState, def *pipeline.Stage, workspacePath string, attempt int) map[string]string {
+	folder := pipeline.RunFolder{Dir: run.RunDir}
+	env := map[string]string{
+		"AO_PROJECT":   run.ProjectID,
+		"AO_RUN_ID":    string(run.RunID),
+		"AO_RUN_DIR":   run.RunDir,
+		"AO_STAGE":     def.ID,
+		"AO_ATTEMPT":   strconv.Itoa(attempt),
+		"AO_CONTEXT":   folder.ContextPath(),
+		"AO_WORKSPACE": workspacePath,
+	}
+	if run.Subject.SessionID != "" {
+		env["AO_SESSION_ID"] = run.Subject.SessionID
+	}
+	if pr := run.Subject.PR; pr != nil {
+		env["AO_PR_NUMBER"] = strconv.Itoa(pr.Number)
+		env["AO_PR_REPO"] = pr.Repo
+		env["AO_PR_HEAD"] = pr.HeadSHA
+	}
+	// OutputPath is empty unless the stage declares `produces`, and validation
+	// only allows that on an agent stage.
+	if out := folder.OutputPath(def); out != "" {
+		env["AO_OUTPUT"] = out
+	}
+	// AO_PREV_* is unset at a join, where it would be ambiguous: PrevStage is
+	// empty exactly there (and at the entry stage).
+	if st.PrevStage != "" {
+		env["AO_PREV_STAGE"] = st.PrevStage
+		if prev := run.Stages[st.PrevStage]; prev != nil {
+			env["AO_PREV_OUTCOME"] = string(prev.Outcome)
+		}
+	}
+	if st.EnteredVia == pipeline.EntryFailure && st.FailedStage != "" {
+		env["AO_FAILED_STAGE"] = st.FailedStage
+		env["AO_FAILED_OUTCOME"] = string(st.FailedOutcome)
+	}
+	return env
+}
+
+// nudge delivers the stage's one nudge and reports it back, which is what moves
+// the stage to its second and last attempt. A delivery failure is not fatal: the
+// stage stays running and settles on its next poll, because the reducer already
+// recorded the nudge as spent.
+func (e *Engine) nudge(runID pipeline.RunID, eff pipeline.NudgeStage) {
+	if e.messenger == nil || eff.SessionID == "" {
+		e.log.Warn("pipeline nudge undeliverable", "run", runID, "stage", eff.Stage, "session", eff.SessionID)
+		return
+	}
+	if err := e.messenger.Send(e.baseCtx, eff.SessionID, eff.Message); err != nil {
+		e.log.Warn("pipeline nudge send", "run", runID, "stage", eff.Stage, "err", err)
+		return
+	}
+	e.dispatch(runID, pipeline.NudgeDelivered{Stage: eff.Stage, Now: e.now()})
+}
+
+// teardownStage stops a stage's work. kill true is run cancellation (tear the
+// session down with it); kill false is the deadline path, which stops the work
+// and leaves the session alive so a human can see what it was doing (spec
+// section 7.2).
+func (e *Engine) teardownStage(runID pipeline.RunID, stage string, kill bool) {
+	key := stageKey{RunID: runID, Stage: stage}
+	handle, ok := e.inflight[key]
+	if !ok {
+		return
+	}
+	delete(e.inflight, key)
+	var err error
+	if kill {
+		err = e.execs.Cancel(e.baseCtx, handle)
+	} else {
+		err = e.execs.Interrupt(e.baseCtx, handle)
+	}
+	if err != nil {
+		e.log.Warn("pipeline stage teardown", "run", runID, "stage", stage, "kill", kill, "err", err)
+	}
+}
+
+// settleSession applies the stage's kill-on rule. An outcome in the list kills
+// the session; anything else keeps it, because no_output, no_signal and
+// timed_out are precisely the cases where a human needs to see what the agent
+// was doing (spec section 7.2).
+//
+// ponytail: a kept session is only logged today. Task 16 adds the orphan
+// registry that marks it pipeline-orphaned in the session list and bounds the
+// leak (cap 3 per pipeline, 24h TTL); until then a kept session is visible in
+// the sidebar like any other and has to be killed by hand.
+func (e *Engine) settleSession(runID pipeline.RunID, eff pipeline.SettleSession) {
+	if eff.SessionID == "" {
+		return
+	}
+	run, ok := e.runs[runID]
+	if !ok {
+		return
+	}
+	def := run.Def.StageByID(eff.Stage)
+	if def == nil {
+		return
+	}
+	for _, killOn := range def.EffectiveKillOn() {
+		if killOn != eff.Outcome {
+			continue
+		}
+		if e.sessions == nil {
+			e.log.Warn("pipeline session kill skipped: no session seam wired", "run", runID, "stage", eff.Stage)
+			return
+		}
+		if err := e.sessions.Kill(e.baseCtx, eff.SessionID); err != nil {
+			e.log.Warn("pipeline session kill", "run", runID, "stage", eff.Stage, "err", err)
+		}
+		return
+	}
+	e.log.Info("pipeline session kept alive",
+		"run", runID, "stage", eff.Stage, "session", eff.SessionID, "outcome", eff.Outcome)
+}
+
+// runSettled tears down what the run owns and hands its concurrency key on.
+// Owned trees are destroyed on success and kept on failure, the same rule as
+// sessions and for the same reason (spec section 5.5).
+func (e *Engine) runSettled(runID pipeline.RunID, eff pipeline.RunSettled) {
+	for _, path := range e.owned[runID] {
+		if eff.Status != pipeline.RunSucceeded {
+			e.log.Info("pipeline workspace kept", "run", runID, "path", path, "status", eff.Status)
+			continue
+		}
+		if err := e.workspaces.Destroy(e.baseCtx, path); err != nil {
+			e.log.Warn("pipeline workspace destroy", "run", runID, "path", path, "err", err)
+		}
+	}
+	delete(e.owned, runID)
+
+	for key := range e.inflight {
+		if key.RunID == runID {
+			delete(e.inflight, key)
+		}
+	}
+	if key, ok := e.keys[runID]; ok {
+		e.releaseKey(runID, key)
+	}
+}
+
+// releaseKey gives up a run's concurrency key and starts whatever was waiting
+// for it. The queued trigger starts on another goroutine: it may belong to this
+// engine, and posting onto our own mailbox from the actor would deadlock.
+func (e *Engine) releaseKey(runID pipeline.RunID, key groupKey) {
+	delete(e.keys, runID)
+	next, queued := e.concurrency.Release(key, runID)
+	if !queued {
+		return
+	}
+	start := e.startQueued
+	if start == nil {
+		start = func(pt pendingTrigger) { e.do(func() { e.startTrigger(pt, key) }) }
+	}
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+		start(next)
+	}()
+}
+
+// tick polls every inflight stage, then feeds Tick so the reducer can time out
+// anything past its deadline. Polling runs first, so a stage that settled on
+// its own is finalized normally rather than timed out.
+func (e *Engine) tick() {
+	e.pollInflight()
+	for _, runID := range e.runIDs() {
+		e.dispatch(runID, pipeline.Tick{Now: e.now()})
+	}
+}
+
+// pollInflight polls each running stage once and turns the observation into the
+// event the reducer expects. Keys are snapshotted and sorted first: a settling
+// stage can start or cancel siblings, and the walk has to be deterministic.
+func (e *Engine) pollInflight() {
+	keys := make([]stageKey, 0, len(e.inflight))
+	for key := range e.inflight {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].RunID != keys[j].RunID {
+			return keys[i].RunID < keys[j].RunID
+		}
+		return keys[i].Stage < keys[j].Stage
+	})
+
+	for _, key := range keys {
+		handle, ok := e.inflight[key]
+		if !ok {
+			// Removed by an earlier iteration's cascade; nothing to poll.
+			continue
+		}
+		out, err := e.execs.Poll(e.baseCtx, handle)
+		if err != nil {
+			// A handle that cannot be polled will never settle on its own, so
+			// the stage fails with the reason rather than burning its deadline.
+			delete(e.inflight, key)
+			e.dispatch(key.RunID, pipeline.StageLaunchFailed{
+				Stage:  key.Stage,
+				Reason: fmt.Sprintf("stage poll failed: %v", err),
+				Now:    e.now(),
+			})
+			continue
+		}
+		if out.State == executors.PollRunning {
+			continue
+		}
+		e.recordOutputTail(key, handle)
+		// The handle is dropped by pruneInflight, and only once the stage has
+		// actually settled: a nudged stage keeps running against the same
+		// session, and it still has to be polled for the answer.
+		if ev := e.pollEvent(key, out); ev != nil {
+			e.dispatch(key.RunID, ev)
+		}
+	}
+}
+
+// pollEvent maps one terminal observation onto the reducer's vocabulary. The
+// artifact check happens here because the driver is what stats the file: the
+// reducer only ever reads the answer (spec section 6.2).
+func (e *Engine) pollEvent(key stageKey, out executors.Poll) pipeline.Event {
+	now := e.now()
+	run, ok := e.runs[key.RunID]
+	if !ok {
+		return nil
+	}
+	artifactOK := (pipeline.RunFolder{Dir: run.RunDir}).VerifyArtifact(run.Def.StageByID(key.Stage))
+
+	switch out.State {
+	case executors.PollSignaledDone:
+		return pipeline.AgentSignaled{Stage: key.Stage, Done: true, ArtifactOK: artifactOK, Now: now}
+	case executors.PollSignaledFail:
+		return pipeline.AgentSignaled{Stage: key.Stage, Done: false, Reason: out.Reason, Now: now}
+	case executors.PollExited:
+		return pipeline.CommandExited{Stage: key.Stage, ExitCode: out.ExitCode, Now: now}
+	case executors.PollIdle:
+		return pipeline.SessionIdle{Stage: key.Stage, ArtifactOK: artifactOK, Now: now}
+	case executors.PollGone:
+		return pipeline.SessionGone{Stage: key.Stage, Now: now}
+	default:
+		return nil
+	}
+}
+
+// recordOutputTail copies the executor's capped output onto the stage before it
+// settles, so run detail can show why a command failed without opening the log
+// file. The full stream is always on disk.
+//
+// The reducer has no event carrying output, so the driver writes it: the engine
+// owns the run map, and the write is copy-on-write like every other, so the
+// state the reducer is handed next is still a value nobody else holds.
+func (e *Engine) recordOutputTail(key stageKey, handle executors.Handle) {
+	tailer, ok := handle.(executors.OutputTailer)
+	if !ok {
+		return
+	}
+	text, _ := tailer.OutputTail()
+	if text == "" {
+		return
+	}
+	run, ok := e.runs[key.RunID]
+	if !ok {
+		return
+	}
+	st, ok := run.Stages[key.Stage]
+	if !ok || st == nil {
+		return
+	}
+	updated := *st
+	updated.OutputTail = text
+	stages := make(map[string]*pipeline.StageState, len(run.Stages))
+	for id, s := range run.Stages {
+		stages[id] = s
+	}
+	stages[key.Stage] = &updated
+	run.Stages = stages
+	e.runs[key.RunID] = run
+}
+
+// reconcileLostStages settles every stage a previous process left in flight
+// (decision D16). An agent stage settles no_signal and a command stage failed,
+// then both route their failure edge normally: a daemon restart cannot resume a
+// Poll loop, and an honest settle beats a stuck board.
+func (e *Engine) reconcileLostStages() {
+	for _, runID := range e.runIDs() {
+		run := e.runs[runID]
+		if runSettled(run.Status) {
+			continue
+		}
+		for i := range run.Def.Stages {
+			stageID := run.Def.Stages[i].ID
+			st := e.runs[runID].Stages[stageID]
+			if st == nil || st.Outcome.IsSettled() {
+				continue
+			}
+			// Pending with an attempt recorded is a launch that was committed
+			// and never reported: the same lost-handle case.
+			if st.Outcome != pipeline.OutcomeRunning && st.Attempt == 0 {
+				continue
+			}
+			if _, live := e.inflight[stageKey{RunID: runID, Stage: stageID}]; live {
+				continue
+			}
+			e.dispatch(runID, lostStageEvent(run.Def.StageByID(stageID), stageID, e.now()))
+		}
+	}
+}
+
+// lostStageEvent is the honest settlement for a stage whose handle died with
+// the previous process.
+func lostStageEvent(def *pipeline.Stage, stageID string, now time.Time) pipeline.Event {
+	if def != nil && def.Executor == pipeline.ExecutorAgent {
+		// no_signal: the session may well still be alive, but nothing in this
+		// process is listening to it any more.
+		return pipeline.SessionGone{Stage: stageID, Now: now}
+	}
+	return pipeline.StageLaunchFailed{
+		Stage:  stageID,
+		Reason: "the pipeline engine restarted while this stage was running; its process handle is lost",
+		Now:    now,
+	}
+}
+
+// pruneInflight drops handles for stages that have settled, so a later poll
+// never touches a stage the reducer already closed.
+func (e *Engine) pruneInflight(runID pipeline.RunID) {
+	run, ok := e.runs[runID]
+	if !ok {
+		return
+	}
+	for key := range e.inflight {
+		if key.RunID != runID {
+			continue
+		}
+		if st := run.Stages[key.Stage]; st == nil || st.Outcome.IsSettled() {
+			delete(e.inflight, key)
+		}
+	}
+}
+
+// runIDs lists the engine's runs in a stable order, so every walk over them is
+// deterministic.
+func (e *Engine) runIDs() []pipeline.RunID {
+	ids := make([]pipeline.RunID, 0, len(e.runs))
+	for id := range e.runs {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+// runSettled reports whether a run reached a terminal status. The pipeline
+// package keeps its own copy of this unexported, and the driver needs it to
+// tell a live run from a closed one.
+func runSettled(status pipeline.RunStatus) bool {
+	return status == pipeline.RunSucceeded || status == pipeline.RunFailed || status == pipeline.RunCancelled
+}
+
+// appendUnique adds path once, keeping the teardown list free of the duplicates
+// a memoized `workspace: run` tree would otherwise produce.
+func appendUnique(paths []string, path string) []string {
+	for _, existing := range paths {
+		if existing == path {
+			return paths
+		}
+	}
+	return append(paths, path)
+}

--- a/backend/internal/pipeline/engine/engine_test.go
+++ b/backend/internal/pipeline/engine/engine_test.go
@@ -791,6 +791,49 @@ func TestRestartSettlesLostCommandStageAsFailed(t *testing.T) {
 	}
 }
 
+// TestAmbientEnvAlwaysPresent pins the seven variables the spec's section 12.2
+// table marks "always". Anything a `run:` block or a prompt can rely on
+// unconditionally has to actually be there: the starter templates interpolate
+// $AO_RUN_DIR, and AO_RUN_ID plus AO_STAGE are what `ao pipeline done` resolves
+// itself from.
+func TestAmbientEnvAlwaysPresent(t *testing.T) {
+	h := newHarness(t)
+	// A project subject: no session, no PR, so only the always-present set and
+	// the workspace can resolve.
+	runID := h.trigger(t, joinYAML, pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: "proj-1"})
+
+	in := h.execs.handle(t, "prepare").in
+	runDir := filepath.Join(h.base, "proj-1", string(runID))
+	want := map[string]string{
+		"AO_PROJECT":   "proj-1",
+		"AO_RUN_ID":    string(runID),
+		"AO_RUN_DIR":   runDir,
+		"AO_STAGE":     "prepare",
+		"AO_ATTEMPT":   "1",
+		"AO_CONTEXT":   filepath.Join(runDir, "Context.md"),
+		"AO_WORKSPACE": in.WorkspacePath,
+	}
+	for key, value := range want {
+		got, ok := in.Env[key]
+		if !ok {
+			t.Errorf("%s is unset, but the spec table marks it always present", key)
+			continue
+		}
+		if got != value {
+			t.Errorf("%s = %q, want %q", key, got, value)
+		}
+	}
+	if in.Env["AO_WORKSPACE"] == "" {
+		t.Error("AO_WORKSPACE is empty, want the resolved tree")
+	}
+	// Nothing that cannot resolve for this subject leaked in.
+	for _, key := range []string{"AO_SESSION_ID", "AO_PR_NUMBER", "AO_PR_REPO", "AO_PR_HEAD", "AO_OUTPUT", "AO_PREV_STAGE", "AO_FAILED_STAGE"} {
+		if got, ok := in.Env[key]; ok {
+			t.Errorf("%s = %q, want unset for a project subject at the entry stage", key, got)
+		}
+	}
+}
+
 // TestAmbientEnvOnFailureEntry covers the failure-entry half of the spec's
 // ambient table, including the inherited tree.
 func TestAmbientEnvOnFailureEntry(t *testing.T) {

--- a/backend/internal/pipeline/engine/engine_test.go
+++ b/backend/internal/pipeline/engine/engine_test.go
@@ -1,0 +1,1046 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/triggers"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+// fakeHandle is one started stage in the fake executor. The test scripts what
+// each poll returns by pushing states onto next.
+type fakeHandle struct {
+	in    executors.StartInput
+	mu    sync.Mutex
+	polls []executors.Poll
+
+	interrupted bool
+	cancelled   bool
+}
+
+func (h *fakeHandle) RunID() pipeline.RunID { return h.in.RunID }
+func (h *fakeHandle) StageID() string       { return h.in.Stage.ID }
+func (h *fakeHandle) Attempt() int          { return h.in.Attempt }
+func (h *fakeHandle) SessionID() string     { return "sess-" + h.in.Stage.ID }
+
+// fakeExecutor records every Start and replays scripted poll results.
+type fakeExecutor struct {
+	mu      sync.Mutex
+	started []*fakeHandle
+	failOn  map[string]error
+}
+
+func newFakeExecutor() *fakeExecutor {
+	return &fakeExecutor{failOn: map[string]error{}}
+}
+
+func (x *fakeExecutor) Start(_ context.Context, in executors.StartInput) (executors.Handle, error) {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if err := x.failOn[in.Stage.ID]; err != nil {
+		return nil, err
+	}
+	h := &fakeHandle{in: in}
+	x.started = append(x.started, h)
+	return h, nil
+}
+
+func (x *fakeExecutor) Poll(_ context.Context, h executors.Handle) (executors.Poll, error) {
+	fh, ok := h.(*fakeHandle)
+	if !ok {
+		return executors.Poll{}, errors.New("unexpected handle")
+	}
+	fh.mu.Lock()
+	defer fh.mu.Unlock()
+	if len(fh.polls) == 0 {
+		return executors.Poll{State: executors.PollRunning}, nil
+	}
+	out := fh.polls[0]
+	fh.polls = fh.polls[1:]
+	return out, nil
+}
+
+func (x *fakeExecutor) Cancel(_ context.Context, h executors.Handle) error {
+	if fh, ok := h.(*fakeHandle); ok {
+		fh.cancelled = true
+	}
+	return nil
+}
+
+func (x *fakeExecutor) Interrupt(_ context.Context, h executors.Handle) error {
+	if fh, ok := h.(*fakeHandle); ok {
+		fh.interrupted = true
+	}
+	return nil
+}
+
+// handle returns the most recent start of a stage.
+func (x *fakeExecutor) handle(t *testing.T, stage string) *fakeHandle {
+	t.Helper()
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	for i := len(x.started) - 1; i >= 0; i-- {
+		if x.started[i].in.Stage.ID == stage {
+			return x.started[i]
+		}
+	}
+	t.Fatalf("stage %q was never started (started: %v)", stage, x.startedIDs())
+	return nil
+}
+
+func (x *fakeExecutor) startedIDs() []string {
+	ids := make([]string, 0, len(x.started))
+	for _, h := range x.started {
+		ids = append(ids, h.in.Stage.ID)
+	}
+	return ids
+}
+
+// script queues poll results for a started stage.
+func (x *fakeExecutor) script(t *testing.T, stage string, polls ...executors.Poll) {
+	t.Helper()
+	h := x.handle(t, stage)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.polls = append(h.polls, polls...)
+}
+
+// fakeProvisioner hands every stage a directory under root and records the
+// destroy calls the teardown policy makes.
+type fakeProvisioner struct {
+	root string
+
+	mu        sync.Mutex
+	requests  []executors.WorkspaceRequest
+	destroyed []string
+	failOn    map[string]error
+}
+
+func newFakeProvisioner(root string) *fakeProvisioner {
+	return &fakeProvisioner{root: root, failOn: map[string]error{}}
+}
+
+func (p *fakeProvisioner) Provision(_ context.Context, req executors.WorkspaceRequest) (string, bool, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.requests = append(p.requests, req)
+	if err := p.failOn[req.StageID]; err != nil {
+		return "", false, err
+	}
+	if req.Kind == pipeline.WorkspaceInherit {
+		return req.InheritPath, false, nil
+	}
+	path := filepath.Join(p.root, req.StageID)
+	owned := req.Kind == pipeline.WorkspaceRun || req.Kind == pipeline.WorkspaceStage
+	if req.Kind == pipeline.WorkspaceRun {
+		path = filepath.Join(p.root, "run")
+	}
+	return path, owned, nil
+}
+
+func (p *fakeProvisioner) Destroy(_ context.Context, path string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.destroyed = append(p.destroyed, path)
+	return nil
+}
+
+func (p *fakeProvisioner) destroyedPaths() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.destroyed...)
+}
+
+// fakeStore is an in-memory stand-in for the SQLite pipeline store.
+type fakeStore struct {
+	mu      sync.Mutex
+	runs    map[pipeline.RunID]pipeline.RunState
+	hydra   []pipeline.RunState
+	saves   int
+	saveErr error
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{runs: map[pipeline.RunID]pipeline.RunState{}}
+}
+
+func (s *fakeStore) SavePipelineRun(_ context.Context, run pipeline.RunState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.saves++
+	if s.saveErr != nil {
+		return s.saveErr
+	}
+	s.runs[run.RunID] = run
+	return nil
+}
+
+func (s *fakeStore) HydratePipelineEngineState(context.Context, domain.ProjectID) ([]pipeline.RunState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hydra, nil
+}
+
+func (s *fakeStore) saved(id pipeline.RunID) (pipeline.RunState, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	run, ok := s.runs[id]
+	return run, ok
+}
+
+// fakeMessenger records nudges.
+type fakeMessenger struct {
+	mu   sync.Mutex
+	sent []string
+	err  error
+}
+
+func (m *fakeMessenger) Alive(context.Context, string) (bool, error) { return true, nil }
+
+func (m *fakeMessenger) Send(_ context.Context, sessionID, message string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return m.err
+	}
+	m.sent = append(m.sent, sessionID+": "+message)
+	return nil
+}
+
+func (m *fakeMessenger) messages() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.sent...)
+}
+
+// fakeSessions records the kill-on decisions the driver made.
+type fakeSessions struct {
+	mu     sync.Mutex
+	killed []string
+}
+
+func (s *fakeSessions) Kill(_ context.Context, sessionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.killed = append(s.killed, sessionID)
+	return nil
+}
+
+func (s *fakeSessions) killedIDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.killed...)
+}
+
+// fakeCredentials serves engine-held credentials from a map.
+type fakeCredentials struct {
+	values map[string]map[string]string
+}
+
+func (c fakeCredentials) Resolve(_ context.Context, _ string, names []string) (map[string]string, error) {
+	out := map[string]string{}
+	for _, name := range names {
+		env, ok := c.values[name]
+		if !ok {
+			return nil, errors.New("unknown credential " + name)
+		}
+		for k, v := range env {
+			out[k] = v
+		}
+	}
+	return out, nil
+}
+
+func (c fakeCredentials) Names(context.Context, string) ([]string, error) {
+	names := make([]string, 0, len(c.values))
+	for name := range c.values {
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+type harness struct {
+	engine *Engine
+	execs  *fakeExecutor
+	ws     *fakeProvisioner
+	store  *fakeStore
+	msgr   *fakeMessenger
+	sess   *fakeSessions
+	base   string
+
+	mu  sync.Mutex
+	now time.Time
+}
+
+// newHarness wires an engine over the fakes with a frozen clock and a
+// deterministic run id, so every test drives time and ticks explicitly.
+func newHarness(t *testing.T, opts ...func(*Config)) *harness {
+	t.Helper()
+	base := t.TempDir()
+	h := &harness{
+		execs: newFakeExecutor(),
+		ws:    newFakeProvisioner(filepath.Join(base, "trees")),
+		store: newFakeStore(),
+		msgr:  &fakeMessenger{},
+		sess:  &fakeSessions{},
+		base:  filepath.Join(base, "pipelines"),
+		now:   time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC),
+	}
+	n := 0
+	cfg := Config{
+		ProjectID:  "proj-1",
+		Store:      h.store,
+		Executors:  h.execs,
+		Workspaces: h.ws,
+		Sessions:   h.sess,
+		Messenger:  h.msgr,
+		BaseDir:    h.base,
+		Clock:      h.clock,
+		NewRunID: func() pipeline.RunID {
+			n++
+			return pipeline.RunID("run-" + string(rune('a'+n-1)))
+		},
+		// Long enough that the internal ticker never fires: tests call Tick.
+		TickInterval: time.Hour,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	h.engine = New(cfg)
+	if err := h.engine.Start(context.Background()); err != nil {
+		t.Fatalf("start engine: %v", err)
+	}
+	t.Cleanup(func() { _ = h.engine.Stop(context.Background()) })
+	return h
+}
+
+func (h *harness) clock() time.Time {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.now
+}
+
+func (h *harness) advance(d time.Duration) {
+	h.mu.Lock()
+	h.now = h.now.Add(d)
+	h.mu.Unlock()
+}
+
+// trigger starts a run from raw YAML, failing the test if the definition does
+// not parse: a broken fixture must not read as an engine bug.
+func (h *harness) trigger(t *testing.T, yamlSrc string, subject pipeline.Subject) pipeline.RunID {
+	t.Helper()
+	cfg, err := pipeline.ParseDefinition([]byte(yamlSrc))
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	runID, err := h.engine.TriggerRun(triggers.TriggerRequest{
+		Definition: pipeline.Definition{
+			ID:         "pl-1",
+			ProjectID:  "proj-1",
+			Name:       cfg.Name,
+			YAMLSource: yamlSrc,
+			Config:     *cfg,
+		},
+		Event:   "manual",
+		Subject: subject,
+	})
+	if err != nil {
+		t.Fatalf("trigger run: %v", err)
+	}
+	return runID
+}
+
+func (h *harness) run(t *testing.T, id pipeline.RunID) pipeline.RunState {
+	t.Helper()
+	run, ok := h.engine.Run(id)
+	if !ok {
+		t.Fatalf("engine has no run %s", id)
+	}
+	return run
+}
+
+func (h *harness) outcome(t *testing.T, id pipeline.RunID, stage string) pipeline.Outcome {
+	t.Helper()
+	st := h.run(t, id).Stages[stage]
+	if st == nil {
+		t.Fatalf("run %s has no stage %q", id, stage)
+	}
+	return st.Outcome
+}
+
+// writeOutput fills a stage's declared artifact so VerifyArtifact passes.
+func (h *harness) writeOutput(t *testing.T, id pipeline.RunID, name, body string) {
+	t.Helper()
+	path := filepath.Join(h.base, "proj-1", string(id), "agent-outputs", name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+}
+
+func userSessionSubject() pipeline.Subject {
+	return pipeline.Subject{Kind: pipeline.SubjectSession, ProjectID: "proj-1", SessionID: "sess-user"}
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const twoStageYAML = `
+name: review-then-publish
+stages:
+  - id: review
+    executor: agent
+    agent: claude-code
+    produces: review.md
+    prompt: review the diff
+    on_success: publish
+  - id: publish
+    executor: command
+    run: echo published
+`
+
+const failureRouteYAML = `
+name: build-and-diagnose
+stages:
+  - id: build
+    executor: command
+    run: make build
+    on_failure: diagnose
+  - id: diagnose
+    executor: agent
+    agent: claude-code
+    prompt: work out why the build failed
+`
+
+const joinYAML = `
+name: fan-in
+stages:
+  - id: prepare
+    executor: command
+    run: echo prepare
+    on_success: [lint, test]
+  - id: lint
+    executor: command
+    run: echo lint
+    on_success: report
+  - id: test
+    executor: command
+    run: echo test
+    on_success: report
+  - id: report
+    executor: agent
+    agent: claude-code
+    prompt: summarize
+    needs: [lint, test]
+`
+
+const sessionWorkspaceYAML = `
+name: needs-a-session
+stages:
+  - id: review
+    executor: agent
+    agent: claude-code
+    workspace: session
+    prompt: review it
+`
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestHappyPathRunSettlesSucceeded is the whole loop end to end: an agent stage
+// that honours its produces contract, then a command stage that exits 0.
+func TestHappyPathRunSettlesSucceeded(t *testing.T) {
+	h := newHarness(t)
+	runID := h.trigger(t, twoStageYAML, userSessionSubject())
+
+	if got := h.outcome(t, runID, "review"); got != pipeline.OutcomeRunning {
+		t.Fatalf("review outcome = %q, want running", got)
+	}
+	if got := h.outcome(t, runID, "publish"); got != pipeline.OutcomePending {
+		t.Fatalf("publish outcome = %q, want pending", got)
+	}
+
+	h.writeOutput(t, runID, "review.md", "looks fine")
+	h.execs.script(t, "review", executors.Poll{State: executors.PollSignaledDone})
+	h.engine.Tick()
+
+	if got := h.outcome(t, runID, "review"); got != pipeline.OutcomeSucceeded {
+		t.Fatalf("review outcome = %q, want succeeded", got)
+	}
+	h.execs.script(t, "publish", executors.Poll{State: executors.PollExited, ExitCode: 0})
+	h.engine.Tick()
+
+	run := h.run(t, runID)
+	if run.Status != pipeline.RunSucceeded {
+		t.Fatalf("run status = %q, want succeeded", run.Status)
+	}
+
+	// Context.md carries the pointer line for the verified artifact.
+	ctxRaw, err := os.ReadFile(filepath.Join(h.base, "proj-1", string(runID), "Context.md"))
+	if err != nil {
+		t.Fatalf("read Context.md: %v", err)
+	}
+	want := "stage `review` finished, its output is at agent-outputs/review.md"
+	if !strings.Contains(string(ctxRaw), want) {
+		t.Fatalf("Context.md = %q, want it to contain %q", ctxRaw, want)
+	}
+
+	// run.json is the on-disk projection, and the store is the record.
+	if _, err := os.Stat(filepath.Join(h.base, "proj-1", string(runID), "run.json")); err != nil {
+		t.Fatalf("run.json: %v", err)
+	}
+	saved, ok := h.store.saved(runID)
+	if !ok || saved.Status != pipeline.RunSucceeded {
+		t.Fatalf("store has %+v, want a succeeded run", saved.Status)
+	}
+	// The frozen definition is what actually ran.
+	frozen, err := os.ReadFile(filepath.Join(h.base, "proj-1", string(runID), "definition.yaml"))
+	if err != nil {
+		t.Fatalf("read frozen definition: %v", err)
+	}
+	if string(frozen) != twoStageYAML {
+		t.Fatalf("frozen definition does not match the source YAML")
+	}
+}
+
+// TestNudgeRoundTrip walks the one nudge a stage gets: done with no artifact,
+// the spec's message into the live session, attempt 2, then a real settlement.
+func TestNudgeRoundTrip(t *testing.T) {
+	h := newHarness(t)
+	runID := h.trigger(t, twoStageYAML, userSessionSubject())
+
+	h.execs.script(t, "review", executors.Poll{State: executors.PollSignaledDone})
+	h.engine.Tick()
+
+	msgs := h.msgr.messages()
+	if len(msgs) != 1 {
+		t.Fatalf("messenger got %v, want exactly one nudge", msgs)
+	}
+	if !strings.Contains(msgs[0], "agent-outputs/review.md does not exist or is empty") {
+		t.Fatalf("nudge message = %q", msgs[0])
+	}
+	if !strings.HasPrefix(msgs[0], "sess-review: ") {
+		t.Fatalf("nudge went to %q, want the stage's own session", msgs[0])
+	}
+
+	run := h.run(t, runID)
+	if got := run.Stages["review"].Outcome; got != pipeline.OutcomeRunning {
+		t.Fatalf("review outcome = %q, want it to stay running through the nudge", got)
+	}
+	if got := run.Stages["review"].Attempt; got != 2 {
+		t.Fatalf("review attempt = %d, want 2 after the nudge was delivered", got)
+	}
+
+	// The agent answers the nudge: artifact written, signal repeated.
+	h.writeOutput(t, runID, "review.md", "now with content")
+	h.execs.script(t, "review", executors.Poll{State: executors.PollSignaledDone})
+	h.engine.Tick()
+	if got := h.outcome(t, runID, "review"); got != pipeline.OutcomeSucceeded {
+		t.Fatalf("review outcome = %q, want succeeded after the nudge", got)
+	}
+}
+
+// TestNudgeSpentSettlesNoOutput is the second arrival at the same dead end: two
+// attempts total, then the stage settles no_output.
+func TestNudgeSpentSettlesNoOutput(t *testing.T) {
+	h := newHarness(t)
+	runID := h.trigger(t, twoStageYAML, userSessionSubject())
+
+	h.execs.script(t, "review",
+		executors.Poll{State: executors.PollSignaledDone},
+		executors.Poll{State: executors.PollSignaledDone},
+	)
+	h.engine.Tick()
+	h.engine.Tick()
+
+	if got := h.outcome(t, runID, "review"); got != pipeline.OutcomeNoOutput {
+		t.Fatalf("review outcome = %q, want no_output", got)
+	}
+	if got := h.outcome(t, runID, "publish"); got != pipeline.OutcomeSkipped {
+		t.Fatalf("publish outcome = %q, want skipped", got)
+	}
+	if run := h.run(t, runID); run.Status != pipeline.RunFailed {
+		t.Fatalf("run status = %q, want failed", run.Status)
+	}
+	// no_output is not in the default kill-on set: the session is kept so a
+	// human can see what the agent was doing.
+	if killed := h.sess.killedIDs(); len(killed) != 0 {
+		t.Fatalf("killed %v, want the session kept on no_output", killed)
+	}
+}
+
+// TestDeadlineTimesOutAndInterrupts checks the tick path: a stage past its
+// deadline settles timed_out, its process is interrupted, and the session is
+// kept.
+func TestDeadlineTimesOutAndInterrupts(t *testing.T) {
+	h := newHarness(t)
+	runID := h.trigger(t, twoStageYAML, userSessionSubject())
+
+	h.advance(pipeline.DefaultStageDeadline + time.Minute)
+	h.engine.Tick()
+
+	if got := h.outcome(t, runID, "review"); got != pipeline.OutcomeTimedOut {
+		t.Fatalf("review outcome = %q, want timed_out", got)
+	}
+	if !h.execs.handle(t, "review").interrupted {
+		t.Fatal("timed-out stage was not interrupted")
+	}
+	if killed := h.sess.killedIDs(); len(killed) != 0 {
+		t.Fatalf("killed %v, want the session kept on timed_out", killed)
+	}
+	if run := h.run(t, runID); run.Status != pipeline.RunFailed {
+		t.Fatalf("run status = %q, want failed", run.Status)
+	}
+}
+
+// TestCancelMidRun tears a running run down: the running stage is cancelled and
+// its executor torn down, the pending stage is skipped, nothing routes.
+func TestCancelMidRun(t *testing.T) {
+	h := newHarness(t)
+	runID := h.trigger(t, twoStageYAML, userSessionSubject())
+
+	h.engine.Cancel(runID, "user asked")
+
+	if got := h.outcome(t, runID, "review"); got != pipeline.OutcomeCancelled {
+		t.Fatalf("review outcome = %q, want cancelled", got)
+	}
+	if got := h.outcome(t, runID, "publish"); got != pipeline.OutcomeSkipped {
+		t.Fatalf("publish outcome = %q, want skipped", got)
+	}
+	if !h.execs.handle(t, "review").cancelled {
+		t.Fatal("cancelled stage's executor was not torn down")
+	}
+	run := h.run(t, runID)
+	if run.Status != pipeline.RunCancelled {
+		t.Fatalf("run status = %q, want cancelled", run.Status)
+	}
+	if run.CancelReason != "user asked" {
+		t.Fatalf("cancel reason = %q", run.CancelReason)
+	}
+}
+
+// TestPlanFailureSettlesWithoutStartingAnything is the point of planning at
+// start: the one impossible workspace combination fails the run before any
+// stage runs, with the reason stated, and the run folder is kept.
+func TestPlanFailureSettlesWithoutStartingAnything(t *testing.T) {
+	h := newHarness(t)
+	subject := pipeline.Subject{
+		Kind:      pipeline.SubjectPR,
+		ProjectID: "proj-1",
+		PR:        &pipeline.PRRef{Number: 412, Repo: "acme/app", HeadSHA: "deadbeef"},
+	}
+	runID := h.trigger(t, sessionWorkspaceYAML, subject)
+
+	run := h.run(t, runID)
+	if run.Status != pipeline.RunFailed {
+		t.Fatalf("run status = %q, want failed", run.Status)
+	}
+	st := run.Stages["review"]
+	if st == nil || st.Outcome != pipeline.OutcomeFailed {
+		t.Fatalf("review stage = %+v, want failed", st)
+	}
+	want := "stage 'review' requires workspace 'session'; PR #412 has no local session"
+	if st.Reason != want {
+		t.Fatalf("reason = %q, want %q", st.Reason, want)
+	}
+	if ids := h.execs.startedIDs(); len(ids) != 0 {
+		t.Fatalf("started %v, want no stage started on a plan failure", ids)
+	}
+	if _, err := os.Stat(filepath.Join(h.base, "proj-1", string(runID))); err != nil {
+		t.Fatalf("run folder must be kept on a plan failure: %v", err)
+	}
+	if saved, ok := h.store.saved(runID); !ok || saved.Status != pipeline.RunFailed {
+		t.Fatalf("plan failure was not persisted (%+v)", saved)
+	}
+}
+
+// TestRestartSettlesLostRunningStage is decision D16: a daemon restart cannot
+// resume a Poll loop, so a stage persisted running settles honestly and the
+// run routes its failure edge.
+func TestRestartSettlesLostRunningStage(t *testing.T) {
+	base := t.TempDir()
+	store := newFakeStore()
+	cfg, err := pipeline.ParseDefinition([]byte(failureRouteYAML))
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	// An agent stage the previous process left running, plus the failure target
+	// still pending.
+	lost := pipeline.RunState{
+		RunID:        "run-lost",
+		ProjectID:    "proj-1",
+		PipelineName: cfg.Name,
+		Subject:      userSessionSubject(),
+		Status:       pipeline.RunRunning,
+		RunDir:       filepath.Join(base, "pipelines", "proj-1", "run-lost"),
+		Def:          *cfg,
+		Stages: map[string]*pipeline.StageState{
+			"build":    {ID: "build", Outcome: pipeline.OutcomeSucceeded, Attempt: 1},
+			"diagnose": {ID: "diagnose", Outcome: pipeline.OutcomeRunning, Attempt: 1, SessionID: "sess-old"},
+		},
+	}
+	store.hydra = []pipeline.RunState{lost}
+	if err := os.MkdirAll(lost.RunDir, 0o750); err != nil {
+		t.Fatalf("seed run dir: %v", err)
+	}
+
+	execs := newFakeExecutor()
+	eng := New(Config{
+		ProjectID:    "proj-1",
+		Store:        store,
+		Executors:    execs,
+		Workspaces:   newFakeProvisioner(filepath.Join(base, "trees")),
+		Sessions:     &fakeSessions{},
+		Messenger:    &fakeMessenger{},
+		BaseDir:      filepath.Join(base, "pipelines"),
+		Clock:        func() time.Time { return time.Date(2026, 7, 26, 13, 0, 0, 0, time.UTC) },
+		TickInterval: time.Hour,
+	})
+	if err := eng.Start(context.Background()); err != nil {
+		t.Fatalf("start engine: %v", err)
+	}
+	t.Cleanup(func() { _ = eng.Stop(context.Background()) })
+
+	run, ok := eng.Run("run-lost")
+	if !ok {
+		t.Fatal("hydrated run is missing")
+	}
+	if got := run.Stages["diagnose"].Outcome; got != pipeline.OutcomeNoSignal {
+		t.Fatalf("diagnose outcome = %q, want no_signal for a lost agent stage", got)
+	}
+	if run.Status != pipeline.RunFailed {
+		t.Fatalf("run status = %q, want failed", run.Status)
+	}
+	if ids := execs.startedIDs(); len(ids) != 0 {
+		t.Fatalf("started %v, want nothing restarted after a lost stage", ids)
+	}
+}
+
+// TestRestartSettlesLostCommandStageAsFailed is the command half of D16: a
+// process handle is gone for good, and failed (not no_signal) is the honest
+// outcome.
+func TestRestartSettlesLostCommandStageAsFailed(t *testing.T) {
+	base := t.TempDir()
+	store := newFakeStore()
+	cfg, err := pipeline.ParseDefinition([]byte(failureRouteYAML))
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	store.hydra = []pipeline.RunState{{
+		RunID:        "run-lost",
+		ProjectID:    "proj-1",
+		PipelineName: cfg.Name,
+		Subject:      userSessionSubject(),
+		Status:       pipeline.RunRunning,
+		RunDir:       filepath.Join(base, "pipelines", "proj-1", "run-lost"),
+		Def:          *cfg,
+		Stages: map[string]*pipeline.StageState{
+			"build":    {ID: "build", Outcome: pipeline.OutcomeRunning, Attempt: 1},
+			"diagnose": {ID: "diagnose", Outcome: pipeline.OutcomePending},
+		},
+	}}
+	if err := os.MkdirAll(filepath.Join(base, "pipelines", "proj-1", "run-lost"), 0o750); err != nil {
+		t.Fatalf("seed run dir: %v", err)
+	}
+
+	execs := newFakeExecutor()
+	eng := New(Config{
+		ProjectID:    "proj-1",
+		Store:        store,
+		Executors:    execs,
+		Workspaces:   newFakeProvisioner(filepath.Join(base, "trees")),
+		Sessions:     &fakeSessions{},
+		Messenger:    &fakeMessenger{},
+		BaseDir:      filepath.Join(base, "pipelines"),
+		TickInterval: time.Hour,
+	})
+	if err := eng.Start(context.Background()); err != nil {
+		t.Fatalf("start engine: %v", err)
+	}
+	t.Cleanup(func() { _ = eng.Stop(context.Background()) })
+
+	run, _ := eng.Run("run-lost")
+	if got := run.Stages["build"].Outcome; got != pipeline.OutcomeFailed {
+		t.Fatalf("build outcome = %q, want failed for a lost command stage", got)
+	}
+	// The failure routed: diagnose is the on_failure target and it started.
+	if got := run.Stages["diagnose"].Outcome; got == pipeline.OutcomeSkipped {
+		t.Fatalf("diagnose outcome = %q, want the failure edge taken", got)
+	}
+	if ids := execs.startedIDs(); len(ids) != 1 || ids[0] != "diagnose" {
+		t.Fatalf("started %v, want the failure target", ids)
+	}
+}
+
+// TestAmbientEnvOnFailureEntry covers the failure-entry half of the spec's
+// ambient table, including the inherited tree.
+func TestAmbientEnvOnFailureEntry(t *testing.T) {
+	h := newHarness(t)
+	runID := h.trigger(t, failureRouteYAML, userSessionSubject())
+
+	h.execs.script(t, "build", executors.Poll{State: executors.PollExited, ExitCode: 2})
+	h.engine.Tick()
+
+	env := h.execs.handle(t, "diagnose").in.Env
+	if env["AO_FAILED_STAGE"] != "build" {
+		t.Fatalf("AO_FAILED_STAGE = %q, want build", env["AO_FAILED_STAGE"])
+	}
+	if env["AO_FAILED_OUTCOME"] != string(pipeline.OutcomeFailed) {
+		t.Fatalf("AO_FAILED_OUTCOME = %q", env["AO_FAILED_OUTCOME"])
+	}
+	if _, ok := env["AO_PREV_STAGE"]; ok {
+		t.Fatalf("AO_PREV_STAGE = %q, want unset on a failure entry", env["AO_PREV_STAGE"])
+	}
+	if _, ok := env["AO_OUTPUT"]; ok {
+		t.Fatalf("AO_OUTPUT = %q, want unset without produces", env["AO_OUTPUT"])
+	}
+	if env["AO_RUN_ID"] != string(runID) || env["AO_STAGE"] != "diagnose" {
+		t.Fatalf("identity env = %q/%q, want the two `ao pipeline done` resolves itself from", env["AO_RUN_ID"], env["AO_STAGE"])
+	}
+	if env["AO_ATTEMPT"] != "1" {
+		t.Fatalf("AO_ATTEMPT = %q, want 1", env["AO_ATTEMPT"])
+	}
+	if env["AO_CONTEXT"] != filepath.Join(h.base, "proj-1", string(runID), "Context.md") {
+		t.Fatalf("AO_CONTEXT = %q", env["AO_CONTEXT"])
+	}
+	if env["AO_SESSION_ID"] != "sess-user" {
+		t.Fatalf("AO_SESSION_ID = %q, want the subject's session", env["AO_SESSION_ID"])
+	}
+	// inherit resolves to the failed stage's tree (spec section 5.4).
+	req := h.lastRequest(t, "diagnose")
+	if req.Kind != pipeline.WorkspaceInherit {
+		t.Fatalf("diagnose workspace kind = %q, want inherit", req.Kind)
+	}
+	if req.InheritPath != h.execs.handle(t, "build").in.WorkspacePath {
+		t.Fatalf("inherit path = %q, want the failed stage's tree", req.InheritPath)
+	}
+}
+
+// TestAmbientEnvAtJoinAndOnSuccess: AO_PREV_* resolves for a sole predecessor
+// and is unset at a join, where it would be ambiguous.
+func TestAmbientEnvAtJoinAndOnSuccess(t *testing.T) {
+	h := newHarness(t)
+	runID := h.trigger(t, joinYAML, userSessionSubject())
+
+	h.execs.script(t, "prepare", executors.Poll{State: executors.PollExited, ExitCode: 0})
+	h.engine.Tick()
+
+	lint := h.execs.handle(t, "lint").in.Env
+	if lint["AO_PREV_STAGE"] != "prepare" {
+		t.Fatalf("AO_PREV_STAGE = %q, want prepare", lint["AO_PREV_STAGE"])
+	}
+	if lint["AO_PREV_OUTCOME"] != string(pipeline.OutcomeSucceeded) {
+		t.Fatalf("AO_PREV_OUTCOME = %q", lint["AO_PREV_OUTCOME"])
+	}
+
+	h.execs.script(t, "lint", executors.Poll{State: executors.PollExited, ExitCode: 0})
+	h.execs.script(t, "test", executors.Poll{State: executors.PollExited, ExitCode: 0})
+	h.engine.Tick()
+
+	report := h.execs.handle(t, "report").in.Env
+	if _, ok := report["AO_PREV_STAGE"]; ok {
+		t.Fatalf("AO_PREV_STAGE = %q, want unset at a join", report["AO_PREV_STAGE"])
+	}
+	if _, ok := report["AO_PREV_OUTCOME"]; ok {
+		t.Fatalf("AO_PREV_OUTCOME = %q, want unset at a join", report["AO_PREV_OUTCOME"])
+	}
+	if _, ok := report["AO_OUTPUT"]; ok {
+		t.Fatalf("AO_OUTPUT = %q, want unset without produces", report["AO_OUTPUT"])
+	}
+	_ = runID
+}
+
+// TestPRSubjectEnvAndCredentials: PR variables resolve for a PR subject, and
+// credentials reach a command stage only.
+func TestPRSubjectEnvAndCredentials(t *testing.T) {
+	const yamlSrc = `
+name: publish
+stages:
+  - id: publish
+    executor: command
+    run: gh release create
+    credentials: [github-release]
+`
+	creds := fakeCredentials{values: map[string]map[string]string{
+		"github-release": {"GH_TOKEN": "s3cret"},
+	}}
+	h := newHarness(t, func(c *Config) { c.Credentials = creds })
+	subject := pipeline.Subject{
+		Kind:      pipeline.SubjectPR,
+		ProjectID: "proj-1",
+		SessionID: "sess-pr",
+		PR:        &pipeline.PRRef{Number: 7, Repo: "acme/app", HeadSHA: "abc123", HeadBranch: "feature"},
+	}
+	h.trigger(t, yamlSrc, subject)
+
+	in := h.execs.handle(t, "publish").in
+	if in.Env["AO_PR_NUMBER"] != "7" || in.Env["AO_PR_REPO"] != "acme/app" || in.Env["AO_PR_HEAD"] != "abc123" {
+		t.Fatalf("PR env = %v", in.Env)
+	}
+	if in.Credentials["GH_TOKEN"] != "s3cret" {
+		t.Fatalf("credentials = %v, want the resolved value on a command stage", in.Credentials)
+	}
+}
+
+// TestAgentStageNeverReceivesCredentials is the runtime half of the tier rule:
+// the driver resolves credentials for command stages only.
+func TestAgentStageNeverReceivesCredentials(t *testing.T) {
+	creds := fakeCredentials{values: map[string]map[string]string{"anything": {"K": "V"}}}
+	h := newHarness(t, func(c *Config) { c.Credentials = creds })
+	h.trigger(t, twoStageYAML, userSessionSubject())
+
+	if got := h.execs.handle(t, "review").in.Credentials; len(got) != 0 {
+		t.Fatalf("agent stage got credentials %v", got)
+	}
+}
+
+// TestOwnedWorkspacesDestroyedOnlyOnSuccess is spec section 5.5: owned trees go
+// away on success and are kept on failure, same rule as sessions.
+func TestOwnedWorkspacesDestroyedOnlyOnSuccess(t *testing.T) {
+	const yamlSrc = `
+name: one-command
+stages:
+  - id: build
+    executor: command
+    workspace: run
+    run: make
+`
+	t.Run("succeeded destroys", func(t *testing.T) {
+		h := newHarness(t)
+		h.trigger(t, yamlSrc, pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: "proj-1"})
+		h.execs.script(t, "build", executors.Poll{State: executors.PollExited, ExitCode: 0})
+		h.engine.Tick()
+		if got := h.ws.destroyedPaths(); len(got) != 1 {
+			t.Fatalf("destroyed %v, want the run's owned tree", got)
+		}
+	})
+
+	t.Run("failed keeps", func(t *testing.T) {
+		h := newHarness(t)
+		h.trigger(t, yamlSrc, pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: "proj-1"})
+		h.execs.script(t, "build", executors.Poll{State: executors.PollExited, ExitCode: 1})
+		h.engine.Tick()
+		if got := h.ws.destroyedPaths(); len(got) != 0 {
+			t.Fatalf("destroyed %v, want owned trees kept on failure", got)
+		}
+	})
+}
+
+// TestKillOnDisposition: the default kills on succeeded, an explicit empty list
+// never does.
+func TestKillOnDisposition(t *testing.T) {
+	h := newHarness(t)
+	runID := h.trigger(t, twoStageYAML, userSessionSubject())
+	h.writeOutput(t, runID, "review.md", "content")
+	h.execs.script(t, "review", executors.Poll{State: executors.PollSignaledDone})
+	h.engine.Tick()
+
+	if killed := h.sess.killedIDs(); len(killed) != 1 || killed[0] != "sess-review" {
+		t.Fatalf("killed %v, want the stage session killed on succeeded", killed)
+	}
+
+	const keepYAML = `
+name: keep-session
+stages:
+  - id: review
+    executor: agent
+    agent: claude-code
+    prompt: review
+    session:
+      kill-on: []
+`
+	h2 := newHarness(t)
+	h2.trigger(t, keepYAML, userSessionSubject())
+	h2.execs.script(t, "review", executors.Poll{State: executors.PollSignaledDone})
+	h2.engine.Tick()
+	if killed := h2.sess.killedIDs(); len(killed) != 0 {
+		t.Fatalf("killed %v, want kill-on: [] to never kill", killed)
+	}
+}
+
+// TestLaunchFailureRoutesLikeAnyFailure: a workspace that cannot be provisioned
+// settles the stage failed with the reason stated, and takes the failure edge.
+func TestLaunchFailureRoutesLikeAnyFailure(t *testing.T) {
+	h := newHarness(t)
+	h.ws.failOn["build"] = errors.New("no such ref")
+	runID := h.trigger(t, failureRouteYAML, userSessionSubject())
+
+	st := h.run(t, runID).Stages["build"]
+	if st.Outcome != pipeline.OutcomeFailed {
+		t.Fatalf("build outcome = %q, want failed", st.Outcome)
+	}
+	if !strings.Contains(st.Reason, "no such ref") {
+		t.Fatalf("reason = %q, want the provisioning error", st.Reason)
+	}
+	if got := h.outcome(t, runID, "diagnose"); got == pipeline.OutcomeSkipped {
+		t.Fatal("failure edge was not taken after a launch failure")
+	}
+}
+
+// TestConcurrencySerializesSameKey: a second trigger for the same key queues at
+// depth 1 and starts when the holder settles.
+func TestConcurrencySerializesSameKey(t *testing.T) {
+	h := newHarness(t)
+	first := h.trigger(t, twoStageYAML, userSessionSubject())
+	second := h.trigger(t, twoStageYAML, userSessionSubject())
+
+	if _, ok := h.engine.Run(second); ok {
+		t.Fatal("second run started while the first held the key")
+	}
+
+	h.writeOutput(t, first, "review.md", "done")
+	h.execs.script(t, "review", executors.Poll{State: executors.PollSignaledDone})
+	h.engine.Tick()
+	h.execs.script(t, "publish", executors.Poll{State: executors.PollExited, ExitCode: 0})
+	h.engine.Tick()
+
+	// The queued trigger starts off the actor goroutine, so give it a moment.
+	waitFor(t, func() bool { _, ok := h.engine.Run(second); return ok })
+}
+
+// lastRequest returns the newest workspace request for a stage.
+func (h *harness) lastRequest(t *testing.T, stage string) executors.WorkspaceRequest {
+	t.Helper()
+	h.ws.mu.Lock()
+	defer h.ws.mu.Unlock()
+	for i := len(h.ws.requests) - 1; i >= 0; i-- {
+		if h.ws.requests[i].StageID == stage {
+			return h.ws.requests[i]
+		}
+	}
+	t.Fatalf("no workspace request for stage %q", stage)
+	return executors.WorkspaceRequest{}
+}
+
+// waitFor polls cond until it holds or the test times out. Only the queued
+// trigger path is asynchronous; everything else is driven synchronously.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition never held")
+}

--- a/backend/internal/pipeline/engine/supervisor.go
+++ b/backend/internal/pipeline/engine/supervisor.go
@@ -1,0 +1,195 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/triggers"
+)
+
+// Supervisor owns one Engine per project. It is the single wiring seam the
+// daemon constructs, so the whole subsystem stays behind AO_PIPELINES at one
+// call site, and it is the lookup the trigger bridges and the HTTP service use
+// to reach a project's engine.
+//
+// It also owns the shared concurrency table. Keeping it here rather than in an
+// engine means two projects that somehow resolve the same key (the same repo
+// registered twice, say) still serialize against each other.
+type Supervisor struct {
+	cfg SupervisorConfig
+
+	concurrency *ConcurrencyTable
+
+	mu      sync.Mutex
+	engines map[domain.ProjectID]*Engine
+	started bool
+}
+
+// ProjectLister enumerates the projects to instantiate engines for. Satisfied
+// by *storage/sqlite/store.Store.
+type ProjectLister interface {
+	ListProjects(ctx context.Context) ([]domain.ProjectRecord, error)
+}
+
+// SupervisorConfig constructs a Supervisor. Store, Executors, Workspaces,
+// Projects and BaseDir are required; the rest default.
+type SupervisorConfig struct {
+	Store       Store
+	Executors   executors.StageExecutor
+	Workspaces  executors.WorkspaceProvisioner
+	Sessions    SessionDisposer
+	Messenger   executors.SessionMessenger
+	Credentials Credentials
+	Projects    ProjectLister
+	// BaseDir is the run-folder root, <AO_DATA_DIR>/pipelines.
+	BaseDir      string
+	Logger       *slog.Logger
+	Clock        func() time.Time
+	TickInterval time.Duration
+}
+
+// NewSupervisor builds a Supervisor. It starts no engines; call Start.
+func NewSupervisor(cfg SupervisorConfig) *Supervisor {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return &Supervisor{
+		cfg:         cfg,
+		concurrency: &ConcurrencyTable{},
+		engines:     map[domain.ProjectID]*Engine{},
+	}
+}
+
+// Start instantiates and starts one engine per known project. A single
+// project's hydrate failure is logged and skipped rather than sinking daemon
+// boot: that project can still get an engine later through For, and an engine
+// with no definitions simply idles.
+func (s *Supervisor) Start(ctx context.Context) error {
+	projects, err := s.cfg.Projects.ListProjects(ctx)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.started = true
+	for _, p := range projects {
+		pid := domain.ProjectID(p.ID)
+		if _, ok := s.engines[pid]; ok {
+			continue
+		}
+		eng := s.newEngine(pid)
+		if err := eng.Start(ctx); err != nil {
+			s.cfg.Logger.Error("pipeline engine start failed", "project", pid, "err", err)
+			continue
+		}
+		s.engines[pid] = eng
+	}
+	return nil
+}
+
+// Stop stops every engine. Safe to call once; later lookups error.
+func (s *Supervisor) Stop(ctx context.Context) error {
+	s.mu.Lock()
+	engines := s.engines
+	s.engines = map[domain.ProjectID]*Engine{}
+	s.started = false
+	s.mu.Unlock()
+
+	for _, eng := range engines {
+		_ = eng.Stop(ctx)
+	}
+	return nil
+}
+
+// For returns the engine for a project, lazily creating and starting one for a
+// project registered after Start, so a trigger for a new project is never
+// silently dropped.
+func (s *Supervisor) For(ctx context.Context, projectID domain.ProjectID) (*Engine, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.started {
+		return nil, errors.New("pipeline engine supervisor not started")
+	}
+	if eng, ok := s.engines[projectID]; ok {
+		return eng, nil
+	}
+	eng := s.newEngine(projectID)
+	if err := eng.Start(ctx); err != nil {
+		return nil, err
+	}
+	s.engines[projectID] = eng
+	return eng, nil
+}
+
+func (s *Supervisor) newEngine(pid domain.ProjectID) *Engine {
+	return New(Config{
+		ProjectID:    pid,
+		Store:        s.cfg.Store,
+		Executors:    s.cfg.Executors,
+		Workspaces:   s.cfg.Workspaces,
+		Sessions:     s.cfg.Sessions,
+		Messenger:    s.cfg.Messenger,
+		Credentials:  s.cfg.Credentials,
+		BaseDir:      s.cfg.BaseDir,
+		Concurrency:  s.concurrency,
+		StartQueued:  s.startQueued,
+		Logger:       s.cfg.Logger,
+		Clock:        s.cfg.Clock,
+		TickInterval: s.cfg.TickInterval,
+	})
+}
+
+// startQueued starts a trigger that just took its concurrency key from a run
+// that settled. It routes by the trigger's own project, because the table is
+// shared and the waiting trigger need not belong to the engine that released
+// the key.
+//
+// It runs on a goroutine the releasing engine owns, never on that engine's
+// actor, so posting onto any mailbox from here is safe.
+func (s *Supervisor) startQueued(pt pendingTrigger) {
+	ctx := context.Background()
+	eng, err := s.For(ctx, domain.ProjectID(pt.Subject.ProjectID))
+	if err != nil {
+		s.cfg.Logger.Warn("pipeline queued trigger dropped: no engine",
+			"project", pt.Subject.ProjectID, "pipeline", pt.Definition.Name, "err", err)
+		return
+	}
+	key := keyFor(pt.Definition, pt.Subject)
+	eng.do(func() { eng.startTrigger(pt, key) })
+}
+
+// Provider adapts the supervisor to the trigger bridges' EngineProvider port.
+// The bridges declare that port next to themselves so the dependency points one
+// way; this is the other end of it.
+type Provider struct{ sup *Supervisor }
+
+// Engines returns the bridges' view of the supervisor.
+func (s *Supervisor) Engines() triggers.EngineProvider { return Provider{sup: s} }
+
+var _ triggers.EngineProvider = Provider{}
+
+// For resolves (and lazily starts) a project's engine.
+func (p Provider) For(ctx context.Context, projectID domain.ProjectID) (triggers.Engine, error) {
+	eng, err := p.sup.For(ctx, projectID)
+	if err != nil {
+		// Return an explicit nil so the caller never gets a non-nil interface
+		// wrapping a nil pointer.
+		return nil, err
+	}
+	return eng, nil
+}
+
+// RunReader is the read surface the HTTP service uses for a run the engine may
+// still be holding. The store is the record, so this is only used where the
+// caller needs the engine's live view.
+type RunReader interface {
+	Run(id pipeline.RunID) (pipeline.RunState, bool)
+}
+
+var _ RunReader = (*Engine)(nil)

--- a/backend/internal/pipeline/engine/supervisor_test.go
+++ b/backend/internal/pipeline/engine/supervisor_test.go
@@ -1,0 +1,119 @@
+package engine
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/triggers"
+)
+
+// fakeProjectLister is the supervisor's view of the projects table.
+type fakeProjectLister struct{ ids []string }
+
+func (l fakeProjectLister) ListProjects(context.Context) ([]domain.ProjectRecord, error) {
+	out := make([]domain.ProjectRecord, 0, len(l.ids))
+	for _, id := range l.ids {
+		out = append(out, domain.ProjectRecord{ID: id})
+	}
+	return out, nil
+}
+
+func newTestSupervisor(t *testing.T, projects ...string) (*Supervisor, *fakeExecutor) {
+	t.Helper()
+	base := t.TempDir()
+	execs := newFakeExecutor()
+	sup := NewSupervisor(SupervisorConfig{
+		Store:        newFakeStore(),
+		Executors:    execs,
+		Workspaces:   newFakeProvisioner(filepath.Join(base, "trees")),
+		Sessions:     &fakeSessions{},
+		Messenger:    &fakeMessenger{},
+		Projects:     fakeProjectLister{ids: projects},
+		BaseDir:      filepath.Join(base, "pipelines"),
+		TickInterval: time.Hour,
+	})
+	if err := sup.Start(context.Background()); err != nil {
+		t.Fatalf("start supervisor: %v", err)
+	}
+	t.Cleanup(func() { _ = sup.Stop(context.Background()) })
+	return sup, execs
+}
+
+// TestSupervisorStartsAnEnginePerProject: known projects get an engine up
+// front, and the same project always resolves to the same one.
+func TestSupervisorStartsAnEnginePerProject(t *testing.T) {
+	sup, _ := newTestSupervisor(t, "proj-1", "proj-2")
+
+	first, err := sup.For(context.Background(), "proj-1")
+	if err != nil {
+		t.Fatalf("for: %v", err)
+	}
+	again, err := sup.For(context.Background(), "proj-1")
+	if err != nil {
+		t.Fatalf("for: %v", err)
+	}
+	if first != again {
+		t.Fatal("a project resolved to two different engines")
+	}
+	if _, err := sup.For(context.Background(), "proj-2"); err != nil {
+		t.Fatalf("for proj-2: %v", err)
+	}
+}
+
+// TestSupervisorLazilyStartsUnknownProject: a project registered after boot
+// still gets an engine, so its triggers are not silently dropped.
+func TestSupervisorLazilyStartsUnknownProject(t *testing.T) {
+	sup, _ := newTestSupervisor(t)
+	eng, err := sup.For(context.Background(), "proj-late")
+	if err != nil {
+		t.Fatalf("for: %v", err)
+	}
+	if eng == nil {
+		t.Fatal("no engine for a project registered after Start")
+	}
+}
+
+// TestSupervisorStoppedRefusesLookups keeps a stopped daemon from quietly
+// starting fresh engines.
+func TestSupervisorStoppedRefusesLookups(t *testing.T) {
+	sup, _ := newTestSupervisor(t, "proj-1")
+	if err := sup.Stop(context.Background()); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if _, err := sup.For(context.Background(), "proj-1"); err == nil {
+		t.Fatal("a stopped supervisor handed out an engine")
+	}
+}
+
+// TestSupervisorProviderDrivesRuns is the bridges' path end to end: resolve the
+// project's engine through the EngineProvider port and start a run on it.
+func TestSupervisorProviderDrivesRuns(t *testing.T) {
+	sup, execs := newTestSupervisor(t, "proj-1")
+
+	cfg, err := pipeline.ParseDefinition([]byte(twoStageYAML))
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	eng, err := sup.Engines().For(context.Background(), "proj-1")
+	if err != nil {
+		t.Fatalf("provider: %v", err)
+	}
+	runID, err := eng.TriggerRun(triggers.TriggerRequest{
+		Definition: pipeline.Definition{ID: "pl-1", ProjectID: "proj-1", Name: cfg.Name, YAMLSource: twoStageYAML, Config: *cfg},
+		Event:      string(pipeline.PREventUpdated),
+		Subject:    pipeline.Subject{Kind: pipeline.SubjectSession, ProjectID: "proj-1", SessionID: "sess-user"},
+	})
+	if err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+	if runID == "" {
+		t.Fatal("trigger returned no run id")
+	}
+	if ids := execs.startedIDs(); len(ids) != 1 || ids[0] != "review" {
+		t.Fatalf("started %v, want the entry stage", ids)
+	}
+}

--- a/backend/internal/service/pipeline/pipeline.go
+++ b/backend/internal/service/pipeline/pipeline.go
@@ -1,21 +1,108 @@
-// Package pipelinesvc is the read/write service boundary for the pipelines HTTP
-// API. The v1 implementation was stripped ahead of the v2 rebuild; what remains
-// is the seam the controller and the daemon wire against, plus the merge gate
-// (which holds no opinion while pipelines are not implemented).
+// Package pipelinesvc is the read/write service boundary for the pipelines
+// HTTP API. It sits between the pipelines controller and the two things it
+// orchestrates: the SQLite store (definitions, runs, signals) and the
+// per-project engine supervisor (trigger, cancel).
+//
+// Definition authoring runs YAML through pipeline.ParseDefinition so the editor
+// sees every validation issue in one pass. Run lifecycle mutations route
+// through the engine, never the store, so run state stays owned by the actor
+// loop.
 package pipelinesvc
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/engine"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/triggers"
 )
 
+// ErrEnginesUnavailable means the service was built without an engine
+// supervisor, so nothing can be triggered or cancelled. The read paths and the
+// signal path still work.
+var ErrEnginesUnavailable = errors.New("pipeline engine unavailable")
+
+// Store is the persistence surface the service reads and writes: a subset of
+// *storage/sqlite/store.Store, kept narrow so the service unit-tests against a
+// fake. SignalStore is the slice the signal path needs.
+type Store interface {
+	SignalStore
+
+	ListPipelineDefinitions(ctx context.Context, projectID domain.ProjectID) ([]pipeline.Definition, error)
+	GetPipelineDefinition(ctx context.Context, id pipeline.ID) (pipeline.Definition, bool, error)
+	GetPipelineDefinitionByName(ctx context.Context, projectID domain.ProjectID, name string) (pipeline.Definition, bool, error)
+	CreatePipelineDefinition(ctx context.Context, def pipeline.Definition) error
+	UpdatePipelineDefinition(ctx context.Context, def pipeline.Definition) (bool, error)
+	DeletePipelineDefinition(ctx context.Context, id pipeline.ID) (bool, error)
+
+	ListPipelineRuns(ctx context.Context, projectID domain.ProjectID, filter pipeline.RunFilter) ([]pipeline.RunState, error)
+}
+
+// Engine is the subset of the per-project engine actor the request handlers
+// drive.
+type Engine interface {
+	TriggerRun(req triggers.TriggerRequest) (pipeline.RunID, error)
+	Cancel(runID pipeline.RunID, reason string)
+}
+
+// Engines resolves the engine for a project. *engine.Supervisor satisfies this
+// through SupervisorEngines.
+type Engines interface {
+	For(ctx context.Context, projectID domain.ProjectID) (Engine, error)
+}
+
+// SupervisorEngines adapts a *engine.Supervisor (whose For returns the concrete
+// *engine.Engine) to the Engines interface.
+func SupervisorEngines(sup *engine.Supervisor) Engines { return supervisorEngines{sup: sup} }
+
+type supervisorEngines struct{ sup *engine.Supervisor }
+
+func (s supervisorEngines) For(ctx context.Context, projectID domain.ProjectID) (Engine, error) {
+	eng, err := s.sup.For(ctx, projectID)
+	if err != nil {
+		// An explicit nil, so a caller never gets a non-nil interface wrapping a
+		// nil pointer.
+		return nil, err
+	}
+	return eng, nil
+}
+
+// TriggerInput is a manual trigger: which definition, and optionally the
+// session the run is about.
+type TriggerInput struct {
+	// Ref is the definition id or name to run.
+	Ref string
+	// SessionID makes the run a session-subject run. Empty makes it a
+	// project-subject run, which is first-class (spec section 4).
+	SessionID string
+}
+
 // Manager is the pipelines service the HTTP controller and the lifecycle merge
-// gate depend on.
+// gate depend on. A nil Manager keeps the routes registered but answers 501,
+// which is what the AO_PIPELINES flag being off looks like from the outside.
 type Manager interface {
-	// PRBlocksMerge reports whether the most recent settled pipeline run for a
-	// PR blocks it from merging.
+	ListDefinitions(ctx context.Context, projectID domain.ProjectID) ([]pipeline.Definition, error)
+	CreateDefinition(ctx context.Context, projectID domain.ProjectID, yamlSource string) (pipeline.Definition, error)
+	UpdateDefinition(ctx context.Context, id pipeline.ID, yamlSource string) (pipeline.Definition, error)
+	DeleteDefinition(ctx context.Context, id pipeline.ID) error
+	ValidateDefinition(ctx context.Context, projectID domain.ProjectID, yamlSource string) (valid bool, issues []pipeline.Issue, err error)
+	ConfigSchema() []byte
+
+	ListRuns(ctx context.Context, projectID domain.ProjectID, filter pipeline.RunFilter) ([]pipeline.RunState, error)
+	GetRun(ctx context.Context, id pipeline.RunID) (pipeline.RunState, error)
+	TriggerRun(ctx context.Context, projectID domain.ProjectID, in TriggerInput) (pipeline.RunID, error)
+	CancelRun(ctx context.Context, projectID domain.ProjectID, id pipeline.RunID) (pipeline.RunState, error)
+
+	// PRBlocksMerge reports whether a PR's pipeline runs block it from merging.
+	// It is the read side of the lifecycle merge-readiness gate.
 	PRBlocksMerge(ctx context.Context, projectID domain.ProjectID, prURL, headSHA string) (bool, error)
 	// SignalStage records one `ao pipeline done|fail` against a running stage.
 	// The read side is not here: the agent executor polls the concrete Service
@@ -23,18 +110,336 @@ type Manager interface {
 	SignalStage(ctx context.Context, runID pipeline.RunID, stageID string, kind pipeline.SignalKind, reason string) error
 }
 
-// Service is the concrete Manager.
+// Service is the concrete Manager over a Store plus, once wired, the engine
+// supervisor.
 type Service struct {
-	store SignalStore
+	store Store
+	// creds is the resolver-dependent second validation pass: it rejects a
+	// credential name the project does not declare. Nil skips the pass, which
+	// keeps the pure Validate dependency-free for the editor.
+	creds pipeline.CredentialResolver
+	now   func() time.Time
+	newID func() pipeline.ID
+
+	// mu guards engines only. It exists because the daemon wires the engine
+	// after the service: the executor set needs this Service as its signal
+	// reader, and the supervisor needs the executor set, so the cycle is broken
+	// by binding the engines last (see SetEngines).
+	mu      sync.RWMutex
+	engines Engines
 }
 
-// New builds a Service over the run and signal store.
-func New(store SignalStore) *Service { return &Service{store: store} }
+// Option customizes a Service (test clocks and id allocators).
+type Option func(*Service)
+
+// WithClock overrides the timestamp source.
+func WithClock(now func() time.Time) Option {
+	return func(s *Service) { s.now = now }
+}
+
+// WithIDGen overrides the definition-id allocator.
+func WithIDGen(gen func() pipeline.ID) Option {
+	return func(s *Service) { s.newID = gen }
+}
+
+// WithCredentials wires the credential resolver the save path validates
+// against.
+func WithCredentials(r pipeline.CredentialResolver) Option {
+	return func(s *Service) { s.creds = r }
+}
+
+// WithEngines wires the engine supervisor at construction, for callers that
+// have one in hand already.
+func WithEngines(e Engines) Option {
+	return func(s *Service) { s.engines = e }
+}
+
+// New builds a Service over the run, definition and signal store.
+func New(store Store, opts ...Option) *Service {
+	s := &Service{
+		store: store,
+		now:   func() time.Time { return time.Now().UTC() },
+		newID: func() pipeline.ID { return pipeline.ID("pl-" + uuid.NewString()) },
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// SetEngines binds the engine supervisor after construction. It is called once,
+// during wiring, before any request is served.
+func (s *Service) SetEngines(e Engines) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.engines = e
+}
 
 var _ Manager = (*Service)(nil)
 
-// PRBlocksMerge holds no opinion: without a run store there is no settled run
-// to consult, and pipelines must never fabricate a block.
+// engine resolves the project's engine, or says plainly that there is none.
+func (s *Service) engine(ctx context.Context, projectID domain.ProjectID) (Engine, error) {
+	s.mu.RLock()
+	engines := s.engines
+	s.mu.RUnlock()
+	if engines == nil {
+		return nil, ErrEnginesUnavailable
+	}
+	return engines.For(ctx, projectID)
+}
+
+// ---------------------------------------------------------------------------
+// Definitions
+// ---------------------------------------------------------------------------
+
+// ListDefinitions returns every definition for a project.
+func (s *Service) ListDefinitions(ctx context.Context, projectID domain.ProjectID) ([]pipeline.Definition, error) {
+	return s.store.ListPipelineDefinitions(ctx, projectID)
+}
+
+// CreateDefinition validates the raw YAML, assigns identity and timestamps, and
+// persists the YAML alongside the parsed snapshot. A duplicate name in the
+// project is a 409.
+func (s *Service) CreateDefinition(ctx context.Context, projectID domain.ProjectID, yamlSource string) (pipeline.Definition, error) {
+	cfg, err := s.parse(ctx, projectID, yamlSource)
+	if err != nil {
+		return pipeline.Definition{}, err
+	}
+	if _, ok, err := s.store.GetPipelineDefinitionByName(ctx, projectID, cfg.Name); err != nil {
+		return pipeline.Definition{}, err
+	} else if ok {
+		return pipeline.Definition{}, apierr.Conflict("PIPELINE_NAME_TAKEN",
+			fmt.Sprintf("a pipeline named %q already exists in this project", cfg.Name), nil)
+	}
+
+	now := s.now()
+	def := pipeline.Definition{
+		ID:         s.newID(),
+		ProjectID:  string(projectID),
+		Name:       cfg.Name,
+		YAMLSource: yamlSource,
+		Config:     *cfg,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.store.CreatePipelineDefinition(ctx, def); err != nil {
+		return pipeline.Definition{}, err
+	}
+	return def, nil
+}
+
+// UpdateDefinition re-validates the YAML and overwrites the definition in place
+// (there is no version history). Runs freeze their definition at trigger time,
+// so an edit never touches a run in flight.
+func (s *Service) UpdateDefinition(ctx context.Context, id pipeline.ID, yamlSource string) (pipeline.Definition, error) {
+	existing, ok, err := s.store.GetPipelineDefinition(ctx, id)
+	if err != nil {
+		return pipeline.Definition{}, err
+	}
+	if !ok {
+		return pipeline.Definition{}, notFoundDefinition(id)
+	}
+
+	projectID := domain.ProjectID(existing.ProjectID)
+	cfg, err := s.parse(ctx, projectID, yamlSource)
+	if err != nil {
+		return pipeline.Definition{}, err
+	}
+	// A rename must not collide with another definition in the project;
+	// without this the UNIQUE(project_id, name) constraint surfaces as a 500
+	// instead of the 409 create returns.
+	if cfg.Name != existing.Name {
+		if other, ok, err := s.store.GetPipelineDefinitionByName(ctx, projectID, cfg.Name); err != nil {
+			return pipeline.Definition{}, err
+		} else if ok && other.ID != id {
+			return pipeline.Definition{}, apierr.Conflict("PIPELINE_NAME_TAKEN",
+				fmt.Sprintf("a pipeline named %q already exists in this project", cfg.Name), nil)
+		}
+	}
+
+	def := pipeline.Definition{
+		ID:         id,
+		ProjectID:  existing.ProjectID,
+		Name:       cfg.Name,
+		YAMLSource: yamlSource,
+		Config:     *cfg,
+		CreatedAt:  existing.CreatedAt,
+		UpdatedAt:  s.now(),
+	}
+	updated, err := s.store.UpdatePipelineDefinition(ctx, def)
+	if err != nil {
+		return pipeline.Definition{}, err
+	}
+	if !updated {
+		return pipeline.Definition{}, notFoundDefinition(id)
+	}
+	return def, nil
+}
+
+// DeleteDefinition removes a definition. Runs snapshot their definition, so
+// existing runs are untouched.
+func (s *Service) DeleteDefinition(ctx context.Context, id pipeline.ID) error {
+	deleted, err := s.store.DeletePipelineDefinition(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !deleted {
+		return notFoundDefinition(id)
+	}
+	return nil
+}
+
+// ValidateDefinition dry-runs the parser over the raw YAML and reports the
+// outcome as data, never an error envelope: the editor wants the issue list as
+// a result. Persists nothing.
+func (s *Service) ValidateDefinition(ctx context.Context, projectID domain.ProjectID, yamlSource string) (bool, []pipeline.Issue, error) {
+	cfg, err := pipeline.ParseDefinition([]byte(yamlSource))
+	if err != nil {
+		return false, issuesFromError(err), nil
+	}
+	if err := pipeline.ValidateCredentials(ctx, cfg, string(projectID), s.creds); err != nil {
+		var verr *pipeline.ValidationError
+		if errors.As(err, &verr) {
+			return false, verr.Issues, nil
+		}
+		// A store failure is a real error: telling the author to fix a name that
+		// is fine would be worse than saying the check could not run.
+		return false, nil, err
+	}
+	return true, nil, nil
+}
+
+// ConfigSchema returns the JSON Schema for the definition document, which the
+// editor uses for client-side validation and autocomplete.
+func (s *Service) ConfigSchema() []byte { return pipeline.ConfigJSONSchema() }
+
+// ---------------------------------------------------------------------------
+// Runs
+// ---------------------------------------------------------------------------
+
+// ListRuns returns a project's runs, newest first.
+func (s *Service) ListRuns(ctx context.Context, projectID domain.ProjectID, filter pipeline.RunFilter) ([]pipeline.RunState, error) {
+	return s.store.ListPipelineRuns(ctx, projectID, filter)
+}
+
+// GetRun returns one fully reconstructed run.
+func (s *Service) GetRun(ctx context.Context, id pipeline.RunID) (pipeline.RunState, error) {
+	run, ok, err := s.store.GetPipelineRun(ctx, id)
+	if err != nil {
+		return pipeline.RunState{}, err
+	}
+	if !ok {
+		return pipeline.RunState{}, notFoundRun(id)
+	}
+	return run, nil
+}
+
+// TriggerRun resolves the definition reference (id first, then name within the
+// project) and starts a run through the project engine.
+//
+// The subject is resolved here: a session id makes it a session subject, and
+// nothing makes it a project subject. PR subjects arrive through the trigger
+// bridge; a manual PR trigger lands with the run API pass.
+func (s *Service) TriggerRun(ctx context.Context, projectID domain.ProjectID, in TriggerInput) (pipeline.RunID, error) {
+	def, err := s.resolveDefinition(ctx, projectID, in.Ref)
+	if err != nil {
+		return "", err
+	}
+	eng, err := s.engine(ctx, projectID)
+	if err != nil {
+		return "", err
+	}
+	subject := pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: string(projectID)}
+	if in.SessionID != "" {
+		subject = pipeline.Subject{Kind: pipeline.SubjectSession, ProjectID: string(projectID), SessionID: in.SessionID}
+	}
+	runID, err := eng.TriggerRun(triggers.TriggerRequest{Definition: def, Event: "manual", Subject: subject})
+	if err != nil {
+		return "", apierr.Invalid("PIPELINE_TRIGGER_REJECTED", err.Error(), nil)
+	}
+	return runID, nil
+}
+
+// CancelRun tears an in-flight run down through the project engine and returns
+// the post-cancel state read back from the store. Cancelling an unknown run is
+// a 404; cancelling a settled one is an idempotent no-op.
+func (s *Service) CancelRun(ctx context.Context, projectID domain.ProjectID, id pipeline.RunID) (pipeline.RunState, error) {
+	if _, err := s.GetRun(ctx, id); err != nil {
+		return pipeline.RunState{}, err
+	}
+	eng, err := s.engine(ctx, projectID)
+	if err != nil {
+		return pipeline.RunState{}, err
+	}
+	eng.Cancel(id, "cancelled from the API")
+	// Cancel is synchronous on the engine actor (its persist effect runs before
+	// it returns), so the read-back reflects the cancellation.
+	return s.GetRun(ctx, id)
+}
+
+// PRBlocksMerge holds no opinion. v2 has no blocks-merge contract: a pipeline
+// reports outcomes, and gating a merge on one is a separate feature nobody has
+// specified. Pipelines must never fabricate a block.
 func (s *Service) PRBlocksMerge(context.Context, domain.ProjectID, string, string) (bool, error) {
 	return false, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func (s *Service) resolveDefinition(ctx context.Context, projectID domain.ProjectID, ref string) (pipeline.Definition, error) {
+	if ref == "" {
+		return pipeline.Definition{}, apierr.Invalid("PIPELINE_REF_REQUIRED", "a pipeline id or name is required", nil)
+	}
+	if def, ok, err := s.store.GetPipelineDefinition(ctx, pipeline.ID(ref)); err != nil {
+		return pipeline.Definition{}, err
+	} else if ok && def.ProjectID == string(projectID) {
+		return def, nil
+	}
+	if def, ok, err := s.store.GetPipelineDefinitionByName(ctx, projectID, ref); err != nil {
+		return pipeline.Definition{}, err
+	} else if ok {
+		return def, nil
+	}
+	return pipeline.Definition{}, apierr.NotFound("PIPELINE_NOT_FOUND",
+		fmt.Sprintf("no pipeline definition %q in this project", ref))
+}
+
+// parse validates raw YAML for the save path: the pure rules first, then the
+// resolver-dependent credential pass. A *pipeline.ValidationError passes
+// through untouched so the editor surfaces every problem at once, while a bare
+// YAML syntax error becomes a 400 rather than a 500.
+func (s *Service) parse(ctx context.Context, projectID domain.ProjectID, yamlSource string) (*pipeline.Pipeline, error) {
+	cfg, err := pipeline.ParseDefinition([]byte(yamlSource))
+	if err != nil {
+		var verr *pipeline.ValidationError
+		if errors.As(err, &verr) {
+			return nil, verr
+		}
+		return nil, apierr.Invalid("PIPELINE_PARSE_ERROR", err.Error(), nil)
+	}
+	if err := pipeline.ValidateCredentials(ctx, cfg, string(projectID), s.creds); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// issuesFromError renders a parse failure as the editor's Problems list: a
+// validation error keeps its per-path issues, and a bare syntax error becomes
+// one root-path issue rather than an error envelope.
+func issuesFromError(err error) []pipeline.Issue {
+	var verr *pipeline.ValidationError
+	if errors.As(err, &verr) {
+		return verr.Issues
+	}
+	return []pipeline.Issue{{Path: "", Message: err.Error()}}
+}
+
+func notFoundDefinition(id pipeline.ID) error {
+	return apierr.NotFound("PIPELINE_DEFINITION_NOT_FOUND", fmt.Sprintf("no pipeline definition %q", id))
+}
+
+func notFoundRun(id pipeline.RunID) error {
+	return apierr.NotFound("PIPELINE_RUN_NOT_FOUND", fmt.Sprintf("no pipeline run %q", id))
 }


### PR DESCRIPTION
Closes #321

The keystone task: the per-project engine actor, the effect driver, the ambient environment, and the wiring that turns everything already merged on `pipelines` into a running feature.

## What lands

**`pipeline/engine/engine.go`**, the actor. One goroutine owns `runs map[RunID]RunState` and `inflight map[stageKey]Handle`; every entry point posts a closure onto the mailbox. A 2s ticker polls inflight stages and then feeds `Tick` for deadline enforcement (poll first, so a stage that settled on its own is finalized rather than timed out).

- `TriggerRun`: concurrency admit, run id, run folder plus frozen `definition.yaml`, then `TriggerFired`. A plan failure settles the run `failed` inside the reducer with the reason recorded and persisted, folder kept, no stage started. `cancel-in-progress` cancels the victim first; a queued trigger starts when the key is released.
- Effect execution, all of it: `StartStage` (lazy workspace via the provisioner, ambient env, credentials for command stages only, executor `Start`), `NudgeStage` (messenger, then `NudgeDelivered` back), `InterruptStage`, `CancelStageExec`, `SettleSession`, `AppendContext`, `PersistRun` (store save plus `run.json`), `RunSettled` (destroy owned trees only on success, release the key, start the queued trigger).
- Restart reconciliation (D16): hydrate unsettled runs, settle any stage persisted `running` whose handle is gone as `no_signal` for agent stages and `failed` for command stages, then route failure normally.
- Command output tails are copied onto the stage before it settles, so run detail shows why a command failed without opening the log.

**Ambient env** is the spec section 12.2 table in full: `AO_PROJECT`, `AO_RUN_ID`, `AO_RUN_DIR`, `AO_STAGE`, `AO_ATTEMPT`, `AO_CONTEXT`, `AO_WORKSPACE` always; `AO_SESSION_ID` with a session; `AO_PR_NUMBER`/`AO_PR_REPO`/`AO_PR_HEAD` for PR subjects; `AO_OUTPUT` only with `produces`; `AO_PREV_*` only with exactly one predecessor; `AO_FAILED_*` only on failure entry. A test pins every always-present variable, so the starter templates that interpolate `$AO_RUN_DIR` cannot silently break.

**`supervisor.go`**: per-project lazy engines, the shared `ConcurrencyTable`, and the bridges' `EngineProvider`.

**`adapters.go`**: session spawn/get/interrupt/kill, the nudge messenger, the session workspace lookup, engine-held credentials, and the project checkout, all over the real session service, runtime and store.

**Wiring**: `startPipelineEngine` is real again behind the unchanged `AO_PIPELINES` precedence (env override > persisted setting > off). It builds the pipelines-rooted worktree adapter, the executor set, the supervisor and the PR trigger bridge. A build failure logs and leaves the stack nil, which is the 501 path: an experimental subsystem must not sink boot.

**Service and routes**: the Manager gains definitions CRUD, validate (with the credential pass), schema, list/get runs, trigger and cancel over the supervisor and store. Those routes stop returning 501 when the flag is on.

## Left for later tasks, deliberately

- **DTO pass.** The run wire shapes are still v1's names (`loopState` carries the v2 run status, `stageStatuses` the v2 outcomes) so the OpenAPI document and the generated client do not churn here. The renames, the log and output endpoints, and the removal of the resume and artifact routes belong to the API task; those three routes stay mounted at 501.
- **Orphan sessions.** `SettleSession` kills when the outcome is in `EffectiveKillOn()` and otherwise logs that the session was kept. The orphan registry (mark pipeline-orphaned, cap 3 per pipeline, 24h TTL) is the session-disposition task; there is a `ponytail:` note on the seam.
- **Session trigger bridge** is built but not started: its loop guard is the pipeline-spawned marker on session metadata, and without that marker a pipeline agent going idle would fire the session pipelines forever. It gets wired the moment the marker lands.
- **Agent stage workspaces.** `ports.SpawnConfig` cannot adopt an existing tree, so a spawned session creates its own worktree and `workspace: session`/`run` do not bind an agent stage to the driver-provisioned tree. Command stages, `inherit` and teardown are unaffected. Closing this needs a `SpawnConfig.WorkspacePath` plus a session teardown that never destroys a pipeline-owned tree, which is a session-lifecycle change; flagged to the orchestrator and marked with a `ponytail:` note.

## Tests

Fake executors, provisioner, store, messenger and sessions: happy-path run (agent then command) settles succeeded with the `Context.md` pointer line, `run.json` and the frozen definition on disk; nudge round-trip and the second arrival settling `no_output`; timeout via tick interrupting the stage and keeping the session; cancel mid-run; plan failure settling failed with no stage started and the folder kept; restart settling a lost agent stage `no_signal` and a lost command stage `failed` with the failure edge taken; kill-on default versus `kill-on: []`; owned workspaces destroyed only on success; concurrency serializing the same key; credentials on command stages only; and the ambient env spot checks (always-present set, `AO_PREV_STAGE` unset at a join, `AO_FAILED_STAGE` on failure entry, `AO_OUTPUT` absent without `produces`). Plus adapter and supervisor tests.

`go build ./...`, `go test ./...`, `gofmt -l .` and `golangci-lint run ./...` are clean. Four `internal/cli` spawn tests fail identically on `origin/pipelines` itself (checked at the base commit), so they are inherited, not from this change.

## Risks

Nothing runs until `AO_PIPELINES` is on. The largest surface is the effect driver's re-entrancy: effects feed events back synchronously on the actor goroutine, and the one asynchronous path (starting a queued trigger) deliberately hops off the actor to avoid a mailbox deadlock against itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
