### PR TITLE
feat(pipelines): v2 HTTP API, signal/log/output endpoints, OpenAPI regen

### DIFF
--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -787,11 +787,17 @@ paths:
         schema:
           description: Filter runs to one pipeline name.
           type: string
-      - description: Filter runs by loop state (running|awaiting_context|done|stalled|terminated).
+      - description: Filter runs by run status.
         in: query
         name: status
         schema:
-          description: Filter runs by loop state (running|awaiting_context|done|stalled|terminated).
+          description: Filter runs by run status.
+          enum:
+          - pending
+          - running
+          - succeeded
+          - failed
+          - cancelled
           type: string
       - description: Cap the number of runs returned (newest first).
         in: query
@@ -924,116 +930,6 @@ paths:
       summary: Fetch one pipeline run with its stages and findings
       tags:
       - pipelines
-  /api/v1/pipelines/runs/{runId}/artifacts/{artifactId}:
-    get:
-      operationId: getPipelineArtifact
-      parameters:
-      - description: Pipeline run identifier.
-        in: path
-        name: runId
-        required: true
-        schema:
-          description: Pipeline run identifier.
-          type: string
-      - description: Artifact identifier.
-        in: path
-        name: artifactId
-        required: true
-        schema:
-          description: Artifact identifier.
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PipelineArtifactResponse'
-          description: OK
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIError'
-          description: Not Found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIError'
-          description: Internal Server Error
-        "501":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIError'
-          description: Not Implemented
-      summary: Fetch one pipeline run artifact by id
-      tags:
-      - pipelines
-  /api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status:
-    post:
-      operationId: updatePipelineArtifactStatus
-      parameters:
-      - description: Pipeline run identifier.
-        in: path
-        name: runId
-        required: true
-        schema:
-          description: Pipeline run identifier.
-          type: string
-      - description: Artifact identifier.
-        in: path
-        name: artifactId
-        required: true
-        schema:
-          description: Artifact identifier.
-          type: string
-      - description: Project id the pipeline belongs to (required).
-        in: query
-        name: project
-        schema:
-          description: Project id the pipeline belongs to (required).
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ControllersUpdatePipelineArtifactStatusRequest'
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PipelineArtifactResponse'
-          description: OK
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIError'
-          description: Bad Request
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIError'
-          description: Not Found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIError'
-          description: Internal Server Error
-        "501":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIError'
-          description: Not Implemented
-      summary: Change a pipeline finding's lifecycle status (dismiss, reopen, resolve)
-      tags:
-      - pipelines
   /api/v1/pipelines/runs/{runId}/cancel:
     post:
       operationId: cancelPipelineRun
@@ -1085,9 +981,9 @@ paths:
       summary: Cancel an in-flight pipeline run
       tags:
       - pipelines
-  /api/v1/pipelines/runs/{runId}/resume:
-    post:
-      operationId: resumePipelineRun
+  /api/v1/pipelines/runs/{runId}/outputs/{filename}:
+    get:
+      operationId: getPipelineRunOutput
       parameters:
       - description: Pipeline run identifier.
         in: path
@@ -1096,18 +992,76 @@ paths:
         schema:
           description: Pipeline run identifier.
           type: string
-      - description: Project id the pipeline belongs to (required).
-        in: query
-        name: project
+      - description: Artifact filename. Only a name the run's frozen definition declares
+          as a stage's produces is served.
+        in: path
+        name: filename
+        required: true
         schema:
-          description: Project id the pipeline belongs to (required).
+          description: Artifact filename. Only a name the run's frozen definition
+            declares as a stage's produces is served.
           type: string
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Download one artifact a stage declared with produces
+      tags:
+      - pipelines
+  /api/v1/pipelines/runs/{runId}/stages/{stageId}/log:
+    get:
+      operationId: getPipelineStageLog
+      parameters:
+      - description: Pipeline run identifier.
+        in: path
+        name: runId
+        required: true
+        schema:
+          description: Pipeline run identifier.
+          type: string
+      - description: Stage id as declared in the pipeline definition.
+        in: path
+        name: stageId
+        required: true
+        schema:
+          description: Stage id as declared in the pipeline definition.
+          type: string
+      - description: Return only the last N lines. Omitted returns the whole log.
+        in: query
+        name: tail
+        schema:
+          description: Return only the last N lines. Omitted returns the whole log.
+          minimum: 1
+          type:
+          - "null"
+          - integer
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PipelineRunDetailResponse'
+                $ref: '#/components/schemas/PipelineStageLogResponse'
           description: OK
         "400":
           content:
@@ -1133,7 +1087,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
           description: Not Implemented
-      summary: Resume a stalled or failed pipeline run
+      summary: Fetch a stage's captured stdout and stderr, optionally tailed
       tags:
       - pipelines
   /api/v1/pipelines/runs/{runId}/stages/{stageId}/signal:
@@ -1158,14 +1112,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ControllersSignalPipelineStageRequest'
+              $ref: '#/components/schemas/SignalPipelineStageRequest'
         required: true
       responses:
         "202":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ControllersSignalPipelineStageResponse'
+                $ref: '#/components/schemas/SignalPipelineStageResponse'
           description: Accepted
         "400":
           content:
@@ -2932,36 +2886,6 @@ components:
       - status
       - prs
       type: object
-    ControllersSignalPipelineStageRequest:
-      properties:
-        reason:
-          description: Why the stage failed. Carried on the failure edge and shown
-            in run detail.
-          type: string
-        status:
-          description: 'How the stage settled: done | fail.'
-          enum:
-          - done
-          - fail
-          type: string
-      required:
-      - status
-      type: object
-    ControllersSignalPipelineStageResponse:
-      properties:
-        accepted:
-          type: boolean
-      required:
-      - accepted
-      type: object
-    ControllersUpdatePipelineArtifactStatusRequest:
-      properties:
-        status:
-          description: 'New artifact status: open | resolved | dismissed.'
-          type: string
-      required:
-      - status
-      type: object
     DegradedProject:
       properties:
         id:
@@ -3430,70 +3354,6 @@ components:
       - targetSha
       - status
       type: object
-    PipelineArtifact:
-      properties:
-        anchorSignature:
-          type: string
-        artifactId:
-          type: string
-        belowConfidenceThreshold:
-          type: boolean
-        category:
-          type: string
-        confidence:
-          format: double
-          type: number
-        createdAt:
-          format: date-time
-          type: string
-        data:
-          additionalProperties: {}
-          type: object
-        description:
-          type: string
-        endLine:
-          type: integer
-        filePath:
-          type: string
-        fingerprint:
-          type: string
-        kind:
-          type: string
-        pipelineRunId:
-          type: string
-        sentToAgentAt:
-          format: date-time
-          type:
-          - "null"
-          - string
-        severity:
-          type: string
-        stageName:
-          type: string
-        stageRunId:
-          type: string
-        startLine:
-          type: integer
-        status:
-          type: string
-        title:
-          type: string
-      required:
-      - kind
-      - artifactId
-      - pipelineRunId
-      - stageRunId
-      - stageName
-      - status
-      - createdAt
-      type: object
-    PipelineArtifactResponse:
-      properties:
-        artifact:
-          $ref: '#/components/schemas/PipelineArtifact'
-      required:
-      - artifact
-      type: object
     PipelineDefinitionResponse:
       properties:
         definition:
@@ -3525,36 +3385,45 @@ components:
       - createdAt
       - updatedAt
       type: object
+    PipelineProducedArtifact:
+      properties:
+        exists:
+          type: boolean
+        name:
+          type: string
+      required:
+      - name
+      - exists
+      type: object
     PipelineRunDetail:
       properties:
-        blocksMerge:
-          type: boolean
+        cancelReason:
+          type: string
         createdAt:
           format: date-time
           type: string
-        findings:
-          items:
-            $ref: '#/components/schemas/PipelineArtifact'
-          type: array
-        hasOpenFindings:
-          type: boolean
         headSha:
-          type: string
-        loopRounds:
-          type: integer
-        loopState:
           type: string
         pipelineId:
           type: string
         pipelineName:
           type: string
+        prNumber:
+          type: integer
+        runDir:
+          type: string
         runId:
           type: string
         sessionId:
           type: string
+        settledAt:
+          format: date-time
+          type:
+          - "null"
+          - string
         stageCount:
           type: integer
-        stageStatuses:
+        stageOutcomes:
           additionalProperties:
             type: string
           type:
@@ -3564,7 +3433,21 @@ components:
           items:
             $ref: '#/components/schemas/PipelineStageView'
           type: array
-        terminationReason:
+        status:
+          description: Run-level rollup of the stage outcomes.
+          enum:
+          - pending
+          - running
+          - succeeded
+          - failed
+          - cancelled
+          type: string
+        subjectKind:
+          description: What the run is about.
+          enum:
+          - session
+          - pr
+          - project
           type: string
         updatedAt:
           format: date-time
@@ -3573,18 +3456,13 @@ components:
       - runId
       - pipelineId
       - pipelineName
-      - sessionId
-      - loopState
-      - loopRounds
-      - headSha
+      - status
+      - subjectKind
       - stageCount
-      - stageStatuses
-      - hasOpenFindings
-      - blocksMerge
+      - stageOutcomes
       - createdAt
       - updatedAt
       - stages
-      - findings
       type: object
     PipelineRunDetailResponse:
       properties:
@@ -3595,36 +3473,51 @@ components:
       type: object
     PipelineRunSummary:
       properties:
-        blocksMerge:
-          type: boolean
+        cancelReason:
+          type: string
         createdAt:
           format: date-time
           type: string
-        hasOpenFindings:
-          type: boolean
         headSha:
-          type: string
-        loopRounds:
-          type: integer
-        loopState:
           type: string
         pipelineId:
           type: string
         pipelineName:
           type: string
+        prNumber:
+          type: integer
         runId:
           type: string
         sessionId:
           type: string
+        settledAt:
+          format: date-time
+          type:
+          - "null"
+          - string
         stageCount:
           type: integer
-        stageStatuses:
+        stageOutcomes:
           additionalProperties:
             type: string
           type:
           - object
           - "null"
-        terminationReason:
+        status:
+          description: Run-level rollup of the stage outcomes.
+          enum:
+          - pending
+          - running
+          - succeeded
+          - failed
+          - cancelled
+          type: string
+        subjectKind:
+          description: What the run is about.
+          enum:
+          - session
+          - pr
+          - project
           type: string
         updatedAt:
           format: date-time
@@ -3633,59 +3526,82 @@ components:
       - runId
       - pipelineId
       - pipelineName
-      - sessionId
-      - loopState
-      - loopRounds
-      - headSha
+      - status
+      - subjectKind
       - stageCount
-      - stageStatuses
-      - hasOpenFindings
-      - blocksMerge
+      - stageOutcomes
       - createdAt
       - updatedAt
       type: object
+    PipelineStageLogResponse:
+      properties:
+        content:
+          type: string
+        runId:
+          type: string
+        stageId:
+          type: string
+        truncated:
+          type: boolean
+      required:
+      - runId
+      - stageId
+      - content
+      - truncated
+      type: object
     PipelineStageView:
       properties:
-        artifactIds:
-          items:
-            type: string
-          type: array
         attempt:
           type: integer
-        completedAt:
+        enteredVia:
+          description: Which edge started this stage.
+          enum:
+          - trigger
+          - success
+          - failure
+          type: string
+        failedStage:
+          type: string
+        outcome:
+          enum:
+          - pending
+          - running
+          - succeeded
+          - succeeded_unverified
+          - failed
+          - no_output
+          - no_signal
+          - timed_out
+          - cancelled
+          - skipped
+          type: string
+        outputTail:
+          type: string
+        producedArtifact:
+          $ref: '#/components/schemas/PipelineProducedArtifact'
+        reason:
+          type: string
+        sessionId:
+          type: string
+        settledAt:
           format: date-time
           type:
           - "null"
           - string
-        errorMessage:
-          type: string
-        notes:
-          items:
-            type: string
-          type: array
-        output:
-          type: string
-        sessionId:
-          type: string
-        stageName:
-          type: string
-        stageRunId:
+        stageId:
           type: string
         startedAt:
           format: date-time
           type:
           - "null"
           - string
-        status:
-          type: string
-        verdict:
+        workspaceKind:
           type: string
       required:
-      - stageName
-      - stageRunId
-      - status
+      - stageId
+      - outcome
       - attempt
-      - artifactIds
+      - enteredVia
       type: object
     PipelineValidationIssue:
       properties:
@@ -4394,6 +4310,28 @@ components:
       - title
       - createdAt
       type: object
+    SignalPipelineStageRequest:
+      properties:
+        reason:
+          description: Why the stage failed. Carried on the failure edge and shown
+            in run detail.
+          type: string
+        status:
+          description: 'How the stage settled: done | fail.'
+          enum:
+          - done
+          - fail
+          type: string
+      required:
+      - status
+      type: object
+    SignalPipelineStageResponse:
+      properties:
+        accepted:
+          type: boolean
+      required:
+      - accepted
+      type: object
     SpawnOrchestratorRequest:
       properties:
         clean:
@@ -4512,14 +4450,15 @@ components:
       type: object
     TriggerPipelineRunRequest:
       properties:
-        headSha:
-          description: Head commit SHA to pin the run to.
-          type: string
         pipeline:
           description: 'Definition reference to run: its id or name.'
           type: string
+        prNumber:
+          description: Run against this tracked pull request as the subject.
+          minimum: 1
+          type: integer
         sessionId:
-          description: Session id to scope the run's loop key.
+          description: Run against this session as the subject.
           type: string
       required:
       - pipeline
@@ -4569,9 +4508,14 @@ components:
           type: array
         valid:
           type: boolean
+        warnings:
+          items:
+            $ref: '#/components/schemas/PipelineValidationIssue'
+          type: array
       required:
       - valid
       - issues
+      - warnings
       type: object
     WorkspaceFileResponse:
       properties:
@@ -4683,7 +4627,8 @@ tags:
   name: import
 - description: Developer-only maintenance operations
   name: dev
-- description: Pipeline definitions, runs, manual triggers, and artifacts
+- description: Pipeline definitions, runs, manual triggers, stage signals, logs and
+    outputs
   name: pipelines
 - description: Connect Mobile LAN bridge control (loopback/desktop only)
   name: mobile

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -76,7 +76,7 @@ func Build() ([]byte, error) {
 		*(&openapi31.Tag{Name: "dev"}).WithDescription(
 			"Developer-only maintenance operations"),
 		*(&openapi31.Tag{Name: "pipelines"}).WithDescription(
-			"Pipeline definitions, runs, manual triggers, and artifacts"),
+			"Pipeline definitions, runs, manual triggers, stage signals, logs and outputs"),
 		*(&openapi31.Tag{Name: "mobile"}).WithDescription(
 			"Connect Mobile LAN bridge control (loopback/desktop only)"),
 	}
