### PR TITLE
feat(pipelines-ui): v2 run detail, logs, artifacts, orphan affordance

### DIFF
--- a/frontend/src/renderer/components/PipelineRunDetail.test.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.test.tsx
@@ -447,6 +447,41 @@ describe("PipelineRunDetail sessions", () => {
 		});
 	});
 
+	// The daemon leaves pipelineOrphan on the DTO after a kill, so a terminated
+	// session would otherwise keep offering a kill button that has already run.
+	it("drops the marker once the session is terminated", async () => {
+		setRun(
+			detail({
+				stages: [
+					stage({ stageId: "alive", outcome: "no_output", sessionId: "sess-alive" }),
+					stage({ stageId: "dead", outcome: "no_output", sessionId: "sess-dead" }),
+				],
+			}),
+		);
+		const orphan = {
+			runId: "run-1",
+			outcome: "no_output",
+			pipeline: "review",
+			keptAt: "2026-07-15T00:02:00Z",
+		};
+		setApi({
+			sessions: {
+				"sess-alive": sessionView({ id: "sess-alive", pipelineOrphan: { ...orphan, stage: "alive" } }),
+				"sess-dead": sessionView({
+					id: "sess-dead",
+					isTerminated: true,
+					status: "terminated",
+					pipelineOrphan: { ...orphan, stage: "dead" },
+				}),
+			},
+		});
+		renderDetail("proj-1");
+
+		await within(row("alive")).findByText("kept");
+		expect(within(row("dead")).queryByText("kept")).not.toBeInTheDocument();
+		expect(within(row("dead")).queryByRole("button", { name: "Kill session" })).not.toBeInTheDocument();
+	});
+
 	// A session an earlier run kept is not this run's business. The marker waits
 	// on the sibling stage's badge, so the session lookups have demonstrably
 	// resolved before the absence is asserted.

--- a/frontend/src/renderer/components/PipelineRunDetail.test.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.test.tsx
@@ -4,10 +4,12 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PipelineRunDetail } from "./PipelineRunDetail";
 import type { PipelineRunDetail as RunDetail } from "../hooks/usePipelineRuns";
+import type { WorkspaceSession } from "../types/workspace";
 import type { components } from "../../api/schema";
 
