### PR TITLE
feat(pipelines): kill-on disposition, pipeline-orphaned sessions, LRU+TTL reaper

### DIFF
--- a/backend/internal/daemon/pipeline_wiring.go
+++ b/backend/internal/daemon/pipeline_wiring.go
@@ -19,9 +19,10 @@ import (
 // per-project engine supervisor plus the CDC trigger bridges. It is built only
 // when AO_PIPELINES resolves on, so everything below it stays inert otherwise.
 type pipelineStack struct {
-	supervisor *engine.Supervisor
-	prBridge   *triggers.PRBridge
-	svc        *pipelinesvc.Service
+	supervisor    *engine.Supervisor
+	prBridge      *triggers.PRBridge
+	sessionBridge *triggers.SessionBridge
+	svc           *pipelinesvc.Service
 }
 
 // pipelineDeps is what the pipelines stack needs from the rest of the daemon.
@@ -71,6 +72,11 @@ func buildPipelineStack(ctx context.Context, deps pipelineDeps, log *slog.Logger
 	workspaces := executors.NewWorkspaceResolver(trees, sessions.SessionWorkspaces(), engine.NewCheckoutAdapter(deps.Store))
 	credentials := engine.NewCredentialAdapter(deps.Store)
 
+	// The reaper bounds the sessions the kill-on rule spares: cap 3 per pipeline,
+	// 24h TTL. Its ledger is the marker on the session rows, so the bounds hold
+	// for sessions a previous daemon kept alive too.
+	orphans := engine.NewOrphanRegistry(deps.Store, sessions, log)
+
 	// The service is built first because it is the agent executor's signal
 	// reader, and it gets its engines last, once the supervisor those executors
 	// feed exists. That is the whole cycle, broken at the one seam where late
@@ -83,6 +89,7 @@ func buildPipelineStack(ctx context.Context, deps pipelineDeps, log *slog.Logger
 		Executors:   execs,
 		Workspaces:  workspaces,
 		Sessions:    sessions,
+		Orphans:     orphans,
 		Messenger:   sessions,
 		Credentials: credentials,
 		Projects:    deps.Store,
@@ -94,11 +101,6 @@ func buildPipelineStack(ctx context.Context, deps pipelineDeps, log *slog.Logger
 	}
 
 	// The PR bridge turns CDC pull-request events into runs with a PR subject.
-	//
-	// The session bridge is deliberately not started yet: its loop guard is the
-	// pipeline-spawned marker on session metadata, and without that marker a
-	// pipeline agent going idle would fire the session pipelines, whose agents
-	// go idle, forever. It is wired the moment the marker lands.
 	prBridge := triggers.NewPRBridge(triggers.PRConfig{
 		Broadcaster: deps.Broadcaster,
 		Defs:        deps.Store,
@@ -108,9 +110,22 @@ func buildPipelineStack(ctx context.Context, deps pipelineDeps, log *slog.Logger
 	})
 	prBridge.Start(ctx)
 
+	// The session bridge turns session activity transitions into runs. Its loop
+	// guard is the session adapter, which reads the pipeline-spawned marker every
+	// pipeline session now carries: without it a pipeline agent going idle would
+	// fire the session pipelines, whose agents go idle, forever.
+	sessionBridge := triggers.NewSessionBridge(triggers.SessionConfig{
+		Broadcaster: deps.Broadcaster,
+		Defs:        deps.Store,
+		Engines:     supervisor.Engines(),
+		Spawned:     sessions,
+		Logger:      log,
+	})
+	sessionBridge.Start(ctx)
+
 	svc.SetEngines(pipelinesvc.SupervisorEngines(supervisor))
 
-	return &pipelineStack{supervisor: supervisor, prBridge: prBridge, svc: svc}, nil
+	return &pipelineStack{supervisor: supervisor, prBridge: prBridge, sessionBridge: sessionBridge, svc: svc}, nil
 }
 
 // Manager is the service the HTTP API and the lifecycle merge gate mount. A nil
@@ -130,6 +145,9 @@ func (p *pipelineStack) Stop(ctx context.Context) {
 	}
 	if p.prBridge != nil {
 		p.prBridge.Stop()
+	}
+	if p.sessionBridge != nil {
+		p.sessionBridge.Stop()
 	}
 	if p.supervisor != nil {
 		_ = p.supervisor.Stop(ctx)

--- a/backend/internal/domain/session.go
+++ b/backend/internal/domain/session.go
@@ -38,6 +38,28 @@ type SessionMetadata struct {
 	// even when PreviewURL is unchanged. The desktop browser panel keys
 	// navigation on it so a repeated `ao preview <same-url>` still refreshes.
 	PreviewRevision int64 `json:"previewRevision,omitempty"`
+	// PipelineRunID is the pipeline run that spawned this session, empty for
+	// every session a human or the orchestrator started. It is the pipeline
+	// session trigger bridge's loop guard: without it a pipeline agent going
+	// idle would fire the session pipelines, whose agents go idle, forever.
+	PipelineRunID string `json:"pipelineRunId,omitempty"`
+	// PipelineOrphan is set when a pipeline stage settled on an outcome its
+	// kill-on rule spares (no_output, no_signal, timed_out) and kept the session
+	// alive so a human can see what the agent was doing. Nil for every other
+	// session.
+	PipelineOrphan *PipelineOrphanInfo `json:"pipelineOrphan,omitempty"`
+}
+
+// PipelineOrphanInfo describes why a pipeline left a session alive: the run and
+// stage that owned it, the outcome that spared it, and when it was kept. It is
+// what the session list renders as the pipeline-orphaned badge, next to the kill
+// action (spec section 7.3).
+type PipelineOrphanInfo struct {
+	RunID    string    `json:"runId"`
+	Stage    string    `json:"stage"`
+	Outcome  string    `json:"outcome"`
+	KeptAt   time.Time `json:"keptAt"`
+	Pipeline string    `json:"pipeline"`
 }
 
 // SessionRecord is the persistence shape. It intentionally stores only durable

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2887,6 +2887,8 @@ components:
           type: string
         kind:
           type: string
+        pipelineOrphan:
+          $ref: '#/components/schemas/DomainPipelineOrphanInfo'
         previewRevision:
           format: int64
           type: integer
@@ -3060,6 +3062,26 @@ components:
       required:
       - state
       - lastActivityAt
+      type: object
+    DomainPipelineOrphanInfo:
+      properties:
+        keptAt:
+          format: date-time
+          type: string
+        outcome:
+          type: string
+        pipeline:
+          type: string
+        runId:
+          type: string
+        stage:
+          type: string
+      required:
+      - runId
+      - stage
+      - outcome
+      - keptAt
+      - pipeline
       type: object
     DomainReviewerConfig:
       properties:

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -141,8 +141,14 @@ type SessionView struct {
 	// unchanged) so the desktop browser panel can re-navigate / refresh on a
 	// repeated preview of the same target. Pulled from the json:"-" domain
 	// Metadata.
-	PreviewRevision int64            `json:"previewRevision,omitempty"`
-	PRs             []SessionPRFacts `json:"prs"`
+	PreviewRevision int64 `json:"previewRevision,omitempty"`
+	// PipelineOrphan is set when a pipeline stage kept this session alive instead
+	// of killing it: the run, the stage, the outcome that spared it and when it
+	// was kept. It is what the session list renders as the pipeline-orphaned
+	// badge, next to the existing kill action. Omitted for every other session.
+	// Pulled from the json:"-" domain Metadata.
+	PipelineOrphan *domain.PipelineOrphanInfo `json:"pipelineOrphan,omitempty"`
+	PRs            []SessionPRFacts           `json:"prs"`
 }
 
 // ListSessionsResponse is the body of GET /api/v1/sessions.

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -822,7 +822,14 @@ func previewFileURL(r *http.Request, id domain.SessionID, entry string) (string,
 }
 
 func sessionView(s domain.Session) SessionView {
-	return SessionView{Session: s, Branch: s.Metadata.Branch, PreviewURL: s.Metadata.PreviewURL, PreviewRevision: s.Metadata.PreviewRevision, PRs: sessionPRFacts(s.PRs)}
+	return SessionView{
+		Session:         s,
+		Branch:          s.Metadata.Branch,
+		PreviewURL:      s.Metadata.PreviewURL,
+		PreviewRevision: s.Metadata.PreviewRevision,
+		PipelineOrphan:  s.Metadata.PipelineOrphan,
+		PRs:             sessionPRFacts(s.PRs),
+	}
 }
 
 func sessionViews(sessions []domain.Session) []SessionView {

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -895,6 +895,60 @@ func TestSessionsAPI_SetPreviewMissingAbsoluteFilePathFailsWithoutOverwriting(t 
 	}
 }
 
+// A session a pipeline kept alive carries its badge on the session list: the run
+// and stage that owned it and the outcome that spared it. Without this the
+// reaper's bound is invisible, which is how fifty stale sessions happened.
+func TestSessionsAPI_ListSurfacesPipelineOrphan(t *testing.T) {
+	svc := newFakeSessionService()
+	keptAt := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	s := svc.sessions["ao-1"]
+	s.Metadata = domain.SessionMetadata{
+		PipelineRunID: "run-a",
+		PipelineOrphan: &domain.PipelineOrphanInfo{
+			RunID:    "run-a",
+			Stage:    "review",
+			Outcome:  "no_output",
+			KeptAt:   keptAt,
+			Pipeline: "pr-review",
+		},
+	}
+	svc.sessions["ao-1"] = s
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, "GET", "/api/v1/sessions?project=ao", "")
+	if status != http.StatusOK {
+		t.Fatalf("GET sessions = %d, want 200; body=%s", status, body)
+	}
+	var list struct {
+		Sessions []struct {
+			PipelineOrphan *domain.PipelineOrphanInfo `json:"pipelineOrphan"`
+		} `json:"sessions"`
+	}
+	mustJSON(t, body, &list)
+	if len(list.Sessions) != 1 || list.Sessions[0].PipelineOrphan == nil {
+		t.Fatalf("session list does not carry the pipeline orphan marker: %s", body)
+	}
+	got := *list.Sessions[0].PipelineOrphan
+	if got != *s.Metadata.PipelineOrphan {
+		t.Fatalf("pipelineOrphan = %+v, want %+v", got, *s.Metadata.PipelineOrphan)
+	}
+
+	// The field is omitted for every session no pipeline kept alive, so the badge
+	// never renders on a human's session.
+	plain := newFakeSessionService()
+	body, status, _ = doRequest(t, newSessionTestServer(t, plain), "GET", "/api/v1/sessions?project=ao", "")
+	if status != http.StatusOK {
+		t.Fatalf("GET sessions = %d, want 200; body=%s", status, body)
+	}
+	var raw struct {
+		Sessions []map[string]any `json:"sessions"`
+	}
+	mustJSON(t, body, &raw)
+	if _, present := raw.Sessions[0]["pipelineOrphan"]; present {
+		t.Fatalf("pipelineOrphan present on a session no pipeline kept: %s", body)
+	}
+}
+
 func TestSessionsAPI_SetPreviewBumpsRevisionOnSameURL(t *testing.T) {
 	svc := newFakeSessionService()
 	srv := newSessionTestServer(t, svc)

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -741,5 +741,6 @@ func mergeMetadata(base, in domain.SessionMetadata) domain.SessionMetadata {
 	set(&base.RuntimeHandleID, in.RuntimeHandleID)
 	set(&base.AgentSessionID, in.AgentSessionID)
 	set(&base.Prompt, in.Prompt)
+	set(&base.PipelineRunID, in.PipelineRunID)
 	return base
 }

--- a/backend/internal/pipeline/engine/adapters.go
+++ b/backend/internal/pipeline/engine/adapters.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/triggers"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -78,6 +79,7 @@ var (
 	_ executors.SessionSpawner   = (*SessionAdapter)(nil)
 	_ executors.SessionMessenger = (*SessionAdapter)(nil)
 	_ SessionDisposer            = (*SessionAdapter)(nil)
+	_ triggers.SessionSpawnCheck = (*SessionAdapter)(nil)
 )
 
 // Spawn starts the stage's worker session.
@@ -90,12 +92,16 @@ var (
 // pipeline-owned tree, which is a session-lifecycle change, not an engine one.
 func (a *SessionAdapter) Spawn(ctx context.Context, req executors.SpawnRequest) (executors.SpawnedSession, error) {
 	sess, err := a.cmd.Spawn(ctx, ports.SpawnConfig{
-		ProjectID:   domain.ProjectID(req.ProjectID),
-		Kind:        domain.KindWorker,
-		Harness:     domain.AgentHarness(req.Harness),
-		Prompt:      req.Prompt,
-		DisplayName: req.DisplayName,
-		Env:         req.Env,
+		ProjectID: domain.ProjectID(req.ProjectID),
+		Kind:      domain.KindWorker,
+		Harness:   domain.AgentHarness(req.Harness),
+		Prompt:    req.Prompt,
+		// The run id lands on the session's metadata: it is the marker the
+		// session trigger bridge reads as its loop guard, so it has to be set
+		// here, at spawn, and not once the stage settles.
+		PipelineRunID: req.RunID,
+		DisplayName:   req.DisplayName,
+		Env:           req.Env,
 	})
 	if err != nil {
 		return executors.SpawnedSession{}, err
@@ -156,6 +162,18 @@ func (a *SessionAdapter) Alive(ctx context.Context, sessionID string) (bool, err
 // Send delivers the nudge into the live session.
 func (a *SessionAdapter) Send(ctx context.Context, sessionID, message string) error {
 	return a.cmd.Send(ctx, domain.SessionID(sessionID), message)
+}
+
+// IsPipelineSpawned implements the session trigger bridge's loop guard over the
+// marker Spawn wrote. An unknown session is not pipeline-spawned; a read failure
+// propagates, because the bridge's fail-safe (skip the session) is only correct
+// when it knows the provenance is unknown.
+func (a *SessionAdapter) IsPipelineSpawned(ctx context.Context, sessionID domain.SessionID) (bool, error) {
+	rec, ok, err := a.reader.GetSession(ctx, sessionID)
+	if err != nil || !ok {
+		return false, err
+	}
+	return rec.Metadata.PipelineRunID != "", nil
 }
 
 // GetPath implements the workspace resolver's session seam: where the subject

--- a/backend/internal/pipeline/engine/adapters_test.go
+++ b/backend/internal/pipeline/engine/adapters_test.go
@@ -98,6 +98,51 @@ func TestSessionAdapterSpawnCarriesEnvAndPrompt(t *testing.T) {
 	}
 }
 
+// Every pipeline-spawned session carries its run id into the spawn config, and
+// the adapter reads that marker back as the session trigger bridge's loop guard.
+func TestSessionAdapterMarksAndDetectsPipelineSpawnedSessions(t *testing.T) {
+	cmd := newFakeCommander()
+	adapter := NewSessionAdapter(cmd, fakeSessionRows{}, nil, nil)
+
+	if _, err := adapter.Spawn(context.Background(), executors.SpawnRequest{
+		ProjectID: "proj-1",
+		RunID:     "run-a",
+		Prompt:    "review",
+	}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if cmd.spawned.PipelineRunID != "run-a" {
+		t.Fatalf("spawn config pipeline run id = %q, want run-a: the loop guard has nothing to read without it", cmd.spawned.PipelineRunID)
+	}
+
+	rows := fakeSessionRows{rows: map[domain.SessionID]domain.SessionRecord{
+		"sess-pipeline": {ID: "sess-pipeline", Metadata: domain.SessionMetadata{PipelineRunID: "run-a"}},
+		"sess-human":    {ID: "sess-human"},
+	}}
+	guard := NewSessionAdapter(cmd, rows, nil, nil)
+
+	spawned, err := guard.IsPipelineSpawned(context.Background(), "sess-pipeline")
+	if err != nil || !spawned {
+		t.Fatalf("IsPipelineSpawned(pipeline session) = %v, %v; want true", spawned, err)
+	}
+	spawned, err = guard.IsPipelineSpawned(context.Background(), "sess-human")
+	if err != nil || spawned {
+		t.Fatalf("IsPipelineSpawned(human session) = %v, %v; want false", spawned, err)
+	}
+	// An unknown session is not pipeline-spawned, and is not an error: the
+	// bridge's own fail-safe covers reads it cannot answer.
+	spawned, err = guard.IsPipelineSpawned(context.Background(), "sess-gone")
+	if err != nil || spawned {
+		t.Fatalf("IsPipelineSpawned(missing session) = %v, %v; want false, nil", spawned, err)
+	}
+	// A read failure propagates, so the bridge can take its fail-safe path
+	// instead of treating an unreadable session as human-spawned.
+	if _, err := NewSessionAdapter(cmd, fakeSessionRows{err: errors.New("db down")}, nil, nil).
+		IsPipelineSpawned(context.Background(), "sess-pipeline"); err == nil {
+		t.Fatal("loop guard swallowed a store failure, want the error surfaced")
+	}
+}
+
 func TestSessionAdapterInterruptKeepsTheSession(t *testing.T) {
 	cmd := newFakeCommander()
 	runtime := &fakeRuntime{}

--- a/backend/internal/pipeline/engine/engine.go
+++ b/backend/internal/pipeline/engine/engine.go
@@ -73,6 +73,10 @@ type Config struct {
 	// Sessions applies the kill half of the kill-on rule. Optional: without it
 	// a session is always kept.
 	Sessions SessionDisposer
+	// Orphans marks and bounds the sessions the kill-on rule spares. Optional:
+	// a nil registry keeps every spared session forever and unmarked, which is
+	// what a test engine wants and what production must never be.
+	Orphans *OrphanRegistry
 	// Messenger delivers the one nudge a stage may get. Optional: without it a
 	// nudge cannot be delivered and the stage settles on its next poll.
 	Messenger executors.SessionMessenger
@@ -113,6 +117,7 @@ type Engine struct {
 	execs       executors.StageExecutor
 	workspaces  executors.WorkspaceProvisioner
 	sessions    SessionDisposer
+	orphans     *OrphanRegistry
 	messenger   executors.SessionMessenger
 	creds       Credentials
 	baseDir     string
@@ -151,6 +156,7 @@ func New(cfg Config) *Engine {
 		execs:        cfg.Executors,
 		workspaces:   cfg.Workspaces,
 		sessions:     cfg.Sessions,
+		orphans:      cfg.Orphans,
 		messenger:    cfg.Messenger,
 		creds:        cfg.Credentials,
 		baseDir:      cfg.BaseDir,
@@ -711,12 +717,9 @@ func (e *Engine) teardownStage(runID pipeline.RunID, stage string, kill bool) {
 // settleSession applies the stage's kill-on rule. An outcome in the list kills
 // the session; anything else keeps it, because no_output, no_signal and
 // timed_out are precisely the cases where a human needs to see what the agent
-// was doing (spec section 7.2).
-//
-// ponytail: a kept session is only logged today. Task 16 adds the orphan
-// registry that marks it pipeline-orphaned in the session list and bounds the
-// leak (cap 3 per pipeline, 24h TTL); until then a kept session is visible in
-// the sidebar like any other and has to be killed by hand.
+// was doing (spec section 7.2). A kept session is handed to the orphan registry,
+// which marks it pipeline-orphaned in the session list and bounds the leak (cap
+// 3 per pipeline, 24h TTL).
 func (e *Engine) settleSession(runID pipeline.RunID, eff pipeline.SettleSession) {
 	if eff.SessionID == "" {
 		return
@@ -742,8 +745,17 @@ func (e *Engine) settleSession(runID pipeline.RunID, eff pipeline.SettleSession)
 		}
 		return
 	}
-	e.log.Info("pipeline session kept alive",
-		"run", runID, "stage", eff.Stage, "session", eff.SessionID, "outcome", eff.Outcome)
+
+	// Kept: the outcomes that get here (no_output, no_signal, timed_out) are
+	// exactly the ones a human may want to inspect, which is the whole point of
+	// the feature, so the session survives and gets a badge instead.
+	e.orphans.Keep(e.baseCtx, orphanKey(string(e.projectID), run.PipelineName), domain.PipelineOrphanInfo{
+		RunID:    string(runID),
+		Stage:    eff.Stage,
+		Outcome:  string(eff.Outcome),
+		KeptAt:   e.now(),
+		Pipeline: run.PipelineName,
+	}, eff.SessionID)
 }
 
 // runSettled tears down what the run owns and hands its concurrency key on.

--- a/backend/internal/pipeline/engine/engine_test.go
+++ b/backend/internal/pipeline/engine/engine_test.go
@@ -226,7 +226,9 @@ func (m *fakeMessenger) messages() []string {
 	return append([]string(nil), m.sent...)
 }
 
-// fakeSessions records the kill-on decisions the driver made.
+// fakeSessions is a bare session disposer, for the wirings that only need the
+// kill seam to exist. The harness uses fakeOrphanSessions instead, which also
+// keeps the rows the orphan marker lands on.
 type fakeSessions struct {
 	mu     sync.Mutex
 	killed []string
@@ -237,12 +239,6 @@ func (s *fakeSessions) Kill(_ context.Context, sessionID string) error {
 	defer s.mu.Unlock()
 	s.killed = append(s.killed, sessionID)
 	return nil
-}
-
-func (s *fakeSessions) killedIDs() []string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return append([]string(nil), s.killed...)
 }
 
 // fakeCredentials serves engine-held credentials from a map.
@@ -282,7 +278,7 @@ type harness struct {
 	ws     *fakeProvisioner
 	store  *fakeStore
 	msgr   *fakeMessenger
-	sess   *fakeSessions
+	sess   *fakeOrphanSessions
 	base   string
 
 	mu  sync.Mutex
@@ -299,7 +295,7 @@ func newHarness(t *testing.T, opts ...func(*Config)) *harness {
 		ws:    newFakeProvisioner(filepath.Join(base, "trees")),
 		store: newFakeStore(),
 		msgr:  &fakeMessenger{},
-		sess:  &fakeSessions{},
+		sess:  newAutoOrphanSessions("proj-1"),
 		base:  filepath.Join(base, "pipelines"),
 		now:   time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC),
 	}
@@ -310,6 +306,7 @@ func newHarness(t *testing.T, opts ...func(*Config)) *harness {
 		Executors:  h.execs,
 		Workspaces: h.ws,
 		Sessions:   h.sess,
+		Orphans:    NewOrphanRegistry(h.sess, h.sess, nil),
 		Messenger:  h.msgr,
 		BaseDir:    h.base,
 		Clock:      h.clock,
@@ -1017,6 +1014,51 @@ stages:
 	h2.engine.Tick()
 	if killed := h2.sess.killedIDs(); len(killed) != 0 {
 		t.Fatalf("killed %v, want kill-on: [] to never kill", killed)
+	}
+}
+
+// TestKeptSessionIsMarkedPipelineOrphaned: the kept half of the kill-on rule.
+// The session survives no_output and carries the run, the stage and the outcome
+// that spared it, because a kept session nobody can find is the leak this
+// feature exists to stop.
+func TestKeptSessionIsMarkedPipelineOrphaned(t *testing.T) {
+	h := newHarness(t)
+	runID := h.trigger(t, twoStageYAML, userSessionSubject())
+
+	h.execs.script(t, "review",
+		executors.Poll{State: executors.PollSignaledDone},
+		executors.Poll{State: executors.PollSignaledDone},
+	)
+	h.engine.Tick()
+	h.engine.Tick()
+
+	if got := h.outcome(t, runID, "review"); got != pipeline.OutcomeNoOutput {
+		t.Fatalf("review outcome = %q, want no_output", got)
+	}
+	marker := h.sess.marker("sess-review")
+	if marker == nil {
+		t.Fatal("kept session was not marked pipeline-orphaned")
+	}
+	want := domain.PipelineOrphanInfo{
+		RunID:    string(runID),
+		Stage:    "review",
+		Outcome:  string(pipeline.OutcomeNoOutput),
+		KeptAt:   h.clock(),
+		Pipeline: h.run(t, runID).PipelineName,
+	}
+	if *marker != want {
+		t.Fatalf("orphan marker = %+v, want %+v", *marker, want)
+	}
+
+	// A killed session is not an orphan: the marker exists to explain a session
+	// that is still there.
+	h2 := newHarness(t)
+	killed := h2.trigger(t, twoStageYAML, userSessionSubject())
+	h2.writeOutput(t, killed, "review.md", "content")
+	h2.execs.script(t, "review", executors.Poll{State: executors.PollSignaledDone})
+	h2.engine.Tick()
+	if got := h2.sess.marker("sess-review"); got != nil {
+		t.Fatalf("killed session marked pipeline-orphaned: %+v", got)
 	}
 }
 

--- a/backend/internal/pipeline/engine/orphans.go
+++ b/backend/internal/pipeline/engine/orphans.go
@@ -1,0 +1,188 @@
+// This file bounds the sessions a pipeline keeps alive.
+//
+// Kept-alive is the common case on agent failure (no_output, no_signal and
+// timed_out all spare the session so a human can see what the agent was doing),
+// so without a bound the feature reproduces the exact fifty-stale-worktrees mess
+// v2 exists to fix. Two bounds, neither of them reap-on-run-settle: the run
+// settles seconds after the stage does, which would kill the session before
+// anyone could look at it (spec section 7.3).
+//
+//   - Cap: 3 kept sessions per pipeline, least recently kept evicted.
+//   - TTL: 24h, swept from the supervisor's ticker.
+//
+// Both are fixed constants (decision D7). The ledger the bounds are computed
+// from is the persisted marker on the session rows, not in-process state, so a
+// daemon restart does not forget the sessions it is supposed to reap.
+package engine
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// The reaper's bounds. Fixed, not configurable (decision D7): configurability is
+// a later knob if dogfooding asks for it.
+const (
+	// MaxOrphanedSessionsPerPipeline is how many kept-alive sessions one pipeline
+	// may hold at once. A further keep evicts the least recently kept.
+	MaxOrphanedSessionsPerPipeline = 3
+	// OrphanTTL is how long a kept-alive session survives before the sweep kills
+	// it. This is the bound on the slow leak.
+	OrphanTTL = 24 * time.Hour
+)
+
+// OrphanSessions is the session-store surface the registry needs: write the
+// marker, and read back every session so the cap and the TTL can be computed
+// from what is actually persisted. *storage/sqlite/store.Store satisfies it.
+type OrphanSessions interface {
+	SetSessionPipelineOrphan(ctx context.Context, id domain.SessionID, info *domain.PipelineOrphanInfo, updatedAt time.Time) (bool, error)
+	ListAllSessions(ctx context.Context) ([]domain.SessionRecord, error)
+}
+
+// OrphanRegistry marks the sessions a pipeline kept alive and enforces the two
+// bounds on them. Safe for concurrent use: every project's engine shares one.
+type OrphanRegistry struct {
+	sessions OrphanSessions
+	killer   SessionDisposer
+	log      *slog.Logger
+
+	// mu serializes the read-then-kill cycles, so two engines keeping a session
+	// at the same moment cannot both decide to evict the same one. Kills run
+	// under it: Keep is already synchronous on the calling engine's actor, and
+	// the only cross-project cost is a short wait.
+	mu sync.Mutex
+}
+
+// NewOrphanRegistry builds the registry over the session store and the killer.
+// A nil registry is legal everywhere and simply keeps every session forever,
+// which is what an engine wired without a session store gets.
+func NewOrphanRegistry(sessions OrphanSessions, killer SessionDisposer, log *slog.Logger) *OrphanRegistry {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &OrphanRegistry{sessions: sessions, killer: killer, log: log}
+}
+
+// orphanKey is the cap's grouping key: one budget per pipeline per project, so
+// two projects that both define a `pr-review` pipeline do not share three slots.
+// The engine builds it from its own project id and the run's pipeline name; the
+// registry rebuilds the same key from the persisted marker.
+func orphanKey(projectID, pipeline string) string { return projectID + "/" + pipeline }
+
+// Keep marks the session pipeline-orphaned and enforces the cap for its
+// pipeline, killing the least recently kept session when the keep pushes the
+// pipeline over MaxOrphanedSessionsPerPipeline.
+//
+// key is the grouping key from orphanKey; info is what the session list renders.
+// Failures are logged, never returned: a stage has already settled by the time
+// this runs, and the run must not be held up by a session-list side effect.
+func (r *OrphanRegistry) Keep(ctx context.Context, key string, info domain.PipelineOrphanInfo, sessionID string) {
+	if r == nil || sessionID == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	marked, err := r.sessions.SetSessionPipelineOrphan(ctx, domain.SessionID(sessionID), &info, info.KeptAt)
+	switch {
+	case err != nil:
+		r.log.Warn("pipeline orphan marker not written", "session", sessionID, "run", info.RunID, "err", err)
+	case !marked:
+		r.log.Warn("pipeline orphan marker skipped: session row is gone", "session", sessionID, "run", info.RunID)
+	default:
+		r.log.Info("pipeline session kept alive",
+			"session", sessionID, "run", info.RunID, "stage", info.Stage, "outcome", info.Outcome)
+	}
+
+	kept := r.ledger(ctx)
+	mine := make([]keptSession, 0, len(kept))
+	for _, k := range kept {
+		if k.key == key {
+			mine = append(mine, k)
+		}
+	}
+	for len(mine) > MaxOrphanedSessionsPerPipeline {
+		evicted := mine[0]
+		mine = mine[1:]
+		r.log.Info("pipeline orphan evicted: pipeline is over its kept-session cap",
+			"session", evicted.sessionID, "pipeline", key, "cap", MaxOrphanedSessionsPerPipeline)
+		r.kill(ctx, evicted.sessionID)
+	}
+}
+
+// Sweep kills every kept session past OrphanTTL. It runs from the supervisor's
+// ticker, so the bound holds for sessions this process never kept itself.
+func (r *OrphanRegistry) Sweep(ctx context.Context, now time.Time) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	cutoff := now.Add(-OrphanTTL)
+	for _, kept := range r.ledger(ctx) {
+		// A marker with no timestamp cannot be aged, and killing a session on a
+		// fact we do not have is the wrong direction: the cap still bounds it.
+		if kept.keptAt.IsZero() || kept.keptAt.After(cutoff) {
+			continue
+		}
+		r.log.Info("pipeline orphan reaped: past its 24h TTL",
+			"session", kept.sessionID, "pipeline", kept.key, "keptAt", kept.keptAt)
+		r.kill(ctx, kept.sessionID)
+	}
+}
+
+// keptSession is one row of the ledger.
+type keptSession struct {
+	sessionID string
+	key       string
+	keptAt    time.Time
+}
+
+// ledger reads the currently kept sessions, oldest keep first. Terminated rows
+// are not kept sessions: a session killed by hand, by an eviction or by a
+// previous sweep has already left, and counting it would evict a live session in
+// its place. An unreadable store yields no ledger, which kills nothing.
+func (r *OrphanRegistry) ledger(ctx context.Context) []keptSession {
+	rows, err := r.sessions.ListAllSessions(ctx)
+	if err != nil {
+		r.log.Warn("pipeline orphan ledger unreadable, bounds not enforced this pass", "err", err)
+		return nil
+	}
+	out := make([]keptSession, 0, len(rows))
+	for _, rec := range rows {
+		if rec.IsTerminated || rec.Metadata.PipelineOrphan == nil {
+			continue
+		}
+		marker := rec.Metadata.PipelineOrphan
+		out = append(out, keptSession{
+			sessionID: string(rec.ID),
+			key:       orphanKey(string(rec.ProjectID), marker.Pipeline),
+			keptAt:    marker.KeptAt,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].keptAt.Equal(out[j].keptAt) {
+			return out[i].sessionID < out[j].sessionID
+		}
+		return out[i].keptAt.Before(out[j].keptAt)
+	})
+	return out
+}
+
+// kill tears a reaped session down. Best-effort: a session already gone is not
+// an error, and a failure here must not stop the rest of the sweep.
+func (r *OrphanRegistry) kill(ctx context.Context, sessionID string) {
+	if r.killer == nil {
+		r.log.Warn("pipeline orphan not killed: no session seam wired", "session", sessionID)
+		return
+	}
+	if err := r.killer.Kill(ctx, sessionID); err != nil {
+		r.log.Warn("pipeline orphan kill", "session", sessionID, "err", err)
+	}
+}

--- a/backend/internal/pipeline/engine/orphans_test.go
+++ b/backend/internal/pipeline/engine/orphans_test.go
@@ -1,0 +1,248 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// fakeOrphanSessions is the session store half of the orphan registry: the rows
+// the marker is written onto and the ledger the cap and the TTL are derived
+// from. Killing a session terminates its row, exactly as the real kill does,
+// which is what stops a killed orphan from being counted or killed twice.
+type fakeOrphanSessions struct {
+	mu   sync.Mutex
+	rows map[domain.SessionID]domain.SessionRecord
+	// autoProject, when set, creates a row for any session the marker is written
+	// to, so a caller need not enumerate the sessions it will spawn.
+	autoProject domain.ProjectID
+	killed      []string
+	listErr     error
+	markErr     error
+	marks       int
+}
+
+func newFakeOrphanSessions(project domain.ProjectID, ids ...domain.SessionID) *fakeOrphanSessions {
+	f := &fakeOrphanSessions{rows: map[domain.SessionID]domain.SessionRecord{}}
+	for _, id := range ids {
+		f.rows[id] = domain.SessionRecord{ID: id, ProjectID: project}
+	}
+	return f
+}
+
+// newAutoOrphanSessions stands in for a store where every spawned session
+// already has a row, which is what the engine harness needs: it never enumerates
+// the sessions its stages will spawn.
+func newAutoOrphanSessions(project domain.ProjectID) *fakeOrphanSessions {
+	f := newFakeOrphanSessions(project)
+	f.autoProject = project
+	return f
+}
+
+func (f *fakeOrphanSessions) ListAllSessions(context.Context) ([]domain.SessionRecord, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]domain.SessionRecord, 0, len(f.rows))
+	for _, rec := range f.rows {
+		out = append(out, rec)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+func (f *fakeOrphanSessions) SetSessionPipelineOrphan(_ context.Context, id domain.SessionID, info *domain.PipelineOrphanInfo, _ time.Time) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.markErr != nil {
+		return false, f.markErr
+	}
+	rec, ok := f.rows[id]
+	if !ok {
+		if f.autoProject == "" {
+			return false, nil
+		}
+		rec = domain.SessionRecord{ID: id, ProjectID: f.autoProject}
+	}
+	f.marks++
+	rec.Metadata.PipelineOrphan = info
+	f.rows[id] = rec
+	return true, nil
+}
+
+// Kill implements SessionDisposer over the same rows.
+func (f *fakeOrphanSessions) Kill(_ context.Context, sessionID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.killed = append(f.killed, sessionID)
+	id := domain.SessionID(sessionID)
+	if rec, ok := f.rows[id]; ok {
+		rec.IsTerminated = true
+		f.rows[id] = rec
+	}
+	return nil
+}
+
+func (f *fakeOrphanSessions) killedIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.killed...)
+}
+
+func (f *fakeOrphanSessions) marker(id domain.SessionID) *domain.PipelineOrphanInfo {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.rows[id].Metadata.PipelineOrphan
+}
+
+func keptAt(base time.Time, offset time.Duration) time.Time { return base.Add(offset) }
+
+var orphanBase = time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+
+func orphanInfo(runID, stage, outcome string, at time.Time) domain.PipelineOrphanInfo {
+	return domain.PipelineOrphanInfo{
+		RunID:    runID,
+		Stage:    stage,
+		Outcome:  outcome,
+		KeptAt:   at,
+		Pipeline: "pr-review",
+	}
+}
+
+// A kept session carries the run, the stage and the outcome that spared it, so
+// the session list can say why it is still there.
+func TestOrphanRegistryMarksTheSession(t *testing.T) {
+	rows := newFakeOrphanSessions("proj-1", "sess-1")
+	reg := NewOrphanRegistry(rows, rows, nil)
+
+	info := orphanInfo("run-a", "review", "no_output", orphanBase)
+	reg.Keep(context.Background(), orphanKey("proj-1", "pr-review"), info, "sess-1")
+
+	got := rows.marker("sess-1")
+	if got == nil {
+		t.Fatal("kept session is not marked pipeline-orphaned")
+	}
+	if *got != info {
+		t.Fatalf("marker = %+v, want %+v", *got, info)
+	}
+	if killed := rows.killedIDs(); len(killed) != 0 {
+		t.Fatalf("killed %v, want the first kept session left alone", killed)
+	}
+}
+
+// The cap is what actually prevents the fifty-session case: a fourth kept
+// session in the same pipeline evicts and kills the least recently kept, and
+// another pipeline's kept sessions are none of its business.
+func TestOrphanRegistryEvictsLeastRecentlyKept(t *testing.T) {
+	rows := newFakeOrphanSessions("proj-1", "sess-1", "sess-2", "sess-3", "sess-4", "other-1")
+	reg := NewOrphanRegistry(rows, rows, nil)
+	ctx := context.Background()
+	key := orphanKey("proj-1", "pr-review")
+
+	for i, id := range []string{"sess-1", "sess-2", "sess-3"} {
+		reg.Keep(ctx, key, orphanInfo("run-a", "review", "no_signal", keptAt(orphanBase, time.Duration(i)*time.Minute)), id)
+	}
+	if killed := rows.killedIDs(); len(killed) != 0 {
+		t.Fatalf("killed %v at the cap, want nothing killed until it is exceeded", killed)
+	}
+
+	// A different pipeline has its own budget.
+	otherInfo := orphanInfo("run-z", "triage", "timed_out", keptAt(orphanBase, 4*time.Minute))
+	otherInfo.Pipeline = "session-triage"
+	reg.Keep(ctx, orphanKey("proj-1", "session-triage"), otherInfo, "other-1")
+	if killed := rows.killedIDs(); len(killed) != 0 {
+		t.Fatalf("killed %v, want a second pipeline's keeps to be independent", killed)
+	}
+
+	reg.Keep(ctx, key, orphanInfo("run-b", "review", "no_signal", keptAt(orphanBase, 5*time.Minute)), "sess-4")
+	killed := rows.killedIDs()
+	if len(killed) != 1 || killed[0] != "sess-1" {
+		t.Fatalf("killed %v, want only the least recently kept session (sess-1)", killed)
+	}
+
+	// Re-keeping a session already kept refreshes it rather than counting twice,
+	// so the surviving three stay alive.
+	reg.Keep(ctx, key, orphanInfo("run-b", "review", "no_signal", keptAt(orphanBase, 6*time.Minute)), "sess-4")
+	if killed := rows.killedIDs(); len(killed) != 1 {
+		t.Fatalf("killed %v, want re-keeping the same session to evict nobody", killed)
+	}
+}
+
+// The TTL handles the slow leak: a kept session past 24h is killed by the
+// supervisor's sweep, one still inside the window is not.
+func TestOrphanRegistrySweepKillsPastTTL(t *testing.T) {
+	rows := newFakeOrphanSessions("proj-1", "old", "fresh", "already-dead")
+	reg := NewOrphanRegistry(rows, rows, nil)
+	ctx := context.Background()
+	key := orphanKey("proj-1", "pr-review")
+
+	reg.Keep(ctx, key, orphanInfo("run-a", "review", "timed_out", orphanBase), "old")
+	reg.Keep(ctx, key, orphanInfo("run-b", "review", "no_output", orphanBase.Add(23*time.Hour)), "fresh")
+	reg.Keep(ctx, key, orphanInfo("run-c", "review", "no_output", orphanBase), "already-dead")
+	_ = rows.Kill(ctx, "already-dead")
+
+	reg.Sweep(ctx, orphanBase.Add(OrphanTTL+time.Minute))
+
+	killed := rows.killedIDs()
+	if len(killed) != 2 || killed[0] != "already-dead" || killed[1] != "old" {
+		t.Fatalf("killed %v, want only the past-TTL session swept (the dead one was killed by hand)", killed)
+	}
+
+	// Sweeping again kills nothing new: the swept session's row is terminated,
+	// so it has left the ledger.
+	reg.Sweep(ctx, orphanBase.Add(OrphanTTL+time.Minute))
+	if again := rows.killedIDs(); len(again) != 2 {
+		t.Fatalf("killed %v, want the sweep to be idempotent", again)
+	}
+}
+
+// The ledger lives on the session rows, not in this process, so the bounds still
+// hold for sessions a previous daemon kept alive.
+func TestOrphanRegistryBoundsSurviveARestart(t *testing.T) {
+	rows := newFakeOrphanSessions("proj-1", "sess-1", "sess-2", "sess-3", "sess-4")
+	ctx := context.Background()
+	key := orphanKey("proj-1", "pr-review")
+
+	before := NewOrphanRegistry(rows, rows, nil)
+	for i, id := range []string{"sess-1", "sess-2", "sess-3"} {
+		before.Keep(ctx, key, orphanInfo("run-a", "review", "no_signal", keptAt(orphanBase, time.Duration(i)*time.Minute)), id)
+	}
+
+	// A fresh registry, as a restarted daemon builds, still sees the three kept
+	// sessions and evicts the oldest when the fourth arrives.
+	after := NewOrphanRegistry(rows, rows, nil)
+	after.Keep(ctx, key, orphanInfo("run-b", "review", "no_signal", keptAt(orphanBase, 9*time.Minute)), "sess-4")
+	if killed := rows.killedIDs(); len(killed) != 1 || killed[0] != "sess-1" {
+		t.Fatalf("killed %v, want the pre-restart keeps to still count toward the cap", killed)
+	}
+}
+
+// A store that cannot be read must not kill anything: with no ledger there is no
+// evidence any session is over the cap or past its TTL.
+func TestOrphanRegistryUnreadableLedgerKillsNothing(t *testing.T) {
+	rows := newFakeOrphanSessions("proj-1", "sess-1")
+	reg := NewOrphanRegistry(rows, rows, nil)
+	ctx := context.Background()
+	rows.listErr = errors.New("db down")
+
+	reg.Keep(ctx, orphanKey("proj-1", "pr-review"), orphanInfo("run-a", "review", "no_output", orphanBase), "sess-1")
+	reg.Sweep(ctx, orphanBase.Add(2*OrphanTTL))
+	if killed := rows.killedIDs(); len(killed) != 0 {
+		t.Fatalf("killed %v with an unreadable ledger, want nothing killed", killed)
+	}
+}
+
+// A nil registry is the no-reaper wiring (a test engine, or a daemon built
+// without the session store). It must be inert, not a panic.
+func TestOrphanRegistryNilIsInert(t *testing.T) {
+	var reg *OrphanRegistry
+	reg.Keep(context.Background(), "proj-1/pr-review", orphanInfo("run-a", "review", "no_output", orphanBase), "sess-1")
+	reg.Sweep(context.Background(), orphanBase)
+}

--- a/backend/internal/pipeline/engine/supervisor.go
+++ b/backend/internal/pipeline/engine/supervisor.go
@@ -13,6 +13,10 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/triggers"
 )
 
+// defaultSweepInterval is how often the reaper looks for kept sessions past the
+// 24h TTL. Hourly: the bound is a day, so nothing is gained by looking sooner.
+const defaultSweepInterval = time.Hour
+
 // Supervisor owns one Engine per project. It is the single wiring seam the
 // daemon constructs, so the whole subsystem stays behind AO_PIPELINES at one
 // call site, and it is the lookup the trigger bridges and the HTTP service use
@@ -29,6 +33,10 @@ type Supervisor struct {
 	mu      sync.Mutex
 	engines map[domain.ProjectID]*Engine
 	started bool
+	reaping bool
+
+	sweepQuit chan struct{}
+	sweepWG   sync.WaitGroup
 }
 
 // ProjectLister enumerates the projects to instantiate engines for. Satisfied
@@ -47,11 +55,18 @@ type SupervisorConfig struct {
 	Messenger   executors.SessionMessenger
 	Credentials Credentials
 	Projects    ProjectLister
+	// Orphans is the reaper the supervisor owns: every engine hands it the
+	// sessions their kill-on rules spared, and the supervisor's sweep ticker
+	// enforces the 24h TTL. Nil means no reaper, which is a test wiring.
+	Orphans *OrphanRegistry
 	// BaseDir is the run-folder root, <AO_DATA_DIR>/pipelines.
 	BaseDir      string
 	Logger       *slog.Logger
 	Clock        func() time.Time
 	TickInterval time.Duration
+	// SweepInterval is how often the reaper runs. Defaults to
+	// defaultSweepInterval; tests shorten it.
+	SweepInterval time.Duration
 }
 
 // NewSupervisor builds a Supervisor. It starts no engines; call Start.
@@ -59,10 +74,14 @@ func NewSupervisor(cfg SupervisorConfig) *Supervisor {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
+	if cfg.SweepInterval <= 0 {
+		cfg.SweepInterval = defaultSweepInterval
+	}
 	return &Supervisor{
 		cfg:         cfg,
 		concurrency: &ConcurrencyTable{},
 		engines:     map[domain.ProjectID]*Engine{},
+		sweepQuit:   make(chan struct{}),
 	}
 }
 
@@ -90,7 +109,43 @@ func (s *Supervisor) Start(ctx context.Context) error {
 		}
 		s.engines[pid] = eng
 	}
+	s.startReaper()
 	return nil
+}
+
+// startReaper launches the sweep ticker. Called with s.mu held.
+func (s *Supervisor) startReaper() {
+	if s.cfg.Orphans == nil || s.reaping {
+		return
+	}
+	s.reaping = true
+	s.sweepWG.Add(1)
+	go s.reap()
+}
+
+// reap sweeps past-TTL kept sessions until Stop. It is a slow loop on purpose:
+// the bound is 24h, so hourly granularity is plenty and a busy daemon never
+// notices it.
+func (s *Supervisor) reap() {
+	defer s.sweepWG.Done()
+	ticker := time.NewTicker(s.cfg.SweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.sweepQuit:
+			return
+		case <-ticker.C:
+			s.cfg.Orphans.Sweep(context.Background(), s.now())
+		}
+	}
+}
+
+// now is the supervisor's clock, the same seam the engines take.
+func (s *Supervisor) now() time.Time {
+	if s.cfg.Clock != nil {
+		return s.cfg.Clock()
+	}
+	return time.Now().UTC()
 }
 
 // Stop stops every engine. Safe to call once; later lookups error.
@@ -99,7 +154,14 @@ func (s *Supervisor) Stop(ctx context.Context) error {
 	engines := s.engines
 	s.engines = map[domain.ProjectID]*Engine{}
 	s.started = false
+	stopReaper := s.reaping
+	s.reaping = false
 	s.mu.Unlock()
+
+	if stopReaper {
+		close(s.sweepQuit)
+		s.sweepWG.Wait()
+	}
 
 	for _, eng := range engines {
 		_ = eng.Stop(ctx)
@@ -134,6 +196,7 @@ func (s *Supervisor) newEngine(pid domain.ProjectID) *Engine {
 		Executors:    s.cfg.Executors,
 		Workspaces:   s.cfg.Workspaces,
 		Sessions:     s.cfg.Sessions,
+		Orphans:      s.cfg.Orphans,
 		Messenger:    s.cfg.Messenger,
 		Credentials:  s.cfg.Credentials,
 		BaseDir:      s.cfg.BaseDir,

--- a/backend/internal/pipeline/engine/supervisor_test.go
+++ b/backend/internal/pipeline/engine/supervisor_test.go
@@ -89,6 +89,46 @@ func TestSupervisorStoppedRefusesLookups(t *testing.T) {
 	}
 }
 
+// The supervisor owns the reaper: its ticker sweeps past-TTL kept sessions, so
+// the 24h bound holds without anything else having to run.
+func TestSupervisorSweepsOrphansOnItsTicker(t *testing.T) {
+	base := t.TempDir()
+	rows := newFakeOrphanSessions("proj-1", "stale")
+	orphans := NewOrphanRegistry(rows, rows, nil)
+	orphans.Keep(context.Background(), orphanKey("proj-1", "pr-review"),
+		orphanInfo("run-a", "review", "no_signal", orphanBase), "stale")
+
+	now := orphanBase.Add(OrphanTTL + time.Hour)
+	sup := NewSupervisor(SupervisorConfig{
+		Store:         newFakeStore(),
+		Executors:     newFakeExecutor(),
+		Workspaces:    newFakeProvisioner(filepath.Join(base, "trees")),
+		Sessions:      rows,
+		Messenger:     &fakeMessenger{},
+		Orphans:       orphans,
+		Projects:      fakeProjectLister{ids: []string{"proj-1"}},
+		BaseDir:       filepath.Join(base, "pipelines"),
+		Clock:         func() time.Time { return now },
+		TickInterval:  time.Hour,
+		SweepInterval: time.Millisecond,
+	})
+	if err := sup.Start(context.Background()); err != nil {
+		t.Fatalf("start supervisor: %v", err)
+	}
+	t.Cleanup(func() { _ = sup.Stop(context.Background()) })
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if killed := rows.killedIDs(); len(killed) == 1 && killed[0] == "stale" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("killed %v, want the past-TTL session swept by the supervisor ticker", rows.killedIDs())
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
 // TestSupervisorProviderDrivesRuns is the bridges' path end to end: resolve the
 // project's engine through the EngineProvider port and start a run on it.
 func TestSupervisorProviderDrivesRuns(t *testing.T) {

--- a/backend/internal/pipeline/executors/agent.go
+++ b/backend/internal/pipeline/executors/agent.go
@@ -16,6 +16,10 @@ import (
 // onto ports.SpawnConfig.
 type SpawnRequest struct {
 	ProjectID string
+	// RunID marks the session as pipeline-spawned on its own metadata, which is
+	// what the session trigger bridge reads as its loop guard: a pipeline agent
+	// going idle must not fire the session pipelines.
+	RunID string
 	// Harness is the stage's `agent:` key. Empty lets the project default pick.
 	Harness string
 	// Prompt is the v2 preamble followed by the stage's own prompt.
@@ -133,6 +137,7 @@ func (e *AgentExecutor) Start(ctx context.Context, in StartInput) (Handle, error
 
 	session, err := e.sessions.Spawn(ctx, SpawnRequest{
 		ProjectID:     in.ProjectID,
+		RunID:         string(in.RunID),
 		Harness:       in.Stage.Agent,
 		Prompt:        buildAgentPrompt(in),
 		WorkspacePath: in.WorkspacePath,

--- a/backend/internal/ports/session.go
+++ b/backend/internal/ports/session.go
@@ -31,6 +31,12 @@ type SpawnConfig struct {
 	// session id in the read model (e.g. orchestrator sessions).
 	DisplayName string
 
+	// PipelineRunID marks the session as spawned by a pipeline run. It lands on
+	// the session's metadata and is read as the pipeline session trigger bridge's
+	// loop guard: a pipeline agent going idle must not fire the session
+	// pipelines. Empty for every human or orchestrator spawn.
+	PipelineRunID string
+
 	// Env is extra environment for the spawned session, merged over the
 	// project's env vars (an entry here wins on collision, so a caller's
 	// ambient identity cannot be masked by project config). AO-internal vars

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -387,7 +387,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: runtime: %w", id, err)
 	}
 
-	metadata := domain.SessionMetadata{Branch: ws.Branch, WorkspacePath: ws.Path, RuntimeHandleID: handle.ID, Prompt: prompt}
+	metadata := domain.SessionMetadata{Branch: ws.Branch, WorkspacePath: ws.Path, RuntimeHandleID: handle.ID, Prompt: prompt, PipelineRunID: cfg.PipelineRunID}
 	if err := m.lcm.MarkSpawned(ctx, id, metadata); err != nil {
 		_ = m.runtime.Destroy(ctx, handle)
 		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -740,6 +740,37 @@ func TestSpawn_AssignsIDAndGoesIdle(t *testing.T) {
 	}
 }
 
+// A pipeline-spawned session is marked at spawn: the pipeline session trigger
+// bridge reads that marker as its loop guard, so without it a pipeline agent
+// going idle would fire the session pipelines, whose agents go idle, forever.
+func TestSpawn_MarksPipelineSpawnedSessions(t *testing.T) {
+	m, st, _, _ := newManager()
+	s, err := m.Spawn(ctx, ports.SpawnConfig{
+		ProjectID:     "mer",
+		Kind:          domain.KindWorker,
+		Harness:       domain.HarnessClaudeCode,
+		Prompt:        "review the diff",
+		PipelineRunID: "run-a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Metadata.PipelineRunID != "run-a" {
+		t.Fatalf("spawned metadata pipeline run id = %q, want run-a", s.Metadata.PipelineRunID)
+	}
+	if got := st.sessions["mer-1"].Metadata.PipelineRunID; got != "run-a" {
+		t.Fatalf("persisted pipeline run id = %q, want run-a", got)
+	}
+
+	plain, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, Harness: domain.HarnessClaudeCode, Prompt: "do it"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plain.Metadata.PipelineRunID != "" {
+		t.Fatalf("a human spawn carries a pipeline run id: %q", plain.Metadata.PipelineRunID)
+	}
+}
+
 func TestSpawn_DeliversPromptAfterStartWhenAgentRequestsIt(t *testing.T) {
 	st := newFakeStore()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -258,6 +258,8 @@ type Session struct {
 	FirstSignalAt   sql.NullTime
 	PreviewURL      string
 	PreviewRevision int64
+	PipelineRunID   string
+	PipelineOrphan  string
 }
 
 type SessionWorktree struct {

--- a/backend/internal/storage/sqlite/gen/sessions.sql.go
+++ b/backend/internal/storage/sqlite/gen/sessions.sql.go
@@ -16,7 +16,8 @@ import (
 const getSession = `-- name: GetSession :one
 SELECT id, project_id, num, issue_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
-    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision
+    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision,
+    pipeline_run_id, pipeline_orphan
 FROM sessions WHERE id = ?
 `
 
@@ -44,6 +45,8 @@ func (q *Queries) GetSession(ctx context.Context, id domain.SessionID) (Session,
 		&i.FirstSignalAt,
 		&i.PreviewURL,
 		&i.PreviewRevision,
+		&i.PipelineRunID,
+		&i.PipelineOrphan,
 	)
 	return i, err
 }
@@ -53,8 +56,8 @@ INSERT INTO sessions (
     id, project_id, num, issue_id, kind, harness, display_name,
     activity_state, activity_last_at, first_signal_at, is_terminated,
     branch, workspace_path, runtime_handle_id, agent_session_id, prompt,
-    preview_url, preview_revision, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    preview_url, preview_revision, pipeline_run_id, pipeline_orphan, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type InsertSessionParams struct {
@@ -76,6 +79,8 @@ type InsertSessionParams struct {
 	Prompt          string
 	PreviewURL      string
 	PreviewRevision int64
+	PipelineRunID   string
+	PipelineOrphan  string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
@@ -100,6 +105,8 @@ func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) er
 		arg.Prompt,
 		arg.PreviewURL,
 		arg.PreviewRevision,
+		arg.PipelineRunID,
+		arg.PipelineOrphan,
 		arg.CreatedAt,
 		arg.UpdatedAt,
 	)
@@ -109,7 +116,8 @@ func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) er
 const listAllSessions = `-- name: ListAllSessions :many
 SELECT id, project_id, num, issue_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
-    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision
+    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision,
+    pipeline_run_id, pipeline_orphan
 FROM sessions ORDER BY project_id, num
 `
 
@@ -143,6 +151,8 @@ func (q *Queries) ListAllSessions(ctx context.Context) ([]Session, error) {
 			&i.FirstSignalAt,
 			&i.PreviewURL,
 			&i.PreviewRevision,
+			&i.PipelineRunID,
+			&i.PipelineOrphan,
 		); err != nil {
 			return nil, err
 		}
@@ -160,7 +170,8 @@ func (q *Queries) ListAllSessions(ctx context.Context) ([]Session, error) {
 const listSessionsByProject = `-- name: ListSessionsByProject :many
 SELECT id, project_id, num, issue_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
-    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision
+    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision,
+    pipeline_run_id, pipeline_orphan
 FROM sessions WHERE project_id = ? ORDER BY num
 `
 
@@ -194,6 +205,8 @@ func (q *Queries) ListSessionsByProject(ctx context.Context, projectID domain.Pr
 			&i.FirstSignalAt,
 			&i.PreviewURL,
 			&i.PreviewRevision,
+			&i.PipelineRunID,
+			&i.PipelineOrphan,
 		); err != nil {
 			return nil, err
 		}
@@ -261,6 +274,29 @@ func (q *Queries) SessionIsSeed(ctx context.Context, id domain.SessionID) (bool,
 	return is_seed, err
 }
 
+const setSessionPipelineOrphan = `-- name: SetSessionPipelineOrphan :execrows
+UPDATE sessions SET pipeline_orphan = ?, updated_at = ? WHERE id = ?
+`
+
+type SetSessionPipelineOrphanParams struct {
+	PipelineOrphan string
+	UpdatedAt      time.Time
+	ID             domain.SessionID
+}
+
+// Writes the pipeline-orphan marker only, or clears it when handed an empty
+// string. A targeted
+// UPDATE rather than a read-modify-write of the whole row: the pipeline engine
+// marks a session the session manager may be updating at the same moment, and
+// the marker must not carry a stale copy of the rest of the row back with it.
+func (q *Queries) SetSessionPipelineOrphan(ctx context.Context, arg SetSessionPipelineOrphanParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, setSessionPipelineOrphan, arg.PipelineOrphan, arg.UpdatedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const setSessionPreviewURL = `-- name: SetSessionPreviewURL :execrows
 UPDATE sessions SET preview_url = ?, preview_revision = preview_revision + 1, updated_at = ? WHERE id = ?
 `
@@ -287,7 +323,7 @@ UPDATE sessions SET
     issue_id = ?, kind = ?, harness = ?, display_name = ?,
     activity_state = ?, activity_last_at = ?, first_signal_at = ?, is_terminated = ?,
     branch = ?, workspace_path = ?, runtime_handle_id = ?, agent_session_id = ?, prompt = ?,
-    preview_url = ?, preview_revision = ?, updated_at = ?
+    preview_url = ?, preview_revision = ?, pipeline_run_id = ?, pipeline_orphan = ?, updated_at = ?
 WHERE id = ?
 `
 
@@ -307,6 +343,8 @@ type UpdateSessionParams struct {
 	Prompt          string
 	PreviewURL      string
 	PreviewRevision int64
+	PipelineRunID   string
+	PipelineOrphan  string
 	UpdatedAt       time.Time
 	ID              domain.SessionID
 }
@@ -328,6 +366,8 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) er
 		arg.Prompt,
 		arg.PreviewURL,
 		arg.PreviewRevision,
+		arg.PipelineRunID,
+		arg.PipelineOrphan,
 		arg.UpdatedAt,
 		arg.ID,
 	)

--- a/backend/internal/storage/sqlite/migrations/0048_session_pipeline_metadata.sql
+++ b/backend/internal/storage/sqlite/migrations/0048_session_pipeline_metadata.sql
@@ -1,0 +1,73 @@
+-- +goose Up
+-- Two pipeline facts on the session row.
+--
+-- pipeline_run_id records the pipeline run that spawned the session. It is the
+-- session trigger bridge's loop guard: without a durable marker, a pipeline
+-- agent going idle fires the session pipelines, whose agents go idle, forever.
+-- It must survive a daemon restart, so it is a column and not in-process state.
+--
+-- pipeline_orphan is the JSON PipelineOrphanInfo a stage writes when its
+-- kill-on rule spared the session (no_output, no_signal, timed_out): the run,
+-- the stage, the outcome that spared it and when it was kept. Empty string
+-- means the session is not pipeline-orphaned. JSON rather than five columns
+-- because nothing queries inside it: the daemon reads it whole and the session
+-- list renders it whole.
+-- +goose StatementBegin
+ALTER TABLE sessions ADD COLUMN pipeline_run_id TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE sessions ADD COLUMN pipeline_orphan TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+
+-- Recreate the sessions update CDC trigger so marking a session
+-- pipeline-orphaned fans out a session_updated event. Without this the badge
+-- would only appear on the next unrelated session change, which is exactly the
+-- moment nobody is looking. Guard-only change: session_updated is an
+-- invalidation nudge, so the payload stays as-is.
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.display_name <> NEW.display_name
+    OR OLD.pipeline_orphan <> NEW.pipeline_orphan
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object('id', NEW.id, 'activity', NEW.activity_state, 'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END), 'previewUrl', NEW.preview_url, 'previewRevision', NEW.preview_revision),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.display_name <> NEW.display_name
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object('id', NEW.id, 'activity', NEW.activity_state, 'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END), 'previewUrl', NEW.preview_url, 'previewRevision', NEW.preview_revision),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE sessions DROP COLUMN pipeline_orphan;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE sessions DROP COLUMN pipeline_run_id;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/sessions.sql
+++ b/backend/internal/storage/sqlite/queries/sessions.sql
@@ -6,33 +6,36 @@ INSERT INTO sessions (
     id, project_id, num, issue_id, kind, harness, display_name,
     activity_state, activity_last_at, first_signal_at, is_terminated,
     branch, workspace_path, runtime_handle_id, agent_session_id, prompt,
-    preview_url, preview_revision, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    preview_url, preview_revision, pipeline_run_id, pipeline_orphan, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: UpdateSession :exec
 UPDATE sessions SET
     issue_id = ?, kind = ?, harness = ?, display_name = ?,
     activity_state = ?, activity_last_at = ?, first_signal_at = ?, is_terminated = ?,
     branch = ?, workspace_path = ?, runtime_handle_id = ?, agent_session_id = ?, prompt = ?,
-    preview_url = ?, preview_revision = ?, updated_at = ?
+    preview_url = ?, preview_revision = ?, pipeline_run_id = ?, pipeline_orphan = ?, updated_at = ?
 WHERE id = ?;
 
 -- name: GetSession :one
 SELECT id, project_id, num, issue_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
-    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision
+    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision,
+    pipeline_run_id, pipeline_orphan
 FROM sessions WHERE id = ?;
 
 -- name: ListSessionsByProject :many
 SELECT id, project_id, num, issue_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
-    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision
+    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision,
+    pipeline_run_id, pipeline_orphan
 FROM sessions WHERE project_id = ? ORDER BY num;
 
 -- name: ListAllSessions :many
 SELECT id, project_id, num, issue_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
-    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision
+    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision,
+    pipeline_run_id, pipeline_orphan
 FROM sessions ORDER BY project_id, num;
 
 
@@ -44,6 +47,14 @@ UPDATE sessions SET display_name = ?, updated_at = ? WHERE id = ?;
 -- so a repeated `ao preview <same-url>` still trips the sessions_cdc_update
 -- trigger and the desktop browser panel re-navigates / refreshes.
 UPDATE sessions SET preview_url = ?, preview_revision = preview_revision + 1, updated_at = ? WHERE id = ?;
+
+-- name: SetSessionPipelineOrphan :execrows
+-- Writes the pipeline-orphan marker only, or clears it when handed an empty
+-- string. A targeted
+-- UPDATE rather than a read-modify-write of the whole row: the pipeline engine
+-- marks a session the session manager may be updating at the same moment, and
+-- the marker must not carry a stale copy of the rest of the row back with it.
+UPDATE sessions SET pipeline_orphan = ?, updated_at = ? WHERE id = ?;
 
 -- name: SessionIsSeed :one
 -- SessionIsSeed reports whether the session id matches a row still in seed

--- a/backend/internal/storage/sqlite/store/session_store.go
+++ b/backend/internal/storage/sqlite/store/session_store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -72,6 +73,29 @@ func (s *Store) SetSessionPreviewURL(ctx context.Context, id domain.SessionID, p
 	})
 	if err != nil {
 		return false, fmt.Errorf("set preview url for session %s: %w", id, err)
+	}
+	return rows > 0, nil
+}
+
+// SetSessionPipelineOrphan writes (info non-nil) or clears (info nil) the
+// pipeline-orphan marker for an existing session, and nothing else. It returns
+// ok=false when the session id does not exist. The sessions_cdc_update trigger
+// fans out a session_updated event when the marker changes, which is what makes
+// the badge appear in the live session list.
+func (s *Store) SetSessionPipelineOrphan(ctx context.Context, id domain.SessionID, info *domain.PipelineOrphanInfo, updatedAt time.Time) (bool, error) {
+	encoded, err := encodePipelineOrphan(info)
+	if err != nil {
+		return false, fmt.Errorf("encode pipeline orphan for session %s: %w", id, err)
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	rows, err := s.qw.SetSessionPipelineOrphan(ctx, gen.SetSessionPipelineOrphanParams{
+		ID:             id,
+		PipelineOrphan: encoded,
+		UpdatedAt:      updatedAt,
+	})
+	if err != nil {
+		return false, fmt.Errorf("set pipeline orphan for session %s: %w", id, err)
 	}
 	return rows > 0, nil
 }
@@ -210,6 +234,8 @@ func rowToRecord(row gen.Session) domain.SessionRecord {
 			Prompt:          row.Prompt,
 			PreviewURL:      row.PreviewURL,
 			PreviewRevision: row.PreviewRevision,
+			PipelineRunID:   row.PipelineRunID,
+			PipelineOrphan:  decodePipelineOrphan(row.PipelineOrphan),
 		},
 		CreatedAt: row.CreatedAt,
 		UpdatedAt: row.UpdatedAt,
@@ -237,6 +263,8 @@ func recordToInsert(rec domain.SessionRecord, num int64) gen.InsertSessionParams
 		Prompt:          rec.Metadata.Prompt,
 		PreviewURL:      rec.Metadata.PreviewURL,
 		PreviewRevision: rec.Metadata.PreviewRevision,
+		PipelineRunID:   rec.Metadata.PipelineRunID,
+		PipelineOrphan:  mustEncodePipelineOrphan(rec.Metadata.PipelineOrphan),
 		CreatedAt:       rec.CreatedAt,
 		UpdatedAt:       rec.UpdatedAt,
 	}
@@ -261,8 +289,50 @@ func recordToUpdate(rec domain.SessionRecord) gen.UpdateSessionParams {
 		Prompt:          rec.Metadata.Prompt,
 		PreviewURL:      rec.Metadata.PreviewURL,
 		PreviewRevision: rec.Metadata.PreviewRevision,
+		PipelineRunID:   rec.Metadata.PipelineRunID,
+		PipelineOrphan:  mustEncodePipelineOrphan(rec.Metadata.PipelineOrphan),
 		UpdatedAt:       rec.UpdatedAt,
 	}
+}
+
+// encodePipelineOrphan marshals the orphan marker for the pipeline_orphan
+// column. A nil marker is the empty string, which is what "not pipeline
+// orphaned" looks like on the row.
+func encodePipelineOrphan(info *domain.PipelineOrphanInfo) (string, error) {
+	if info == nil {
+		return "", nil
+	}
+	raw, err := json.Marshal(info)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+// mustEncodePipelineOrphan is the full-row (insert/update) path, which has no
+// error channel. PipelineOrphanInfo is four strings and a timestamp, so
+// marshalling cannot fail; an impossible failure drops the marker rather than
+// the whole write, because losing a badge beats losing the session row.
+func mustEncodePipelineOrphan(info *domain.PipelineOrphanInfo) string {
+	encoded, err := encodePipelineOrphan(info)
+	if err != nil {
+		return ""
+	}
+	return encoded
+}
+
+// decodePipelineOrphan reads the column back. Empty means not orphaned, and so
+// does unparseable: a corrupt marker must not fail the session read, because the
+// session itself is still real and still needs to be listable and killable.
+func decodePipelineOrphan(raw string) *domain.PipelineOrphanInfo {
+	if raw == "" {
+		return nil
+	}
+	var info domain.PipelineOrphanInfo
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return nil
+	}
+	return &info
 }
 
 // nullTimeToTime / timeToNullTime bridge the nullable first_signal_at column

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -758,6 +758,98 @@ func TestSetSessionPreviewURLBumpsRevisionAndFiresCDCOnSameURL(t *testing.T) {
 	}
 }
 
+// A pipeline-spawned session carries its run id on the row so the session
+// trigger bridge's loop guard survives a daemon restart, and the orphan marker
+// round-trips whole through the JSON column.
+func TestSessionPipelineMetadataRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+
+	rec := sampleRecord("mer")
+	rec.Metadata.PipelineRunID = "run-a"
+	r, err := s.CreateSession(ctx, rec)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, _, _ := s.GetSession(ctx, r.ID)
+	if got.Metadata.PipelineRunID != "run-a" {
+		t.Fatalf("pipeline run id = %q, want the spawn marker persisted", got.Metadata.PipelineRunID)
+	}
+	if got.Metadata.PipelineOrphan != nil {
+		t.Fatalf("fresh session is orphaned: %+v", got.Metadata.PipelineOrphan)
+	}
+
+	keptAt := time.Now().UTC().Truncate(time.Second)
+	info := &domain.PipelineOrphanInfo{
+		RunID:    "run-a",
+		Stage:    "review",
+		Outcome:  "no_output",
+		KeptAt:   keptAt,
+		Pipeline: "pr-review",
+	}
+	ok, err := s.SetSessionPipelineOrphan(ctx, r.ID, info, keptAt)
+	if err != nil || !ok {
+		t.Fatalf("mark orphan: ok=%v err=%v", ok, err)
+	}
+	got, _, _ = s.GetSession(ctx, r.ID)
+	if got.Metadata.PipelineOrphan == nil {
+		t.Fatal("orphan marker not persisted")
+	}
+	if *got.Metadata.PipelineOrphan != *info {
+		t.Fatalf("orphan marker = %+v, want %+v", *got.Metadata.PipelineOrphan, *info)
+	}
+
+	// A full row update must not drop the marker, and clearing it round-trips.
+	if err := s.UpdateSession(ctx, got); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if again, _, _ := s.GetSession(ctx, r.ID); again.Metadata.PipelineOrphan == nil {
+		t.Fatal("orphan marker lost on a full row update")
+	}
+	if ok, err := s.SetSessionPipelineOrphan(ctx, r.ID, nil, keptAt); err != nil || !ok {
+		t.Fatalf("clear orphan: ok=%v err=%v", ok, err)
+	}
+	if cleared, _, _ := s.GetSession(ctx, r.ID); cleared.Metadata.PipelineOrphan != nil {
+		t.Fatalf("orphan marker not cleared: %+v", cleared.Metadata.PipelineOrphan)
+	}
+
+	if ok, err := s.SetSessionPipelineOrphan(ctx, "mer-missing", info, keptAt); err != nil || ok {
+		t.Fatalf("mark unknown session: ok=%v err=%v, want ok=false", ok, err)
+	}
+}
+
+// Marking a session pipeline-orphaned must reach the live session list: the
+// badge is the whole visibility half of the reaper (spec section 7.3), and a
+// badge that only appears on the next unrelated update is not visibility.
+func TestSetSessionPipelineOrphanFiresCDCEvent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	r, _ := s.CreateSession(ctx, sampleRecord("mer"))
+
+	base, _ := s.LatestSeq(ctx)
+	keptAt := time.Now().UTC()
+	info := &domain.PipelineOrphanInfo{RunID: "run-a", Stage: "review", Outcome: "no_signal", KeptAt: keptAt, Pipeline: "pr-review"}
+	if ok, err := s.SetSessionPipelineOrphan(ctx, r.ID, info, keptAt); err != nil || !ok {
+		t.Fatalf("mark orphan: ok=%v err=%v", ok, err)
+	}
+
+	evs, err := s.EventsAfter(ctx, base, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updates := 0
+	for _, e := range evs {
+		if string(e.Type) == "session_updated" {
+			updates++
+		}
+	}
+	if updates != 1 {
+		t.Fatalf("session_updated events = %d, want 1 after marking the session orphaned", updates)
+	}
+}
+
 func TestRenameSessionFiresCDCEvent(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1037,6 +1037,7 @@ export interface components {
             isTerminated: boolean;
             issueId?: string;
             kind: string;
+            pipelineOrphan?: components["schemas"]["DomainPipelineOrphanInfo"];
             /** Format: int64 */
             previewRevision?: number;
             previewUrl?: string;
@@ -1102,6 +1103,14 @@ export interface components {
             /** Format: date-time */
             lastActivityAt: string;
             state: string;
+        };
+        DomainPipelineOrphanInfo: {
+            /** Format: date-time */
+            keptAt: string;
+            outcome: string;
+            pipeline: string;
+            runId: string;
+            stage: string;
         };
         DomainReviewerConfig: {
             harness: string;


### PR DESCRIPTION
Closes #325

Pipelines v2, Task 16: session disposition, pipeline-orphaned sessions, and the reaper.

## What lands

- **`domain.SessionMetadata` gains `PipelineRunID` and `PipelineOrphan`** (`*PipelineOrphanInfo`, the plan's exact JSON shape: `runId`, `stage`, `outcome`, `keptAt`, `pipeline`). Both persist on the `sessions` row (migration `0048`), so they survive a daemon restart. `pipeline_orphan` joins the `sessions_cdc_update` guard, so marking a session orphaned fans out `session_updated` and the badge appears in the live list instead of on the next unrelated change.
- **`pipeline/engine/orphans.go`**: `OrphanRegistry` with the fixed bounds of decision D7 (`MaxOrphanedSessionsPerPipeline = 3`, `OrphanTTL = 24h`). `Keep` marks the session and evicts plus kills the least recently kept when a pipeline goes over its cap; `Sweep` kills past-TTL sessions and runs from a new supervisor ticker (hourly). The ledger the bounds are computed from is the persisted marker, not in-process state, so the bounds still hold for sessions a previous daemon kept alive.
- **Keep path wired at `SettleSession`**: an outcome in `EffectiveKillOn()` kills, anything else keeps, marks and registers. `no_output`, `no_signal` and `timed_out` are exactly the outcomes a human may want to inspect, so they are never quietly killed.
- **Pipeline-spawned sessions are marked at spawn** (`ports.SpawnConfig.PipelineRunID` to `SessionMetadata.PipelineRunID`), and `SessionAdapter.IsPipelineSpawned` satisfies `triggers.SessionSpawnCheck`. With the marker in place, the **session trigger bridge is now wired** in `daemon/pipeline_wiring.go` (it refused to start without a loop guard).
- **DTO**: `SessionView.pipelineOrphan` rides the existing session list response; `openapi.yaml` and `frontend/src/api/schema.ts` regenerated (additive only).

## Tests

- `orphans_test.go`: marker contents, cap 3 with LRU eviction, per-pipeline independence, re-keep refreshes rather than double counts, TTL sweep with idempotence, bounds survive a restart, unreadable ledger kills nothing, nil registry inert.
- `engine_test.go`: `no_output` keeps and marks with run id, stage, outcome and pipeline; a killed session gets no marker. Existing `kill-on` default / `kill-on: []` coverage still holds.
- Store round-trip plus CDC fan-out, session-manager spawn marker, adapter loop guard (including the read-failure path), session DTO surfacing and omission.

## Verification

- `go build ./... && go test ./... && gofmt -l .` clean, `golangci-lint run ./...` reports 0 issues.
- Note: four `internal/cli` `TestSpawn*` tests fail locally when the shell exports `AO_*` worker env vars. They fail identically on `origin/pipelines` and pass with a clean env, so they are environmental and not from this branch.

## Risks and follow-ups

- The reaper's eviction and sweep kills leave the marker on the killed row as history rather than clearing it; a terminated row is out of the ledger, so it is never counted or killed twice.
- The frontend badge and kill action (plan Task 20) consume this DTO field; nothing renders it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