@@ -225,7 +225,11 @@ var schemaNames = map[string]string{
 	"ControllersPipelineRunsQuery":                  "PipelineRunsQuery",
 	"ControllersPipelineIDParam":                    "PipelineIDParam",
 	"ControllersPipelineRunIDParam":                 "PipelineRunIDParam",
-	"ControllersPipelineArtifactIDParam":            "PipelineArtifactIDParam",
+	"ControllersPipelineStageIDParam":               "PipelineStageIDParam",
+	"ControllersPipelineOutputParam":                "PipelineOutputParam",
+	"ControllersPipelineStageLogQuery":              "PipelineStageLogQuery",
+	"ControllersPipelineStageLogResponse":           "PipelineStageLogResponse",
+	"ControllersPipelineProducedArtifact":           "PipelineProducedArtifact",
 	"ControllersPipelineDefinitionSummary":          "PipelineDefinitionSummary",
 	"ControllersListPipelineDefinitionsResponse":    "ListPipelineDefinitionsResponse",
 	"ControllersPipelineDefinitionResponse":         "PipelineDefinitionResponse",
@@ -241,9 +245,8 @@ var schemaNames = map[string]string{
 	"ControllersPipelineRunDetailResponse":          "PipelineRunDetailResponse",
 	"ControllersTriggerPipelineRunRequest":          "TriggerPipelineRunRequest",
 	"ControllersTriggerPipelineRunResponse":         "TriggerPipelineRunResponse",
-	"ControllersPipelineArtifactResponse":           "PipelineArtifactResponse",
-	// pipeline artifact wire shape (embedded in run detail + artifact fetch)
-	"ControllersPipelineArtifact": "PipelineArtifact",
+	"ControllersSignalPipelineStageRequest":         "SignalPipelineStageRequest",
+	"ControllersSignalPipelineStageResponse":        "SignalPipelineStageResponse",
 	// httpd/controllers: settings wire envelopes
 	"ControllersPipelinesSettingResponse":   "PipelinesSettingResponse",
 	"ControllersSetPipelinesSettingRequest": "SetPipelinesSettingRequest",
@@ -431,13 +434,11 @@ func settingsOperations() []operation {
 	}
 }
 
-// pipelineOperations declares the /pipelines operations (definitions CRUD, JSON
-// schema, runs list/detail, manual trigger, cancel/resume, artifact fetch).
-// Must stay 1:1 with the routes PipelinesController.Register mounts (enforced by
-// the parity test). A nil PipelinesController.Svc returns 501 on every route.
-
-// pipelineOperations declares the /pipelines operations (definitions CRUD, JSON
-// schema, runs list/detail, manual trigger, cancel/resume, artifact fetch).
+// pipelineOperations declares the /pipelines operations: definitions CRUD, the
+// JSON schema, runs list/detail, manual trigger, cancel, the stage signal, and
+// the run folder reads (stage log, declared output). There is no resume and no
+// artifact route: v2 has neither (spec sections 14.1 and 6.2).
+//
 // Must stay 1:1 with the routes PipelinesController.Register mounts (enforced by
 // the parity test). A nil PipelinesController.Svc returns 501 on every route.
 func pipelineOperations() []operation {
@@ -534,11 +535,11 @@ func pipelineOperations() []operation {
 			},
 		},
 		{
-			method: http.MethodPost, path: "/api/v1/pipelines/runs/{runId}/resume", id: "resumePipelineRun", tag: "pipelines",
-			summary:    "Resume a stalled or failed pipeline run",
-			pathParams: []any{controllers.PipelineRunIDParam{}, controllers.PipelineProjectQuery{}},
+			method: http.MethodGet, path: "/api/v1/pipelines/runs/{runId}/stages/{stageId}/log", id: "getPipelineStageLog", tag: "pipelines",
+			summary:    "Fetch a stage's captured stdout and stderr, optionally tailed",
+			pathParams: []any{controllers.PipelineStageIDParam{}, controllers.PipelineStageLogQuery{}},
 			resps: []respUnit{
-				{http.StatusOK, controllers.PipelineRunDetailResponse{}},
+				{http.StatusOK, controllers.PipelineStageLogResponse{}},
 				{http.StatusBadRequest, envelope.APIError{}},
 				{http.StatusNotFound, envelope.APIError{}},
 				{http.StatusInternalServerError, envelope.APIError{}},
@@ -546,28 +547,16 @@ func pipelineOperations() []operation {
 			},
 		},
 		{
-			method: http.MethodGet, path: "/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}", id: "getPipelineArtifact", tag: "pipelines",
-			summary:    "Fetch one pipeline run artifact by id",
-			pathParams: []any{controllers.PipelineArtifactIDParam{}},
+			method: http.MethodGet, path: "/api/v1/pipelines/runs/{runId}/outputs/{filename}", id: "getPipelineRunOutput", tag: "pipelines",
+			summary:    "Download one artifact a stage declared with produces",
+			pathParams: []any{controllers.PipelineOutputParam{}},
 			resps: []respUnit{
-				{http.StatusOK, controllers.PipelineArtifactResponse{}},
+				{http.StatusOK, ""},
 				{http.StatusNotFound, envelope.APIError{}},
 				{http.StatusInternalServerError, envelope.APIError{}},
 				{http.StatusNotImplemented, envelope.APIError{}},
 			},
-		},
-		{
-			method: http.MethodPost, path: "/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status", id: "updatePipelineArtifactStatus", tag: "pipelines",
-			summary:    "Change a pipeline finding's lifecycle status (dismiss, reopen, resolve)",
-			pathParams: []any{controllers.PipelineArtifactIDParam{}, controllers.PipelineProjectQuery{}},
-			reqBody:    controllers.UpdatePipelineArtifactStatusRequest{},
-			resps: []respUnit{
-				{http.StatusOK, controllers.PipelineArtifactResponse{}},
-				{http.StatusBadRequest, envelope.APIError{}},
-				{http.StatusNotFound, envelope.APIError{}},
-				{http.StatusInternalServerError, envelope.APIError{}},
-				{http.StatusNotImplemented, envelope.APIError{}},
-			},
+			contentTypes: map[int]string{http.StatusOK: "text/plain"},
 		},
 		{
 			method: http.MethodPost, path: "/api/v1/pipelines/runs/{runId}/stages/{stageId}/signal", id: "signalPipelineStage", tag: "pipelines",

--- a/backend/internal/httpd/controllers/pipelines.go
+++ b/backend/internal/httpd/controllers/pipelines.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"errors"
+	"mime"
 	"net/http"
 	"sort"
 	"strconv"
@@ -17,10 +18,9 @@ import (
 	pipelinesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/pipeline"
 )
 
-// The wire shapes below are v1's, kept frozen so the OpenAPI document and the
-// generated frontend client do not churn while the v2 engine lands. The v2 DTO
-// pass renames them (run status, stage outcomes) and adds the signal, log and
-// output routes.
+// The wire shapes below are v2's: run statuses and stage outcomes from the v2
+// taxonomy, one declared artifact per stage instead of a findings subsystem,
+// and no resume (spec section 14.1).
 
 // ---------------------------------------------------------------------------
 // Path / query params (reflected into the OpenAPI spec by apispec.Build)
@@ -36,16 +36,17 @@ type PipelineRunIDParam struct {
 	RunID string `path:"runId" description:"Pipeline run identifier."`
 }
 
-// PipelineArtifactIDParam carries both path segments of the artifact route.
-type PipelineArtifactIDParam struct {
-	RunID      string `path:"runId" description:"Pipeline run identifier."`
-	ArtifactID string `path:"artifactId" description:"Artifact identifier."`
-}
-
-// PipelineStageIDParam carries both path segments of the stage signal route.
+// PipelineStageIDParam carries both path segments of the stage signal and log
+// routes.
 type PipelineStageIDParam struct {
 	RunID   string `path:"runId" description:"Pipeline run identifier."`
 	StageID string `path:"stageId" description:"Stage id as declared in the pipeline definition."`
+}
+
+// PipelineOutputParam carries both path segments of the run output route.
+type PipelineOutputParam struct {
+	RunID    string `path:"runId" description:"Pipeline run identifier."`
+	Filename string `path:"filename" description:"Artifact filename. Only a name the run's frozen definition declares as a stage's produces is served."`
 }
 
 // PipelineProjectQuery is the shared `project` scoping query for the collection
@@ -58,8 +59,13 @@ type PipelineProjectQuery struct {
 type PipelineRunsQuery struct {
 	Project  string `query:"project,omitempty" description:"Project id (required)."`
 	Pipeline string `query:"pipeline,omitempty" description:"Filter runs to one pipeline name."`
-	Status   string `query:"status,omitempty" description:"Filter runs by loop state (running|awaiting_context|done|stalled|terminated)."`
+	Status   string `query:"status,omitempty" enum:"pending,running,succeeded,failed,cancelled" description:"Filter runs by run status."`
 	Limit    *int   `query:"limit,omitempty" minimum:"1" description:"Cap the number of runs returned (newest first)."`
+}
+
+// PipelineStageLogQuery is the query string for the stage log route.
+type PipelineStageLogQuery struct {
+	Tail *int `query:"tail,omitempty" minimum:"1" description:"Return only the last N lines. Omitted returns the whole log."`
 }
 
 // ---------------------------------------------------------------------------
@@ -116,27 +122,38 @@ type PipelineValidationIssue struct {
 // ValidatePipelineDefinitionResponse is the body of POST /api/v1/pipelines/validate.
 // A validation failure is reported here as data (valid=false with the issue
 // list), not as an error envelope, so the editor can render the Problems list.
+//
+// Warnings are a separate array from issues, and they arrive whether or not the
+// document is valid: a warned pipeline still saves and still runs, so the editor
+// renders the two lists differently (spec section 13).
 type ValidatePipelineDefinitionResponse struct {
-	Valid  bool                      `json:"valid"`
-	Issues []PipelineValidationIssue `json:"issues"`
+	Valid    bool                      `json:"valid"`
+	Issues   []PipelineValidationIssue `json:"issues"`
+	Warnings []PipelineValidationIssue `json:"warnings"`
 }
 
 // PipelineRunSummary is the compact per-run wire shape (list + detail base).
+// It is what one Kanban card needs: the run status column, the subject it is
+// about, and the stage outcome map the card's progress strip renders.
 type PipelineRunSummary struct {
-	RunID             string            `json:"runId"`
-	PipelineID        string            `json:"pipelineId"`
-	PipelineName      string            `json:"pipelineName"`
-	SessionID         string            `json:"sessionId"`
-	LoopState         string            `json:"loopState"`
-	TerminationReason string            `json:"terminationReason,omitempty"`
-	LoopRounds        int               `json:"loopRounds"`
-	HeadSHA           string            `json:"headSha"`
-	StageCount        int               `json:"stageCount"`
-	StageStatuses     map[string]string `json:"stageStatuses"`
-	HasOpenFindings   bool              `json:"hasOpenFindings"`
-	BlocksMerge       bool              `json:"blocksMerge"`
-	CreatedAt         time.Time         `json:"createdAt"`
-	UpdatedAt         time.Time         `json:"updatedAt"`
+	RunID        string `json:"runId"`
+	PipelineID   string `json:"pipelineId"`
+	PipelineName string `json:"pipelineName"`
+	Status       string `json:"status" enum:"pending,running,succeeded,failed,cancelled" description:"Run-level rollup of the stage outcomes."`
+	SubjectKind  string `json:"subjectKind" enum:"session,pr,project" description:"What the run is about."`
+	// SessionID is set for a session subject, and for a PR subject that has a
+	// local session tracking it. Sessionless PR runs are first-class.
+	SessionID string `json:"sessionId,omitempty"`
+	PRNumber  int    `json:"prNumber,omitempty"`
+	HeadSHA   string `json:"headSha,omitempty"`
+	// CancelReason is why a cancelled run was torn down.
+	CancelReason string `json:"cancelReason,omitempty"`
+	StageCount   int    `json:"stageCount"`
+	// StageOutcomes maps stage id to its v2 outcome, for every planned stage.
+	StageOutcomes map[string]string `json:"stageOutcomes"`
+	CreatedAt     time.Time         `json:"createdAt"`
+	UpdatedAt     time.Time         `json:"updatedAt"`
+	SettledAt     *time.Time        `json:"settledAt,omitempty"`
 }
 
 // ListPipelineRunsResponse is the body of GET /api/v1/pipelines/runs.
@@ -144,78 +161,62 @@ type ListPipelineRunsResponse struct {
 	Runs []PipelineRunSummary `json:"runs"`
 }
 
-// PipelineStageView is one stage's state within a run detail.
-type PipelineStageView struct {
-	StageName    string     `json:"stageName"`
-	StageRunID   string     `json:"stageRunId"`
-	Status       string     `json:"status"`
-	Attempt      int        `json:"attempt"`
-	Verdict      string     `json:"verdict,omitempty"`
-	StartedAt    *time.Time `json:"startedAt,omitempty"`
-	CompletedAt  *time.Time `json:"completedAt,omitempty"`
-	ErrorMessage string     `json:"errorMessage,omitempty"`
-	// Output is a capped tail of the stage's combined stdout+stderr (command
-	// stages only), empty otherwise.
-	Output string `json:"output,omitempty"`
-	// SessionID is the AO session the stage ran in (agent stages only), so the UI
-	// can link straight to it.
-	SessionID string `json:"sessionId,omitempty"`
-	// Notes are human-relevant one-line annotations for the stage.
-	Notes       []string `json:"notes,omitempty"`
-	ArtifactIDs []string `json:"artifactIds"`
+// PipelineProducedArtifact is a stage's declared `produces` file and whether the
+// engine found it. Exists=false with a name is the missing-artifact state run
+// detail renders next to a no_output stage.
+type PipelineProducedArtifact struct {
+	Name   string `json:"name"`
+	Exists bool   `json:"exists"`
 }
 
-// PipelineArtifact is the wire shape for one artifact (a finding or a free-form
-// JSON blob) attached to a run. The v2 rebuild replaces it with the `produces`
-// output contract; it is kept here, frozen, only so the OpenAPI document stays
-// stable while the engine is rebuilt.
-type PipelineArtifact struct {
-	Kind string `json:"kind"`
-
-	FilePath        string         `json:"filePath,omitempty"`
-	StartLine       int            `json:"startLine,omitempty"`
-	EndLine         int            `json:"endLine,omitempty"`
-	Title           string         `json:"title,omitempty"`
-	Description     string         `json:"description,omitempty"`
-	Category        string         `json:"category,omitempty"`
-	Severity        string         `json:"severity,omitempty"`
-	Confidence      float64        `json:"confidence,omitempty"`
-	AnchorSignature string         `json:"anchorSignature,omitempty"`
-	Data            map[string]any `json:"data,omitempty"`
-
-	ArtifactID    string `json:"artifactId"`
-	PipelineRunID string `json:"pipelineRunId"`
-	StageRunID    string `json:"stageRunId"`
-	StageName     string `json:"stageName"`
-
-	Fingerprint string `json:"fingerprint,omitempty"`
-	Status      string `json:"status"`
-
-	CreatedAt     time.Time  `json:"createdAt"`
-	SentToAgentAt *time.Time `json:"sentToAgentAt,omitempty"`
-
-	BelowConfidenceThreshold bool `json:"belowConfidenceThreshold,omitempty"`
+// PipelineStageView is one stage's state within a run detail.
+type PipelineStageView struct {
+	StageID string `json:"stageId"`
+	Outcome string `json:"outcome" enum:"pending,running,succeeded,succeeded_unverified,failed,no_output,no_signal,timed_out,cancelled,skipped"`
+	// Attempt is 0 before the stage starts, 1 normally, and 2 after its one
+	// nudge. Run detail tags attempt 2 as "nudged".
+	Attempt    int    `json:"attempt"`
+	EnteredVia string `json:"enteredVia" enum:"trigger,success,failure" description:"Which edge started this stage."`
+	// FailedStage names the stage whose failure routed here, set only when
+	// enteredVia is failure.
+	FailedStage string `json:"failedStage,omitempty"`
+	// SessionID is the AO session the stage ran in (agent stages), so the UI can
+	// link straight to it. It survives a settled stage whose session was kept.
+	SessionID     string     `json:"sessionId,omitempty"`
+	WorkspaceKind string     `json:"workspaceKind,omitempty"`
+	StartedAt     *time.Time `json:"startedAt,omitempty"`
+	SettledAt     *time.Time `json:"settledAt,omitempty"`
+	// Reason carries the fail reason, cancel reason, or plan-failure reason.
+	Reason string `json:"reason,omitempty"`
+	// OutputTail is a capped tail of the stage's captured stdout+stderr, so run
+	// detail can say why a command failed without fetching the full log.
+	OutputTail       string                    `json:"outputTail,omitempty"`
+	ProducedArtifact *PipelineProducedArtifact `json:"producedArtifact,omitempty"`
 }
 
 // PipelineRunDetail is the full reconstructed run: the summary plus per-stage
-// state and the run's materialized findings.
+// state, in plan order.
 type PipelineRunDetail struct {
 	PipelineRunSummary
-	Stages   []PipelineStageView `json:"stages"`
-	Findings []PipelineArtifact  `json:"findings"`
+	// RunDir is the run folder on disk, shown in run detail so a human can go
+	// look at what actually happened.
+	RunDir string              `json:"runDir,omitempty"`
+	Stages []PipelineStageView `json:"stages"`
 }
 
-// PipelineRunDetailResponse is the body of GET /api/v1/pipelines/runs/{runId},
-// cancel, and resume.
+// PipelineRunDetailResponse is the body of GET /api/v1/pipelines/runs/{runId}
+// and cancel.
 type PipelineRunDetailResponse struct {
 	Run PipelineRunDetail `json:"run"`
 }
 
-// TriggerPipelineRunRequest is the manual-trigger body.
+// TriggerPipelineRunRequest is the manual-trigger body. The subject is resolved
+// server-side from these pointers: a PR number wins over a session id, and
+// neither makes it a project-subject run.
 type TriggerPipelineRunRequest struct {
 	Pipeline  string `json:"pipeline" description:"Definition reference to run: its id or name."`
-	SessionID string `json:"sessionId,omitempty" description:"Session id to scope the run's loop key."`
-	HeadSHA   string `json:"headSha,omitempty" description:"Head commit SHA to pin the run to."`
+	SessionID string `json:"sessionId,omitempty" description:"Run against this session as the subject."`
+	PRNumber  int    `json:"prNumber,omitempty" minimum:"1" description:"Run against this tracked pull request as the subject."`
 }
 
 // TriggerPipelineRunResponse is the body of POST /api/v1/pipelines/runs (201).
@@ -223,16 +224,14 @@ type TriggerPipelineRunResponse struct {
 	RunID string `json:"runId"`
 }
 
-// PipelineArtifactResponse is the body of the artifact-fetch and
-// artifact-status routes.
-type PipelineArtifactResponse struct {
-	Artifact PipelineArtifact `json:"artifact"`
-}
-
-// UpdatePipelineArtifactStatusRequest is the body of the artifact-status route:
-// the new lifecycle status for one finding.
-type UpdatePipelineArtifactStatusRequest struct {
-	Status string `json:"status" description:"New artifact status: open | resolved | dismissed."`
+// PipelineStageLogResponse is the body of the stage log route: the captured
+// stdout+stderr of one stage, optionally tailed.
+type PipelineStageLogResponse struct {
+	RunID   string `json:"runId"`
+	StageID string `json:"stageId"`
+	Content string `json:"content"`
+	// Truncated says content is a tail, so the viewer can offer the whole log.
+	Truncated bool `json:"truncated"`
 }
 
 // SignalPipelineStageRequest is the body of the stage signal route: how an
@@ -255,17 +254,16 @@ type SignalPipelineStageResponse struct {
 
 // PipelinesController owns the /pipelines routes. A nil Svc (the AO_PIPELINES
 // flag off) answers 501 on every one of them.
-//
-// The wire shapes here are still v1's. The v2 DTO pass (run status, stage
-// outcomes, the signal, log and output routes, and the OpenAPI regen) is its
-// own task; this controller maps v2 state onto the frozen fields so the routes
-// stop returning 501 without churning the generated client.
 type PipelinesController struct {
 	Svc pipelinesvc.Manager
 }
 
 // Register mounts the pipeline routes. Static run/schema segments are declared
 // before the {id} definition routes so chi matches them ahead of the param.
+//
+// There is no resume route (spec section 14.1: failed runs are dead, re-running
+// means a new run) and no artifact routes: v2's replacement for the findings
+// subsystem is the per-stage declared artifact served by the outputs route.
 func (c *PipelinesController) Register(r chi.Router) {
 	r.Get("/pipelines", c.listDefinitions)
 	r.Post("/pipelines", c.createDefinition)
@@ -276,13 +274,9 @@ func (c *PipelinesController) Register(r chi.Router) {
 	r.Post("/pipelines/runs", c.triggerRun)
 	r.Get("/pipelines/runs/{runId}", c.getRun)
 	r.Post("/pipelines/runs/{runId}/cancel", c.cancelRun)
-	// Resume is gone in v2 (there is no resume, spec section 14.1) and the
-	// artifact subsystem is deleted, but the routes stay mounted at 501 until
-	// the API pass removes them from the OpenAPI document too.
-	r.Post("/pipelines/runs/{runId}/resume", notImplementedHandler("POST", "/api/v1/pipelines/runs/{runId}/resume"))
-	r.Get("/pipelines/runs/{runId}/artifacts/{artifactId}", notImplementedHandler("GET", "/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}"))
-	r.Post("/pipelines/runs/{runId}/artifacts/{artifactId}/status", notImplementedHandler("POST", "/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status"))
 	r.Post("/pipelines/runs/{runId}/stages/{stageId}/signal", c.signalStage)
+	r.Get("/pipelines/runs/{runId}/stages/{stageId}/log", c.stageLog)
+	r.Get("/pipelines/runs/{runId}/outputs/{filename}", c.runOutput)
 
 	r.Put("/pipelines/{id}", c.updateDefinition)
 	r.Delete("/pipelines/{id}", c.deleteDefinition)
@@ -337,10 +331,91 @@ func writePipelineSignalError(w http.ResponseWriter, r *http.Request, err error)
 	}
 }
 
-// notImplementedHandler answers the locked 501 envelope for one operation.
-func notImplementedHandler(method, path string) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		apispec.NotImplemented(w, r, method, path)
+// ---------------------------------------------------------------------------
+// Run folder: stage logs and declared outputs
+// ---------------------------------------------------------------------------
+
+const (
+	stageLogPath  = "/api/v1/pipelines/runs/{runId}/stages/{stageId}/log"
+	runOutputPath = "/api/v1/pipelines/runs/{runId}/outputs/{filename}"
+)
+
+// stageLog serves a stage's captured stdout and stderr from the run folder's
+// stage-logs directory, optionally tailed to the last N lines.
+func (c *PipelinesController) stageLog(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "GET", stageLogPath)
+		return
+	}
+	tail := 0
+	if raw := r.URL.Query().Get("tail"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 {
+			envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_TAIL", "tail must be a positive integer", nil)
+			return
+		}
+		tail = n
+	}
+
+	runID := pipeline.RunID(chi.URLParam(r, "runId"))
+	stageID := chi.URLParam(r, "stageId")
+	log, err := c.Svc.StageLog(r.Context(), runID, stageID, tail)
+	if err != nil {
+		writeRunFileError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, PipelineStageLogResponse{
+		RunID:     string(runID),
+		StageID:   log.StageID,
+		Content:   log.Content,
+		Truncated: log.Truncated,
+	})
+}
+
+// runOutput serves one declared artifact out of the run folder's agent-outputs
+// directory, as the file itself so the browser can download it.
+//
+// The filename is authorization, not a path: the service matches it against the
+// run's frozen `produces` set before anything touches the filesystem, so an
+// undeclared name, a traversal, an absolute path and a planted symlink are all
+// the same 404.
+func (c *PipelinesController) runOutput(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "GET", runOutputPath)
+		return
+	}
+	runID := pipeline.RunID(chi.URLParam(r, "runId"))
+	out, err := c.Svc.RunOutput(r.Context(), runID, chi.URLParam(r, "filename"))
+	if err != nil {
+		writeRunFileError(w, r, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	// Never let a browser render agent-authored bytes inline as HTML, and never
+	// let the filename be sniffed into something else.
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": out.Filename}))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(out.Content)
+}
+
+// writeRunFileError maps the run-folder read errors onto the wire. Every "there
+// is nothing at this URL" cause is a 404: an undeclared filename must not be
+// distinguishable from a missing one, or the endpoint becomes an oracle for
+// what the run folder contains.
+func writeRunFileError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, pipeline.ErrOutputNotDeclared):
+		envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "PIPELINE_OUTPUT_NOT_FOUND", "Unknown pipeline run output", nil)
+	case errors.Is(err, pipelinesvc.ErrOutputMissing):
+		envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "PIPELINE_OUTPUT_NOT_FOUND", "Unknown pipeline run output", nil)
+	case errors.Is(err, pipelinesvc.ErrStageNotFound):
+		envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "PIPELINE_STAGE_NOT_FOUND", "Unknown pipeline stage", nil)
+	case errors.Is(err, pipelinesvc.ErrStageLogMissing), errors.Is(err, pipelinesvc.ErrRunFolderMissing):
+		envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "PIPELINE_STAGE_LOG_NOT_FOUND", "Pipeline stage has no log yet", nil)
+	default:
+		writePipelineError(w, r, err)
 	}
 }
 