-const { usePipelineRunMock, getMock, postMock, navigateMock } = vi.hoisted(() => ({
+const { usePipelineRunMock, workspacesMock, getMock, postMock, navigateMock } = vi.hoisted(() => ({
 	usePipelineRunMock: vi.fn(),
+	workspacesMock: vi.fn(),
 	getMock: vi.fn(),
 	postMock: vi.fn(),
 	navigateMock: vi.fn(),
@@ -31,12 +33,14 @@ vi.mock("../lib/api-client", () => ({
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => navigateMock,
 }));
+vi.mock("../hooks/useWorkspaceQuery", () => ({
+	useWorkspaceQuery: () => ({ data: workspacesMock() }),
+	workspaceQueryKey: ["workspaces"],
+}));
 
 type StageView = RunDetail["stages"][number];
-type SessionView = components["schemas"]["ControllersSessionView"];
 
 const LOG_URL = "/api/v1/pipelines/runs/{runId}/stages/{stageId}/log";
-const SESSION_URL = "/api/v1/sessions/{sessionId}";
 
 function stage(overrides: Partial<StageView> & { stageId: string }): StageView {
 	return {
@@ -67,18 +71,28 @@ function detail(overrides: Partial<RunDetail>): RunDetail {
 	};
 }
 
-function sessionView(overrides: Partial<SessionView> & { id: string }): SessionView {
+function sessionView(overrides: Partial<WorkspaceSession> & { id: string }): WorkspaceSession {
 	return {
-		activity: { lastActivityAt: "2026-07-15T00:00:00Z", state: "idle" },
-		createdAt: "2026-07-15T00:00:00Z",
-		isTerminated: false,
-		kind: "worker",
-		projectId: "proj-1",
-		prs: [],
+		workspaceId: "proj-1",
+		workspaceName: "proj-1",
+		title: overrides.id,
+		provider: "claude",
+		branch: `session/${overrides.id}`,
 		status: "idle",
+		createdAt: "2026-07-15T00:00:00Z",
 		updatedAt: "2026-07-15T00:00:00Z",
+		activity: { state: "idle", lastActivityAt: "2026-07-15T00:00:00Z" },
+		prs: [],
 		...overrides,
 	};
+}
+
+// The sessions the shell's workspace query has loaded, which is where run detail
+// reads orphan markers and PR urls from.
+function setSessions(sessions: WorkspaceSession[]) {
+	workspacesMock.mockReturnValue([
+		{ id: "proj-1", name: "proj-1", kind: "single_repo", path: "/tmp/proj-1", sessions },
+	]);
 }
 
 function setRun(run: RunDetail) {
@@ -90,22 +104,14 @@ function setRun(run: RunDetail) {
 function setApi({
 	log,
 	logError,
-	sessions = {},
 }: {
 	log?: components["schemas"]["PipelineStageLogResponse"];
 	logError?: { code?: string; message: string };
-	sessions?: Record<string, SessionView>;
 } = {}) {
-	getMock.mockImplementation((url: string, opts: { params: { path: Record<string, string> } }) => {
+	getMock.mockImplementation((url: string) => {
 		if (url === LOG_URL) {
 			if (logError) return Promise.resolve({ data: undefined, error: logError });
 			return Promise.resolve(log ? { data: log, error: undefined } : { data: undefined, error: { message: "no log" } });
-		}
-		if (url === SESSION_URL) {
-			const found = sessions[opts.params.path.sessionId];
-			return Promise.resolve(
-				found ? { data: { session: found }, error: undefined } : { data: undefined, error: { message: "no session" } },
-			);
 		}
 		throw new Error(`unexpected GET ${url}`);
 	});
@@ -127,6 +133,8 @@ function row(stageId: string): HTMLElement {
 
 beforeEach(() => {
 	usePipelineRunMock.mockReset();
+	workspacesMock.mockReset();
+	setSessions([]);
 	getMock.mockReset();
 	postMock.mockReset().mockResolvedValue({ error: undefined });
 	navigateMock.mockReset();
@@ -171,25 +179,23 @@ describe("PipelineRunDetail header", () => {
 
 	it("links a PR subject out to the PR when the tracked session knows its url", async () => {
 		setRun(detail({ subjectKind: "pr", prNumber: 12, sessionId: "sess-pr" }));
-		setApi({
-			sessions: {
-				"sess-pr": sessionView({
-					id: "sess-pr",
-					prs: [
-						{
-							number: 12,
-							url: "https://github.com/acme/repo/pull/12",
-							state: "open",
-							ci: "passing",
-							mergeability: "mergeable",
-							review: "approved",
-							reviewComments: false,
-							updatedAt: "2026-07-15T00:00:00Z",
-						},
-					],
-				}),
-			},
-		});
+		setSessions([
+			sessionView({
+				id: "sess-pr",
+				prs: [
+					{
+						number: 12,
+						url: "https://github.com/acme/repo/pull/12",
+						state: "open",
+						ci: "passing",
+						mergeability: "mergeable",
+						review: "approved",
+						reviewComments: false,
+						updatedAt: "2026-07-15T00:00:00Z",
+					},
+				],
+			}),
+		]);
 		renderDetail("proj-1");
 
 		const link = await screen.findByRole("link", { name: "PR #12" });
@@ -424,20 +430,18 @@ describe("PipelineRunDetail sessions", () => {
 
 	it("marks a kept session and offers to kill it", async () => {
 		setRun(detail({ stages: [stage({ stageId: "review", outcome: "no_signal", sessionId: "sess-kept" })] }));
-		setApi({
-			sessions: {
-				"sess-kept": sessionView({
-					id: "sess-kept",
-					pipelineOrphan: {
-						runId: "run-1",
-						stage: "review",
-						outcome: "no_signal",
-						pipeline: "review",
-						keptAt: "2026-07-15T00:02:00Z",
-					},
-				}),
-			},
-		});
+		setSessions([
+			sessionView({
+				id: "sess-kept",
+				pipelineOrphan: {
+					runId: "run-1",
+					stage: "review",
+					outcome: "no_signal",
+					pipeline: "review",
+					keptAt: "2026-07-15T00:02:00Z",
+				},
+			}),
+		]);
 		renderDetail("proj-1");
 
 		expect(await within(row("review")).findByText("kept")).toBeInTheDocument();
@@ -466,17 +470,10 @@ describe("PipelineRunDetail sessions", () => {
 			pipeline: "review",
 			keptAt: "2026-07-15T00:02:00Z",
 		};
-		setApi({
-			sessions: {
-				"sess-alive": sessionView({ id: "sess-alive", pipelineOrphan: { ...orphan, stage: "alive" } }),
-				"sess-dead": sessionView({
-					id: "sess-dead",
-					isTerminated: true,
-					status: "terminated",
-					pipelineOrphan: { ...orphan, stage: "dead" },
-				}),
-			},
-		});
+		setSessions([
+			sessionView({ id: "sess-alive", pipelineOrphan: { ...orphan, stage: "alive" } }),
+			sessionView({ id: "sess-dead", status: "terminated", pipelineOrphan: { ...orphan, stage: "dead" } }),
+		]);
 		renderDetail("proj-1");
 
 		await within(row("alive")).findByText("kept");
@@ -496,30 +493,28 @@ describe("PipelineRunDetail sessions", () => {
 				],
 			}),
 		);
-		setApi({
-			sessions: {
-				"sess-mine": sessionView({
-					id: "sess-mine",
-					pipelineOrphan: {
-						runId: "run-1",
-						stage: "mine",
-						outcome: "no_output",
-						pipeline: "review",
-						keptAt: "2026-07-15T00:02:00Z",
-					},
-				}),
-				"sess-other": sessionView({
-					id: "sess-other",
-					pipelineOrphan: {
-						runId: "run-99",
-						stage: "theirs",
-						outcome: "no_output",
-						pipeline: "review",
-						keptAt: "2026-07-15T00:02:00Z",
-					},
-				}),
-			},
-		});
+		setSessions([
+			sessionView({
+				id: "sess-mine",
+				pipelineOrphan: {
+					runId: "run-1",
+					stage: "mine",
+					outcome: "no_output",
+					pipeline: "review",
+					keptAt: "2026-07-15T00:02:00Z",
+				},
+			}),
+			sessionView({
+				id: "sess-other",
+				pipelineOrphan: {
+					runId: "run-99",
+					stage: "theirs",
+					outcome: "no_output",
+					pipeline: "review",
+					keptAt: "2026-07-15T00:02:00Z",
+				},
+			}),
+		]);
 		renderDetail("proj-1");
 
 		await within(row("mine")).findByText("kept");

--- a/frontend/src/renderer/components/PipelineRunDetail.test.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.test.tsx
@@ -22,7 +22,9 @@ vi.mock("../lib/api-client", () => ({
 		GET: (...args: unknown[]) => getMock(...args),
 		POST: (...args: unknown[]) => postMock(...args),
 	},
-	apiErrorMessage: (e: unknown) => (e instanceof Error ? e.message : "error"),
+	apiErrorCode: (e: unknown) => (e as { code?: string } | undefined)?.code,
+	apiErrorMessage: (e: unknown, fallback = "Request failed") =>
+		e instanceof Error ? e.message : ((e as { message?: string } | undefined)?.message ?? fallback),
 	getApiBaseUrl: () => "http://127.0.0.1:3001",
 	hasTrustedApiBaseUrl: () => true,
 }));
@@ -87,13 +89,16 @@ function setRun(run: RunDetail) {
 // behind the orphan marker. Anything else is an unexpected call and fails loudly.
 function setApi({
 	log,
+	logError,
 	sessions = {},
 }: {
 	log?: components["schemas"]["PipelineStageLogResponse"];
+	logError?: { code?: string; message: string };
 	sessions?: Record<string, SessionView>;
 } = {}) {
 	getMock.mockImplementation((url: string, opts: { params: { path: Record<string, string> } }) => {
 		if (url === LOG_URL) {
+			if (logError) return Promise.resolve({ data: undefined, error: logError });
 			return Promise.resolve(log ? { data: log, error: undefined } : { data: undefined, error: { message: "no log" } });
 		}
 		if (url === SESSION_URL) {
@@ -317,6 +322,27 @@ describe("PipelineRunDetail stage log", () => {
 
 		await userEvent.setup().click(within(row("lint")).getByRole("button", { name: "Log" }));
 		expect(await within(row("lint")).findByText("No log was captured for this stage.")).toBeInTheDocument();
+	});
+
+	// The daemon 404s a stage with no log file on disk. That is the empty case,
+	// not a failure, and showing a raw error code for it reads as a broken viewer.
+	it("treats a missing log file as an empty log, not as an error", async () => {
+		setRun(detail({ stages: [stage({ stageId: "review", outcome: "no_signal" })] }));
+		setApi({ logError: { code: "PIPELINE_STAGE_LOG_NOT_FOUND", message: "Pipeline stage has no log yet" } });
+		renderDetail("proj-1");
+
+		await userEvent.setup().click(within(row("review")).getByRole("button", { name: "Log" }));
+		expect(await within(row("review")).findByText("No log was captured for this stage.")).toBeInTheDocument();
+		expect(within(row("review")).queryByText(/PIPELINE_STAGE_LOG_NOT_FOUND/)).not.toBeInTheDocument();
+	});
+
+	it("surfaces a log the daemon could not read", async () => {
+		setRun(detail({ stages: [stage({ stageId: "lint" })] }));
+		setApi({ logError: { code: "INTERNAL", message: "disk on fire" } });
+		renderDetail("proj-1");
+
+		await userEvent.setup().click(within(row("lint")).getByRole("button", { name: "Log" }));
+		expect(await within(row("lint")).findByText(/disk on fire/)).toBeInTheDocument();
 	});
 
 	it("offers no log for a stage that never ran", () => {

--- a/frontend/src/renderer/components/PipelineRunDetail.test.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.test.tsx
@@ -94,9 +94,7 @@ function setApi({
 } = {}) {
 	getMock.mockImplementation((url: string, opts: { params: { path: Record<string, string> } }) => {
 		if (url === LOG_URL) {
-			return Promise.resolve(
-				log ? { data: log, error: undefined } : { data: undefined, error: { message: "no log" } },
-			);
+			return Promise.resolve(log ? { data: log, error: undefined } : { data: undefined, error: { message: "no log" } });
 		}
 		if (url === SESSION_URL) {
 			const found = sessions[opts.params.path.sessionId];
@@ -117,7 +115,9 @@ function renderDetail(project?: string) {
 }
 
 function row(stageId: string): HTMLElement {
-	return screen.getByText(stageId).closest("[data-stage]") as HTMLElement;
+	const found = document.querySelector(`[data-stage="${stageId}"]`);
+	if (!found) throw new Error(`no row for stage ${stageId}`);
+	return found as HTMLElement;
 }
 
 beforeEach(() => {
@@ -329,9 +329,7 @@ describe("PipelineRunDetail stage log", () => {
 
 describe("PipelineRunDetail artifacts", () => {
 	it("links a produced artifact through the outputs endpoint", () => {
-		setRun(
-			detail({ stages: [stage({ stageId: "audit", producedArtifact: { name: "audit.md", exists: true } })] }),
-		);
+		setRun(detail({ stages: [stage({ stageId: "audit", producedArtifact: { name: "audit.md", exists: true } })] }));
 		renderDetail("proj-1");
 
 		expect(within(row("audit")).getByRole("link", { name: "audit.md" })).toHaveAttribute(
@@ -397,9 +395,7 @@ describe("PipelineRunDetail sessions", () => {
 	});
 
 	it("marks a kept session and offers to kill it", async () => {
-		setRun(
-			detail({ stages: [stage({ stageId: "review", outcome: "no_signal", sessionId: "sess-kept" })] }),
-		);
+		setRun(detail({ stages: [stage({ stageId: "review", outcome: "no_signal", sessionId: "sess-kept" })] }));
 		setApi({
 			sessions: {
 				"sess-kept": sessionView({
@@ -425,15 +421,35 @@ describe("PipelineRunDetail sessions", () => {
 		});
 	});
 
+	// A session an earlier run kept is not this run's business. The marker waits
+	// on the sibling stage's badge, so the session lookups have demonstrably
+	// resolved before the absence is asserted.
 	it("does not mark a session another run kept", async () => {
-		setRun(detail({ stages: [stage({ stageId: "review", sessionId: "sess-other" })] }));
+		setRun(
+			detail({
+				stages: [
+					stage({ stageId: "mine", outcome: "no_output", sessionId: "sess-mine" }),
+					stage({ stageId: "theirs", sessionId: "sess-other" }),
+				],
+			}),
+		);
 		setApi({
 			sessions: {
+				"sess-mine": sessionView({
+					id: "sess-mine",
+					pipelineOrphan: {
+						runId: "run-1",
+						stage: "mine",
+						outcome: "no_output",
+						pipeline: "review",
+						keptAt: "2026-07-15T00:02:00Z",
+					},
+				}),
 				"sess-other": sessionView({
 					id: "sess-other",
 					pipelineOrphan: {
 						runId: "run-99",
-						stage: "review",
+						stage: "theirs",
 						outcome: "no_output",
 						pipeline: "review",
 						keptAt: "2026-07-15T00:02:00Z",
@@ -443,9 +459,9 @@ describe("PipelineRunDetail sessions", () => {
 		});
 		renderDetail("proj-1");
 
-		await waitFor(() => expect(getMock).toHaveBeenCalledWith(SESSION_URL, expect.anything()));
-		expect(within(row("review")).queryByText("kept")).not.toBeInTheDocument();
-		expect(within(row("review")).queryByRole("button", { name: "Kill session" })).not.toBeInTheDocument();
+		await within(row("mine")).findByText("kept");
+		expect(within(row("theirs")).queryByText("kept")).not.toBeInTheDocument();
+		expect(within(row("theirs")).queryByRole("button", { name: "Kill session" })).not.toBeInTheDocument();
 	});
 });
 

--- a/frontend/src/renderer/components/PipelineRunDetail.test.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.test.tsx
@@ -4,9 +4,11 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PipelineRunDetail } from "./PipelineRunDetail";
 import type { PipelineRunDetail as RunDetail } from "../hooks/usePipelineRuns";
+import type { components } from "../../api/schema";
 
-const { usePipelineRunMock, postMock, navigateMock } = vi.hoisted(() => ({
+const { usePipelineRunMock, getMock, postMock, navigateMock } = vi.hoisted(() => ({
 	usePipelineRunMock: vi.fn(),
+	getMock: vi.fn(),
 	postMock: vi.fn(),
 	navigateMock: vi.fn(),
 }));
@@ -16,20 +18,31 @@ vi.mock("../hooks/usePipelineRuns", () => ({
 	pipelineRunQueryKey: (runId: string) => ["pipeline-run", runId],
 }));
 vi.mock("../lib/api-client", () => ({
-	apiClient: { POST: (...args: unknown[]) => postMock(...args) },
+	apiClient: {
+		GET: (...args: unknown[]) => getMock(...args),
+		POST: (...args: unknown[]) => postMock(...args),
+	},
 	apiErrorMessage: (e: unknown) => (e instanceof Error ? e.message : "error"),
+	getApiBaseUrl: () => "http://127.0.0.1:3001",
+	hasTrustedApiBaseUrl: () => true,
 }));
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => navigateMock,
 }));
 
 type StageView = RunDetail["stages"][number];
+type SessionView = components["schemas"]["ControllersSessionView"];
+
+const LOG_URL = "/api/v1/pipelines/runs/{runId}/stages/{stageId}/log";
+const SESSION_URL = "/api/v1/sessions/{sessionId}";
 
 function stage(overrides: Partial<StageView> & { stageId: string }): StageView {
 	return {
 		outcome: "succeeded",
 		attempt: 1,
 		enteredVia: "success",
+		startedAt: "2026-07-15T00:00:00Z",
+		settledAt: "2026-07-15T00:01:30Z",
 		...overrides,
 	};
 }
@@ -52,8 +65,47 @@ function detail(overrides: Partial<RunDetail>): RunDetail {
 	};
 }
 
+function sessionView(overrides: Partial<SessionView> & { id: string }): SessionView {
+	return {
+		activity: { lastActivityAt: "2026-07-15T00:00:00Z", state: "idle" },
+		createdAt: "2026-07-15T00:00:00Z",
+		isTerminated: false,
+		kind: "worker",
+		projectId: "proj-1",
+		prs: [],
+		status: "idle",
+		updatedAt: "2026-07-15T00:00:00Z",
+		...overrides,
+	};
+}
+
 function setRun(run: RunDetail) {
 	usePipelineRunMock.mockReturnValue({ data: run, isLoading: false, isError: false, error: null });
+}
+
+// Route every GET the view makes: the stage log endpoint and the session lookup
+// behind the orphan marker. Anything else is an unexpected call and fails loudly.
+function setApi({
+	log,
+	sessions = {},
+}: {
+	log?: components["schemas"]["PipelineStageLogResponse"];
+	sessions?: Record<string, SessionView>;
+} = {}) {
+	getMock.mockImplementation((url: string, opts: { params: { path: Record<string, string> } }) => {
+		if (url === LOG_URL) {
+			return Promise.resolve(
+				log ? { data: log, error: undefined } : { data: undefined, error: { message: "no log" } },
+			);
+		}
+		if (url === SESSION_URL) {
+			const found = sessions[opts.params.path.sessionId];
+			return Promise.resolve(
+				found ? { data: { session: found }, error: undefined } : { data: undefined, error: { message: "no session" } },
+			);
+		}
+		throw new Error(`unexpected GET ${url}`);
+	});
 }
 
 function renderDetail(project?: string) {
@@ -64,65 +116,340 @@ function renderDetail(project?: string) {
 	);
 }
 
+function row(stageId: string): HTMLElement {
+	return screen.getByText(stageId).closest("[data-stage]") as HTMLElement;
+}
+
 beforeEach(() => {
 	usePipelineRunMock.mockReset();
+	getMock.mockReset();
 	postMock.mockReset().mockResolvedValue({ error: undefined });
 	navigateMock.mockReset();
+	setApi();
 });
 
 afterEach(() => vi.restoreAllMocks());
 
-describe("PipelineRunDetail", () => {
+describe("PipelineRunDetail header", () => {
+	it("shows the pipeline, the run status and the run folder path", () => {
+		setRun(detail({ status: "failed", runDir: "/Users/x/.ao/pipelines/proj-1/run-1" }));
+		renderDetail("proj-1");
+
+		expect(screen.getByRole("heading", { name: "review" })).toBeInTheDocument();
+		expect(screen.getByText("failed")).toBeInTheDocument();
+		expect(screen.getByText("/Users/x/.ao/pipelines/proj-1/run-1")).toBeInTheDocument();
+	});
+
+	it("dates the run by when it was created and when it settled", () => {
+		setRun(detail({ status: "succeeded", createdAt: "2026-07-15T00:00:00Z", settledAt: "2026-07-15T00:05:00Z" }));
+		renderDetail("proj-1");
+
+		expect(screen.getByText(/^created /)).toBeInTheDocument();
+		expect(screen.getByText(/^settled /)).toBeInTheDocument();
+	});
+
+	it("says a running run has not settled instead of inventing a settled time", () => {
+		setRun(detail({ status: "running", settledAt: null }));
+		renderDetail("proj-1");
+
+		expect(screen.queryByText(/^settled /)).not.toBeInTheDocument();
+		expect(screen.getByText("not settled")).toBeInTheDocument();
+	});
+
+	it("links a session subject to its session page", async () => {
+		setRun(detail({ subjectKind: "session", sessionId: "sess-42" }));
+		renderDetail("proj-1");
+
+		await userEvent.setup().click(screen.getByRole("button", { name: "sess-42" }));
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/sessions/$sessionId", params: { sessionId: "sess-42" } });
+	});
+
+	it("links a PR subject out to the PR when the tracked session knows its url", async () => {
+		setRun(detail({ subjectKind: "pr", prNumber: 12, sessionId: "sess-pr" }));
+		setApi({
+			sessions: {
+				"sess-pr": sessionView({
+					id: "sess-pr",
+					prs: [
+						{
+							number: 12,
+							url: "https://github.com/acme/repo/pull/12",
+							state: "open",
+							ci: "passing",
+							mergeability: "mergeable",
+							review: "approved",
+							reviewComments: false,
+							updatedAt: "2026-07-15T00:00:00Z",
+						},
+					],
+				}),
+			},
+		});
+		renderDetail("proj-1");
+
+		const link = await screen.findByRole("link", { name: "PR #12" });
+		expect(link).toHaveAttribute("href", "https://github.com/acme/repo/pull/12");
+	});
+
+	it("still names a sessionless PR subject, as plain text rather than a dead link", () => {
+		setRun(detail({ subjectKind: "pr", prNumber: 12, sessionId: "" }));
+		renderDetail("proj-1");
+
+		expect(screen.getByText("PR #12")).toBeInTheDocument();
+		expect(screen.queryByRole("link", { name: "PR #12" })).not.toBeInTheDocument();
+	});
+
+	it("shows the cancel reason next to a cancelled run's status", () => {
+		setRun(detail({ status: "cancelled", cancelReason: "superseded by a newer run" }));
+		renderDetail("proj-1");
+
+		expect(screen.getByText("· superseded by a newer run")).toBeInTheDocument();
+	});
+});
+
+describe("PipelineRunDetail stages", () => {
+	// The API returns stages in the definition's document order, so the view must
+	// not re-sort them: a run reads top to bottom the way it was written.
+	it("renders stages in the order the API returned them", () => {
+		setRun(
+			detail({ stages: [stage({ stageId: "review" }), stage({ stageId: "assess" }), stage({ stageId: "publish" })] }),
+		);
+		const { container } = render(
+			<QueryClientProvider client={new QueryClient()}>
+				<PipelineRunDetail runId="run-1" project="proj-1" />
+			</QueryClientProvider>,
+		);
+
+		const ids = Array.from(container.querySelectorAll("[data-stage]")).map((el) => el.getAttribute("data-stage"));
+		expect(ids).toEqual(["review", "assess", "publish"]);
+	});
+
 	it("renders each stage with its outcome, attempt and reason", () => {
+		setRun(detail({ stages: [stage({ stageId: "lint", outcome: "failed", attempt: 2, reason: "exit 1" })] }));
+		renderDetail("proj-1");
+
+		expect(within(row("lint")).getByText("failed")).toBeInTheDocument();
+		expect(within(row("lint")).getByText("attempt 2")).toBeInTheDocument();
+		expect(within(row("lint")).getByText("exit 1")).toBeInTheDocument();
+	});
+
+	// Attempt 2 exists only because the engine nudged once (spec 7.1), so the
+	// screen names the nudge rather than leaving a bare number to decode.
+	it("tags attempt 2 as nudged and leaves a first attempt untagged", () => {
 		setRun(
 			detail({
-				stages: [stage({ stageId: "lint", outcome: "failed", attempt: 2, reason: "exit 1" })],
+				stages: [stage({ stageId: "second", attempt: 2 }), stage({ stageId: "first", attempt: 1 })],
 			}),
 		);
 		renderDetail("proj-1");
 
-		const row = screen.getByText("lint").closest("[data-stage]") as HTMLElement;
-		expect(within(row).getByText("failed")).toBeInTheDocument();
-		// Attempt 2 is the one nudge a stage gets, and it is labelled as such.
-		expect(within(row).getByText(/attempt 2/)).toBeInTheDocument();
-		expect(within(row).getByText(/nudged/)).toBeInTheDocument();
-		expect(within(row).getByText("exit 1")).toBeInTheDocument();
+		expect(within(row("second")).getByText("nudged")).toBeInTheDocument();
+		expect(within(row("first")).queryByText("nudged")).not.toBeInTheDocument();
+		expect(within(row("first")).queryByText(/attempt/)).not.toBeInTheDocument();
 	});
 
 	it("spells succeeded_unverified the way the spec does", () => {
 		setRun(detail({ stages: [stage({ stageId: "answer", outcome: "succeeded_unverified" })] }));
 		renderDetail("proj-1");
 
-		const row = screen.getByText("answer").closest("[data-stage]") as HTMLElement;
-		expect(within(row).getByText("succeeded (unverified)")).toBeInTheDocument();
-	});
-
-	it("names a declared artifact and flags it when the engine did not find one", () => {
-		setRun(
-			detail({
-				stages: [
-					stage({ stageId: "assess", outcome: "no_output", producedArtifact: { name: "review.md", exists: false } }),
-					stage({ stageId: "audit", outcome: "succeeded", producedArtifact: { name: "audit.md", exists: true } }),
-				],
-			}),
-		);
-		renderDetail("proj-1");
-
-		const missing = screen.getByText("assess").closest("[data-stage]") as HTMLElement;
-		expect(within(missing).getByText("review.md (missing)")).toBeInTheDocument();
-
-		const present = screen.getByText("audit").closest("[data-stage]") as HTMLElement;
-		expect(within(present).getByText("audit.md")).toBeInTheDocument();
+		expect(within(row("answer")).getByText("succeeded (unverified)")).toBeInTheDocument();
 	});
 
 	it("names the stage whose failure routed here", () => {
 		setRun(detail({ stages: [stage({ stageId: "notify", enteredVia: "failure", failedStage: "publish" })] }));
 		renderDetail("proj-1");
 
-		const row = screen.getByText("notify").closest("[data-stage]") as HTMLElement;
-		expect(within(row).getByText("via publish failing")).toBeInTheDocument();
+		expect(within(row("notify")).getByText("via publish failing")).toBeInTheDocument();
 	});
 
+	it("times a settled stage and marks a running one as still going", () => {
+		setRun(
+			detail({
+				stages: [
+					stage({ stageId: "done", startedAt: "2026-07-15T00:00:00Z", settledAt: "2026-07-15T00:01:30Z" }),
+					stage({ stageId: "live", outcome: "running", startedAt: "2026-07-15T00:00:00Z", settledAt: null }),
+				],
+			}),
+		);
+		renderDetail("proj-1");
+
+		expect(within(row("done")).getByText("1m 30s")).toBeInTheDocument();
+		expect(within(row("live")).getByText(/^running for /)).toBeInTheDocument();
+	});
+
+	it("shows no duration for a stage that never started", () => {
+		setRun(detail({ stages: [stage({ stageId: "later", outcome: "pending", startedAt: null, settledAt: null })] }));
+		renderDetail("proj-1");
+
+		expect(within(row("later")).queryByText(/running for/)).not.toBeInTheDocument();
+	});
+});
+
+describe("PipelineRunDetail stage log", () => {
+	it("keeps the log collapsed until asked, then fetches the tail", async () => {
+		setRun(detail({ stages: [stage({ stageId: "lint", outcome: "failed" })] }));
+		setApi({ log: { runId: "run-1", stageId: "lint", content: "npm ERR! boom", truncated: false } });
+		renderDetail("proj-1");
+
+		expect(getMock).not.toHaveBeenCalledWith(LOG_URL, expect.anything());
+
+		await userEvent.setup().click(within(row("lint")).getByRole("button", { name: "Log" }));
+
+		expect(await within(row("lint")).findByText("npm ERR! boom")).toBeInTheDocument();
+		expect(getMock).toHaveBeenCalledWith(LOG_URL, {
+			params: { path: { runId: "run-1", stageId: "lint" }, query: { tail: 200 } },
+		});
+	});
+
+	it("says so when the tail is only part of the log", async () => {
+		setRun(detail({ stages: [stage({ stageId: "lint" })] }));
+		setApi({ log: { runId: "run-1", stageId: "lint", content: "line", truncated: true } });
+		renderDetail("proj-1");
+
+		await userEvent.setup().click(within(row("lint")).getByRole("button", { name: "Log" }));
+		expect(await within(row("lint")).findByText(/last 200 lines/)).toBeInTheDocument();
+	});
+
+	it("reports an empty log rather than an empty box", async () => {
+		setRun(detail({ stages: [stage({ stageId: "lint" })] }));
+		setApi({ log: { runId: "run-1", stageId: "lint", content: "", truncated: false } });
+		renderDetail("proj-1");
+
+		await userEvent.setup().click(within(row("lint")).getByRole("button", { name: "Log" }));
+		expect(await within(row("lint")).findByText("No log was captured for this stage.")).toBeInTheDocument();
+	});
+
+	it("offers no log for a stage that never ran", () => {
+		setRun(detail({ stages: [stage({ stageId: "skipped", outcome: "skipped", startedAt: null, settledAt: null })] }));
+		renderDetail("proj-1");
+
+		expect(within(row("skipped")).queryByRole("button", { name: "Log" })).not.toBeInTheDocument();
+	});
+});
+
+describe("PipelineRunDetail artifacts", () => {
+	it("links a produced artifact through the outputs endpoint", () => {
+		setRun(
+			detail({ stages: [stage({ stageId: "audit", producedArtifact: { name: "audit.md", exists: true } })] }),
+		);
+		renderDetail("proj-1");
+
+		expect(within(row("audit")).getByRole("link", { name: "audit.md" })).toHaveAttribute(
+			"href",
+			"http://127.0.0.1:3001/api/v1/pipelines/runs/run-1/outputs/audit.md",
+		);
+	});
+
+	// no_output is the whole point of the taxonomy: the agent said done and the
+	// file was not there. Saying that beats a link to nothing.
+	it("explains a no_output stage instead of linking a file that does not exist", () => {
+		setRun(
+			detail({
+				stages: [
+					stage({ stageId: "assess", outcome: "no_output", producedArtifact: { name: "review.md", exists: false } }),
+				],
+			}),
+		);
+		renderDetail("proj-1");
+
+		expect(within(row("assess")).queryByRole("link")).not.toBeInTheDocument();
+		expect(within(row("assess")).getByText(/review\.md/)).toHaveTextContent(
+			"review.md is missing: the agent signalled done and the file was not there.",
+		);
+	});
+
+	it("distinguishes a missing artifact on a settled stage from one that is not due yet", () => {
+		setRun(
+			detail({
+				stages: [
+					stage({ stageId: "gone", outcome: "succeeded", producedArtifact: { name: "out.md", exists: false } }),
+					stage({
+						stageId: "queued",
+						outcome: "pending",
+						startedAt: null,
+						settledAt: null,
+						producedArtifact: { name: "later.md", exists: false },
+					}),
+				],
+			}),
+		);
+		renderDetail("proj-1");
+
+		expect(within(row("gone")).getByText("out.md is not in the run folder.")).toBeInTheDocument();
+		expect(within(row("queued")).getByText("produces later.md")).toBeInTheDocument();
+	});
+});
+
+describe("PipelineRunDetail sessions", () => {
+	it("links a stage's session id to the session page", async () => {
+		setRun(detail({ stages: [stage({ stageId: "fix", sessionId: "sess-fix-1" })] }));
+		renderDetail("proj-1");
+
+		await userEvent.setup().click(within(row("fix")).getByRole("button", { name: "sess-fix-1" }));
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/sessions/$sessionId", params: { sessionId: "sess-fix-1" } });
+	});
+
+	it("does not render a stage session link when the stage has no sessionId (command stages)", () => {
+		setRun(detail({ stages: [stage({ stageId: "lint" })] }));
+		renderDetail("proj-1");
+
+		expect(within(row("lint")).queryByRole("button", { name: /sess-/ })).not.toBeInTheDocument();
+	});
+
+	it("marks a kept session and offers to kill it", async () => {
+		setRun(
+			detail({ stages: [stage({ stageId: "review", outcome: "no_signal", sessionId: "sess-kept" })] }),
+		);
+		setApi({
+			sessions: {
+				"sess-kept": sessionView({
+					id: "sess-kept",
+					pipelineOrphan: {
+						runId: "run-1",
+						stage: "review",
+						outcome: "no_signal",
+						pipeline: "review",
+						keptAt: "2026-07-15T00:02:00Z",
+					},
+				}),
+			},
+		});
+		renderDetail("proj-1");
+
+		expect(await within(row("review")).findByText("kept")).toBeInTheDocument();
+
+		await userEvent.setup().click(within(row("review")).getByRole("button", { name: "Kill session" }));
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+		expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/kill", {
+			params: { path: { sessionId: "sess-kept" } },
+		});
+	});
+
+	it("does not mark a session another run kept", async () => {
+		setRun(detail({ stages: [stage({ stageId: "review", sessionId: "sess-other" })] }));
+		setApi({
+			sessions: {
+				"sess-other": sessionView({
+					id: "sess-other",
+					pipelineOrphan: {
+						runId: "run-99",
+						stage: "review",
+						outcome: "no_output",
+						pipeline: "review",
+						keptAt: "2026-07-15T00:02:00Z",
+					},
+				}),
+			},
+		});
+		renderDetail("proj-1");
+
+		await waitFor(() => expect(getMock).toHaveBeenCalledWith(SESSION_URL, expect.anything()));
+		expect(within(row("review")).queryByText("kept")).not.toBeInTheDocument();
+		expect(within(row("review")).queryByRole("button", { name: "Kill session" })).not.toBeInTheDocument();
+	});
+});
+
+describe("PipelineRunDetail actions", () => {
 	it("cancels a running run with the run's project scope", async () => {
 		setRun(detail({ status: "running" }));
 		renderDetail("proj-7");
@@ -136,12 +463,14 @@ describe("PipelineRunDetail", () => {
 	});
 
 	// v2 has no resume: a failed run is dead, and re-running means a new run.
-	it("offers no Cancel and no Resume on a settled run", () => {
+	// The findings panel went with the findings subsystem (D10).
+	it("offers no Cancel, no Resume and no findings on a settled run", () => {
 		setRun(detail({ status: "failed" }));
 		renderDetail("proj-1");
 
 		expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Resume" })).not.toBeInTheDocument();
+		expect(screen.queryByText(/finding/i)).not.toBeInTheDocument();
 	});
 
 	it("disables the action when the run's project is unknown", () => {
@@ -149,63 +478,5 @@ describe("PipelineRunDetail", () => {
 		renderDetail(undefined);
 
 		expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
-	});
-
-	it("shows the cancel reason next to a cancelled run's status", () => {
-		setRun(detail({ status: "cancelled", cancelReason: "superseded by a newer run" }));
-		renderDetail("proj-1");
-
-		expect(screen.getByText("· superseded by a newer run")).toBeInTheDocument();
-	});
-
-	it("links the run-level session id to the session page", async () => {
-		setRun(detail({ sessionId: "sess-42" }));
-		renderDetail("proj-1");
-
-		await userEvent.setup().click(screen.getByRole("button", { name: "sess-42" }));
-		expect(navigateMock).toHaveBeenCalledWith({ to: "/sessions/$sessionId", params: { sessionId: "sess-42" } });
-	});
-
-	it("renders a dash instead of a link when the run has no session", () => {
-		setRun(detail({ sessionId: "" }));
-		renderDetail("proj-1");
-
-		expect(screen.getByText("—", { exact: false })).toBeInTheDocument();
-		expect(screen.queryByRole("button", { name: "sess-42" })).not.toBeInTheDocument();
-	});
-
-	it("links a stage's session id to the session page", async () => {
-		setRun(detail({ stages: [stage({ stageId: "fix", sessionId: "sess-fix-1" })] }));
-		renderDetail("proj-1");
-
-		const row = screen.getByText("fix").closest("[data-stage]") as HTMLElement;
-		await userEvent.setup().click(within(row).getByRole("button", { name: "sess-fix-1" }));
-		expect(navigateMock).toHaveBeenCalledWith({ to: "/sessions/$sessionId", params: { sessionId: "sess-fix-1" } });
-	});
-
-	it("does not render a stage session link when the stage has no sessionId (command stages)", () => {
-		setRun(detail({ stages: [stage({ stageId: "lint" })] }));
-		renderDetail("proj-1");
-
-		const row = screen.getByText("lint").closest("[data-stage]") as HTMLElement;
-		expect(within(row).queryAllByRole("button")).toHaveLength(0);
-	});
-
-	// The API returns stages in the definition's document order, so the view must
-	// not re-sort them: a run reads top to bottom the way it was written.
-	it("renders stages in the order the API returned them", () => {
-		setRun(
-			detail({
-				stages: [stage({ stageId: "review" }), stage({ stageId: "assess" }), stage({ stageId: "publish" })],
-			}),
-		);
-		const { container } = render(
-			<QueryClientProvider client={new QueryClient()}>
-				<PipelineRunDetail runId="run-1" project="proj-1" />
-			</QueryClientProvider>,
-		);
-
-		const ids = Array.from(container.querySelectorAll("[data-stage]")).map((el) => el.getAttribute("data-stage"));
-		expect(ids).toEqual(["review", "assess", "publish"]);
 	});
 });

--- a/frontend/src/renderer/components/PipelineRunDetail.test.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.test.tsx
@@ -342,7 +342,9 @@ describe("PipelineRunDetail stage log", () => {
 		renderDetail("proj-1");
 
 		await userEvent.setup().click(within(row("lint")).getByRole("button", { name: "Log" }));
-		expect(await within(row("lint")).findByText(/disk on fire/)).toBeInTheDocument();
+		// The query retries once before it settles into its error state, so this
+		// waits past the retry rather than racing it.
+		expect(await within(row("lint")).findByText(/disk on fire/, {}, { timeout: 5000 })).toBeInTheDocument();
 	});
 
 	it("offers no log for a stage that never ran", () => {

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -1,27 +1,37 @@
 import { useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { cn } from "../lib/utils";
 import { formatTimeCompact } from "../lib/format-time";
-import { apiClient, apiErrorMessage } from "../lib/api-client";
-import { runStatusTone, shortSha, stageOutcomeDotTone, stageOutcomeLabel } from "../lib/pipeline-display";
+import { apiClient, apiErrorMessage, getApiBaseUrl } from "../lib/api-client";
+import {
+	formatStageDuration,
+	runStatusTone,
+	shortSha,
+	stageOutcomeDotTone,
+	stageOutcomeLabel,
+} from "../lib/pipeline-display";
 import { pipelineRunQueryKey, usePipelineRun } from "../hooks/usePipelineRuns";
+import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import type { RunStatus, StageOutcome } from "../lib/pipeline-draft";
 import type { components } from "../../api/schema";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 
 type PipelineStageView = components["schemas"]["PipelineStageView"];
+type SessionView = components["schemas"]["ControllersSessionView"];
 
-// Read-only detail for one pipeline run: per-stage outcomes plus the one
-// lifecycle action v2 keeps. There is no resume (spec section 14.1) and no
-// findings panel: the findings subsystem is deleted, and a stage's contract is
-// its one declared artifact.
-//
-// Task 24 rewrites this into the full v2 surface: outcome badges, the nudge tag,
-// the collapsible log viewer over the stage log endpoint, artifact download
-// links over the outputs endpoint, and the orphaned-session affordance. This is
-// the mechanical port that keeps the build green on the v2 DTO.
+// How much of a stage log the viewer asks for. The log is the main debugging
+// surface for a command stage that failed, and the interesting part of a failure
+// is the end of it.
+const LOG_TAIL_LINES = 200;
+
+// Read-only detail for one pipeline run. Its job is to make the outcome taxonomy
+// (spec section 7) legible: which stage settled how, whether it was nudged,
+// which failure routed into it, what it produced or failed to produce, and what
+// its log says. There is no resume (spec section 14.1) and no findings panel:
+// the findings subsystem is deleted (D10), and a stage's contract is its one
+// declared artifact.
 export function PipelineRunDetail({ runId, project }: { runId: string; project?: string }) {
 	const queryClient = useQueryClient();
 	const { data: run, isLoading, isError, error } = usePipelineRun(runId);
@@ -56,46 +66,61 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 
 	// Stages arrive in plan order from the API; only a live run can be cancelled.
 	const stages = run.stages;
-	const canCancel = run.status === "pending" || run.status === "running";
+	const status = run.status as RunStatus;
+	const canCancel = status === "pending" || status === "running";
 
 	return (
 		<div className="flex h-full min-h-0 flex-col overflow-y-auto bg-background text-foreground">
-			<header className="flex flex-wrap items-center gap-3 border-b border-border px-6 py-5">
-				<div className="min-w-0">
-					<div className="flex items-center gap-2">
-						<h1 className="truncate text-subtitle font-bold tracking-tight text-foreground">{run.pipelineName}</h1>
-						<span className={cn("text-caption font-semibold", runStatusTone(run.status as RunStatus))}>
-							{run.status}
-						</span>
-						{run.cancelReason && <span className="text-caption text-passive">· {run.cancelReason}</span>}
+			<header className="border-b border-border px-6 py-5">
+				<div className="flex flex-wrap items-center gap-2">
+					<h1 className="truncate text-subtitle font-bold tracking-tight text-foreground">{run.pipelineName}</h1>
+					<Badge variant="outline" className={cn("gap-1.5", runStatusTone(status))} data-run-status={status}>
+						<span className={cn("h-1.5 w-1.5 rounded-full", stageOutcomeDotTone(status as StageOutcome))} />
+						{status}
+					</Badge>
+					{run.cancelReason && <span className="text-caption text-passive">· {run.cancelReason}</span>}
+					<div className="ml-auto flex items-center gap-2">
+						{actionError && <span className="text-caption text-error">{actionError}</span>}
+						{canCancel && (
+							<Button
+								size="sm"
+								variant="outline"
+								disabled={cancel.isPending || !project}
+								title={project ? undefined : "Open this run from the board to cancel it"}
+								onClick={() => cancel.mutate()}
+							>
+								{cancel.isPending ? "Cancelling…" : "Cancel"}
+							</Button>
+						)}
 					</div>
-					<p className="mt-0.5 truncate font-mono text-micro text-passive">
-						{run.runId} · session {run.sessionId ? <SessionLink sessionId={run.sessionId} /> : "—"}
-						{run.prNumber ? ` · PR #${run.prNumber}` : ""}
-						{run.headSha ? ` · ${shortSha(run.headSha)}` : ""} · updated {formatTimeCompact(run.updatedAt)}
-					</p>
 				</div>
-				<div className="ml-auto flex items-center gap-2">
-					{actionError && <span className="text-caption text-error">{actionError}</span>}
-					{canCancel && (
-						<Button
-							size="sm"
-							variant="outline"
-							disabled={cancel.isPending || !project}
-							title={project ? undefined : "Open this run from the board to cancel it"}
-							onClick={() => cancel.mutate()}
-						>
-							{cancel.isPending ? "Cancelling…" : "Cancel"}
-						</Button>
+
+				<div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-micro text-passive">
+					<span>{run.runId}</span>
+					<span aria-hidden="true">·</span>
+					<RunSubject run={run} />
+					<span aria-hidden="true">·</span>
+					<span title={absoluteTime(run.createdAt)}>created {formatTimeCompact(run.createdAt)}</span>
+					<span aria-hidden="true">·</span>
+					{run.settledAt ? (
+						<span title={absoluteTime(run.settledAt)}>settled {formatTimeCompact(run.settledAt)}</span>
+					) : (
+						<span>not settled</span>
 					)}
 				</div>
+
+				{run.runDir && (
+					<p className="mt-1 truncate font-mono text-micro text-passive" title={run.runDir}>
+						{run.runDir}
+					</p>
+				)}
 			</header>
 
 			<section aria-label="Stages" className="px-6 py-4">
 				<h2 className="mb-2 text-micro font-semibold uppercase tracking-wide text-passive">Stages</h2>
 				<div className="flex flex-col gap-2">
 					{stages.map((stage) => (
-						<StageRow key={stage.stageId} stage={stage} />
+						<StageRow key={stage.stageId} runId={run.runId} stage={stage} />
 					))}
 					{stages.length === 0 && <p className="text-caption text-passive">No stages yet.</p>}
 				</div>
@@ -104,54 +129,210 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 	);
 }
 
-// One stage row: outcome, attempt, and a collapsible block for the captured
-// output tail when the stage produced one.
-function StageRow({ stage }: { stage: PipelineStageView }) {
-	const [showOutput, setShowOutput] = useState(false);
-	const outcome = stage.outcome as StageOutcome;
-	return (
-		<div
-			data-stage={stage.stageId}
-			className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-card px-3 py-2"
-		>
-			<span className={cn("h-2 w-2 shrink-0 rounded-full", stageOutcomeDotTone(outcome))} />
-			<span className="font-mono text-caption font-medium text-foreground">{stage.stageId}</span>
-			<span className="font-mono text-micro text-passive">{stageOutcomeLabel(outcome)}</span>
-			{stage.sessionId && (
-				<span className="font-mono text-micro text-passive">
-					· session <SessionLink sessionId={stage.sessionId} />
-				</span>
-			)}
-			{stage.enteredVia === "failure" && stage.failedStage && (
-				<Badge variant="outline">via {stage.failedStage} failing</Badge>
-			)}
-			{stage.producedArtifact && (
-				<Badge variant={stage.producedArtifact.exists ? "outline" : "warning"}>
-					{stage.producedArtifact.exists ? stage.producedArtifact.name : `${stage.producedArtifact.name} (missing)`}
-				</Badge>
-			)}
-			<span className="ml-auto flex items-center gap-2 font-mono text-micro text-passive">
-				{stage.outputTail && (
-					<button
-						type="button"
-						onClick={() => setShowOutput((v) => !v)}
-						className="rounded px-1 text-passive underline-offset-2 hover:text-foreground hover:underline"
-						aria-expanded={showOutput}
+// What the run is about. A PR subject only has a url when a local session tracks
+// it (the run DTO carries the number, not the link), and a sessionless PR is
+// first-class (spec section 4), so the number renders as plain text rather than
+// as a link to a guessed url.
+function RunSubject({ run }: { run: components["schemas"]["PipelineRunDetail"] }) {
+	const session = useSessionView(run.sessionId);
+	if (run.subjectKind === "pr" && run.prNumber) {
+		const prUrl = session?.prs?.find((pr) => pr.number === run.prNumber)?.url;
+		return (
+			<span className="flex items-center gap-2">
+				{prUrl ? (
+					<a
+						href={prUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="rounded text-passive underline-offset-2 hover:text-foreground hover:underline"
 					>
-						{showOutput ? "Hide output" : "Output"}
-					</button>
+						PR #{run.prNumber}
+					</a>
+				) : (
+					<span>PR #{run.prNumber}</span>
 				)}
-				<span>
-					attempt {stage.attempt}
-					{stage.attempt > 1 ? " · nudged" : ""}
-				</span>
+				{run.headSha && <span>{shortSha(run.headSha)}</span>}
+				{run.sessionId && <SessionLink sessionId={run.sessionId} />}
 			</span>
-			{stage.reason && <p className="w-full font-mono text-micro text-error">{stage.reason}</p>}
-			{stage.outputTail && showOutput && (
-				<pre className="max-h-80 w-full overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-background px-2 py-1.5 font-mono text-micro text-muted-foreground">
-					{stage.outputTail}
-				</pre>
+		);
+	}
+	if (run.sessionId) return <SessionLink sessionId={run.sessionId} />;
+	return <span>{run.subjectKind} subject</span>;
+}
+
+// One stage row: how it settled, how long it took, why it was entered, what it
+// produced, and the two things a human reaches for when it went wrong (the log
+// and the session that is still alive).
+function StageRow({ runId, stage }: { runId: string; stage: PipelineStageView }) {
+	const [showLog, setShowLog] = useState(false);
+	const outcome = stage.outcome as StageOutcome;
+	const settled = Boolean(stage.settledAt);
+	const duration = formatStageDuration(stage.startedAt, stage.settledAt);
+	// A stage the plan never reached has no log file, so do not offer a button
+	// that can only 404.
+	const hasLog = Boolean(stage.startedAt);
+
+	return (
+		<div data-stage={stage.stageId} className="rounded-md border border-border bg-card px-3 py-2.5">
+			<div className="flex flex-wrap items-center gap-2">
+				<span className="font-mono text-caption font-medium text-foreground">{stage.stageId}</span>
+				<Badge variant="outline" className="gap-1.5">
+					<span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", stageOutcomeDotTone(outcome))} />
+					{stageOutcomeLabel(outcome)}
+				</Badge>
+				{stage.attempt > 1 && (
+					<>
+						<span className="font-mono text-micro text-passive">attempt {stage.attempt}</span>
+						<Badge variant="warning" title="The engine nudged this stage once and it ran again (spec 7.1)">
+							nudged
+						</Badge>
+					</>
+				)}
+				{stage.enteredVia === "failure" && stage.failedStage && (
+					<Badge variant="outline">via {stage.failedStage} failing</Badge>
+				)}
+				<span className="ml-auto flex items-center gap-2 font-mono text-micro text-passive">
+					{duration && <span>{settled ? duration : `running for ${duration}`}</span>}
+					{hasLog && (
+						<button
+							type="button"
+							onClick={() => setShowLog((v) => !v)}
+							aria-expanded={showLog}
+							className="rounded px-1 text-passive underline-offset-2 hover:text-foreground hover:underline"
+						>
+							{showLog ? "Hide log" : "Log"}
+						</button>
+					)}
+				</span>
+			</div>
+
+			{stage.reason && <p className="mt-1.5 font-mono text-micro text-error">{stage.reason}</p>}
+
+			{(stage.producedArtifact || stage.sessionId) && (
+				<div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-micro text-passive">
+					{stage.producedArtifact && (
+						<StageArtifact runId={runId} artifact={stage.producedArtifact} outcome={outcome} />
+					)}
+					{stage.sessionId && <StageSession runId={runId} stageId={stage.stageId} sessionId={stage.sessionId} />}
+				</div>
 			)}
+
+			{showLog && <StageLog runId={runId} stageId={stage.stageId} live={!settled} />}
+		</div>
+	);
+}
+
+// The declared artifact, verified against the run folder by the API. The three
+// states are deliberately distinct: `no_output` is the agent saying done with
+// nothing there (spec section 7), a settled stage missing its file means the run
+// folder no longer has it, and a stage that has not run yet is simply not due.
+function StageArtifact({
+	runId,
+	artifact,
+	outcome,
+}: {
+	runId: string;
+	artifact: components["schemas"]["PipelineProducedArtifact"];
+	outcome: StageOutcome;
+}) {
+	if (artifact.exists) {
+		return (
+			<a
+				href={`${getApiBaseUrl()}/api/v1/pipelines/runs/${encodeURIComponent(runId)}/outputs/${encodeURIComponent(artifact.name)}`}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="rounded text-accent underline-offset-2 hover:underline"
+			>
+				{artifact.name}
+			</a>
+		);
+	}
+	if (outcome === "no_output") {
+		return <span className="text-warning">{artifact.name} is missing: the agent signalled done and the file was not there.</span>;
+	}
+	if (outcome === "pending" || outcome === "running") {
+		return <span>produces {artifact.name}</span>;
+	}
+	return <span className="text-warning">{artifact.name} is not in the run folder.</span>;
+}
+
+// A stage's session, plus the affordance for one the engine kept alive:
+// `no_output`, `no_signal` and `timed_out` spare the session precisely so a
+// human can look at it (spec section 7.2), and the bound on that is a visible
+// marker and a kill button, not a silent reaper.
+function StageSession({ runId, stageId, sessionId }: { runId: string; stageId: string; sessionId: string }) {
+	const queryClient = useQueryClient();
+	const session = useSessionView(sessionId);
+	const [killError, setKillError] = useState<string | null>(null);
+	const orphan = session?.pipelineOrphan;
+	const keptHere = orphan?.runId === runId && orphan?.stage === stageId;
+
+	const kill = useMutation({
+		mutationFn: async () => {
+			const { error: apiError } = await apiClient.POST("/api/v1/sessions/{sessionId}/kill", {
+				params: { path: { sessionId } },
+			});
+			if (apiError) throw new Error(apiErrorMessage(apiError));
+		},
+		onSuccess: () => {
+			setKillError(null);
+			void queryClient.invalidateQueries({ queryKey: sessionViewQueryKey(sessionId) });
+			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+		},
+		onError: (e: unknown) => setKillError(e instanceof Error ? e.message : "Kill failed"),
+	});
+
+	return (
+		<span className="flex items-center gap-2">
+			<span>session</span>
+			<SessionLink sessionId={sessionId} />
+			{keptHere && orphan && (
+				<>
+					<Badge
+						variant="warning"
+						title={`Kept alive after ${stageOutcomeLabel(orphan.outcome as StageOutcome)}, ${formatTimeCompact(orphan.keptAt)}, so you can see what the agent was doing.`}
+					>
+						kept
+					</Badge>
+					<Button size="sm" variant="ghost" disabled={kill.isPending} onClick={() => kill.mutate()}>
+						{kill.isPending ? "Killing…" : "Kill session"}
+					</Button>
+				</>
+			)}
+			{killError && <span className="text-error">{killError}</span>}
+		</span>
+	);
+}
+
+// The stage's captured stdout and stderr, fetched only once someone opens it and
+// refetched while the stage is still running.
+function StageLog({ runId, stageId, live }: { runId: string; stageId: string; live: boolean }) {
+	const { data, isLoading, error } = useQuery({
+		queryKey: ["pipeline-stage-log", runId, stageId],
+		queryFn: async () => {
+			const { data: body, error: apiError } = await apiClient.GET(
+				"/api/v1/pipelines/runs/{runId}/stages/{stageId}/log",
+				{ params: { path: { runId, stageId }, query: { tail: LOG_TAIL_LINES } } },
+			);
+			if (apiError) throw new Error(apiErrorMessage(apiError, "Could not read the stage log"));
+			return body;
+		},
+		retry: 1,
+		refetchInterval: live ? 5_000 : false,
+	});
+
+	if (isLoading) return <p className="mt-1.5 font-mono text-micro text-passive">Loading log…</p>;
+	if (error) {
+		return <p className="mt-1.5 font-mono text-micro text-error">{apiErrorMessage(error, "Could not read the stage log")}</p>;
+	}
+	if (!data?.content) return <p className="mt-1.5 font-mono text-micro text-passive">No log was captured for this stage.</p>;
+
+	return (
+		<div className="mt-1.5">
+			{data.truncated && <p className="mb-1 font-mono text-micro text-passive">Showing the last 200 lines.</p>}
+			<pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-background px-2 py-1.5 font-mono text-micro text-muted-foreground">
+				{data.content}
+			</pre>
 		</div>
 	);
 }
@@ -170,4 +351,34 @@ function SessionLink({ sessionId }: { sessionId: string }) {
 			{sessionId}
 		</button>
 	);
+}
+
+function sessionViewQueryKey(sessionId: string) {
+	return ["pipeline-session", sessionId] as const;
+}
+
+// One session's DTO, for the two things run detail reads off it: the orphan
+// marker (`pipelineOrphan`, added with the kill-on disposition) and the PR url a
+// PR-subject run needs and does not carry itself. Shared query key, so several
+// stages on one session cost one request.
+function useSessionView(sessionId: string | undefined): SessionView | undefined {
+	const { data } = useQuery({
+		queryKey: sessionViewQueryKey(sessionId ?? ""),
+		enabled: Boolean(sessionId),
+		queryFn: async () => {
+			const { data: body, error: apiError } = await apiClient.GET("/api/v1/sessions/{sessionId}", {
+				params: { path: { sessionId: sessionId as string } },
+			});
+			if (apiError) throw new Error(apiErrorMessage(apiError, "Could not load the session"));
+			return body?.session;
+		},
+		retry: 1,
+		refetchInterval: 15_000,
+	});
+	return data;
+}
+
+function absoluteTime(iso: string): string {
+	const ts = new Date(iso);
+	return Number.isFinite(ts.getTime()) ? ts.toLocaleString() : iso;
 }

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -275,7 +275,11 @@ function StageSession({ runId, stageId, sessionId }: { runId: string; stageId: s
 	const session = useSessionView(sessionId);
 	const [killError, setKillError] = useState<string | null>(null);
 	const orphan = session?.pipelineOrphan;
-	const keptHere = orphan?.runId === runId && orphan?.stage === stageId;
+	// `pipelineOrphan` survives on the DTO after the session is killed, so the
+	// terminated check is what makes the marker mean "still alive, go look at
+	// it" rather than "was spared once". Without it the kill button stays after
+	// it has done its job.
+	const keptHere = orphan?.runId === runId && orphan?.stage === stageId && !session?.isTerminated;
 
 	const kill = useMutation({
 		mutationFn: async () => {

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -11,15 +11,16 @@ import {
 	stageOutcomeDotTone,
 	stageOutcomeLabel,
 } from "../lib/pipeline-display";
+import { useKillSession } from "../hooks/useKillSession";
 import { pipelineRunQueryKey, usePipelineRun } from "../hooks/usePipelineRuns";
-import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import type { RunStatus, StageOutcome } from "../lib/pipeline-draft";
+import type { WorkspaceSession } from "../types/workspace";
 import type { components } from "../../api/schema";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 
 type PipelineStageView = components["schemas"]["PipelineStageView"];
-type SessionView = components["schemas"]["ControllersSessionView"];
 
 // How much of a stage log the viewer asks for. The log is the main debugging
 // surface for a command stage that failed, and the interesting part of a failure
@@ -138,7 +139,7 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 // first-class (spec section 4), so the number renders as plain text rather than
 // as a link to a guessed url.
 function RunSubject({ run }: { run: components["schemas"]["PipelineRunDetail"] }) {
-	const session = useSessionView(run.sessionId);
+	const session = useSessionFacts(run.sessionId);
 	if (run.subjectKind === "pr" && run.prNumber) {
 		const prUrl = session?.prs?.find((pr) => pr.number === run.prNumber)?.url;
 		return (
@@ -271,30 +272,21 @@ function StageArtifact({
 // human can look at it (spec section 7.2), and the bound on that is a visible
 // marker and a kill button, not a silent reaper.
 function StageSession({ runId, stageId, sessionId }: { runId: string; stageId: string; sessionId: string }) {
-	const queryClient = useQueryClient();
-	const session = useSessionView(sessionId);
+	const session = useSessionFacts(sessionId);
 	const [killError, setKillError] = useState<string | null>(null);
 	const orphan = session?.pipelineOrphan;
 	// `pipelineOrphan` survives on the DTO after the session is killed, so the
 	// terminated check is what makes the marker mean "still alive, go look at
 	// it" rather than "was spared once". Without it the kill button stays after
 	// it has done its job.
-	const keptHere = orphan?.runId === runId && orphan?.stage === stageId && !session?.isTerminated;
+	const keptHere = orphan?.runId === runId && orphan?.stage === stageId && session?.status !== "terminated";
 
-	const kill = useMutation({
-		mutationFn: async () => {
-			const { error: apiError } = await apiClient.POST("/api/v1/sessions/{sessionId}/kill", {
-				params: { path: { sessionId } },
-			});
-			if (apiError) throw new Error(apiErrorMessage(apiError));
-		},
-		onSuccess: () => {
-			setKillError(null);
-			void queryClient.invalidateQueries({ queryKey: sessionViewQueryKey(sessionId) });
-			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-		},
-		onError: (e: unknown) => setKillError(e instanceof Error ? e.message : "Kill failed"),
-	});
+	// The shared kill mutation: one endpoint, one set of telemetry events, and a
+	// workspace refetch that is also what refreshes the marker on this row.
+	const kill = useKillSession(
+		{ id: sessionId, workspaceId: session?.workspaceId ?? "" },
+		{ onKilled: () => setKillError(null), onError: setKillError },
+	);
 
 	return (
 		<span className="flex items-center gap-2">
@@ -374,29 +366,19 @@ function SessionLink({ sessionId }: { sessionId: string }) {
 	);
 }
 
-function sessionViewQueryKey(sessionId: string) {
-	return ["pipeline-session", sessionId] as const;
-}
-
-// One session's DTO, for the two things run detail reads off it: the orphan
-// marker (`pipelineOrphan`, added with the kill-on disposition) and the PR url a
-// PR-subject run needs and does not carry itself. Shared query key, so several
-// stages on one session cost one request.
-function useSessionView(sessionId: string | undefined): SessionView | undefined {
-	const { data } = useQuery({
-		queryKey: sessionViewQueryKey(sessionId ?? ""),
-		enabled: Boolean(sessionId),
-		queryFn: async () => {
-			const { data: body, error: apiError } = await apiClient.GET("/api/v1/sessions/{sessionId}", {
-				params: { path: { sessionId: sessionId as string } },
-			});
-			if (apiError) throw new Error(apiErrorMessage(apiError, "Could not load the session"));
-			return body?.session;
-		},
-		retry: 1,
-		refetchInterval: 15_000,
-	});
-	return data;
+// The two things run detail reads off a session: the orphan marker
+// (`pipelineOrphan`) and the PR url a PR-subject run needs and does not carry
+// itself. Both ride the workspace query the shell has already loaded, so this
+// screen adds no request of its own and sees the same session facts as the
+// board.
+function useSessionFacts(sessionId: string | undefined): WorkspaceSession | undefined {
+	const workspaces = useWorkspaceQuery().data;
+	if (!sessionId) return undefined;
+	for (const workspace of workspaces ?? []) {
+		const found = workspace.sessions.find((session) => session.id === sessionId);
+		if (found) return found;
+	}
+	return undefined;
 }
 
 function absoluteTime(iso: string): string {

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -248,7 +248,11 @@ function StageArtifact({
 		);
 	}
 	if (outcome === "no_output") {
-		return <span className="text-warning">{artifact.name} is missing: the agent signalled done and the file was not there.</span>;
+		return (
+			<span className="text-warning">
+				{artifact.name} is missing: the agent signalled done and the file was not there.
+			</span>
+		);
 	}
 	if (outcome === "pending" || outcome === "running") {
 		return <span>produces {artifact.name}</span>;
@@ -323,9 +327,12 @@ function StageLog({ runId, stageId, live }: { runId: string; stageId: string; li
 
 	if (isLoading) return <p className="mt-1.5 font-mono text-micro text-passive">Loading log…</p>;
 	if (error) {
-		return <p className="mt-1.5 font-mono text-micro text-error">{apiErrorMessage(error, "Could not read the stage log")}</p>;
+		return (
+			<p className="mt-1.5 font-mono text-micro text-error">{apiErrorMessage(error, "Could not read the stage log")}</p>
+		);
 	}
-	if (!data?.content) return <p className="mt-1.5 font-mono text-micro text-passive">No log was captured for this stage.</p>;
+	if (!data?.content)
+		return <p className="mt-1.5 font-mono text-micro text-passive">No log was captured for this stage.</p>;
 
 	return (
 		<div className="mt-1.5">

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { cn } from "../lib/utils";
 import { formatTimeCompact } from "../lib/format-time";
-import { apiClient, apiErrorMessage, getApiBaseUrl } from "../lib/api-client";
+import { apiClient, apiErrorCode, apiErrorMessage, getApiBaseUrl } from "../lib/api-client";
 import {
 	formatStageDuration,
 	runStatusTone,
@@ -25,6 +25,10 @@ type SessionView = components["schemas"]["ControllersSessionView"];
 // surface for a command stage that failed, and the interesting part of a failure
 // is the end of it.
 const LOG_TAIL_LINES = 200;
+
+// The daemon's code for "this stage has no log file", which the viewer renders
+// as an empty log rather than as a failure.
+const LOG_NOT_FOUND_CODE = "PIPELINE_STAGE_LOG_NOT_FOUND";
 
 // Read-only detail for one pipeline run. Its job is to make the outcome taxonomy
 // (spec section 7) legible: which stage settled how, whether it was nudged,
@@ -157,7 +161,9 @@ function RunSubject({ run }: { run: components["schemas"]["PipelineRunDetail"] }
 		);
 	}
 	if (run.sessionId) return <SessionLink sessionId={run.sessionId} />;
-	return <span>{run.subjectKind} subject</span>;
+	// A project subject (a manual trigger) has neither a PR nor a session to
+	// point at, and saying so is the whole of it.
+	return <span>{run.subjectKind}</span>;
 }
 
 // One stage row: how it settled, how long it took, why it was entered, what it
@@ -298,7 +304,7 @@ function StageSession({ runId, stageId, sessionId }: { runId: string; stageId: s
 					>
 						kept
 					</Badge>
-					<Button size="sm" variant="ghost" disabled={kill.isPending} onClick={() => kill.mutate()}>
+					<Button size="sm" variant="outline" disabled={kill.isPending} onClick={() => kill.mutate()}>
 						{kill.isPending ? "Killing…" : "Kill session"}
 					</Button>
 				</>
@@ -318,6 +324,10 @@ function StageLog({ runId, stageId, live }: { runId: string; stageId: string; li
 				"/api/v1/pipelines/runs/{runId}/stages/{stageId}/log",
 				{ params: { path: { runId, stageId }, query: { tail: LOG_TAIL_LINES } } },
 			);
+			// A stage with no log file on disk is the empty case, not an error:
+			// showing an error code for "nothing was written" reads as a bug in
+			// the viewer rather than as the fact it is.
+			if (apiErrorCode(apiError) === LOG_NOT_FOUND_CODE) return { content: "", truncated: false };
 			if (apiError) throw new Error(apiErrorMessage(apiError, "Could not read the stage log"));
 			return body;
 		},

--- a/frontend/src/renderer/lib/pipeline-display.test.ts
+++ b/frontend/src/renderer/lib/pipeline-display.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { SETTLED_OUTCOMES, type StageOutcome } from "./pipeline-draft";
 import {
+	formatStageDuration,
 	KANBAN_COLUMNS,
 	runStatusOf,
 	runStatusTone,
@@ -78,33 +79,43 @@ describe("stageOutcomeDotTone", () => {
 });
 
 describe("runStatusOf", () => {
-	it("prefers the v2 status field", () => {
-		expect(runStatusOf({ status: "succeeded", loopState: "stalled" })).toBe("succeeded");
-	});
-
-	it("falls back to the v1 loop state until the API regen lands", () => {
-		expect(runStatusOf({ loopState: "running" })).toBe("running");
-		expect(runStatusOf({ loopState: "awaiting_context" })).toBe("running");
-		expect(runStatusOf({ loopState: "done" })).toBe("succeeded");
-		expect(runStatusOf({ loopState: "stalled" })).toBe("failed");
-		expect(runStatusOf({ loopState: "terminated" })).toBe("cancelled");
+	it("reads the run's status field", () => {
+		expect(runStatusOf({ status: "succeeded" })).toBe("succeeded");
 	});
 
 	it("reads an unknown or missing status as pending rather than dropping the run", () => {
 		expect(runStatusOf({})).toBe("pending");
 		expect(runStatusOf({ status: "exploded" })).toBe("pending");
-		expect(runStatusOf({ loopState: "who_knows" })).toBe("pending");
 	});
 });
 
 describe("stageOutcomesOf", () => {
-	it("prefers stageOutcomes and falls back to the v1 stageStatuses map", () => {
+	it("reads the outcome map, treating a null one as empty", () => {
 		expect(stageOutcomesOf({ stageOutcomes: { lint: "succeeded_unverified" } })).toEqual({
 			lint: "succeeded_unverified",
 		});
-		expect(stageOutcomesOf({ stageStatuses: { lint: "running" } })).toEqual({ lint: "running" });
-		expect(stageOutcomesOf({ stageStatuses: null })).toEqual({});
+		expect(stageOutcomesOf({ stageOutcomes: null })).toEqual({});
 		expect(stageOutcomesOf({})).toEqual({});
+	});
+});
+
+describe("formatStageDuration", () => {
+	it("scales from seconds to hours", () => {
+		expect(formatStageDuration("2026-07-15T00:00:00Z", "2026-07-15T00:00:09Z")).toBe("9s");
+		expect(formatStageDuration("2026-07-15T00:00:00Z", "2026-07-15T00:01:30Z")).toBe("1m 30s");
+		expect(formatStageDuration("2026-07-15T00:00:00Z", "2026-07-15T02:05:00Z")).toBe("2h 5m");
+	});
+
+	it("measures an unsettled stage against now", () => {
+		const startedAt = new Date(Date.now() - 90_000).toISOString();
+		expect(formatStageDuration(startedAt, null)).toBe("1m 30s");
+	});
+
+	it("has no duration for a stage that never started, or for clocks that ran backwards", () => {
+		expect(formatStageDuration(null, null)).toBe("");
+		expect(formatStageDuration(undefined, "2026-07-15T00:01:00Z")).toBe("");
+		expect(formatStageDuration("2026-07-15T00:01:00Z", "2026-07-15T00:00:00Z")).toBe("");
+		expect(formatStageDuration("not a date", "2026-07-15T00:00:00Z")).toBe("");
 	});
 });
 

--- a/frontend/src/renderer/lib/pipeline-display.ts
+++ b/frontend/src/renderer/lib/pipeline-display.ts
@@ -88,41 +88,25 @@ export function stageOutcomeLabel(outcome: StageOutcome): string {
 	return outcome === "succeeded_unverified" ? "succeeded (unverified)" : outcome.replace(/_/g, " ");
 }
 
-// The run fields this module reads. Task 18 regenerates `api/schema.ts` with the
-// v2 DTO (`status`, `stageOutcomes`); until then the runs list still serves the
-// v1 `loopState`/`stageStatuses`, so both readers below prefer the v2 field and
-// fall back to the v1 one. The board therefore keys on RunStatus today and keeps
-// working the day the regen lands.
-// ponytail: drop the v1 fallbacks (and this type) once Task 18 has merged.
+// The run fields this module reads, straight off the v2 run DTO.
 export type RunDisplayFields = {
 	status?: string;
-	loopState?: string;
 	stageOutcomes?: { [key: string]: string } | null;
-	stageStatuses?: { [key: string]: string } | null;
 };
 
 const RUN_STATUSES: readonly string[] = KANBAN_COLUMNS.map((col) => col.status);
-
-// v1 loop states → the v2 run status they stood for.
-const LOOP_STATE_STATUS: Record<string, RunStatus> = {
-	running: "running",
-	awaiting_context: "running",
-	done: "succeeded",
-	stalled: "failed",
-	terminated: "cancelled",
-};
 
 // An unknown status reads as "pending" so an unrecognised run still lands in a
 // column instead of vanishing off the board.
 export function runStatusOf(run: RunDisplayFields): RunStatus {
 	if (run.status && RUN_STATUSES.includes(run.status)) return run.status as RunStatus;
-	return LOOP_STATE_STATUS[run.loopState ?? ""] ?? "pending";
+	return "pending";
 }
 
-// v1 statuses that are not v2 outcomes (e.g. "outdated") fall through to the
-// neutral branch of stageOutcomeDotTone, which is why this cast is safe.
+// An outcome the UI does not know falls through to the neutral branch of
+// stageOutcomeDotTone, which is why this cast is safe.
 export function stageOutcomesOf(run: RunDisplayFields): Record<string, StageOutcome> {
-	return (run.stageOutcomes ?? run.stageStatuses ?? {}) as Record<string, StageOutcome>;
+	return (run.stageOutcomes ?? {}) as Record<string, StageOutcome>;
 }
 
 // A short commit reference for a run header.
@@ -130,39 +114,17 @@ export function shortSha(sha: string): string {
 	return sha.length > 12 ? sha.slice(0, 12) : sha;
 }
 
-// --- v1 leftovers -----------------------------------------------------------
-// PipelineRunDetail still renders the v1 loop/findings vocabulary; Task 24
-// rewrites it onto the outcome palette above. These three exist only to keep it
-// compiling until then, and go with it.
-
-export function loopStateTone(state: string): string {
-	switch (state) {
-		case "running":
-			return "text-working";
-		case "awaiting_context":
-			return "text-warning";
-		case "done":
-			return "text-success";
-		case "stalled":
-			return "text-error";
-		case "terminated":
-		default:
-			return "text-passive";
-	}
-}
-
-export function stageStatusDotTone(status: string): string {
-	return stageOutcomeDotTone(status as StageOutcome);
-}
-
-export function severityBadgeVariant(severity: string | undefined): "error" | "warning" | "neutral" {
-	switch ((severity ?? "").toLowerCase()) {
-		case "critical":
-		case "high":
-			return "error";
-		case "medium":
-			return "warning";
-		default:
-			return "neutral";
-	}
+// How long a stage took, for run detail. An unsettled stage is measured against
+// now, so a running stage's row keeps counting; a stage that never started has
+// no duration at all rather than a misleading zero.
+export function formatStageDuration(startedAt?: string | null, settledAt?: string | null): string {
+	if (!startedAt) return "";
+	const start = new Date(startedAt).getTime();
+	const end = settledAt ? new Date(settledAt).getTime() : Date.now();
+	if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return "";
+	const seconds = Math.round((end - start) / 1000);
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+	return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
 }


### PR DESCRIPTION
Pipelines v2, Task 24. Closes #330.

## What this screen is for

Run detail is where the outcome taxonomy (spec section 7) has to become legible. Eight stage outcomes only pay for themselves if a human can see which one happened, why the stage was entered, what it produced or failed to produce, and what its log says. That is the whole rewrite.

## Header

Pipeline name, run status badge, subject, run folder path, created and settled.

- The status badge reuses `runStatusTone` for the text and `stageOutcomeDotTone` for the dot rather than introducing a second palette (#317 owns the vocabulary).
- **Subject.** A session subject links to its session page. A PR subject renders `PR #N`, linked out when the run's tracked session carries that PR's url and as plain text when it does not: the run DTO carries the number, not a url, and a sessionless PR subject is first-class (spec section 4), so the screen names the PR rather than linking a guessed one.
- A run that has not settled says `not settled` instead of borrowing `updatedAt` and calling it a settle time.

## Per-stage rows, in plan order

Outcome badge (dot plus the spec's own wording, so `succeeded (unverified)` reads as itself), `attempt N` with a **nudged** tag from attempt 2 (the one nudge, spec 7.1), a `via <stage> failing` badge naming the stage whose failure routed here, duration, and the reason line.

- **Log viewer.** Collapsible, fetches `/pipelines/runs/{runId}/stages/{stageId}/log?tail=200` only when opened, and refetches every 5s while the stage is still running. A stage with no log file on disk (the daemon's `PIPELINE_STAGE_LOG_NOT_FOUND`) is the empty case, not an error, so it reads "No log was captured for this stage." rather than an error code; a truncated tail says it is showing the last 200 lines. A stage that never started gets no Log button at all.
- **Artifact.** Three distinct states, not two: a verified artifact links through `/pipelines/runs/{runId}/outputs/{filename}`; a `no_output` stage says `<name> is missing: the agent signalled done and the file was not there.`; a settled stage whose file is gone from the run folder says that instead. A stage that has not run yet just shows `produces <name>`. `producedArtifact.exists` is verified against the run folder by #328, so "the agent produced nothing" and "someone deleted the run folder" stay distinguishable on screen.
- **Session and orphan affordance.** A stage's session links to its page. When `pipelineOrphan` names *this* run and *this* stage and the session is still alive, the row carries a `kept` badge (tooltip: the outcome that spared it and when) plus a **Kill session** button. Matching on run id and stage id means a session an earlier run kept is not mislabelled as this run's, and the alive check matters because the daemon leaves `pipelineOrphan` on the DTO after a kill, so without it the button would linger after doing its job.

Cancel is offered for pending/running runs only. **Resume is gone and the findings panel is gone**; neither was ported, and a test asserts their absence.

## Rebased onto Task 25

#332 landed while this was in flight, so the session facts here come from what it built rather than from a second path: `useKillSession` for the kill (one endpoint, one set of telemetry events) and `pipelineOrphan` on `WorkspaceSession` via the workspace query the shell has already loaded. This screen therefore issues no session request of its own, and the shared mutation's workspace refetch is what clears the marker after a kill.

## Also removed

`pipeline-display.ts` still carried the v1 leftovers #328 flagged for this task: `loopStateTone`, `stageStatusDotTone`, `severityBadgeVariant` (all unreferenced once run detail stopped rendering the v1 loop/findings vocabulary) and the v1 `loopState`/`stageStatuses` fallbacks in `runStatusOf`/`stageOutcomesOf`. `formatStageDuration` lands there instead, next to the rest of the display vocabulary.

## Live verification

Real engine, real runs, no seeded DTOs and no shimmed endpoints. A second daemon built from this branch (`AO_PORT=3099`, `AO_DATA_DIR=/tmp/ao-t24/data`, `AO_PIPELINES=on`), a scratch git repo registered as project `scratch`, and the renderer served by vite against that daemon (`VITE_AO_API_BASE_URL=http://127.0.0.1:3099`), opened through `ao preview`. Screens below are what the browser rendered from the daemon's JSON.

**1. Failure routing, skip cascade and logs** (`t24-demo`, four command stages, `defaults.on_failure: notify-failure`):

```
build          succeeded     4s   log: "building the scratch project / build ok"
verify         failed        2s   reason "command exited 1", log ends "check 4 of 7 failed: ..."
publish        skipped
notify-failure succeeded     2s   via verify failing, log "t24-demo failed at verify (failed)"
```

Header read `t24-demo · failed`, the run id, `project`, created/settled, and `/tmp/ao-t24/data/pipelines/scratch/run-70a12fbb-...`. Skipped rows correctly carry no duration and no Log button.

**2. Nudged stage, missing artifact and kept session** (`t24-agent-demo`: an agent stage with `produces: review.md` on the `fake` harness, which walks a real session lifecycle without signalling, so the engine nudges once and then settles):

```
review          no output   attempt 2  nudged   4s
                reason "declared artifact agent-outputs/review.md is missing or empty"
                "review.md is missing: the agent signalled done and the file was not there."
                session scratch-2  [kept]  [Kill session]
post-review     skipped
notify-failure  succeeded   via review failing
```

That is the nudged stage and the failure-routed stage the task asked for, on one screen. The `kept` badge came from the real `pipelineOrphan` the engine stamped on `scratch-2` (`outcome no_output`, this run, stage `review`).

**3. Kill session.** Clicked it on the live row: the daemon terminated the session, the workspace refetch landed, and the badge and button disappeared while the session link stayed. Before the alive check was added, both survived the kill, because the daemon keeps `pipelineOrphan` on a terminated session.

**4. Artifact link.** Writing `agent-outputs/review.md` into that run folder flipped `producedArtifact.exists` to true on the next poll and the row rendered the link, `href` `http://127.0.0.1:3099/api/v1/pipelines/runs/run-c4405e9f-.../outputs/review.md`, which serves the file. To be exact about what was live here: the run itself settled `no_output`, and the file was placed by hand to exercise the exists-true branch against the real outputs endpoint. No run in this session produced an artifact on its own, because the only harness available without token spend never writes one.

**5. Running run and cancel.** A 120s soak stage rendered `running` with the accent badge, `not settled`, `running for 18s`, a live log tail, and a `pending` downstream stage. Clicking Cancel settled the run: `cancelled · cancelled from the API`, `soak cancelled`, `after skipped`.

No console errors on any of these screens.

**Not driven live:** `timed_out` and `succeeded_unverified` (both need a stage that outlives its deadline or an agent stage with no `produces`, neither of which the fake harness reaches quickly), and a PR-subject run (no local PR on the scratch repo). Those four paths are covered by tests only, and the PR-subject link falls back to plain text when no url resolves, which is the same code path a sessionless PR takes.

## Verification

- Full renderer build (`vite build`) green, `tsc --noEmit` clean, **1130 renderer tests pass**, prettier clean on all four changed files.
- 31 tests on this component (up from 12), covering each header field, stage ordering, the nudge tag, failure routing, durations, all three artifact states, log collapse/fetch/empty/truncated/404, the orphan marker (matched, foreign-run, terminated) and its kill call, and the absence of resume and findings.
- Mutation-checked the assertions most likely to be vacuous: forcing `keptHere` true, dropping the terminated check, blanking the resolved PR url, and rewording the `no_output` copy each fail exactly the test that claims to cover them. The two absence tests wait on a sibling stage's badge before asserting, so neither can pass just because data had not arrived.

## Follow-up for someone else

The daemon leaves `pipelineOrphan` on a session after it is killed. This screen and #332's board badge both work around it on the client. Clearing it in `SetSessionPipelineOrphan` on kill would be the real fix, and it is backend work this PR does not touch.
