### PR TITLE
feat(pipelines-ui): pipeline-orphaned session badge and kill

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -25,6 +25,12 @@ vi.mock("../lib/api-client", () => ({
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
 }));
 
+vi.mock("../lib/telemetry", () => ({
+	captureRendererEvent: vi.fn(),
+	captureRendererException: vi.fn(),
+	addRendererExceptionStep: vi.fn(),
+}));
+
 vi.mock("../lib/bridge", () => ({
 	aoBridge: {
 		notifications: {
@@ -618,6 +624,83 @@ describe("SessionsBoard", () => {
 		expect(screen.queryByText("Session can no longer be restored")).not.toBeInTheDocument();
 	});
 
+	it("badges a pipeline-orphaned session and explains the outcome that spared it", async () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [workspaceWithSessions([orphanedSession()])],
+			isError: false,
+			isSuccess: true,
+		});
+
+		renderBoard("p1");
+
+		const badge = screen.getByTestId("pipeline-orphan-badge");
+		expect(badge).toHaveTextContent("pipeline");
+
+		await userEvent.hover(badge);
+
+		const tooltip = await screen.findByRole("tooltip");
+		expect(tooltip).toHaveTextContent("pr-review");
+		expect(tooltip).toHaveTextContent("review");
+		expect(tooltip).toHaveTextContent("no output");
+		expect(tooltip).toHaveTextContent("kept for you to inspect");
+		expect(tooltip).toHaveTextContent("run-7");
+		expect(tooltip).toHaveTextContent(/kept .*ago|kept just now/);
+	});
+
+	it("does not badge ordinary sessions as pipeline-orphaned", async () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [workspaceWithSessions([orphanedSession({ id: "s-plain", title: "plain worker", pipelineOrphan: undefined })])],
+			isError: false,
+			isSuccess: true,
+		});
+
+		renderBoard("p1");
+
+		expect(screen.getByText("plain worker")).toBeInTheDocument();
+		expect(screen.queryByTestId("pipeline-orphan-badge")).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /^Kill / })).not.toBeInTheDocument();
+	});
+
+	it("kills a pipeline-orphaned session through the existing kill endpoint after confirmation", async () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [workspaceWithSessions([orphanedSession()])],
+			isError: false,
+			isSuccess: true,
+		});
+		const queryClient = renderBoard("p1");
+		const invalidate = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
+
+		await userEvent.click(screen.getByRole("button", { name: "Kill orphaned review stage" }));
+		expect(postMock).not.toHaveBeenCalled();
+
+		await userEvent.click(screen.getByRole("button", { name: "Kill session" }));
+
+		await waitFor(() =>
+			expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/kill", {
+				params: { path: { sessionId: "s-orphan" } },
+			}),
+		);
+		expect(invalidate).toHaveBeenCalledWith({ queryKey: ["workspaces"] });
+		expect(navigateMock).not.toHaveBeenCalled();
+	});
+
+	it("keeps the kill dialog open and shows the daemon error when the kill fails", async () => {
+		postMock.mockResolvedValueOnce({ error: { code: "KILL_FAILED", message: "worktree busy" } });
+		workspaceQueryMock.mockReturnValue({
+			data: [workspaceWithSessions([orphanedSession()])],
+			isError: false,
+			isSuccess: true,
+		});
+
+		renderBoard("p1");
+
+		await userEvent.click(screen.getByRole("button", { name: "Kill orphaned review stage" }));
+		await userEvent.click(screen.getByRole("button", { name: "Kill session" }));
+
+		expect(await screen.findByText("Could not kill session")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Kill session" })).toBeInTheDocument();
+	});
+
 	it("opens a merged Done session from the card body without showing restore", async () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [workspaceWithSessions([terminatedSession({ id: "s-merged", title: "merged worker", status: "merged" })])],
@@ -647,6 +730,32 @@ function workspaceWithSessions(sessions: WorkspaceSession[]): WorkspaceSummary {
 		name: "radic",
 		path: "/tmp/radic",
 		sessions,
+	};
+}
+
+// A stage session the engine's kill-on policy spared: `no_signal` status keeps
+// it in the "Needs you" column, so the card renders without expanding a stack.
+function orphanedSession(overrides: Partial<WorkspaceSession> = {}): WorkspaceSession {
+	return {
+		id: "s-orphan",
+		workspaceId: "p1",
+		workspaceName: "radic",
+		title: "pr-review review stage",
+		provider: "claude-code",
+		kind: "worker",
+		branch: "ao/pipelines/run-7/review",
+		status: "no_signal",
+		activity: { state: "exited", lastActivityAt: "2026-01-01T00:00:00Z" },
+		updatedAt: "2026-01-01T00:00:00Z",
+		prs: [],
+		pipelineOrphan: {
+			runId: "run-7",
+			stage: "review",
+			outcome: "no_output",
+			keptAt: "2026-01-01T00:00:00Z",
+			pipeline: "pr-review",
+		},
+		...overrides,
 	};
 }
 

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -649,7 +649,9 @@ describe("SessionsBoard", () => {
 
 	it("does not badge ordinary sessions as pipeline-orphaned", async () => {
 		workspaceQueryMock.mockReturnValue({
-			data: [workspaceWithSessions([orphanedSession({ id: "s-plain", title: "plain worker", pipelineOrphan: undefined })])],
+			data: [
+				workspaceWithSessions([orphanedSession({ id: "s-plain", title: "plain worker", pipelineOrphan: undefined })]),
+			],
 			isError: false,
 			isSuccess: true,
 		});

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { AlertTriangle, ChevronRight, Plus, RotateCw } from "lucide-react";
 import {
+	type PipelineOrphanInfo,
 	type WorkspaceSession,
 	canonicalTrackerIssueId,
 	newestActiveOrchestrator,
@@ -19,12 +20,19 @@ import {
 	type AttentionZoneView,
 } from "../lib/session-presentation";
 import { useSessionScmSummary, type SessionPRSummary } from "../hooks/useSessionScmSummary";
+import { useKillSession } from "../hooks/useKillSession";
 import { useRestoreSession } from "../hooks/useRestoreSession";
 import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { NotificationCenter } from "./NotificationCenter";
 import { BoardWelcome, ProjectBoardEmpty } from "./BoardEmptyStates";
+import { ConfirmDialog } from "./ConfirmDialog";
 import { OrchestratorIcon } from "./icons";
+import { Badge } from "./ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 import { TopbarButton, TopbarKillError } from "./TopbarButton";
+import { formatTimeCompact } from "../lib/format-time";
+import { stageOutcomeLabel } from "../lib/pipeline-display";
+import type { StageOutcome } from "../lib/pipeline-draft";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { restartProjectOrchestrator } from "../lib/restart-orchestrator";
 import { prBrowserUrl, sessionPRDisplaySummaries } from "../lib/pr-display";
@@ -461,6 +469,10 @@ function SessionCard({
 }) {
 	const badge = getSessionStatusView(session.status);
 	const issueId = canonicalTrackerIssueId(session.issueId);
+	const orphan = session.pipelineOrphan;
+	// A killed orphan keeps the badge (it still explains where the session came
+	// from) but loses the kill action: there is nothing left to stop.
+	const showOrphanKill = orphan !== undefined && session.status !== "terminated";
 	const branch = session.branch || "";
 	const showBranch = branch !== "" && !sameLabel(branch, session.title) && !sameLabel(branch, session.id);
 	const prSummaries = sessionPRDisplaySummaries(session, useSessionScmSummary(session.id).data);
@@ -502,6 +514,7 @@ function SessionCard({
 							{issueId}
 						</span>
 					)}
+					{orphan && <PipelineOrphanBadge orphan={orphan} />}
 					<span className="ml-auto shrink-0 font-mono text-2xs tracking-wide-xs text-passive">
 						{agentLabel(session.provider)}
 					</span>
@@ -521,7 +534,10 @@ function SessionCard({
 				<div className="border-t border-border px-3.25 py-1.5 text-2xs text-destructive">{restoreError}</div>
 			)}
 			<div
-				className={cn("border-t border-border px-3.25 py-2 font-mono text-2xs text-passive", restoreAction && "pr-20")}
+				className={cn(
+					"border-t border-border px-3.25 py-2 font-mono text-2xs text-passive",
+					(restoreAction || showOrphanKill) && "pr-20",
+				)}
 				onClick={(event) => event.stopPropagation()}
 			>
 				{prSummaries.length === 0 ? (
@@ -551,7 +567,89 @@ function SessionCard({
 					{isRestoring ? "Restoring" : "Restore"}
 				</button>
 			)}
+			{orphan && showOrphanKill && <PipelineOrphanKillButton orphan={orphan} session={session} />}
 		</div>
+	);
+}
+
+// The "pipeline" badge on a session the pipeline engine deliberately spared.
+// Deliberately neutral: this is not an error state. The tooltip leads with the
+// outcome, because the outcome is the reason the session is still here at all
+// (a stage that ended no_output / no_signal / timed_out is worth a human look
+// before its workspace goes away), and the reaper will not keep it forever.
+function PipelineOrphanBadge({ orphan }: { orphan: PipelineOrphanInfo }) {
+	return (
+		<TooltipProvider delayDuration={0}>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<Badge className="cursor-help" data-testid="pipeline-orphan-badge" tabIndex={0}>
+						pipeline
+					</Badge>
+				</TooltipTrigger>
+				<TooltipContent className="max-w-72 space-y-1 px-2.5 py-2 text-left" side="bottom">
+					<p className="text-2xs leading-relaxed text-popover-foreground">
+						Stage <span className="font-mono">{orphan.stage}</span> ended{" "}
+						<span className="font-medium text-warning">{stageOutcomeLabel(orphan.outcome as StageOutcome)}</span>, so
+						this session was kept for you to inspect instead of being cleaned up.
+					</p>
+					<p className="font-mono text-micro text-muted-foreground">
+						{orphan.pipeline} · run {orphan.runId}
+					</p>
+					<p className="text-micro text-muted-foreground">kept {formatTimeCompact(orphan.keptAt)}</p>
+				</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+}
+
+// Hover-revealed kill for a spared stage session, mirroring the Done column's
+// restore affordance so the card gains no permanent clutter. Kill tears down the
+// runtime and the kept workspace, so it goes through the shared confirm dialog.
+function PipelineOrphanKillButton({ orphan, session }: { orphan: PipelineOrphanInfo; session: WorkspaceSession }) {
+	const [confirming, setConfirming] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const kill = useKillSession(session, {
+		onKilled: () => setConfirming(false),
+		onError: setError,
+	});
+	const label = `Kill orphaned ${orphan.stage} stage`;
+	return (
+		<>
+			<button
+				aria-label={label}
+				className="absolute bottom-1.5 right-2 z-10 inline-flex h-control-xs items-center justify-center rounded-sm border border-error/40 bg-surface px-2.5 text-2xs font-semibold text-error opacity-0 shadow-sm transition-opacity duration-normal ease-out hover:opacity-90 focus:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100"
+				onClick={(event) => {
+					event.stopPropagation();
+					setError(null);
+					setConfirming(true);
+				}}
+				title={label}
+				type="button"
+			>
+				Kill
+			</button>
+			<ConfirmDialog
+				busy={kill.isPending}
+				confirmLabel="Kill session"
+				description={
+					<p className="text-xs leading-5 text-muted-foreground">
+						Stage <span className="font-mono text-foreground">{orphan.stage}</span> of run{" "}
+						<span className="font-mono text-foreground">{orphan.runId}</span> ({orphan.pipeline}) ended{" "}
+						{stageOutcomeLabel(orphan.outcome as StageOutcome)}, which is why this session is still here. Killing it
+						tears down the agent and its kept workspace. This cannot be undone.
+					</p>
+				}
+				destructive
+				error={error}
+				onConfirm={() => kill.mutate()}
+				onOpenChange={(open) => {
+					if (!open) setConfirming(false);
+				}}
+				open={confirming}
+				size="sm"
+				title="Kill this pipeline stage session?"
+			/>
+		</>
 	);
 }
 

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -514,7 +514,6 @@ function SessionCard({
 							{issueId}
 						</span>
 					)}
-					{orphan && <PipelineOrphanBadge orphan={orphan} />}
 					<span className="ml-auto shrink-0 font-mono text-2xs tracking-wide-xs text-passive">
 						{agentLabel(session.provider)}
 					</span>
@@ -522,13 +521,22 @@ function SessionCard({
 				<div
 					className={cn(
 						"px-3.25 text-control font-medium leading-snug tracking-tight text-foreground",
-						showBranch ? "pb-2" : "pb-3",
+						showBranch || orphan ? "pb-2" : "pb-3",
 						"line-clamp-2 overflow-hidden",
 					)}
 				>
 					{session.title}
 				</div>
-				{showBranch && <div className="px-3.25 pb-2.5 font-mono text-2xs text-passive">{branch}</div>}
+				{/* The pipeline badge shares the branch line rather than the header
+				    row: the header already carries the status label, the intake chip
+				    and the agent name, and a fourth chip wraps it on a column-width
+				    card. */}
+				{(showBranch || orphan) && (
+					<div className="flex items-center gap-2 px-3.25 pb-2.5">
+						{orphan && <PipelineOrphanBadge orphan={orphan} />}
+						{showBranch && <span className="min-w-0 truncate font-mono text-2xs text-passive">{branch}</span>}
+					</div>
+				)}
 			</div>
 			{restoreError && (
 				<div className="border-t border-border px-3.25 py-1.5 text-2xs text-destructive">{restoreError}</div>
@@ -592,8 +600,9 @@ function PipelineOrphanBadge({ orphan }: { orphan: PipelineOrphanInfo }) {
 						<span className="font-medium text-warning">{stageOutcomeLabel(orphan.outcome as StageOutcome)}</span>, so
 						this session was kept for you to inspect instead of being cleaned up.
 					</p>
-					<p className="font-mono text-micro text-muted-foreground">
-						{orphan.pipeline} · run {orphan.runId}
+					{/* Run ids are `run-<uuid>`, so they self-label and need to wrap. */}
+					<p className="break-all font-mono text-micro text-muted-foreground">
+						{orphan.pipeline} · {orphan.runId}
 					</p>
 					<p className="text-micro text-muted-foreground">kept {formatTimeCompact(orphan.keptAt)}</p>
 				</TooltipContent>
@@ -633,7 +642,7 @@ function PipelineOrphanKillButton({ orphan, session }: { orphan: PipelineOrphanI
 				confirmLabel="Kill session"
 				description={
 					<p className="text-xs leading-5 text-muted-foreground">
-						Stage <span className="font-mono text-foreground">{orphan.stage}</span> of run{" "}
+						Stage <span className="font-mono text-foreground">{orphan.stage}</span> of{" "}
 						<span className="font-mono text-foreground">{orphan.runId}</span> ({orphan.pipeline}) ended{" "}
 						{stageOutcomeLabel(orphan.outcome as StageOutcome)}, which is why this session is still here. Killing it
 						tears down the agent and its kept workspace. This cannot be undone.

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import {
 	GitBranch,
@@ -18,8 +18,8 @@ import {
 	sessionIsActive,
 	type WorkspaceSession,
 } from "../types/workspace";
+import { useKillSession } from "../hooks/useKillSession";
 import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
-import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { addRendererExceptionStep, captureRendererEvent, captureRendererException } from "../lib/telemetry";
 import { useUiStore } from "../stores/ui-store";
@@ -323,28 +323,15 @@ export function TopbarKillButton({
 	orchestratorId?: string;
 	onKilled: (workspaceId: string, orchestratorId?: string) => void;
 }) {
-	const queryClient = useQueryClient();
 	const [confirming, setConfirming] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
-	const kill = useMutation({
-		mutationFn: async () => {
-			void captureRendererEvent("ao.renderer.session_kill_requested", { project_id: session.workspaceId });
-			const { error: apiError } = await apiClient.POST("/api/v1/sessions/{sessionId}/kill", {
-				params: { path: { sessionId: session.id } },
-			});
-			if (apiError) throw new Error(apiErrorMessage(apiError));
-		},
-		onSuccess: () => {
-			void captureRendererEvent("ao.renderer.session_kill_succeeded", { project_id: session.workspaceId });
+	const kill = useKillSession(session, {
+		onKilled: () => {
 			setConfirming(false);
-			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
 			onKilled(session.workspaceId, orchestratorId);
 		},
-		onError: (e) => {
-			void captureRendererEvent("ao.renderer.session_kill_failed", { project_id: session.workspaceId });
-			setError(e instanceof Error ? e.message : "Kill failed");
-		},
+		onError: setError,
 	});
 
 	if (confirming) {

--- a/frontend/src/renderer/hooks/useKillSession.ts
+++ b/frontend/src/renderer/hooks/useKillSession.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { captureRendererEvent } from "../lib/telemetry";
+import type { WorkspaceSession } from "../types/workspace";
+import { workspaceQueryKey } from "./useWorkspaceQuery";
+
+/**
+ * The one session-kill mutation: POST /sessions/{id}/kill with telemetry around
+ * it, then a workspace refetch so the session drops into the board's terminated
+ * group. Shared by the session topbar's kill button and the board's
+ * pipeline-orphan card action, so there is a single place that knows the
+ * endpoint and the event names.
+ */
+export function useKillSession(
+	session: Pick<WorkspaceSession, "id" | "workspaceId">,
+	callbacks: { onKilled?: () => void; onError?: (message: string) => void } = {},
+) {
+	const queryClient = useQueryClient();
+	const { onKilled, onError } = callbacks;
+
+	return useMutation({
+		mutationFn: async () => {
+			void captureRendererEvent("ao.renderer.session_kill_requested", { project_id: session.workspaceId });
+			const { error: apiError } = await apiClient.POST("/api/v1/sessions/{sessionId}/kill", {
+				params: { path: { sessionId: session.id } },
+			});
+			if (apiError) throw new Error(apiErrorMessage(apiError, "Could not kill session"));
+		},
+		onSuccess: () => {
+			void captureRendererEvent("ao.renderer.session_kill_succeeded", { project_id: session.workspaceId });
+			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+			onKilled?.();
+		},
+		onError: (e) => {
+			void captureRendererEvent("ao.renderer.session_kill_failed", { project_id: session.workspaceId });
+			onError?.(e instanceof Error ? e.message : "Kill failed");
+		},
+	});
+}

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -76,6 +76,7 @@ async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 				previewUrl: session.previewUrl,
 				previewRevision: session.previewRevision,
 				prs: (session.prs ?? []).map(toPullRequestFacts),
+				pipelineOrphan: session.pipelineOrphan,
 			})),
 	}));
 }

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -209,7 +209,13 @@ export type WorkspaceRepoSummary = {
 
 /** Glanceable worker status. Maps 1:1 to the accent colors in DESIGN.md. */
 export type WorkerDisplayStatus =
-	"working" | "needs_you" | "mergeable" | "ci_failed" | "no_signal" | "done" | "unknown";
+	| "working"
+	| "needs_you"
+	| "mergeable"
+	| "ci_failed"
+	| "no_signal"
+	| "done"
+	| "unknown";
 
 export function workerDisplayStatus(session: WorkspaceSession): WorkerDisplayStatus {
 	if (session.displayStatus) return session.displayStatus;

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -115,6 +115,23 @@ export type PullRequestFacts = {
 	updatedAt: string;
 };
 
+/**
+ * Why a pipeline stage's session is still alive. The engine's kill-on policy
+ * spares a stage session whose outcome is worth a human look (`no_output`,
+ * `no_signal`, `timed_out`), capped at 3 per pipeline with a 24h TTL, and the
+ * daemon stamps this on the session DTO. Absent for every ordinary session.
+ */
+export type PipelineOrphanInfo = {
+	runId: string;
+	stage: string;
+	/** The settled stage outcome that spared the session. */
+	outcome: string;
+	/** ISO timestamp of when the engine decided to keep it. */
+	keptAt: string;
+	/** Pipeline definition name. */
+	pipeline: string;
+};
+
 export type WorkspaceSession = {
 	id: string;
 	terminalHandleId?: string;
@@ -154,6 +171,11 @@ export type WorkspaceSession = {
 	 * done server-side, so {@link status} already reflects all of these.
 	 */
 	prs: PullRequestFacts[];
+	/**
+	 * Set when a pipeline stage session was deliberately kept alive rather than
+	 * cleaned up. See {@link PipelineOrphanInfo}.
+	 */
+	pipelineOrphan?: PipelineOrphanInfo;
 	/**
 	 * Display status as derived by the daemon at read time. Optional override; when
 	 * absent it is derived from {@link SessionStatus} via {@link workerDisplayStatus}.

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -209,13 +209,7 @@ export type WorkspaceRepoSummary = {
 
 /** Glanceable worker status. Maps 1:1 to the accent colors in DESIGN.md. */
 export type WorkerDisplayStatus =
-	| "working"
-	| "needs_you"
-	| "mergeable"
-	| "ci_failed"
-	| "no_signal"
-	| "done"
-	| "unknown";
+	"working" | "needs_you" | "mergeable" | "ci_failed" | "no_signal" | "done" | "unknown";
 
 export function workerDisplayStatus(session: WorkspaceSession): WorkerDisplayStatus {
 	if (session.displayStatus) return session.displayStatus;


### PR DESCRIPTION
Pipelines v2, Task 25. Frontend only. The backend half shipped in #327, so `pipelineOrphan` was already on the wire and no endpoint, mutation or schema regen was needed here.

Closes #329

## What changed

- `types/workspace.ts`: `PipelineOrphanInfo` (`runId`, `stage`, `outcome`, `keptAt`, `pipeline`, mirroring `domain.PipelineOrphanInfo`) plus `WorkspaceSession.pipelineOrphan`; `useWorkspaceQuery` passes the DTO field through.
- `SessionsBoard.tsx`: a session carrying `pipelineOrphan` renders a neutral **"pipeline"** badge (shadcn `Badge`) with a shadcn tooltip that leads with the outcome that spared it: *"Stage `review` ended no output, so this session was kept for you to inspect instead of being cleaned up"*, then `<pipeline> · <runId>` and `kept 2h ago`. Deliberately not an error tone: the reaper spared this session because a human may want to look at it.
- Kill action: hover-revealed `Kill` in the card footer, mirroring the Done column's restore affordance, behind the existing `ConfirmDialog`. It names the stage, run, pipeline and outcome, and says the kept workspace goes away. Hidden once the session is terminated (nothing left to stop); the badge stays, since it still explains where the session came from.
- The session kill mutation moved out of `TopbarKillButton` into `hooks/useKillSession.ts`, so the topbar and the board share one endpoint call, one set of telemetry events (`session_kill_requested/succeeded/failed`) and one workspace invalidation. No new mutation and no new endpoint.

`Sidebar.tsx` was left alone: its session rows render a status dot and the title only, no badges, so there is no badge surface there to extend.

## Layout note

The first preview put the badge in the card header, where a fourth chip wrapped "Changes requested" onto two lines on a column-width card. The badge now shares the branch line instead (second commit), which leaves the header untouched for every existing card.

## Tests

`SessionsBoard.test.tsx` gains four cases: badge + tooltip content (outcome, pipeline, run id, kept-at), no badge on an ordinary session, kill wiring (arms the dialog, then POSTs `/api/v1/sessions/{sessionId}/kill` and invalidates the workspace query), and the failure path keeping the dialog open with the daemon's message.

## Verification

- `npm test` in `frontend/`: 91 files, 1110 tests passing.
- `npm run typecheck` and `npm run typecheck:e2e` clean.
- Renderer bundle build (`vite build --config vite.renderer.config.ts`) green. Note `frontend/package.json` has no `build` script (AGENTS.md is stale there); the renderer vite build is the bundle step that would catch a missing export.
- `npx prettier@3 --check` clean on all changed files. `types/workspace.ts` carries 7 lines of unrelated reformat (a pre-existing prettier violation in `WorkerDisplayStatus`) because the Prettier workflow checks every file a PR touches.
- **`ao preview`**: run from inside the session against the renderer dev server (`npm run dev:web`). **No live orphan existed to look at**, since one only appears after a real pipeline run settles a stage as `no_output` / `no_signal` / `timed_out`. To verify visually I temporarily stamped `pipelineOrphan` onto one `mock-data.ts` demo session, previewed the board, confirmed the badge, the tooltip (including a realistic `run-<uuid>` id wrapping inside the tooltip), the hover-revealed Kill button and the confirm dialog, then reverted the fixture. That temporary fixture is not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