@@ -439,16 +514,26 @@ func (c *PipelinesController) validateDefinition(w http.ResponseWriter, r *http.
 		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
 		return
 	}
-	valid, issues, err := c.Svc.ValidateDefinition(r.Context(), projectID, in.YAMLSource)
+	valid, issues, warnings, err := c.Svc.ValidateDefinition(r.Context(), projectID, in.YAMLSource)
 	if err != nil {
 		writePipelineError(w, r, err)
 		return
 	}
-	out := make([]PipelineValidationIssue, 0, len(issues))
-	for _, is := range issues {
+	envelope.WriteJSON(w, http.StatusOK, ValidatePipelineDefinitionResponse{
+		Valid:    valid,
+		Issues:   validationIssues(issues),
+		Warnings: validationIssues(warnings),
+	})
+}
+
+// validationIssues maps the service's issue list onto the wire, never nil so a
+// clean document sends [] rather than null.
+func validationIssues(in []pipeline.Issue) []PipelineValidationIssue {
+	out := make([]PipelineValidationIssue, 0, len(in))
+	for _, is := range in {
 		out = append(out, PipelineValidationIssue{Path: is.Path, Message: is.Message})
 	}
-	envelope.WriteJSON(w, http.StatusOK, ValidatePipelineDefinitionResponse{Valid: valid, Issues: out})
+	return out
 }
 
 func (c *PipelinesController) schema(w http.ResponseWriter, r *http.Request) {
@@ -511,9 +596,10 @@ func (c *PipelinesController) getRun(w http.ResponseWriter, r *http.Request) {
 	envelope.WriteJSON(w, http.StatusOK, PipelineRunDetailResponse{Run: runDetail(run)})
 }
 
-// triggerRun starts a manual run. headSha in the body is ignored: v2 pins a run
-// to its subject, not to a commit, and a manual PR subject arrives with the
-// run API pass.
+// triggerRun starts a manual run. The body names what the run is about; the
+// subject itself (including the PR's head SHA and fork provenance) is resolved
+// server-side, because the fork flag decides whether credentials are injected
+// anywhere in the run.
 func (c *PipelinesController) triggerRun(w http.ResponseWriter, r *http.Request) {
 	if c.Svc == nil {
 		apispec.NotImplemented(w, r, "POST", "/api/v1/pipelines/runs")
@@ -528,9 +614,14 @@ func (c *PipelinesController) triggerRun(w http.ResponseWriter, r *http.Request)
 		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
 		return
 	}
+	if in.PRNumber < 0 {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_PR_NUMBER", "prNumber must be a positive integer", nil)
+		return
+	}
 	runID, err := c.Svc.TriggerRun(r.Context(), projectID, pipelinesvc.TriggerInput{
 		Ref:       in.Pipeline,
 		SessionID: in.SessionID,
+		PRNumber:  in.PRNumber,
 	})
 	if err != nil {
 		writePipelineError(w, r, err)
@@ -599,45 +690,60 @@ func definitionSummary(d pipeline.Definition) PipelineDefinitionSummary {
 	}
 }
 
-// runSummary maps a v2 run onto the frozen wire shape. loopState carries the v2
-// run status and stageStatuses the v2 stage outcomes; the fields keep their
-// names until the DTO pass renames them along with the OpenAPI document.
+// runSummary maps a v2 run onto the Kanban card's wire shape.
 func runSummary(run pipeline.RunState) PipelineRunSummary {
 	outcomes := make(map[string]string, len(run.Stages))
 	for id, st := range run.Stages {
 		outcomes[id] = string(st.Outcome)
 	}
-	headSHA := ""
+	out := PipelineRunSummary{
+		RunID:         string(run.RunID),
+		PipelineID:    string(run.PipelineID),
+		PipelineName:  run.PipelineName,
+		Status:        string(run.Status),
+		SubjectKind:   string(run.Subject.Kind),
+		SessionID:     run.Subject.SessionID,
+		CancelReason:  run.CancelReason,
+		StageCount:    len(run.Stages),
+		StageOutcomes: outcomes,
+		CreatedAt:     run.CreatedAt,
+		UpdatedAt:     run.UpdatedAt,
+	}
 	if run.Subject.PR != nil {
-		headSHA = run.Subject.PR.HeadSHA
+		out.PRNumber = run.Subject.PR.Number
+		out.HeadSHA = run.Subject.PR.HeadSHA
 	}
-	return PipelineRunSummary{
-		RunID:             string(run.RunID),
-		PipelineID:        string(run.PipelineID),
-		PipelineName:      run.PipelineName,
-		SessionID:         run.Subject.SessionID,
-		LoopState:         string(run.Status),
-		TerminationReason: run.CancelReason,
-		HeadSHA:           headSHA,
-		StageCount:        len(run.Stages),
-		StageStatuses:     outcomes,
-		CreatedAt:         run.CreatedAt,
-		UpdatedAt:         run.UpdatedAt,
+	if !run.SettledAt.IsZero() {
+		settled := run.SettledAt
+		out.SettledAt = &settled
 	}
+	return out
 }
 
+// runDetail adds per-stage state, in the definition's document order so run
+// detail reads top to bottom the way the pipeline was written. Stages the plan
+// never reached are simply absent from run.Stages.
 func runDetail(run pipeline.RunState) PipelineRunDetail {
+	folder := pipeline.RunFolder{Dir: run.RunDir}
 	stages := make([]PipelineStageView, 0, len(run.Stages))
-	for id, st := range run.Stages {
+	seen := make(map[string]bool, len(run.Stages))
+
+	appendStage := func(id string) {
+		st, ok := run.Stages[id]
+		if !ok || st == nil || seen[id] {
+			return
+		}
+		seen[id] = true
 		view := PipelineStageView{
-			StageName:    id,
-			Status:       string(st.Outcome),
-			Attempt:      st.Attempt,
-			Verdict:      string(st.EnteredVia),
-			ErrorMessage: st.Reason,
-			Output:       st.OutputTail,
-			SessionID:    st.SessionID,
-			ArtifactIDs:  []string{},
+			StageID:       id,
+			Outcome:       string(st.Outcome),
+			Attempt:       st.Attempt,
+			EnteredVia:    string(st.EnteredVia),
+			FailedStage:   st.FailedStage,
+			SessionID:     st.SessionID,
+			WorkspaceKind: string(st.WorkspaceKind),
+			Reason:        st.Reason,
+			OutputTail:    st.OutputTail,
 		}
 		if !st.StartedAt.IsZero() {
 			started := st.StartedAt
@@ -645,17 +751,39 @@ func runDetail(run pipeline.RunState) PipelineRunDetail {
 		}
 		if !st.SettledAt.IsZero() {
 			settled := st.SettledAt
-			view.CompletedAt = &settled
+			view.SettledAt = &settled
+		}
+		if stage := run.Def.StageByID(id); stage != nil && stage.Produces != "" {
+			view.ProducedArtifact = &PipelineProducedArtifact{
+				Name: stage.Produces,
+				// Verified against the run folder rather than inferred from the
+				// outcome: a no_output stage and a run folder someone deleted
+				// look the same in the outcome and different on disk.
+				Exists: run.RunDir != "" && folder.VerifyArtifact(stage),
+			}
 		}
 		stages = append(stages, view)
 	}
-	sort.Slice(stages, func(i, j int) bool { return stages[i].StageName < stages[j].StageName })
+
+	for i := range run.Def.Stages {
+		appendStage(run.Def.Stages[i].ID)
+	}
+	// Anything the frozen definition does not list (it should be nothing) still
+	// has to reach the UI rather than vanish.
+	leftovers := make([]string, 0, len(run.Stages))
+	for id := range run.Stages {
+		if !seen[id] {
+			leftovers = append(leftovers, id)
+		}
+	}
+	sort.Strings(leftovers)
+	for _, id := range leftovers {
+		appendStage(id)
+	}
 
 	return PipelineRunDetail{
 		PipelineRunSummary: runSummary(run),
+		RunDir:             run.RunDir,
 		Stages:             stages,
-		// The findings subsystem is deleted in v2; the field stays until the
-		// DTO pass removes it from the OpenAPI document.
-		Findings: []PipelineArtifact{},
 	}
 }

--- a/backend/internal/httpd/controllers/pipelines_test.go
+++ b/backend/internal/httpd/controllers/pipelines_test.go
@@ -7,13 +7,21 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers"
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
 	pipelinesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
 
 // fakePipelineService records the last signal it was handed and answers with a
@@ -133,6 +141,521 @@ func TestPipelineSignal_BadRequests(t *testing.T) {
 			assertErrorCode(t, body, status, http.StatusBadRequest, tc.wantCode)
 			if svc.calls != 0 {
 				t.Fatalf("service was called %d times for a rejected body", svc.calls)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The v2 surface, driven end to end through a real service over a real store
+// and a real run folder. The outputs endpoint is a file server pointed at a
+// caller-supplied name, so nothing short of the real filesystem tests it.
+// ---------------------------------------------------------------------------
+
+const runFixtureYAML = `name: review
+stages:
+  - id: review
+    executor: agent
+    agent: claude
+    prompt: review the diff
+    produces: review.md
+    on_success: publish
+    on_failure: notify
+  - id: publish
+    executor: command
+    run: make publish
+  - id: notify
+    executor: command
+    run: make notify
+`
+
+// nothingResolver is a credential store that declares nothing, which is exactly
+// the state a user is in the moment they click a starter template.
+type nothingResolver struct{}
+
+func (nothingResolver) Resolve(context.Context, string, []string) (map[string]string, error) {
+	return nil, nil
+}
+func (nothingResolver) Exists(context.Context, string, string) (bool, error) { return false, nil }
+
+// newPipelineV2Server wires the real service over a real store, seeds one run
+// with a run folder on disk, and returns the server plus that folder.
+func newPipelineV2Server(t *testing.T) (*httptest.Server, pipeline.RunFolder) {
+	t.Helper()
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "proj", Path: t.TempDir(), RegisteredAt: now}); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+
+	folder, err := pipeline.CreateRunFolder(t.TempDir(), "proj", "run-1", []byte(runFixtureYAML))
+	if err != nil {
+		t.Fatalf("create run folder: %v", err)
+	}
+	def, err := pipeline.ParseDefinition([]byte(runFixtureYAML))
+	if err != nil {
+		t.Fatalf("parse definition: %v", err)
+	}
+
+	run := pipeline.RunState{
+		RunID:        "run-1",
+		ProjectID:    "proj",
+		PipelineID:   "pl-1",
+		PipelineName: "review",
+		Subject: pipeline.Subject{
+			Kind:      pipeline.SubjectPR,
+			ProjectID: "proj",
+			SessionID: "sess-1",
+			PR:        &pipeline.PRRef{Number: 412, Repo: "acme/app", HeadSHA: "deadbeef"},
+		},
+		Status: pipeline.RunFailed,
+		RunDir: folder.Dir,
+		Def:    *def,
+		Stages: map[string]*pipeline.StageState{
+			"review": {
+				ID: "review", Outcome: pipeline.OutcomeNoOutput, Attempt: 2,
+				EnteredVia: pipeline.EntryTrigger, SessionID: "sess-9",
+				WorkspaceKind: pipeline.WorkspaceSession,
+				StartedAt:     now, SettledAt: now.Add(time.Minute),
+			},
+			"notify": {
+				ID: "notify", Outcome: pipeline.OutcomeSucceeded, Attempt: 1,
+				EnteredVia: pipeline.EntryFailure, FailedStage: "review",
+				OutputTail: "notified\n",
+				StartedAt:  now.Add(time.Minute), SettledAt: now.Add(2 * time.Minute),
+			},
+			"publish": {ID: "publish", Outcome: pipeline.OutcomeSkipped},
+		},
+		CreatedAt: now,
+		UpdatedAt: now.Add(2 * time.Minute),
+		SettledAt: now.Add(2 * time.Minute),
+	}
+	if err := store.SavePipelineRun(ctx, run); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	svc := pipelinesvc.New(store, pipelinesvc.WithCredentials(nothingResolver{}))
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := httptest.NewServer(httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{Pipelines: svc}, httpd.ControlDeps{}))
+	t.Cleanup(srv.Close)
+	return srv, folder
+}
+
+func TestPipelineRuns_ListDTOShape(t *testing.T) {
+	srv, _ := newPipelineV2Server(t)
+
+	body, status, headers := doRequest(t, srv, "GET", "/api/v1/pipelines/runs?project=proj", "")
+	assertJSON(t, headers)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", status, body)
+	}
+	var res struct {
+		Runs []controllers.PipelineRunSummary `json:"runs"`
+	}
+	mustJSON(t, body, &res)
+	if len(res.Runs) != 1 {
+		t.Fatalf("runs = %d, want 1", len(res.Runs))
+	}
+	got := res.Runs[0]
+	if got.RunID != "run-1" || got.Status != "failed" || got.SubjectKind != "pr" {
+		t.Fatalf("summary = %+v", got)
+	}
+	if got.PRNumber != 412 || got.HeadSHA != "deadbeef" || got.SessionID != "sess-1" {
+		t.Fatalf("subject fields = %+v", got)
+	}
+	if got.StageCount != 3 || got.StageOutcomes["review"] != "no_output" || got.StageOutcomes["publish"] != "skipped" {
+		t.Fatalf("stage rollup = %+v", got)
+	}
+	if got.SettledAt == nil {
+		t.Fatal("settledAt is nil for a settled run")
+	}
+	// The v1 fields are gone from the wire, not merely unused.
+	for _, dead := range []string{"loopState", "loopRounds", "hasOpenFindings", "blocksMerge", "stageStatuses"} {
+		if strings.Contains(string(body), `"`+dead+`"`) {
+			t.Errorf("v1 field %q still on the wire", dead)
+		}
+	}
+}
+
+func TestPipelineRuns_DetailDTOShape(t *testing.T) {
+	srv, folder := newPipelineV2Server(t)
+	// review declared review.md and settled no_output, so the artifact is named
+	// but absent: that is the missing-artifact state run detail renders.
+	body, status, headers := doRequest(t, srv, "GET", "/api/v1/pipelines/runs/run-1", "")
+	assertJSON(t, headers)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", status, body)
+	}
+	var res struct {
+		Run controllers.PipelineRunDetail `json:"run"`
+	}
+	mustJSON(t, body, &res)
+
+	// Document order, not map order.
+	var ids []string
+	for _, s := range res.Run.Stages {
+		ids = append(ids, s.StageID)
+	}
+	if want := []string{"review", "publish", "notify"}; !slices.Equal(ids, want) {
+		t.Fatalf("stage order = %v, want %v", ids, want)
+	}
+	if res.Run.RunDir != folder.Dir {
+		t.Errorf("runDir = %q, want %q", res.Run.RunDir, folder.Dir)
+	}
+
+	review := res.Run.Stages[0]
+	if review.Outcome != "no_output" || review.Attempt != 2 || review.EnteredVia != "trigger" {
+		t.Fatalf("review = %+v", review)
+	}
+	if review.SessionID != "sess-9" || review.WorkspaceKind != "session" {
+		t.Fatalf("review session/workspace = %+v", review)
+	}
+	if review.ProducedArtifact == nil || review.ProducedArtifact.Name != "review.md" || review.ProducedArtifact.Exists {
+		t.Fatalf("producedArtifact = %+v, want review.md absent", review.ProducedArtifact)
+	}
+	if review.StartedAt == nil || review.SettledAt == nil {
+		t.Fatal("review is settled but carries no timestamps")
+	}
+
+	notify := res.Run.Stages[2]
+	if notify.EnteredVia != "failure" || notify.FailedStage != "review" || notify.OutputTail != "notified\n" {
+		t.Fatalf("notify = %+v", notify)
+	}
+	// A command stage declares no produces, so it has no artifact block at all.
+	if notify.ProducedArtifact != nil {
+		t.Fatalf("notify.producedArtifact = %+v, want nil", notify.ProducedArtifact)
+	}
+	if strings.Contains(string(body), `"findings"`) {
+		t.Error("the deleted findings array is still on the wire")
+	}
+
+	// Write the artifact and the same stage now reports it present.
+	if err := os.WriteFile(folder.OutputPath(res2Stage(t, folder)), []byte("# findings\n"), 0o600); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	body, _, _ = doRequest(t, srv, "GET", "/api/v1/pipelines/runs/run-1", "")
+	mustJSON(t, body, &res)
+	if !res.Run.Stages[0].ProducedArtifact.Exists {
+		t.Fatal("producedArtifact.exists stayed false after the file was written")
+	}
+}
+
+// res2Stage is the review stage of the fixture definition, for OutputPath.
+func res2Stage(t *testing.T, _ pipeline.RunFolder) *pipeline.Stage {
+	t.Helper()
+	def, err := pipeline.ParseDefinition([]byte(runFixtureYAML))
+	if err != nil {
+		t.Fatalf("parse definition: %v", err)
+	}
+	return def.StageByID("review")
+}
+
+func TestPipelineRuns_DetailUnknownRunIs404(t *testing.T) {
+	srv, _ := newPipelineV2Server(t)
+	body, status, headers := doRequest(t, srv, "GET", "/api/v1/pipelines/runs/run-nope", "")
+	assertJSON(t, headers)
+	assertErrorCode(t, body, status, http.StatusNotFound, "PIPELINE_RUN_NOT_FOUND")
+}
+
+// ---------------------------------------------------------------------------
+// Stage log
+// ---------------------------------------------------------------------------
+
+func TestPipelineStageLog_TailsTheLog(t *testing.T) {
+	srv, folder := newPipelineV2Server(t)
+	if err := os.WriteFile(folder.LogPath("notify"), []byte("one\ntwo\nthree\n"), 0o600); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	body, status, headers := doRequest(t, srv, "GET", "/api/v1/pipelines/runs/run-1/stages/notify/log", "")
+	assertJSON(t, headers)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", status, body)
+	}
+	var res controllers.PipelineStageLogResponse
+	mustJSON(t, body, &res)
+	if res.RunID != "run-1" || res.StageID != "notify" || res.Content != "one\ntwo\nthree\n" || res.Truncated {
+		t.Fatalf("whole log = %+v", res)
+	}
+
+	body, status, _ = doRequest(t, srv, "GET", "/api/v1/pipelines/runs/run-1/stages/notify/log?tail=2", "")
+	if status != http.StatusOK {
+		t.Fatalf("tail status = %d, want 200; body=%s", status, body)
+	}
+	mustJSON(t, body, &res)
+	if res.Content != "two\nthree\n" || !res.Truncated {
+		t.Fatalf("tail = %+v", res)
+	}
+}
+
+func TestPipelineStageLog_Rejections(t *testing.T) {
+	srv, _ := newPipelineV2Server(t)
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+		wantCode   string
+	}{
+		{"unknown run", "/api/v1/pipelines/runs/run-nope/stages/notify/log", http.StatusNotFound, "PIPELINE_RUN_NOT_FOUND"},
+		{"unknown stage", "/api/v1/pipelines/runs/run-1/stages/nope/log", http.StatusNotFound, "PIPELINE_STAGE_NOT_FOUND"},
+		{"no log yet", "/api/v1/pipelines/runs/run-1/stages/notify/log", http.StatusNotFound, "PIPELINE_STAGE_LOG_NOT_FOUND"},
+		{"negative tail", "/api/v1/pipelines/runs/run-1/stages/notify/log?tail=-3", http.StatusBadRequest, "INVALID_TAIL"},
+		{"non-numeric tail", "/api/v1/pipelines/runs/run-1/stages/notify/log?tail=all", http.StatusBadRequest, "INVALID_TAIL"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, status, headers := doRequest(t, srv, "GET", tc.path, "")
+			assertJSON(t, headers)
+			assertErrorCode(t, body, status, tc.wantStatus, tc.wantCode)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Outputs: adversarial
+// ---------------------------------------------------------------------------
+
+func TestPipelineRunOutput_ServesADeclaredArtifact(t *testing.T) {
+	srv, folder := newPipelineV2Server(t)
+	if err := os.WriteFile(filepath.Join(folder.Dir, "agent-outputs", "review.md"), []byte("# findings\n"), 0o600); err != nil {
+		t.Fatalf("seed artifact: %v", err)
+	}
+
+	body, status, headers := doRequest(t, srv, "GET", "/api/v1/pipelines/runs/run-1/outputs/review.md", "")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", status, body)
+	}
+	if string(body) != "# findings\n" {
+		t.Fatalf("body = %q", body)
+	}
+	if got := headers.Get("Content-Disposition"); !strings.Contains(got, "review.md") {
+		t.Errorf("Content-Disposition = %q", got)
+	}
+	// Agent-authored bytes must never render inline as HTML.
+	if got := headers.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+	if got := headers.Get("Content-Type"); !strings.HasPrefix(got, "text/plain") {
+		t.Errorf("Content-Type = %q, want text/plain", got)
+	}
+}
+
+// The endpoint is a file server pointed at a caller-supplied name. Every one of
+// these must be a 404 with no bytes of the target: traversal (raw and encoded),
+// absolute paths, and files that exist in the run folder but are not declared.
+func TestPipelineRunOutput_RejectsTraversalAbsoluteAndUndeclared(t *testing.T) {
+	srv, folder := newPipelineV2Server(t)
+	if err := os.WriteFile(filepath.Join(folder.Dir, "agent-outputs", "review.md"), []byte("# findings\n"), 0o600); err != nil {
+		t.Fatalf("seed artifact: %v", err)
+	}
+	// Real, readable files just outside the allowlist so a leak is observable.
+	if err := os.WriteFile(filepath.Join(folder.Dir, "secret.txt"), []byte("SENSITIVE"), 0o600); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+
+	for _, raw := range []string{
+		"%2e%2e",
+		"%2e%2e%2fsecret.txt",
+		"%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd",
+		"..%252fsecret.txt",
+		"%2fetc%2fpasswd",
+		"..%5c..%5csecret.txt",
+		"secret.txt",
+		"run.json",
+		"definition.yaml",
+		"review.md%00.png",
+		"Review.md",
+		"review.md%20",
+		"%2e%2freview.md",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			body, status, _ := doRequest(t, srv, "GET", "/api/v1/pipelines/runs/run-1/outputs/"+raw, "")
+			if status == http.StatusOK {
+				t.Fatalf("served %q with 200: %q", raw, body)
+			}
+			for _, leak := range []string{"SENSITIVE", "root:", "# findings"} {
+				if strings.Contains(string(body), leak) {
+					t.Fatalf("response for %q leaked %q: %s", raw, leak, body)
+				}
+			}
+		})
+	}
+}
+
+func TestPipelineRunOutput_DeclaredButNotWrittenIs404(t *testing.T) {
+	srv, _ := newPipelineV2Server(t)
+	body, status, headers := doRequest(t, srv, "GET", "/api/v1/pipelines/runs/run-1/outputs/review.md", "")
+	assertJSON(t, headers)
+	assertErrorCode(t, body, status, http.StatusNotFound, "PIPELINE_OUTPUT_NOT_FOUND")
+}
+
+// A symlink planted under the declared name is the one way a declared filename
+// could still resolve outside the run folder.
+func TestPipelineRunOutput_RejectsASymlinkEscape(t *testing.T) {
+	srv, folder := newPipelineV2Server(t)
+	outside := filepath.Join(t.TempDir(), "id_rsa")
+	if err := os.WriteFile(outside, []byte("PRIVATE KEY"), 0o600); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(folder.Dir, "agent-outputs", "review.md")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	body, status, _ := doRequest(t, srv, "GET", "/api/v1/pipelines/runs/run-1/outputs/review.md", "")
+	if status == http.StatusOK || strings.Contains(string(body), "PRIVATE KEY") {
+		t.Fatalf("symlink served: status=%d body=%s", status, body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validate: warnings are their own array
+// ---------------------------------------------------------------------------
+
+func TestPipelineValidate_WarningsAreSeparateFromIssues(t *testing.T) {
+	srv, _ := newPipelineV2Server(t)
+	// Two stages, no failure route anywhere: valid, but warned (spec 13).
+	yaml := "name: two\nstages:\n  - id: a\n    executor: command\n    run: make a\n    on_success: b\n  - id: b\n    executor: command\n    run: make b\n"
+
+	body, status, headers := doRequest(t, srv, "POST", "/api/v1/pipelines/validate?project=proj",
+		`{"yamlSource":`+strconv.Quote(yaml)+`}`)
+	assertJSON(t, headers)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", status, body)
+	}
+	var res controllers.ValidatePipelineDefinitionResponse
+	mustJSON(t, body, &res)
+	if !res.Valid {
+		t.Fatalf("valid = false for a warned-but-legal pipeline: %+v", res)
+	}
+	if len(res.Issues) != 0 {
+		t.Fatalf("issues = %+v, want none", res.Issues)
+	}
+	if len(res.Warnings) == 0 {
+		t.Fatalf("warnings = none, want the missing-failure-route warning; body=%s", body)
+	}
+}
+
+func TestPipelineValidate_IssuesAndWarningsCoexist(t *testing.T) {
+	srv, _ := newPipelineV2Server(t)
+	// Same missing-failure-route warning, plus an unknown on_success target.
+	yaml := "name: two\nstages:\n  - id: a\n    executor: command\n    run: make a\n    on_success: nope\n  - id: b\n    executor: command\n    run: make b\n"
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/pipelines/validate?project=proj",
+		`{"yamlSource":`+strconv.Quote(yaml)+`}`)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", status, body)
+	}
+	var res controllers.ValidatePipelineDefinitionResponse
+	mustJSON(t, body, &res)
+	if res.Valid || len(res.Issues) == 0 {
+		t.Fatalf("expected issues on an invalid document: %+v", res)
+	}
+	if len(res.Warnings) == 0 {
+		t.Fatalf("warnings were dropped because the document was invalid; body=%s", body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unknown credential: the first thing a user sees after clicking a template
+// ---------------------------------------------------------------------------
+
+func TestPipelineValidate_UnknownCredentialNamesTheFixingCommand(t *testing.T) {
+	srv, _ := newPipelineV2Server(t)
+	yaml := "name: gate\nstages:\n  - id: publish\n    executor: command\n    run: gh release create\n    credentials: [github-release]\n"
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/pipelines/validate?project=proj",
+		`{"yamlSource":`+strconv.Quote(yaml)+`}`)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", status, body)
+	}
+	var res controllers.ValidatePipelineDefinitionResponse
+	mustJSON(t, body, &res)
+	if res.Valid || len(res.Issues) != 1 {
+		t.Fatalf("res = %+v, want exactly one issue", res)
+	}
+	assertActionableCredentialMessage(t, res.Issues[0].Message)
+	if res.Issues[0].Path != "stages[0].credentials[0]" {
+		t.Errorf("path = %q, want stages[0].credentials[0]", res.Issues[0].Path)
+	}
+}
+
+// The save path runs the same check, so clicking a template and hitting save
+// gets the same actionable message rather than a bare rejection.
+func TestPipelineCreate_UnknownCredentialNamesTheFixingCommand(t *testing.T) {
+	srv, _ := newPipelineV2Server(t)
+	yaml := "name: gate\nstages:\n  - id: publish\n    executor: command\n    run: gh release create\n    credentials: [github-release]\n"
+
+	body, status, headers := doRequest(t, srv, "POST", "/api/v1/pipelines?project=proj",
+		`{"yamlSource":`+strconv.Quote(yaml)+`}`)
+	assertJSON(t, headers)
+	if status != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", status, body)
+	}
+	assertActionableCredentialMessage(t, string(body))
+}
+
+func assertActionableCredentialMessage(t *testing.T, msg string) {
+	t.Helper()
+	for _, want := range []string{
+		`unknown credential`,
+		`github-release`,
+		"ao pipeline credential set github-release",
+		"--project proj",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message %q is missing %q", msg, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Flag off: every route, including the new ones, answers the locked 501
+// ---------------------------------------------------------------------------
+
+func TestPipelineRoutes_NilServiceReturns501(t *testing.T) {
+	srv := newPipelineTestServer(t, nil)
+	tests := []struct{ method, path, body string }{
+		{"GET", "/api/v1/pipelines?project=proj", ""},
+		{"POST", "/api/v1/pipelines?project=proj", `{"yamlSource":"name: x"}`},
+		{"PUT", "/api/v1/pipelines/pl-1", `{"yamlSource":"name: x"}`},
+		{"DELETE", "/api/v1/pipelines/pl-1", ""},
+		{"POST", "/api/v1/pipelines/validate?project=proj", `{"yamlSource":"name: x"}`},
+		{"GET", "/api/v1/pipelines/schema", ""},
+		{"GET", "/api/v1/pipelines/runs?project=proj", ""},
+		{"POST", "/api/v1/pipelines/runs?project=proj", `{"pipeline":"review"}`},
+		{"GET", "/api/v1/pipelines/runs/run-1", ""},
+		{"POST", "/api/v1/pipelines/runs/run-1/cancel?project=proj", ""},
+		{"POST", signalPath, `{"status":"done"}`},
+		{"GET", "/api/v1/pipelines/runs/run-1/stages/review/log", ""},
+		{"GET", "/api/v1/pipelines/runs/run-1/outputs/review.md", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			body, status, headers := doRequest(t, srv, tc.method, tc.path, tc.body)
+			assertJSON(t, headers)
+			assertErrorCode(t, body, status, http.StatusNotImplemented, "NOT_IMPLEMENTED")
+		})
+	}
+}
+
+// The two v1 routes v2 deletes are gone from the router, not merely 501.
+func TestPipelineRoutes_ResumeAndArtifactsAreGone(t *testing.T) {
+	srv, _ := newPipelineV2Server(t)
+	for _, tc := range []struct{ method, path string }{
+		{"POST", "/api/v1/pipelines/runs/run-1/resume?project=proj"},
+		{"GET", "/api/v1/pipelines/runs/run-1/artifacts/art-1"},
+		{"POST", "/api/v1/pipelines/runs/run-1/artifacts/art-1/status?project=proj"},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			_, status, _ := doRequest(t, srv, tc.method, tc.path, `{}`)
+			if status != http.StatusNotFound && status != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want the route to be unmounted", status)
 			}
 		})
 	}

--- a/backend/internal/pipeline/credentials.go
+++ b/backend/internal/pipeline/credentials.go
@@ -33,6 +33,11 @@ type CredentialResolver interface {
 // A store failure comes back as an ordinary error, not a *ValidationError:
 // "unknown credential" on a failed read would tell the author to fix a name
 // that is fine.
+//
+// The message names the exact command that fixes it. Two of the three starter
+// templates declare credentials, so this error is the first thing a new user
+// sees after clicking a template; a bare "unknown credential" there reads as
+// the feature being broken rather than as one command being missing.
 func ValidateCredentials(ctx context.Context, p *Pipeline, projectID string, r CredentialResolver) error {
 	if r == nil || p == nil {
 		return nil
@@ -50,7 +55,7 @@ func ValidateCredentials(ctx context.Context, p *Pipeline, projectID string, r C
 			}
 			issues = append(issues, Issue{
 				Path:    fmt.Sprintf("stages[%d].credentials[%d]", i, j),
-				Message: fmt.Sprintf("unknown credential %q: set it with `ao pipeline credential set %s KEY=VALUE`", name, name),
+				Message: unknownCredentialMessage(name, projectID),
 			})
 		}
 	}
@@ -58,6 +63,17 @@ func ValidateCredentials(ctx context.Context, p *Pipeline, projectID string, r C
 		return &ValidationError{Issues: issues}
 	}
 	return nil
+}
+
+// unknownCredentialMessage spells the one command that turns this error into a
+// working pipeline. KEY=VALUE stays a placeholder because only the author knows
+// which environment variable the stage's script reads.
+func unknownCredentialMessage(name, projectID string) string {
+	cmd := fmt.Sprintf("ao pipeline credential set %s KEY=VALUE", name)
+	if projectID != "" {
+		cmd += " --project " + projectID
+	}
+	return fmt.Sprintf("unknown credential %q; create it with: %s", name, cmd)
 }
 
 // KnownCredentialSet turns the project's declared credential names into the

--- a/backend/internal/pipeline/credentials_test.go
+++ b/backend/internal/pipeline/credentials_test.go
@@ -89,6 +89,29 @@ func TestValidateCredentials_UnknownNameFlagsTheExactPath(t *testing.T) {
 	}
 }
 
+// The starter templates declare credentials, so this message is the first thing
+// a new user sees after clicking a template and saving. It has to be the fix,
+// not just the diagnosis.
+func TestValidateCredentials_UnknownNameNamesTheFixingCommand(t *testing.T) {
+	def := credsPipeline(t)
+	err := ValidateCredentials(context.Background(), def, "proj-7", newMemResolver(nil))
+
+	var verr *ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("error = %T (%v), want *ValidationError", err, err)
+	}
+	msg := verr.Issues[0].Message
+	for _, want := range []string{
+		`unknown credential "apple-signing"`,
+		"ao pipeline credential set apple-signing",
+		"--project proj-7",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message = %q, want it to contain %q", msg, want)
+		}
+	}
+}
+
 func TestValidateCredentials_EveryNameKnownIsClean(t *testing.T) {
 	def := credsPipeline(t)
 	resolver := newMemResolver(map[string]map[string]string{

--- a/backend/internal/pipeline/definition.go
+++ b/backend/internal/pipeline/definition.go
@@ -249,17 +249,29 @@ func (l *StageList) UnmarshalYAML(value *yaml.Node) error {
 // Unknown keys are rejected (strict decoding), and every validation rule
 // failure is collected into a single *ValidationError rather than stopping at
 // the first one, so an author sees every problem in one pass. Warnings are
-// dropped here; callers that want to surface them (the editor) call Validate
-// directly.
+// dropped here; callers that want to surface them (the editor) call
+// ParseDefinitionWithWarnings.
 func ParseDefinition(src []byte) (*Pipeline, error) {
+	p, _, err := ParseDefinitionWithWarnings(src)
+	return p, err
+}
+
+// ParseDefinitionWithWarnings is ParseDefinition keeping the warnings.
+//
+// Warnings travel separately from errors all the way to the wire because a
+// warned pipeline still saves and still runs: the editor renders the two
+// lists differently, and folding them together would make a save look
+// impossible when it is merely worth a second look.
+func ParseDefinitionWithWarnings(src []byte) (*Pipeline, []Issue, error) {
 	var p Pipeline
 	if err := decodeStrict(src, &p); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	if _, err := Validate(&p); err != nil {
-		return nil, err
+	warnings, err := Validate(&p)
+	if err != nil {
+		return nil, warnings, err
 	}
-	return &p, nil
+	return &p, warnings, nil
 }
 
 // decodeStrict runs one strict yaml.v3 decode into out. An empty document is

--- a/backend/internal/pipeline/runfolder.go
+++ b/backend/internal/pipeline/runfolder.go
@@ -134,20 +134,22 @@ func (f RunFolder) DeclaredOutput(p *Pipeline, filename string) (string, error) 
 
 // ReadLogTail returns the last n lines of a stage's log, or the whole log when
 // n <= 0. A missing log is not an error: a stage that has not started yet
-// simply has nothing to show, and the second return value says which it was.
+// simply has nothing to show, and exists says which it was. truncated reports
+// whether lines were dropped off the front.
 //
 // ponytail: reads the whole file, then keeps the tail. Stage logs are capped by
 // the executor, so this is bounded in practice; switch to a seek-from-end
 // reader if a stage ever streams gigabytes.
-func (f RunFolder) ReadLogTail(stageID string, n int) (content string, exists bool, err error) {
+func (f RunFolder) ReadLogTail(stageID string, n int) (content string, exists, truncated bool, err error) {
 	raw, err := os.ReadFile(f.LogPath(stageID))
 	if errors.Is(err, os.ErrNotExist) {
-		return "", false, nil
+		return "", false, false, nil
 	}
 	if err != nil {
-		return "", false, fmt.Errorf("read stage log %s: %w", stageID, err)
+		return "", false, false, fmt.Errorf("read stage log %s: %w", stageID, err)
 	}
-	return tailLines(string(raw), n), true, nil
+	tail := tailLines(string(raw), n)
+	return tail, true, len(tail) < len(raw), nil
 }
 
 // tailLines keeps the last n lines of s, preserving its trailing newline.

--- a/backend/internal/pipeline/runfolder.go
+++ b/backend/internal/pipeline/runfolder.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -95,6 +96,74 @@ func (f RunFolder) OutputPath(stage *Stage) string {
 // executors always capture one.
 func (f RunFolder) LogPath(stageID string) string {
 	return filepath.Join(f.Dir, stageLogsDir, stageID+".log")
+}
+
+// ErrOutputNotDeclared means the requested filename is not the `produces` of
+// any stage in the run. It is the whole authorization rule for the outputs
+// endpoint: the declared set is a closed allowlist, so a filename that is not
+// in it never becomes a path at all.
+var ErrOutputNotDeclared = errors.New("pipeline run declares no such output")
+
+// DeclaredOutput resolves one declared artifact filename to its path inside the
+// run folder, or ErrOutputNotDeclared.
+//
+// The filename is matched against the run's `produces` set by exact string
+// equality and never joined onto the folder as caller input. That is what makes
+// traversal ("../../id_rsa"), absolute paths and encoded separators
+// unreachable rather than merely filtered: validation guarantees every declared
+// `produces` is a bare filename, so anything that matches one is a bare
+// filename too.
+func (f RunFolder) DeclaredOutput(p *Pipeline, filename string) (string, error) {
+	if p == nil || filename == "" {
+		return "", ErrOutputNotDeclared
+	}
+	for i := range p.Stages {
+		if p.Stages[i].Produces != filename {
+			continue
+		}
+		// Belt and braces: a definition frozen by an older build, or hand-edited
+		// in the run folder, could carry a `produces` the current validator
+		// would reject. Re-check rather than trust the frozen copy.
+		if checkPathComponent("output filename", filename) != nil {
+			return "", ErrOutputNotDeclared
+		}
+		return filepath.Join(f.Dir, agentOutputsDir, filename), nil
+	}
+	return "", ErrOutputNotDeclared
+}
+
+// ReadLogTail returns the last n lines of a stage's log, or the whole log when
+// n <= 0. A missing log is not an error: a stage that has not started yet
+// simply has nothing to show, and the second return value says which it was.
+//
+// ponytail: reads the whole file, then keeps the tail. Stage logs are capped by
+// the executor, so this is bounded in practice; switch to a seek-from-end
+// reader if a stage ever streams gigabytes.
+func (f RunFolder) ReadLogTail(stageID string, n int) (content string, exists bool, err error) {
+	raw, err := os.ReadFile(f.LogPath(stageID))
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("read stage log %s: %w", stageID, err)
+	}
+	return tailLines(string(raw), n), true, nil
+}
+
+// tailLines keeps the last n lines of s, preserving its trailing newline.
+func tailLines(s string, n int) string {
+	if n <= 0 || s == "" {
+		return s
+	}
+	body, trailer := s, ""
+	if strings.HasSuffix(body, "\n") {
+		body, trailer = body[:len(body)-1], "\n"
+	}
+	lines := strings.Split(body, "\n")
+	if len(lines) <= n {
+		return s
+	}
+	return strings.Join(lines[len(lines)-n:], "\n") + trailer
 }
 
 // WriteRunJSON writes a pretty-printed projection of the run state. SQLite

--- a/backend/internal/pipeline/runfolder_test.go
+++ b/backend/internal/pipeline/runfolder_test.go
@@ -370,17 +370,18 @@ func TestReadLogTail(t *testing.T) {
 	}
 
 	tests := []struct {
-		n    int
-		want string
+		n             int
+		want          string
+		wantTruncated bool
 	}{
-		{0, "one\ntwo\nthree\n"},
-		{-1, "one\ntwo\nthree\n"},
-		{2, "two\nthree\n"},
-		{99, "one\ntwo\nthree\n"},
-		{1, "three\n"},
+		{0, "one\ntwo\nthree\n", false},
+		{-1, "one\ntwo\nthree\n", false},
+		{2, "two\nthree\n", true},
+		{99, "one\ntwo\nthree\n", false},
+		{1, "three\n", true},
 	}
 	for _, tc := range tests {
-		got, exists, tailErr := f.ReadLogTail("review", tc.n)
+		got, exists, truncated, tailErr := f.ReadLogTail("review", tc.n)
 		if tailErr != nil {
 			t.Fatalf("ReadLogTail(%d): %v", tc.n, tailErr)
 		}
@@ -390,6 +391,9 @@ func TestReadLogTail(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("ReadLogTail(%d) = %q, want %q", tc.n, got, tc.want)
 		}
+		if truncated != tc.wantTruncated {
+			t.Errorf("ReadLogTail(%d) truncated = %v, want %v", tc.n, truncated, tc.wantTruncated)
+		}
 	}
 }
 
@@ -398,7 +402,7 @@ func TestReadLogTailMissingLogIsNotAnError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateRunFolder: %v", err)
 	}
-	content, exists, err := f.ReadLogTail("never-started", 10)
+	content, exists, _, err := f.ReadLogTail("never-started", 10)
 	if err != nil {
 		t.Fatalf("ReadLogTail: %v", err)
 	}

--- a/backend/internal/pipeline/runfolder_test.go
+++ b/backend/internal/pipeline/runfolder_test.go
@@ -297,3 +297,112 @@ func hasIndentedLine(raw []byte) bool {
 	}
 	return false
 }
+
+// ---------------------------------------------------------------------------
+// Declared outputs: the outputs endpoint's whole authorization rule
+// ---------------------------------------------------------------------------
+
+func TestDeclaredOutputResolvesADeclaredFilename(t *testing.T) {
+	f := RunFolder{Dir: t.TempDir()}
+	p, err := ParseDefinition([]byte(sampleDefYAML))
+	if err != nil {
+		t.Fatalf("ParseDefinition: %v", err)
+	}
+
+	got, err := f.DeclaredOutput(p, "review.md")
+	if err != nil {
+		t.Fatalf("DeclaredOutput: %v", err)
+	}
+	if want := filepath.Join(f.Dir, "agent-outputs", "review.md"); got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+}
+
+func TestDeclaredOutputRejectsEverythingElse(t *testing.T) {
+	f := RunFolder{Dir: t.TempDir()}
+	p, err := ParseDefinition([]byte(sampleDefYAML))
+	if err != nil {
+		t.Fatalf("ParseDefinition: %v", err)
+	}
+
+	// Traversal, absolute paths, separators, near-misses and the run folder's
+	// own files are all the same answer: not declared, so not servable.
+	for _, name := range []string{
+		"", ".", "..", "../definition.yaml", "../../../etc/passwd",
+		"/etc/passwd", `..\..\secrets`, "agent-outputs/review.md",
+		"review.md/../../run.json", "run.json", "definition.yaml",
+		"Review.md", "review.md ", "review",
+	} {
+		if _, err := f.DeclaredOutput(p, name); err == nil {
+			t.Errorf("DeclaredOutput(%q) resolved, want rejection", name)
+		}
+	}
+}
+
+func TestDeclaredOutputRejectsATraversingProduces(t *testing.T) {
+	// A frozen definition from an older build could carry a `produces` the
+	// current validator rejects. Matching it must still not yield a path.
+	f := RunFolder{Dir: t.TempDir()}
+	p := &Pipeline{Stages: []Stage{{ID: "s", Produces: "../../run.json"}}}
+
+	if _, err := f.DeclaredOutput(p, "../../run.json"); err == nil {
+		t.Fatal("a traversing produces resolved, want rejection")
+	}
+}
+
+func TestDeclaredOutputOnANilPipeline(t *testing.T) {
+	if _, err := (RunFolder{Dir: t.TempDir()}).DeclaredOutput(nil, "review.md"); err == nil {
+		t.Fatal("nil pipeline resolved, want rejection")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Log tail
+// ---------------------------------------------------------------------------
+
+func TestReadLogTail(t *testing.T) {
+	f, err := CreateRunFolder(t.TempDir(), "proj-1", RunID("run-1"), []byte(sampleDefYAML))
+	if err != nil {
+		t.Fatalf("CreateRunFolder: %v", err)
+	}
+	if err := os.WriteFile(f.LogPath("review"), []byte("one\ntwo\nthree\n"), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, "one\ntwo\nthree\n"},
+		{-1, "one\ntwo\nthree\n"},
+		{2, "two\nthree\n"},
+		{99, "one\ntwo\nthree\n"},
+		{1, "three\n"},
+	}
+	for _, tc := range tests {
+		got, exists, tailErr := f.ReadLogTail("review", tc.n)
+		if tailErr != nil {
+			t.Fatalf("ReadLogTail(%d): %v", tc.n, tailErr)
+		}
+		if !exists {
+			t.Fatalf("ReadLogTail(%d): exists = false", tc.n)
+		}
+		if got != tc.want {
+			t.Errorf("ReadLogTail(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}
+
+func TestReadLogTailMissingLogIsNotAnError(t *testing.T) {
+	f, err := CreateRunFolder(t.TempDir(), "proj-1", RunID("run-1"), []byte(sampleDefYAML))
+	if err != nil {
+		t.Fatalf("CreateRunFolder: %v", err)
+	}
+	content, exists, err := f.ReadLogTail("never-started", 10)
+	if err != nil {
+		t.Fatalf("ReadLogTail: %v", err)
+	}
+	if exists || content != "" {
+		t.Fatalf("exists = %v, content = %q, want false and empty", exists, content)
+	}
+}

--- a/backend/internal/service/pipeline/pipeline.go
+++ b/backend/internal/service/pipeline/pipeline.go
@@ -44,6 +44,11 @@ type Store interface {
 	DeletePipelineDefinition(ctx context.Context, id pipeline.ID) (bool, error)
 
 	ListPipelineRuns(ctx context.Context, projectID domain.ProjectID, filter pipeline.RunFilter) ([]pipeline.RunState, error)
+
+	// Sessions and their PRs are how a manual trigger resolves a PR subject
+	// server-side: the pr table reaches a project only through its session.
+	ListSessions(ctx context.Context, projectID domain.ProjectID) ([]domain.SessionRecord, error)
+	ListPRsBySession(ctx context.Context, sessionID domain.SessionID) ([]domain.PullRequest, error)
 }
 
 // Engine is the subset of the per-project engine actor the request handlers
@@ -75,14 +80,18 @@ func (s supervisorEngines) For(ctx context.Context, projectID domain.ProjectID) 
 	return eng, nil
 }
 
-// TriggerInput is a manual trigger: which definition, and optionally the
-// session the run is about.
+// TriggerInput is a manual trigger: which definition, and optionally what the
+// run is about.
 type TriggerInput struct {
 	// Ref is the definition id or name to run.
 	Ref string
 	// SessionID makes the run a session-subject run. Empty makes it a
 	// project-subject run, which is first-class (spec section 4).
 	SessionID string
+	// PRNumber makes the run a PR-subject run. It wins over SessionID, because
+	// a PR subject already carries the session tracking it when there is one,
+	// and a PR subject is the more specific of the two. Zero means no PR.
+	PRNumber int
 }
 
 // Manager is the pipelines service the HTTP controller and the lifecycle merge
@@ -93,13 +102,19 @@ type Manager interface {
 	CreateDefinition(ctx context.Context, projectID domain.ProjectID, yamlSource string) (pipeline.Definition, error)
 	UpdateDefinition(ctx context.Context, id pipeline.ID, yamlSource string) (pipeline.Definition, error)
 	DeleteDefinition(ctx context.Context, id pipeline.ID) error
-	ValidateDefinition(ctx context.Context, projectID domain.ProjectID, yamlSource string) (valid bool, issues []pipeline.Issue, err error)
+	ValidateDefinition(ctx context.Context, projectID domain.ProjectID, yamlSource string) (valid bool, issues, warnings []pipeline.Issue, err error)
 	ConfigSchema() []byte
 
 	ListRuns(ctx context.Context, projectID domain.ProjectID, filter pipeline.RunFilter) ([]pipeline.RunState, error)
 	GetRun(ctx context.Context, id pipeline.RunID) (pipeline.RunState, error)
 	TriggerRun(ctx context.Context, projectID domain.ProjectID, in TriggerInput) (pipeline.RunID, error)
 	CancelRun(ctx context.Context, projectID domain.ProjectID, id pipeline.RunID) (pipeline.RunState, error)
+	// StageLog reads a stage's captured stdout+stderr out of the run folder,
+	// tailed to the last tailLines lines (0 for the whole log).
+	StageLog(ctx context.Context, runID pipeline.RunID, stageID string, tailLines int) (StageLog, error)
+	// RunOutput reads one declared `produces` artifact out of the run folder.
+	// The filename is authorized against the run's frozen declared set.
+	RunOutput(ctx context.Context, runID pipeline.RunID, filename string) (RunOutput, error)
 
 	// PRBlocksMerge reports whether a PR's pipeline runs block it from merging.
 	// It is the read side of the lifecycle merge-readiness gate.
@@ -292,21 +307,25 @@ func (s *Service) DeleteDefinition(ctx context.Context, id pipeline.ID) error {
 // ValidateDefinition dry-runs the parser over the raw YAML and reports the
 // outcome as data, never an error envelope: the editor wants the issue list as
 // a result. Persists nothing.
-func (s *Service) ValidateDefinition(ctx context.Context, projectID domain.ProjectID, yamlSource string) (bool, []pipeline.Issue, error) {
-	cfg, err := pipeline.ParseDefinition([]byte(yamlSource))
+//
+// Warnings come back on their own channel and survive an invalid document: a
+// pipeline can be both unsaveable and worth a second look, and the editor
+// renders the two lists differently.
+func (s *Service) ValidateDefinition(ctx context.Context, projectID domain.ProjectID, yamlSource string) (bool, []pipeline.Issue, []pipeline.Issue, error) {
+	cfg, warnings, err := pipeline.ParseDefinitionWithWarnings([]byte(yamlSource))
 	if err != nil {
-		return false, issuesFromError(err), nil
+		return false, issuesFromError(err), warnings, nil
 	}
 	if err := pipeline.ValidateCredentials(ctx, cfg, string(projectID), s.creds); err != nil {
 		var verr *pipeline.ValidationError
 		if errors.As(err, &verr) {
-			return false, verr.Issues, nil
+			return false, verr.Issues, warnings, nil
 		}
 		// A store failure is a real error: telling the author to fix a name that
 		// is fine would be worse than saying the check could not run.
-		return false, nil, err
+		return false, nil, nil, err
 	}
-	return true, nil, nil
+	return true, nil, warnings, nil
 }
 
 // ConfigSchema returns the JSON Schema for the definition document, which the
@@ -337,11 +356,17 @@ func (s *Service) GetRun(ctx context.Context, id pipeline.RunID) (pipeline.RunSt
 // TriggerRun resolves the definition reference (id first, then name within the
 // project) and starts a run through the project engine.
 //
-// The subject is resolved here: a session id makes it a session subject, and
-// nothing makes it a project subject. PR subjects arrive through the trigger
-// bridge; a manual PR trigger lands with the run API pass.
+// The subject is resolved server-side, never taken from the caller: a PR number
+// is looked up against the project's tracked PRs so the run carries the real
+// head SHA, branches and fork provenance. The fork flag in particular decides
+// whether any credential is injected anywhere in the run (spec section 8), so
+// letting a client assert it would be a hole.
 func (s *Service) TriggerRun(ctx context.Context, projectID domain.ProjectID, in TriggerInput) (pipeline.RunID, error) {
 	def, err := s.resolveDefinition(ctx, projectID, in.Ref)
+	if err != nil {
+		return "", err
+	}
+	subject, err := s.resolveSubject(ctx, projectID, in)
 	if err != nil {
 		return "", err
 	}
@@ -349,15 +374,67 @@ func (s *Service) TriggerRun(ctx context.Context, projectID domain.ProjectID, in
 	if err != nil {
 		return "", err
 	}
-	subject := pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: string(projectID)}
-	if in.SessionID != "" {
-		subject = pipeline.Subject{Kind: pipeline.SubjectSession, ProjectID: string(projectID), SessionID: in.SessionID}
-	}
 	runID, err := eng.TriggerRun(triggers.TriggerRequest{Definition: def, Event: "manual", Subject: subject})
 	if err != nil {
 		return "", apierr.Invalid("PIPELINE_TRIGGER_REJECTED", err.Error(), nil)
 	}
 	return runID, nil
+}
+
+// resolveSubject turns a manual trigger's optional pointers into the subject the
+// run is about: a PR when a number was given, else a session, else the project
+// (which is first-class, spec section 4).
+func (s *Service) resolveSubject(ctx context.Context, projectID domain.ProjectID, in TriggerInput) (pipeline.Subject, error) {
+	if in.PRNumber > 0 {
+		return s.prSubject(ctx, projectID, in.PRNumber)
+	}
+	if in.SessionID != "" {
+		return pipeline.Subject{Kind: pipeline.SubjectSession, ProjectID: string(projectID), SessionID: in.SessionID}, nil
+	}
+	return pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: string(projectID)}, nil
+}
+
+// prSubject looks up one tracked PR by number within the project.
+//
+// ponytail: the pr table is keyed by url and reaches a project only through the
+// session that tracks it, so this walks the project's sessions. Manual triggers
+// are a human clicking a button; add a project-scoped PR query if that stops
+// being true.
+func (s *Service) prSubject(ctx context.Context, projectID domain.ProjectID, number int) (pipeline.Subject, error) {
+	sessions, err := s.store.ListSessions(ctx, projectID)
+	if err != nil {
+		return pipeline.Subject{}, err
+	}
+	for _, sess := range sessions {
+		prs, err := s.store.ListPRsBySession(ctx, sess.ID)
+		if err != nil {
+			return pipeline.Subject{}, err
+		}
+		for _, pr := range prs {
+			if pr.Number != number {
+				continue
+			}
+			return pipeline.Subject{
+				Kind:      pipeline.SubjectPR,
+				ProjectID: string(projectID),
+				SessionID: string(pr.SessionID),
+				PR: &pipeline.PRRef{
+					Number:     pr.Number,
+					Repo:       pr.Repo,
+					URL:        pr.URL,
+					HeadSHA:    pr.HeadSHA,
+					HeadBranch: pr.SourceBranch,
+					BaseBranch: pr.TargetBranch,
+					// Unknown provenance is treated as a fork: identity-only is
+					// the fail-safe answer when nobody can say where the head
+					// lives (decision D17).
+					FromFork: pr.IsFromFork == nil || *pr.IsFromFork,
+				},
+			}, nil
+		}
+	}
+	return pipeline.Subject{}, apierr.NotFound("PIPELINE_PR_NOT_FOUND",
+		fmt.Sprintf("this project tracks no pull request #%d", number))
 }
 
 // CancelRun tears an in-flight run down through the project engine and returns

--- a/backend/internal/service/pipeline/runfiles.go
+++ b/backend/internal/service/pipeline/runfiles.go
@@ -1,0 +1,129 @@
+package pipelinesvc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+)
+
+// Run-folder read errors. The controller maps them onto the log and output
+// routes: 404 for all four, because "no such run", "no such stage", "that file
+// is not a declared output" and "it has not been written yet" are all the same
+// answer to a caller asking for a URL that serves nothing.
+var (
+	// ErrRunFolderMissing means the run carries no run folder, so there is
+	// nothing on disk to read. A run that failed before its folder was created
+	// looks like this.
+	ErrRunFolderMissing = errors.New("pipeline run has no run folder")
+	// ErrStageLogMissing means the stage exists but has not written a log yet.
+	ErrStageLogMissing = errors.New("pipeline stage has no log yet")
+	// ErrOutputMissing means the filename is a declared output of the run, but
+	// the file is not on disk (the producing stage has not run, or settled
+	// no_output).
+	ErrOutputMissing = errors.New("pipeline run output has not been written")
+)
+
+// maxOutputBytes caps what the outputs endpoint will read into memory. Declared
+// artifacts are agent-written markdown, so this is a guard rail against a rogue
+// producer rather than a real limit anyone should hit.
+const maxOutputBytes = 32 << 20
+
+// StageLog is one stage's captured stdout and stderr.
+type StageLog struct {
+	StageID string
+	Content string
+	// TailLines is the number of trailing lines requested, 0 for the whole log.
+	TailLines int
+	// Truncated says the content is a tail rather than the complete log.
+	Truncated bool
+}
+
+// RunOutput is one declared artifact, read from the run folder.
+type RunOutput struct {
+	Filename string
+	Content  []byte
+}
+
+// StageLog reads a stage's log from the run folder, keeping the last tailLines
+// lines (0 or less for the whole log).
+func (s *Service) StageLog(ctx context.Context, runID pipeline.RunID, stageID string, tailLines int) (StageLog, error) {
+	run, err := s.GetRun(ctx, runID)
+	if err != nil {
+		return StageLog{}, err
+	}
+	if stage, ok := run.Stages[stageID]; !ok || stage == nil {
+		return StageLog{}, fmt.Errorf("%w: %s/%s", ErrStageNotFound, runID, stageID)
+	}
+	folder, err := runFolder(run)
+	if err != nil {
+		return StageLog{}, err
+	}
+
+	content, exists, truncated, err := folder.ReadLogTail(stageID, tailLines)
+	if err != nil {
+		return StageLog{}, err
+	}
+	if !exists {
+		return StageLog{}, fmt.Errorf("%w: %s/%s", ErrStageLogMissing, runID, stageID)
+	}
+	return StageLog{StageID: stageID, Content: content, TailLines: tailLines, Truncated: truncated}, nil
+}
+
+// RunOutput reads one declared artifact out of the run's agent-outputs
+// directory.
+//
+// filename is checked against the run's frozen `produces` set before it is
+// resolved to a path at all, so an undeclared name, a traversal or an absolute
+// path never reaches the filesystem. The resolved path must then be a regular
+// file, which is what stops a symlink planted in agent-outputs from serving
+// something outside the run folder.
+func (s *Service) RunOutput(ctx context.Context, runID pipeline.RunID, filename string) (RunOutput, error) {
+	run, err := s.GetRun(ctx, runID)
+	if err != nil {
+		return RunOutput{}, err
+	}
+	folder, err := runFolder(run)
+	if err != nil {
+		return RunOutput{}, err
+	}
+	path, err := folder.DeclaredOutput(&run.Def, filename)
+	if err != nil {
+		return RunOutput{}, err
+	}
+
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return RunOutput{}, fmt.Errorf("%w: %s/%s", ErrOutputMissing, runID, filename)
+	}
+	if err != nil {
+		return RunOutput{}, fmt.Errorf("stat pipeline output %s: %w", filename, err)
+	}
+	// Lstat, not Stat: a symlink is not a regular file, so this rejects one
+	// rather than following it out of the run folder.
+	if !info.Mode().IsRegular() {
+		return RunOutput{}, fmt.Errorf("%w: %s/%s is not a regular file", pipeline.ErrOutputNotDeclared, runID, filename)
+	}
+	if info.Size() > maxOutputBytes {
+		return RunOutput{}, fmt.Errorf("pipeline output %s is %d bytes, over the %d byte limit", filename, info.Size(), maxOutputBytes)
+	}
+
+	content, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return RunOutput{}, fmt.Errorf("%w: %s/%s", ErrOutputMissing, runID, filename)
+	}
+	if err != nil {
+		return RunOutput{}, fmt.Errorf("read pipeline output %s: %w", filename, err)
+	}
+	return RunOutput{Filename: filename, Content: content}, nil
+}
+
+// runFolder is the run's directory on disk, or ErrRunFolderMissing.
+func runFolder(run pipeline.RunState) (pipeline.RunFolder, error) {
+	if run.RunDir == "" {
+		return pipeline.RunFolder{}, fmt.Errorf("%w: %s", ErrRunFolderMissing, run.RunID)
+	}
+	return pipeline.RunFolder{Dir: run.RunDir}, nil
+}

--- a/backend/internal/service/pipeline/runfiles_test.go
+++ b/backend/internal/service/pipeline/runfiles_test.go
@@ -1,0 +1,220 @@
+package pipelinesvc_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline"
+	pipelinesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+const runFilesYAML = `name: review
+stages:
+  - id: review
+    executor: agent
+    agent: claude
+    prompt: review the diff
+    produces: review.md
+    on_success: publish
+  - id: publish
+    executor: command
+    run: make publish
+`
+
+// newRunFilesService stands up a real store and a real run folder on disk, so
+// the traversal and symlink checks run against a filesystem rather than a mock.
+func newRunFilesService(t *testing.T) (*pipelinesvc.Service, pipeline.RunFolder) {
+	t.Helper()
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "proj", Path: t.TempDir(), RegisteredAt: now}); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+
+	folder, err := pipeline.CreateRunFolder(t.TempDir(), "proj", "run-1", []byte(runFilesYAML))
+	if err != nil {
+		t.Fatalf("create run folder: %v", err)
+	}
+	def, err := pipeline.ParseDefinition([]byte(runFilesYAML))
+	if err != nil {
+		t.Fatalf("parse definition: %v", err)
+	}
+
+	run := pipeline.RunState{
+		RunID:        "run-1",
+		ProjectID:    "proj",
+		PipelineID:   "pl-1",
+		PipelineName: "review",
+		Subject:      pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: "proj"},
+		Status:       pipeline.RunRunning,
+		RunDir:       folder.Dir,
+		Def:          *def,
+		Stages: map[string]*pipeline.StageState{
+			"review":  {ID: "review", Outcome: pipeline.OutcomeRunning, Attempt: 1, EnteredVia: pipeline.EntryTrigger, StartedAt: now},
+			"publish": {ID: "publish", Outcome: pipeline.OutcomePending},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := store.SavePipelineRun(ctx, run); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	return pipelinesvc.New(store), folder
+}
+
+// ---------------------------------------------------------------------------
+// Outputs: the endpoint is a file server pointed at a user-influenced path
+// ---------------------------------------------------------------------------
+
+func TestRunOutput_ServesADeclaredArtifact(t *testing.T) {
+	svc, folder := newRunFilesService(t)
+	writeOutput(t, folder, "review.md", "# findings\n")
+
+	got, err := svc.RunOutput(context.Background(), "run-1", "review.md")
+	if err != nil {
+		t.Fatalf("RunOutput: %v", err)
+	}
+	if got.Filename != "review.md" || string(got.Content) != "# findings\n" {
+		t.Fatalf("output = %+v", got)
+	}
+}
+
+// Every one of these is a filename a caller could put in the URL. None of them
+// may resolve, and the reason must not depend on whether the target exists.
+func TestRunOutput_RejectsTraversalAbsoluteAndUndeclaredNames(t *testing.T) {
+	svc, folder := newRunFilesService(t)
+	writeOutput(t, folder, "review.md", "# findings\n")
+	// Real files just outside the allowlist, so a leak would be observable.
+	if err := os.WriteFile(filepath.Join(folder.Dir, "secret.txt"), []byte("shh"), 0o600); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+
+	for _, name := range []string{
+		"",
+		".",
+		"..",
+		"../secret.txt",
+		"../../../etc/passwd",
+		"/etc/passwd",
+		`..\..\secret.txt`,
+		"agent-outputs/review.md",
+		"review.md/../../run.json",
+		"./review.md",
+		"definition.yaml",
+		"run.json",
+		"secret.txt",
+		"review.md\x00.png",
+		"Review.md",
+	} {
+		_, err := svc.RunOutput(context.Background(), "run-1", name)
+		if !errors.Is(err, pipeline.ErrOutputNotDeclared) {
+			t.Errorf("RunOutput(%q) err = %v, want ErrOutputNotDeclared", name, err)
+		}
+	}
+}
+
+// A symlink planted in agent-outputs under the declared name is the one way a
+// declared filename could still point outside the run folder.
+func TestRunOutput_RejectsASymlinkEscape(t *testing.T) {
+	svc, folder := newRunFilesService(t)
+	outside := filepath.Join(t.TempDir(), "id_rsa")
+	if err := os.WriteFile(outside, []byte("PRIVATE KEY"), 0o600); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(folder.Dir, "agent-outputs", "review.md")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	_, err := svc.RunOutput(context.Background(), "run-1", "review.md")
+	if !errors.Is(err, pipeline.ErrOutputNotDeclared) {
+		t.Fatalf("err = %v, want ErrOutputNotDeclared", err)
+	}
+}
+
+// A directory named like the artifact is the same class of trick.
+func TestRunOutput_RejectsADirectory(t *testing.T) {
+	svc, folder := newRunFilesService(t)
+	if err := os.Mkdir(filepath.Join(folder.Dir, "agent-outputs", "review.md"), 0o750); err != nil {
+		t.Fatalf("seed dir: %v", err)
+	}
+
+	if _, err := svc.RunOutput(context.Background(), "run-1", "review.md"); !errors.Is(err, pipeline.ErrOutputNotDeclared) {
+		t.Fatalf("err = %v, want ErrOutputNotDeclared", err)
+	}
+}
+
+func TestRunOutput_DeclaredButNotWrittenYet(t *testing.T) {
+	svc, _ := newRunFilesService(t)
+	if _, err := svc.RunOutput(context.Background(), "run-1", "review.md"); !errors.Is(err, pipelinesvc.ErrOutputMissing) {
+		t.Fatalf("err = %v, want ErrOutputMissing", err)
+	}
+}
+
+func TestRunOutput_UnknownRun(t *testing.T) {
+	svc, _ := newRunFilesService(t)
+	if _, err := svc.RunOutput(context.Background(), "run-nope", "review.md"); err == nil {
+		t.Fatal("an unknown run resolved an output")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Stage logs
+// ---------------------------------------------------------------------------
+
+func TestStageLog_TailsAndReportsTruncation(t *testing.T) {
+	svc, folder := newRunFilesService(t)
+	if err := os.WriteFile(folder.LogPath("review"), []byte("one\ntwo\nthree\n"), 0o600); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+	ctx := context.Background()
+
+	whole, err := svc.StageLog(ctx, "run-1", "review", 0)
+	if err != nil {
+		t.Fatalf("StageLog: %v", err)
+	}
+	if whole.Content != "one\ntwo\nthree\n" || whole.Truncated {
+		t.Fatalf("whole log = %+v", whole)
+	}
+
+	tail, err := svc.StageLog(ctx, "run-1", "review", 2)
+	if err != nil {
+		t.Fatalf("StageLog tail: %v", err)
+	}
+	if tail.Content != "two\nthree\n" || !tail.Truncated {
+		t.Fatalf("tail = %+v", tail)
+	}
+}
+
+func TestStageLog_Rejections(t *testing.T) {
+	svc, _ := newRunFilesService(t)
+	ctx := context.Background()
+
+	if _, err := svc.StageLog(ctx, "run-1", "nope", 0); !errors.Is(err, pipelinesvc.ErrStageNotFound) {
+		t.Errorf("unknown stage err = %v, want ErrStageNotFound", err)
+	}
+	if _, err := svc.StageLog(ctx, "run-1", "review", 0); !errors.Is(err, pipelinesvc.ErrStageLogMissing) {
+		t.Errorf("unwritten log err = %v, want ErrStageLogMissing", err)
+	}
+	if _, err := svc.StageLog(ctx, "run-nope", "review", 0); err == nil {
+		t.Error("an unknown run returned a log")
+	}
+}
+
+func writeOutput(t *testing.T, folder pipeline.RunFolder, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(folder.Dir, "agent-outputs", name), []byte(body), 0o600); err != nil {
+		t.Fatalf("write output %s: %v", name, err)
+	}
+}

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -349,40 +349,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Fetch one pipeline run artifact by id */
-        get: operations["getPipelineArtifact"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Change a pipeline finding's lifecycle status (dismiss, reopen, resolve) */
-        post: operations["updatePipelineArtifactStatus"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/v1/pipelines/runs/{runId}/cancel": {
         parameters: {
             query?: never;
@@ -400,17 +366,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/pipelines/runs/{runId}/resume": {
+    "/api/v1/pipelines/runs/{runId}/outputs/{filename}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** Download one artifact a stage declared with produces */
+        get: operations["getPipelineRunOutput"];
         put?: never;
-        /** Resume a stalled or failed pipeline run */
-        post: operations["resumePipelineRun"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pipelines/runs/{runId}/stages/{stageId}/log": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch a stage's captured stdout and stderr, optionally tailed */
+        get: operations["getPipelineStageLog"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1049,22 +1032,6 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        ControllersSignalPipelineStageRequest: {
-            /** @description Why the stage failed. Carried on the failure edge and shown in run detail. */
-            reason?: string;
-            /**
-             * @description How the stage settled: done | fail.
-             * @enum {string}
-             */
-            status: "done" | "fail";
-        };
-        ControllersSignalPipelineStageResponse: {
-            accepted: boolean;
-        };
-        ControllersUpdatePipelineArtifactStatusRequest: {
-            /** @description New artifact status: open | resolved | dismissed. */
-            status: string;
-        };
         DegradedProject: {
             id: string;
             kind: string;
@@ -1242,36 +1209,6 @@ export interface components {
             targetSha: string;
             title: string;
         };
-        PipelineArtifact: {
-            anchorSignature?: string;
-            artifactId: string;
-            belowConfidenceThreshold?: boolean;
-            category?: string;
-            /** Format: double */
-            confidence?: number;
-            /** Format: date-time */
-            createdAt: string;
-            data?: {
-                [key: string]: unknown;
-            };
-            description?: string;
-            endLine?: number;
-            filePath?: string;
-            fingerprint?: string;
-            kind: string;
-            pipelineRunId: string;
-            /** Format: date-time */
-            sentToAgentAt?: null | string;
-            severity?: string;
-            stageName: string;
-            stageRunId: string;
-            startLine?: number;
-            status: string;
-            title?: string;
-        };
-        PipelineArtifactResponse: {
-            artifact: components["schemas"]["PipelineArtifact"];
-        };
         PipelineDefinitionResponse: {
             definition: components["schemas"]["PipelineDefinitionSummary"];
         };
@@ -1285,25 +1222,38 @@ export interface components {
             updatedAt: string;
             yamlSource: string;
         };
+        PipelineProducedArtifact: {
+            exists: boolean;
+            name: string;
+        };
         PipelineRunDetail: {
-            blocksMerge: boolean;
+            cancelReason?: string;
             /** Format: date-time */
             createdAt: string;
-            findings: components["schemas"]["PipelineArtifact"][];
-            hasOpenFindings: boolean;
-            headSha: string;
-            loopRounds: number;
-            loopState: string;
+            headSha?: string;
             pipelineId: string;
             pipelineName: string;
+            prNumber?: number;
+            runDir?: string;
             runId: string;
-            sessionId: string;
+            sessionId?: string;
+            /** Format: date-time */
+            settledAt?: null | string;
             stageCount: number;
-            stageStatuses: {
+            stageOutcomes: {
                 [key: string]: string;
             } | null;
             stages: components["schemas"]["PipelineStageView"][];
-            terminationReason?: string;
+            /**
+             * @description Run-level rollup of the stage outcomes.
+             * @enum {string}
+             */
+            status: "pending" | "running" | "succeeded" | "failed" | "cancelled";
+            /**
+             * @description What the run is about.
+             * @enum {string}
+             */
+            subjectKind: "session" | "pr" | "project";
             /** Format: date-time */
             updatedAt: string;
         };
@@ -1311,40 +1261,60 @@ export interface components {
             run: components["schemas"]["PipelineRunDetail"];
         };
         PipelineRunSummary: {
-            blocksMerge: boolean;
+            cancelReason?: string;
             /** Format: date-time */
             createdAt: string;
-            hasOpenFindings: boolean;
-            headSha: string;
-            loopRounds: number;
-            loopState: string;
+            headSha?: string;
             pipelineId: string;
             pipelineName: string;
+            prNumber?: number;
             runId: string;
-            sessionId: string;
+            sessionId?: string;
+            /** Format: date-time */
+            settledAt?: null | string;
             stageCount: number;
-            stageStatuses: {
+            stageOutcomes: {
                 [key: string]: string;
             } | null;
-            terminationReason?: string;
+            /**
+             * @description Run-level rollup of the stage outcomes.
+             * @enum {string}
+             */
+            status: "pending" | "running" | "succeeded" | "failed" | "cancelled";
+            /**
+             * @description What the run is about.
+             * @enum {string}
+             */
+            subjectKind: "session" | "pr" | "project";
             /** Format: date-time */
             updatedAt: string;
         };
+        PipelineStageLogResponse: {
+            content: string;
+            runId: string;
+            stageId: string;
+            truncated: boolean;
+        };
         PipelineStageView: {
-            artifactIds: string[];
             attempt: number;
-            /** Format: date-time */
-            completedAt?: null | string;
-            errorMessage?: string;
-            notes?: string[];
-            output?: string;
+            /**
+             * @description Which edge started this stage.
+             * @enum {string}
+             */
+            enteredVia: "trigger" | "success" | "failure";
+            failedStage?: string;
+            /** @enum {string} */
+            outcome: "pending" | "running" | "succeeded" | "succeeded_unverified" | "failed" | "no_output" | "no_signal" | "timed_out" | "cancelled" | "skipped";
+            outputTail?: string;
+            producedArtifact?: components["schemas"]["PipelineProducedArtifact"];
+            reason?: string;
             sessionId?: string;
-            stageName: string;
-            stageRunId: string;
+            /** Format: date-time */
+            settledAt?: null | string;
+            stageId: string;
             /** Format: date-time */
             startedAt?: null | string;
-            status: string;
-            verdict?: string;
+            workspaceKind?: string;
         };
         PipelineValidationIssue: {
             /** @description Human-readable description of the problem. */
@@ -1630,6 +1600,18 @@ export interface components {
             title: string;
             workingDir: string;
         };
+        SignalPipelineStageRequest: {
+            /** @description Why the stage failed. Carried on the failure edge and shown in run detail. */
+            reason?: string;
+            /**
+             * @description How the stage settled: done | fail.
+             * @enum {string}
+             */
+            status: "done" | "fail";
+        };
+        SignalPipelineStageResponse: {
+            accepted: boolean;
+        };
         SpawnOrchestratorRequest: {
             clean?: boolean;
             projectId: string;
@@ -1678,11 +1660,11 @@ export interface components {
             repo?: string;
         };
         TriggerPipelineRunRequest: {
-            /** @description Head commit SHA to pin the run to. */
-            headSha?: string;
             /** @description Definition reference to run: its id or name. */
             pipeline: string;
-            /** @description Session id to scope the run's loop key. */
+            /** @description Run against this tracked pull request as the subject. */
+            prNumber?: number;
+            /** @description Run against this session as the subject. */
             sessionId?: string;
         };
         TriggerPipelineRunResponse: {
@@ -1703,6 +1685,7 @@ export interface components {
         ValidatePipelineDefinitionResponse: {
             issues: components["schemas"]["PipelineValidationIssue"][];
             valid: boolean;
+            warnings: components["schemas"]["PipelineValidationIssue"][];
         };
         WorkspaceFileResponse: {
             additions: number;
@@ -2783,8 +2766,8 @@ export interface operations {
                 project?: string;
                 /** @description Filter runs to one pipeline name. */
                 pipeline?: string;
-                /** @description Filter runs by loop state (running|awaiting_context|done|stalled|terminated). */
-                status?: string;
+                /** @description Filter runs by run status. */
+                status?: "pending" | "running" | "succeeded" | "failed" | "cancelled";
                 /** @description Cap the number of runs returned (newest first). */
                 limit?: null | number;
             };
@@ -2954,126 +2937,6 @@ export interface operations {
             };
         };
     };
-    getPipelineArtifact: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Pipeline run identifier. */
-                runId: string;
-                /** @description Artifact identifier. */
-                artifactId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PipelineArtifactResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["APIError"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["APIError"];
-                };
-            };
-            /** @description Not Implemented */
-            501: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["APIError"];
-                };
-            };
-        };
-    };
-    updatePipelineArtifactStatus: {
-        parameters: {
-            query?: {
-                /** @description Project id the pipeline belongs to (required). */
-                project?: string;
-            };
-            header?: never;
-            path: {
-                /** @description Pipeline run identifier. */
-                runId: string;
-                /** @description Artifact identifier. */
-                artifactId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllersUpdatePipelineArtifactStatusRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PipelineArtifactResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["APIError"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["APIError"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["APIError"];
-                };
-            };
-            /** @description Not Implemented */
-            501: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["APIError"];
-                };
-            };
-        };
-    };
     cancelPipelineRun: {
         parameters: {
             query?: {
@@ -3136,16 +2999,15 @@ export interface operations {
             };
         };
     };
-    resumePipelineRun: {
+    getPipelineRunOutput: {
         parameters: {
-            query?: {
-                /** @description Project id the pipeline belongs to (required). */
-                project?: string;
-            };
+            query?: never;
             header?: never;
             path: {
                 /** @description Pipeline run identifier. */
                 runId: string;
+                /** @description Artifact filename. Only a name the run's frozen definition declares as a stage's produces is served. */
+                filename: string;
             };
             cookie?: never;
         };
@@ -3157,7 +3019,62 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PipelineRunDetailResponse"];
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    getPipelineStageLog: {
+        parameters: {
+            query?: {
+                /** @description Return only the last N lines. Omitted returns the whole log. */
+                tail?: null | number;
+            };
+            header?: never;
+            path: {
+                /** @description Pipeline run identifier. */
+                runId: string;
+                /** @description Stage id as declared in the pipeline definition. */
+                stageId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PipelineStageLogResponse"];
                 };
             };
             /** @description Bad Request */
@@ -3212,7 +3129,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ControllersSignalPipelineStageRequest"];
+                "application/json": components["schemas"]["SignalPipelineStageRequest"];
             };
         };
         responses: {
@@ -3222,7 +3139,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ControllersSignalPipelineStageResponse"];
+                    "application/json": components["schemas"]["SignalPipelineStageResponse"];
                 };
             };
             /** @description Bad Request */

--- a/frontend/src/renderer/components/PipelineRunCard.tsx
+++ b/frontend/src/renderer/components/PipelineRunCard.tsx
@@ -9,7 +9,6 @@ import {
 	stageOutcomesOf,
 } from "../lib/pipeline-display";
 import type { PipelineRunSummary } from "../hooks/usePipelineRuns";
-import { Badge } from "./ui/badge";
 
 // Card view of a single pipeline run in a Kanban column: pipeline name, run
 // status, session, per-stage outcome dots, an unverified-success hint, and a
@@ -30,11 +29,6 @@ export function PipelineRunCard({ run, onOpen }: { run: PipelineRunSummary; onOp
 		>
 			<div className="flex items-baseline gap-2">
 				<span className="truncate font-mono text-caption font-semibold text-foreground">{run.pipelineName}</span>
-				{run.blocksMerge && (
-					<Badge variant="error" className="shrink-0">
-						Blocks merge
-					</Badge>
-				)}
 				<span className={cn("ml-auto text-micro font-medium", runStatusTone(status))}>{status}</span>
 			</div>
 			<div className="flex items-center gap-2 font-mono text-micro text-passive">

--- a/frontend/src/renderer/components/PipelineRunDetail.test.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PipelineRunDetail } from "./PipelineRunDetail";
-import type { PipelineArtifact, PipelineRunDetail as RunDetail } from "../hooks/usePipelineRuns";
+import type { PipelineRunDetail as RunDetail } from "../hooks/usePipelineRuns";
 
 const { usePipelineRunMock, postMock, navigateMock } = vi.hoisted(() => ({
 	usePipelineRunMock: vi.fn(),
@@ -25,24 +25,11 @@ vi.mock("@tanstack/react-router", () => ({
 
 type StageView = RunDetail["stages"][number];
 
-function stage(overrides: Partial<StageView> & { stageName: string }): StageView {
+function stage(overrides: Partial<StageView> & { stageId: string }): StageView {
 	return {
-		stageRunId: `sr-${overrides.stageName}`,
-		status: "succeeded",
+		outcome: "succeeded",
 		attempt: 1,
-		artifactIds: [],
-		...overrides,
-	};
-}
-
-function finding(overrides: Partial<PipelineArtifact> & { artifactId: string }): PipelineArtifact {
-	return {
-		kind: "finding",
-		pipelineRunId: "run-1",
-		stageRunId: "sr-1",
-		stageName: "review",
-		status: "open",
-		createdAt: "2026-07-15T00:00:00Z",
+		enteredVia: "success",
 		...overrides,
 	};
 }
@@ -52,15 +39,12 @@ function detail(overrides: Partial<RunDetail>): RunDetail {
 		runId: "run-1",
 		pipelineId: "def-1",
 		pipelineName: "review",
+		status: "running",
+		subjectKind: "session",
 		sessionId: "sess-1",
-		loopState: "running",
-		loopRounds: 2,
 		headSha: "abcdef1234567890",
 		stageCount: 1,
-		stageStatuses: { review: "running" },
-		hasOpenFindings: false,
-		blocksMerge: false,
-		findings: [],
+		stageOutcomes: { review: "running" },
 		stages: [],
 		createdAt: "2026-07-15T00:00:00Z",
 		updatedAt: "2026-07-15T00:00:00Z",
@@ -89,42 +73,58 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("PipelineRunDetail", () => {
-	it("renders each stage with status, attempt, verdict, and error message", () => {
+	it("renders each stage with its outcome, attempt and reason", () => {
 		setRun(
 			detail({
-				stages: [stage({ stageName: "lint", status: "failed", attempt: 2, verdict: "fail", errorMessage: "exit 1" })],
+				stages: [stage({ stageId: "lint", outcome: "failed", attempt: 2, reason: "exit 1" })],
 			}),
 		);
 		renderDetail("proj-1");
 
 		const row = screen.getByText("lint").closest("[data-stage]") as HTMLElement;
 		expect(within(row).getByText("failed")).toBeInTheDocument();
-		expect(within(row).getByText("attempt 2")).toBeInTheDocument();
-		expect(within(row).getByText("fail")).toBeInTheDocument();
+		// Attempt 2 is the one nudge a stage gets, and it is labelled as such.
+		expect(within(row).getByText(/attempt 2/)).toBeInTheDocument();
+		expect(within(row).getByText(/nudged/)).toBeInTheDocument();
 		expect(within(row).getByText("exit 1")).toBeInTheDocument();
 	});
 
-	it("hides dismissed findings until the show-dismissed toggle is on", async () => {
+	it("spells succeeded_unverified the way the spec does", () => {
+		setRun(detail({ stages: [stage({ stageId: "answer", outcome: "succeeded_unverified" })] }));
+		renderDetail("proj-1");
+
+		const row = screen.getByText("answer").closest("[data-stage]") as HTMLElement;
+		expect(within(row).getByText("succeeded (unverified)")).toBeInTheDocument();
+	});
+
+	it("names a declared artifact and flags it when the engine did not find one", () => {
 		setRun(
 			detail({
-				findings: [
-					finding({ artifactId: "f1", title: "Open bug", filePath: "a.ts", startLine: 10, severity: "high" }),
-					finding({ artifactId: "f2", title: "Dismissed nit", status: "dismissed" }),
+				stages: [
+					stage({ stageId: "assess", outcome: "no_output", producedArtifact: { name: "review.md", exists: false } }),
+					stage({ stageId: "audit", outcome: "succeeded", producedArtifact: { name: "audit.md", exists: true } }),
 				],
 			}),
 		);
 		renderDetail("proj-1");
 
-		expect(screen.getByText("Open bug")).toBeInTheDocument();
-		expect(screen.getByText("a.ts:10")).toBeInTheDocument();
-		expect(screen.queryByText("Dismissed nit")).not.toBeInTheDocument();
+		const missing = screen.getByText("assess").closest("[data-stage]") as HTMLElement;
+		expect(within(missing).getByText("review.md (missing)")).toBeInTheDocument();
 
-		await userEvent.setup().click(screen.getByRole("switch"));
-		expect(screen.getByText("Dismissed nit")).toBeInTheDocument();
+		const present = screen.getByText("audit").closest("[data-stage]") as HTMLElement;
+		expect(within(present).getByText("audit.md")).toBeInTheDocument();
+	});
+
+	it("names the stage whose failure routed here", () => {
+		setRun(detail({ stages: [stage({ stageId: "notify", enteredVia: "failure", failedStage: "publish" })] }));
+		renderDetail("proj-1");
+
+		const row = screen.getByText("notify").closest("[data-stage]") as HTMLElement;
+		expect(within(row).getByText("via publish failing")).toBeInTheDocument();
 	});
 
 	it("cancels a running run with the run's project scope", async () => {
-		setRun(detail({ loopState: "running" }));
+		setRun(detail({ status: "running" }));
 		renderDetail("proj-7");
 
 		await userEvent.setup().click(screen.getByRole("button", { name: "Cancel" }));
@@ -135,57 +135,27 @@ describe("PipelineRunDetail", () => {
 		});
 	});
 
-	it("offers Resume for a stalled run and not Cancel", () => {
-		setRun(detail({ loopState: "stalled" }));
+	// v2 has no resume: a failed run is dead, and re-running means a new run.
+	it("offers no Cancel and no Resume on a settled run", () => {
+		setRun(detail({ status: "failed" }));
 		renderDetail("proj-1");
 
-		expect(screen.getByRole("button", { name: "Resume" })).toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Resume" })).not.toBeInTheDocument();
 	});
 
 	it("disables the action when the run's project is unknown", () => {
-		setRun(detail({ loopState: "running" }));
+		setRun(detail({ status: "running" }));
 		renderDetail(undefined);
 
 		expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
 	});
 
-	it("dismisses an open finding via the artifact-status endpoint", async () => {
-		setRun(detail({ findings: [finding({ artifactId: "f1", title: "Open bug" })] }));
-		renderDetail("proj-9");
+	it("shows the cancel reason next to a cancelled run's status", () => {
+		setRun(detail({ status: "cancelled", cancelReason: "superseded by a newer run" }));
+		renderDetail("proj-1");
 
-		const row = screen.getByText("Open bug").closest("[data-finding]") as HTMLElement;
-		await userEvent.setup().click(within(row).getByRole("button", { name: "Dismiss" }));
-
-		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
-		expect(postMock).toHaveBeenCalledWith("/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status", {
-			params: { path: { runId: "run-1", artifactId: "f1" }, query: { project: "proj-9" } },
-			body: { status: "dismissed" },
-		});
-	});
-
-	it("reopens a dismissed finding with status open", async () => {
-		setRun(detail({ findings: [finding({ artifactId: "f2", title: "Nit", status: "dismissed" })] }));
-		renderDetail("proj-9");
-
-		// Reveal the dismissed row first.
-		await userEvent.setup().click(screen.getByRole("switch"));
-		const row = screen.getByText("Nit").closest("[data-finding]") as HTMLElement;
-		await userEvent.setup().click(within(row).getByRole("button", { name: "Undo" }));
-
-		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
-		expect(postMock).toHaveBeenCalledWith("/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status", {
-			params: { path: { runId: "run-1", artifactId: "f2" }, query: { project: "proj-9" } },
-			body: { status: "open" },
-		});
-	});
-
-	it("disables the dismiss button when the run's project is unknown", () => {
-		setRun(detail({ findings: [finding({ artifactId: "f1", title: "Open bug" })] }));
-		renderDetail(undefined);
-
-		const row = screen.getByText("Open bug").closest("[data-finding]") as HTMLElement;
-		expect(within(row).getByRole("button", { name: "Dismiss" })).toBeDisabled();
+		expect(screen.getByText("· superseded by a newer run")).toBeInTheDocument();
 	});
 
 	it("links the run-level session id to the session page", async () => {
@@ -205,11 +175,7 @@ describe("PipelineRunDetail", () => {
 	});
 
 	it("links a stage's session id to the session page", async () => {
-		setRun(
-			detail({
-				stages: [stage({ stageName: "fix", sessionId: "sess-fix-1" })],
-			}),
-		);
+		setRun(detail({ stages: [stage({ stageId: "fix", sessionId: "sess-fix-1" })] }));
 		renderDetail("proj-1");
 
 		const row = screen.getByText("fix").closest("[data-stage]") as HTMLElement;
@@ -217,29 +183,29 @@ describe("PipelineRunDetail", () => {
 		expect(navigateMock).toHaveBeenCalledWith({ to: "/sessions/$sessionId", params: { sessionId: "sess-fix-1" } });
 	});
 
-	it("does not render a stage session link when the stage has no sessionId (command/builtin stages)", () => {
-		setRun(detail({ stages: [stage({ stageName: "lint" })] }));
+	it("does not render a stage session link when the stage has no sessionId (command stages)", () => {
+		setRun(detail({ stages: [stage({ stageId: "lint" })] }));
 		renderDetail("proj-1");
 
 		const row = screen.getByText("lint").closest("[data-stage]") as HTMLElement;
 		expect(within(row).queryAllByRole("button")).toHaveLength(0);
 	});
 
-	it("renders stage notes as read-only annotations", () => {
+	// The API returns stages in the definition's document order, so the view must
+	// not re-sort them: a run reads top to bottom the way it was written.
+	it("renders stages in the order the API returned them", () => {
 		setRun(
 			detail({
-				stages: [
-					stage({
-						stageName: "triage",
-						notes: ["fork PR: findings skipped", "exit mode fell back to timeout"],
-					}),
-				],
+				stages: [stage({ stageId: "review" }), stage({ stageId: "assess" }), stage({ stageId: "publish" })],
 			}),
 		);
-		renderDetail("proj-1");
+		const { container } = render(
+			<QueryClientProvider client={new QueryClient()}>
+				<PipelineRunDetail runId="run-1" project="proj-1" />
+			</QueryClientProvider>,
+		);
 
-		const row = screen.getByText("triage").closest("[data-stage]") as HTMLElement;
-		expect(within(row).getByText("fork PR: findings skipped")).toBeInTheDocument();
-		expect(within(row).getByText("exit mode fell back to timeout")).toBeInTheDocument();
+		const ids = Array.from(container.querySelectorAll("[data-stage]")).map((el) => el.getAttribute("data-stage"));
+		expect(ids).toEqual(["review", "assess", "publish"]);
 	});
 });

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -1,58 +1,47 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { cn } from "../lib/utils";
 import { formatTimeCompact } from "../lib/format-time";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
-import { loopStateTone, severityBadgeVariant, shortSha, stageStatusDotTone } from "../lib/pipeline-display";
-import { pipelineRunQueryKey, usePipelineRun, type PipelineArtifact } from "../hooks/usePipelineRuns";
+import { runStatusTone, shortSha, stageOutcomeDotTone, stageOutcomeLabel } from "../lib/pipeline-display";
+import { pipelineRunQueryKey, usePipelineRun } from "../hooks/usePipelineRuns";
+import type { RunStatus, StageOutcome } from "../lib/pipeline-draft";
 import type { components } from "../../api/schema";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
-import { Switch } from "./ui/switch";
 
 type PipelineStageView = components["schemas"]["PipelineStageView"];
 
-// Read-only detail for one pipeline run: per-stage state, materialized findings,
-// and cancel/resume actions. No followup thread, no artifact editing — v1 detail
-// is observe-only beyond the two lifecycle buttons.
+// Read-only detail for one pipeline run: per-stage outcomes plus the one
+// lifecycle action v2 keeps. There is no resume (spec section 14.1) and no
+// findings panel: the findings subsystem is deleted, and a stage's contract is
+// its one declared artifact.
+//
+// Task 24 rewrites this into the full v2 surface: outcome badges, the nudge tag,
+// the collapsible log viewer over the stage log endpoint, artifact download
+// links over the outputs endpoint, and the orphaned-session affordance. This is
+// the mechanical port that keeps the build green on the v2 DTO.
 export function PipelineRunDetail({ runId, project }: { runId: string; project?: string }) {
 	const queryClient = useQueryClient();
 	const { data: run, isLoading, isError, error } = usePipelineRun(runId);
-	const [showDismissed, setShowDismissed] = useState(false);
 	const [actionError, setActionError] = useState<string | null>(null);
 
-	const refresh = () => {
-		void queryClient.invalidateQueries({ queryKey: pipelineRunQueryKey(runId) });
-		void queryClient.invalidateQueries({ queryKey: ["pipeline-runs"] });
-	};
-
-	const lifecycleMutation = (
-		path: "/api/v1/pipelines/runs/{runId}/cancel" | "/api/v1/pipelines/runs/{runId}/resume",
-	) => ({
+	const cancel = useMutation({
 		mutationFn: async () => {
 			if (!project) throw new Error("Project is unknown for this run");
-			const { error: apiError } = await apiClient.POST(path, {
+			const { error: apiError } = await apiClient.POST("/api/v1/pipelines/runs/{runId}/cancel", {
 				params: { path: { runId }, query: { project } },
 			});
 			if (apiError) throw new Error(apiErrorMessage(apiError));
 		},
 		onSuccess: () => {
 			setActionError(null);
-			refresh();
+			void queryClient.invalidateQueries({ queryKey: pipelineRunQueryKey(runId) });
+			void queryClient.invalidateQueries({ queryKey: ["pipeline-runs"] });
 		},
 		onError: (e: unknown) => setActionError(e instanceof Error ? e.message : "Action failed"),
 	});
-
-	const cancel = useMutation(lifecycleMutation("/api/v1/pipelines/runs/{runId}/cancel"));
-	const resume = useMutation(lifecycleMutation("/api/v1/pipelines/runs/{runId}/resume"));
-
-	const stages = useMemo(() => [...(run?.stages ?? [])].sort((a, b) => a.stageName.localeCompare(b.stageName)), [run]);
-	const findings = useMemo(() => {
-		const list = run?.findings ?? [];
-		return showDismissed ? list : list.filter((f) => f.status !== "dismissed");
-	}, [run, showDismissed]);
-	const dismissedCount = (run?.findings ?? []).filter((f) => f.status === "dismissed").length;
 
 	if (isLoading) {
 		return <p className="p-6 text-caption text-passive">Loading run…</p>;
@@ -65,8 +54,9 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 		);
 	}
 
-	const canCancel = run.loopState === "running" || run.loopState === "awaiting_context";
-	const canResume = run.loopState === "stalled";
+	// Stages arrive in plan order from the API; only a live run can be cancelled.
+	const stages = run.stages;
+	const canCancel = run.status === "pending" || run.status === "running";
 
 	return (
 		<div className="flex h-full min-h-0 flex-col overflow-y-auto bg-background text-foreground">
@@ -74,14 +64,15 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 				<div className="min-w-0">
 					<div className="flex items-center gap-2">
 						<h1 className="truncate text-subtitle font-bold tracking-tight text-foreground">{run.pipelineName}</h1>
-						<span className={cn("text-caption font-semibold", loopStateTone(run.loopState))}>{run.loopState}</span>
-						{run.terminationReason && <span className="text-caption text-passive">· {run.terminationReason}</span>}
-						{run.blocksMerge && <Badge variant="error">Blocks merge</Badge>}
+						<span className={cn("text-caption font-semibold", runStatusTone(run.status as RunStatus))}>
+							{run.status}
+						</span>
+						{run.cancelReason && <span className="text-caption text-passive">· {run.cancelReason}</span>}
 					</div>
 					<p className="mt-0.5 truncate font-mono text-micro text-passive">
-						{run.runId} · session {run.sessionId ? <SessionLink sessionId={run.sessionId} /> : "—"} ·{" "}
-						{shortSha(run.headSha)} · {run.loopRounds} round
-						{run.loopRounds === 1 ? "" : "s"} · updated {formatTimeCompact(run.updatedAt)}
+						{run.runId} · session {run.sessionId ? <SessionLink sessionId={run.sessionId} /> : "—"}
+						{run.prNumber ? ` · PR #${run.prNumber}` : ""}
+						{run.headSha ? ` · ${shortSha(run.headSha)}` : ""} · updated {formatTimeCompact(run.updatedAt)}
 					</p>
 				</div>
 				<div className="ml-auto flex items-center gap-2">
@@ -97,79 +88,50 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 							{cancel.isPending ? "Cancelling…" : "Cancel"}
 						</Button>
 					)}
-					{canResume && (
-						<Button
-							size="sm"
-							variant="primary"
-							disabled={resume.isPending || !project}
-							title={project ? undefined : "Open this run from the board to resume it"}
-							onClick={() => resume.mutate()}
-						>
-							{resume.isPending ? "Resuming…" : "Resume"}
-						</Button>
-					)}
 				</div>
 			</header>
 
-			<section aria-label="Stages" className="border-b border-border px-6 py-4">
+			<section aria-label="Stages" className="px-6 py-4">
 				<h2 className="mb-2 text-micro font-semibold uppercase tracking-wide text-passive">Stages</h2>
 				<div className="flex flex-col gap-2">
 					{stages.map((stage) => (
-						<StageRow key={stage.stageRunId || stage.stageName} stage={stage} />
+						<StageRow key={stage.stageId} stage={stage} />
 					))}
 					{stages.length === 0 && <p className="text-caption text-passive">No stages yet.</p>}
-				</div>
-			</section>
-
-			<section aria-label="Findings" className="px-6 py-4">
-				<div className="mb-2 flex items-center gap-3">
-					<h2 className="text-micro font-semibold uppercase tracking-wide text-passive">
-						Findings <span className="font-mono text-passive">{findings.length}</span>
-					</h2>
-					{dismissedCount > 0 && (
-						<label className="ml-auto flex items-center gap-2 text-caption text-muted-foreground">
-							<Switch checked={showDismissed} onCheckedChange={setShowDismissed} />
-							Show dismissed ({dismissedCount})
-						</label>
-					)}
-				</div>
-				<div className="flex flex-col gap-2">
-					{findings.map((finding) => (
-						<FindingRow
-							key={finding.artifactId}
-							finding={finding}
-							runId={runId}
-							project={project}
-							onChanged={refresh}
-						/>
-					))}
-					{findings.length === 0 && <p className="text-caption text-passive">No findings.</p>}
 				</div>
 			</section>
 		</div>
 	);
 }
 
-// One stage row: status/verdict summary plus a collapsible block for the
-// captured command output (last 64 KiB of combined stdout+stderr), when present.
+// One stage row: outcome, attempt, and a collapsible block for the captured
+// output tail when the stage produced one.
 function StageRow({ stage }: { stage: PipelineStageView }) {
 	const [showOutput, setShowOutput] = useState(false);
+	const outcome = stage.outcome as StageOutcome;
 	return (
 		<div
-			data-stage={stage.stageName}
+			data-stage={stage.stageId}
 			className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-card px-3 py-2"
 		>
-			<span className={cn("h-2 w-2 shrink-0 rounded-full", stageStatusDotTone(stage.status))} />
-			<span className="font-mono text-caption font-medium text-foreground">{stage.stageName}</span>
-			<span className="font-mono text-micro text-passive">{stage.status}</span>
+			<span className={cn("h-2 w-2 shrink-0 rounded-full", stageOutcomeDotTone(outcome))} />
+			<span className="font-mono text-caption font-medium text-foreground">{stage.stageId}</span>
+			<span className="font-mono text-micro text-passive">{stageOutcomeLabel(outcome)}</span>
 			{stage.sessionId && (
 				<span className="font-mono text-micro text-passive">
 					· session <SessionLink sessionId={stage.sessionId} />
 				</span>
 			)}
-			{stage.verdict && <Badge variant="outline">{stage.verdict}</Badge>}
+			{stage.enteredVia === "failure" && stage.failedStage && (
+				<Badge variant="outline">via {stage.failedStage} failing</Badge>
+			)}
+			{stage.producedArtifact && (
+				<Badge variant={stage.producedArtifact.exists ? "outline" : "warning"}>
+					{stage.producedArtifact.exists ? stage.producedArtifact.name : `${stage.producedArtifact.name} (missing)`}
+				</Badge>
+			)}
 			<span className="ml-auto flex items-center gap-2 font-mono text-micro text-passive">
-				{stage.output && (
+				{stage.outputTail && (
 					<button
 						type="button"
 						onClick={() => setShowOutput((v) => !v)}
@@ -181,19 +143,13 @@ function StageRow({ stage }: { stage: PipelineStageView }) {
 				)}
 				<span>
 					attempt {stage.attempt}
-					{stage.artifactIds.length > 0 &&
-						` · ${stage.artifactIds.length} artifact${stage.artifactIds.length === 1 ? "" : "s"}`}
+					{stage.attempt > 1 ? " · nudged" : ""}
 				</span>
 			</span>
-			{stage.errorMessage && <p className="w-full font-mono text-micro text-error">{stage.errorMessage}</p>}
-			{stage.notes?.map((note, i) => (
-				<p key={i} className="w-full font-mono text-micro text-warning">
-					{note}
-				</p>
-			))}
-			{stage.output && showOutput && (
+			{stage.reason && <p className="w-full font-mono text-micro text-error">{stage.reason}</p>}
+			{stage.outputTail && showOutput && (
 				<pre className="max-h-80 w-full overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-background px-2 py-1.5 font-mono text-micro text-muted-foreground">
-					{stage.output}
+					{stage.outputTail}
 				</pre>
 			)}
 		</div>
@@ -201,8 +157,8 @@ function StageRow({ stage }: { stage: PipelineStageView }) {
 }
 
 // SessionLink navigates to a session's page (from the routes shell), reused for
-// both the run-level session and any stage that ran an agent (command/builtin
-// stages leave stage.sessionId empty and stay plain text).
+// both the run-level session and any stage that ran an agent (command stages
+// leave stage.sessionId empty and stay plain text).
 function SessionLink({ sessionId }: { sessionId: string }) {
 	const navigate = useNavigate();
 	return (
@@ -213,73 +169,5 @@ function SessionLink({ sessionId }: { sessionId: string }) {
 		>
 			{sessionId}
 		</button>
-	);
-}
-
-function FindingRow({
-	finding,
-	runId,
-	project,
-	onChanged,
-}: {
-	finding: PipelineArtifact;
-	runId: string;
-	project?: string;
-	onChanged: () => void;
-}) {
-	const [error, setError] = useState<string | null>(null);
-	const location = finding.filePath
-		? `${finding.filePath}${finding.startLine ? `:${finding.startLine}` : ""}`
-		: undefined;
-	const isDismissed = finding.status === "dismissed";
-
-	// Dismiss hides a false-positive finding so it stops blocking no_open_findings
-	// gates; Undo reopens it. Both POST the new status, then invalidate on success.
-	const setStatus = useMutation({
-		mutationFn: async (status: "open" | "dismissed") => {
-			if (!project) throw new Error("Project is unknown for this run");
-			const { error: apiError } = await apiClient.POST("/api/v1/pipelines/runs/{runId}/artifacts/{artifactId}/status", {
-				params: { path: { runId, artifactId: finding.artifactId }, query: { project } },
-				body: { status },
-			});
-			if (apiError) throw new Error(apiErrorMessage(apiError));
-		},
-		onSuccess: () => {
-			setError(null);
-			onChanged();
-		},
-		onError: (e: unknown) => setError(e instanceof Error ? e.message : "Action failed"),
-	});
-
-	return (
-		<div
-			data-finding={finding.artifactId}
-			className={cn("rounded-md border border-border bg-card px-3 py-2", isDismissed && "opacity-60")}
-		>
-			<div className="flex flex-wrap items-center gap-2">
-				<span className="truncate text-caption font-medium text-foreground">{finding.title || "(untitled)"}</span>
-				{finding.severity && <Badge variant={severityBadgeVariant(finding.severity)}>{finding.severity}</Badge>}
-				<span className="font-mono text-micro text-passive">{finding.status}</span>
-				{typeof finding.confidence === "number" && (
-					<span className="font-mono text-micro text-passive">· {Math.round(finding.confidence * 100)}%</span>
-				)}
-				<span className="ml-auto font-mono text-micro text-passive">{finding.stageName}</span>
-				{finding.kind === "finding" && (
-					<Button
-						size="sm"
-						variant="ghost"
-						className="h-6 px-2 text-micro"
-						disabled={setStatus.isPending || !project}
-						title={project ? undefined : "Open this run from the board to change findings"}
-						onClick={() => setStatus.mutate(isDismissed ? "open" : "dismissed")}
-					>
-						{setStatus.isPending ? "…" : isDismissed ? "Undo" : "Dismiss"}
-					</Button>
-				)}
-			</div>
-			{location && <p className="mt-0.5 font-mono text-micro text-passive">{location}</p>}
-			{finding.description && <p className="mt-1 text-micro text-muted-foreground">{finding.description}</p>}
-			{error && <p className="mt-1 font-mono text-micro text-error">{error}</p>}
-		</div>
 	);
 }

--- a/frontend/src/renderer/components/PipelineWorkbench.test.tsx
+++ b/frontend/src/renderer/components/PipelineWorkbench.test.tsx
@@ -16,14 +16,12 @@ function run(overrides: Partial<PipelineRunSummary> & { runId: string }): Pipeli
 	return {
 		pipelineId: "def-1",
 		pipelineName: "review",
+		status: "running",
+		subjectKind: "session",
 		sessionId: "sess-1",
-		loopState: "running",
-		loopRounds: 1,
 		headSha: "abcdef1234567890",
 		stageCount: 2,
-		stageStatuses: { lint: "succeeded", test: "running" },
-		hasOpenFindings: false,
-		blocksMerge: false,
+		stageOutcomes: { lint: "succeeded", test: "running" },
 		createdAt: "2026-07-15T00:00:00Z",
 		updatedAt: "2026-07-15T00:00:00Z",
 		projectId: "proj-1",
@@ -45,9 +43,9 @@ afterEach(() => vi.restoreAllMocks());
 describe("PipelineWorkbench", () => {
 	it("groups runs into the five run-status columns", () => {
 		setRuns([
-			run({ runId: "r1", pipelineName: "review", loopState: "running" }),
-			run({ runId: "r2", pipelineName: "audit", loopState: "done" }),
-			run({ runId: "r3", pipelineName: "audit", loopState: "stalled" }),
+			run({ runId: "r1", pipelineName: "review", status: "running" }),
+			run({ runId: "r2", pipelineName: "audit", status: "succeeded" }),
+			run({ runId: "r3", pipelineName: "audit", status: "failed" }),
 		]);
 		render(<PipelineWorkbench />);
 
@@ -60,7 +58,7 @@ describe("PipelineWorkbench", () => {
 	});
 
 	it("renders card fields: pipeline name, run status, and stage count", () => {
-		setRuns([run({ runId: "r1", pipelineName: "review", loopState: "running", stageCount: 2 })]);
+		setRuns([run({ runId: "r1", pipelineName: "review", status: "running", stageCount: 2 })]);
 		const { container } = render(<PipelineWorkbench />);
 
 		const card = container.querySelector('[data-run-id="r1"]') as HTMLElement;
@@ -74,7 +72,7 @@ describe("PipelineWorkbench", () => {
 			run({
 				runId: "r1",
 				stageCount: 3,
-				stageStatuses: { lint: "succeeded", review: "succeeded_unverified", test: "timed_out" },
+				stageOutcomes: { lint: "succeeded", review: "succeeded_unverified", test: "timed_out" },
 			}),
 		]);
 		const { container } = render(<PipelineWorkbench />);
@@ -92,8 +90,8 @@ describe("PipelineWorkbench", () => {
 
 	it("filters the board to the selected pipeline names", async () => {
 		setRuns([
-			run({ runId: "r1", pipelineName: "review", loopState: "running" }),
-			run({ runId: "r2", pipelineName: "audit", loopState: "running" }),
+			run({ runId: "r1", pipelineName: "review", status: "running" }),
+			run({ runId: "r2", pipelineName: "audit", status: "running" }),
 		]);
 		render(<PipelineWorkbench />);
 		const user = userEvent.setup();

--- a/frontend/src/renderer/hooks/usePipelineRuns.ts
+++ b/frontend/src/renderer/hooks/usePipelineRuns.ts
@@ -5,11 +5,10 @@ import { useWorkspaceQuery } from "./useWorkspaceQuery";
 
 // A run summary tagged with the project it belongs to. The pipelines runs API is
 // project-scoped (`?project=ID`), but the Runs section aggregates across every
-// project (like the PR board), so each row carries its projectId for the
-// cancel/resume calls, which are also project-scoped.
+// project (like the PR board), so each row carries its projectId for the cancel
+// call, which is also project-scoped.
 export type PipelineRunSummary = components["schemas"]["PipelineRunSummary"] & { projectId: string };
 export type PipelineRunDetail = components["schemas"]["PipelineRunDetail"];
-export type PipelineArtifact = components["schemas"]["PipelineArtifact"];
 
 // Query keys. Every pipeline key is prefixed "pipeline-" so the event transport
 // can invalidate the whole family with one predicate on a pipeline_* CDC event.
@@ -52,7 +51,8 @@ export function usePipelineRuns() {
 	};
 }
 
-// One run's full detail (stages + findings). GET run detail is not project-scoped.
+// One run's full detail (summary + per-stage state). GET run detail is not
+// project-scoped.
 export function usePipelineRun(runId: string) {
 	return useQuery({
 		queryKey: pipelineRunQueryKey(runId),


### PR DESCRIPTION
Pipelines v2, Task 18. Closes #326.

## Routes

Kept (same operation ids, so frontend churn stays mechanical): `GET/POST /pipelines`, `PUT/DELETE /pipelines/{id}`, `POST /pipelines/validate`, `GET /pipelines/schema`, `GET/POST /pipelines/runs`, `GET /pipelines/runs/{runId}`, `POST /pipelines/runs/{runId}/cancel`, `POST /pipelines/runs/{runId}/stages/{stageId}/signal`.

Removed: `/runs/{runId}/resume` (spec 14.1, there is no resume) and both artifact routes (the findings subsystem is deleted, D10). They are unmounted, not 501.

Added:
- `GET /pipelines/runs/{runId}/stages/{stageId}/log?tail=N`, served from `stage-logs/`.
- `GET /pipelines/runs/{runId}/outputs/{filename}`, served from `agent-outputs/`.

## The outputs endpoint

It is a file server pointed at a caller-supplied name, so the filename is treated as **authorization, not a path**. `RunFolder.DeclaredOutput` matches it by exact string equality against the run's frozen `produces` set before anything touches the filesystem; a name that is not in that closed allowlist never becomes a path. Traversal, absolute paths and encoded separators are therefore unreachable rather than filtered, and `checkPathComponent` re-runs on the matched name so a stale frozen definition cannot smuggle one through. The resolved path must then be a regular file (`Lstat`, so a planted symlink or a directory under the declared name is rejected, not followed). Every rejection is the same 404 so the endpoint is not an oracle for run-folder contents.

Tested adversarially at three layers (run folder, service over a real temp run folder, HTTP): `..`, `%2e%2e%2f`, `..%252f`, backslash traversal, absolute paths, NUL injection, case and whitespace near-misses, undeclared-but-present files (`run.json`, `definition.yaml`, a seeded `secret.txt`), symlink escape, directory-as-artifact. Each asserts no bytes of the target leak. Mutation-checked: neutering the allowlist makes them fail.

## DTOs

`PipelineRunSummary{runId, pipelineId, pipelineName, status, subjectKind, sessionId?, prNumber?, headSha?, cancelReason?, stageCount, stageOutcomes, createdAt, updatedAt, settledAt?}`; `PipelineRunDetail` adds `runDir?` and `stages: PipelineStageView[]` in definition document order; `PipelineStageView{stageId, outcome, attempt, enteredVia, failedStage?, sessionId?, workspaceKind, startedAt?, settledAt?, reason?, outputTail?, producedArtifact?: {name, exists}}`; `ValidatePipelineDefinitionResponse{valid, issues, warnings}`.

`producedArtifact.exists` is verified against the run folder rather than inferred from the outcome, so "the stage produced nothing" and "someone deleted the run folder" stay distinguishable.

`POST /pipelines/runs` gains optional `prNumber`. The subject is resolved **server-side** from the project's tracked PRs, never taken from the caller: the fork flag decides whether any credential is injected anywhere in the run (spec 8, D17), so a client asserting it would be a hole. Unknown provenance is treated as a fork, which is the fail-safe answer.

## Two carryover items

1. **`ValidateCredentials` wired.** #324 had already wired it into `Service.parse` (save) and `ValidateDefinition` (validate), with `WithCredentials` bound in `pipeline_wiring.go`. Verified against both paths and covered by tests at the HTTP layer; the pure `Validate` stays dependency-free.
2. **Unknown-credential message is actionable.** Two of the three starter templates declare credentials, so this error is the first thing a new user sees after clicking a template. It now reads:
   `unknown credential "github-release"; create it with: ao pipeline credential set github-release KEY=VALUE --project proj-7`
   It stays an error (spec 13, D13). `KEY=VALUE` is a placeholder because only the author knows which environment variable the stage's script reads.

`ValidateDefinition` now returns warnings on their own channel, and they survive an invalid document: a pipeline can be both unsaveable and worth a second look.

## Frontend

`frontend/src/api/schema.ts` regenerated from the OpenAPI source (all diff lines are pipeline-related; no unrelated churn). Compile breaks were confined to the run-detail area as the plan predicted. Fixed mechanically to keep the build green:

- `PipelineRunDetail.tsx` ported onto the v2 DTO; findings panel and resume button removed (both are deleted subsystems, they could not survive), plus its test file.
- `PipelineRunCard.tsx`: dropped the `blocksMerge` badge.
- `usePipelineRuns.ts`: dropped the `PipelineArtifact` type export.
- `PipelineWorkbench.test.tsx`: fixtures moved to the v2 field names.

**Left for Task 24** (it owns the real `PipelineRunDetail` rewrite): outcome badge styling, the collapsible log viewer over the new log endpoint, artifact download links over the new outputs endpoint, and the orphaned-session affordance with its kill button. The current view shows outcomes, the nudge tag, the entered-via-failure indicator, the artifact name with a missing state, and the output tail, which is enough to be honest but is not the designed surface. `pipeline-display.ts` still carries its `loopStateTone`/`stageStatusDotTone`/`severityBadgeVariant` v1 leftovers and the v1 fallbacks in `runStatusOf`/`stageOutcomesOf`; those are now dead and should go with Task 24.

## Verification

- `go build ./...`, `go test ./...`, `gofmt -l .` clean, `golangci-lint run ./...` 0 issues.
- Frontend: `tsc --noEmit` clean, 656 renderer tests pass, full `vite build` green.
- Four `internal/cli` `TestSpawn*` tests fail locally on this machine with `daemon returned HTTP 404`. They fail identically on an unmodified `origin/pipelines` worktree, so they are a local-environment artifact (a running daemon on the loopback port), not this change. Confirming against CI.

## Risks

- PR-subject resolution walks the project's sessions to find a PR by number, because the `pr` table reaches a project only through its session. Marked `ponytail:` with the upgrade path; manual triggers are a human clicking a button.
- `RunFolder.ReadLogTail` reads the whole log before tailing. Stage logs are executor-capped, so this is bounded in practice; marked with its ceiling.