### PR TITLE
feat(pipelines): v2 CLI verbs, credential set/ls/rm, drop resume

### DIFF
--- a/backend/internal/cli/pipeline.go
+++ b/backend/internal/cli/pipeline.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -34,50 +36,56 @@ type listPipelineDefinitionsResponse struct {
 	Definitions []pipelineDefinitionSummary `json:"definitions"`
 }
 
+// pipelineRunSummary is v2's run shape: a run status rollup and the subject the
+// run is about, in place of v1's loop state and termination reason.
 type pipelineRunSummary struct {
-	RunID             string    `json:"runId"`
-	PipelineID        string    `json:"pipelineId"`
-	PipelineName      string    `json:"pipelineName"`
-	SessionID         string    `json:"sessionId"`
-	LoopState         string    `json:"loopState"`
-	TerminationReason string    `json:"terminationReason,omitempty"`
-	LoopRounds        int       `json:"loopRounds"`
-	HeadSHA           string    `json:"headSha"`
-	StageCount        int       `json:"stageCount"`
-	HasOpenFindings   bool      `json:"hasOpenFindings"`
-	CreatedAt         time.Time `json:"createdAt"`
-	UpdatedAt         time.Time `json:"updatedAt"`
+	RunID         string            `json:"runId"`
+	PipelineID    string            `json:"pipelineId"`
+	PipelineName  string            `json:"pipelineName"`
+	Status        string            `json:"status"`
+	SubjectKind   string            `json:"subjectKind"`
+	SessionID     string            `json:"sessionId,omitempty"`
+	PRNumber      int               `json:"prNumber,omitempty"`
+	HeadSHA       string            `json:"headSha,omitempty"`
+	CancelReason  string            `json:"cancelReason,omitempty"`
+	StageCount    int               `json:"stageCount"`
+	StageOutcomes map[string]string `json:"stageOutcomes"`
+	CreatedAt     time.Time         `json:"createdAt"`
+	UpdatedAt     time.Time         `json:"updatedAt"`
+	SettledAt     *time.Time        `json:"settledAt,omitempty"`
 }
 
 type listPipelineRunsResponse struct {
 	Runs []pipelineRunSummary `json:"runs"`
 }
 
-type pipelineStageView struct {
-	StageName    string   `json:"stageName"`
-	StageRunID   string   `json:"stageRunId"`
-	Status       string   `json:"status"`
-	Attempt      int      `json:"attempt"`
-	Verdict      string   `json:"verdict,omitempty"`
-	ErrorMessage string   `json:"errorMessage,omitempty"`
-	ArtifactIDs  []string `json:"artifactIds"`
+type pipelineProducedArtifact struct {
+	Name   string `json:"name"`
+	Exists bool   `json:"exists"`
 }
 
-// pipelineFinding captures the finding fields the human view renders; the full
-// artifact blob is preserved in --json output via the raw response.
-type pipelineFinding struct {
-	Kind      string `json:"kind"`
-	StageName string `json:"stageName"`
-	Title     string `json:"title,omitempty"`
-	FilePath  string `json:"filePath,omitempty"`
-	Severity  string `json:"severity,omitempty"`
-	Status    string `json:"status"`
+// pipelineStageView is one stage's v2 state: an outcome from the taxonomy, the
+// attempt (2 means the stage was nudged), the edge it was entered by, and the
+// reason behind a failure or a cancellation.
+type pipelineStageView struct {
+	StageID          string                    `json:"stageId"`
+	Outcome          string                    `json:"outcome"`
+	Attempt          int                       `json:"attempt"`
+	EnteredVia       string                    `json:"enteredVia"`
+	FailedStage      string                    `json:"failedStage,omitempty"`
+	SessionID        string                    `json:"sessionId,omitempty"`
+	WorkspaceKind    string                    `json:"workspaceKind,omitempty"`
+	StartedAt        *time.Time                `json:"startedAt,omitempty"`
+	SettledAt        *time.Time                `json:"settledAt,omitempty"`
+	Reason           string                    `json:"reason,omitempty"`
+	OutputTail       string                    `json:"outputTail,omitempty"`
+	ProducedArtifact *pipelineProducedArtifact `json:"producedArtifact,omitempty"`
 }
 
 type pipelineRunDetail struct {
 	pipelineRunSummary
-	Stages   []pipelineStageView `json:"stages"`
-	Findings []pipelineFinding   `json:"findings"`
+	RunDir string              `json:"runDir,omitempty"`
+	Stages []pipelineStageView `json:"stages"`
 }
 
 type pipelineRunDetailResponse struct {
@@ -86,6 +94,18 @@ type pipelineRunDetailResponse struct {
 
 type triggerPipelineRunResponse struct {
 	RunID string `json:"runId"`
+}
+
+// listPipelineCredentialsResponse is names only, and there is no DTO here with
+// a value field: decision D13 keeps credential values inside the daemon, so
+// nothing the CLI can decode carries one.
+type listPipelineCredentialsResponse struct {
+	Names []string `json:"names"`
+}
+
+type pipelineCredentialResponse struct {
+	Name string   `json:"name"`
+	Keys []string `json:"keys"`
 }
 
 // ---------------------------------------------------------------------------
@@ -111,27 +131,29 @@ type pipelineShowOptions struct {
 }
 
 type pipelineRunOptions struct {
-	project string
-	session string
-	headSHA string
-	json    bool
+	project  string
+	session  string
+	prNumber int
+	json     bool
 }
 
 // ---------------------------------------------------------------------------
 // Command wiring
 // ---------------------------------------------------------------------------
 
+// newPipelineCommand builds the v2 verb set. There is no `resume`: a settled
+// run is final (spec section 14.1), and re-running means triggering a new run.
 func newPipelineCommand(ctx *commandContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pipeline",
-		Short: "Manage AO pipelines (definitions and runs)",
+		Short: "Manage AO pipelines (definitions, runs, credentials)",
 	}
 	cmd.AddCommand(newPipelineListCommand(ctx))
 	cmd.AddCommand(newPipelineRunsCommand(ctx))
 	cmd.AddCommand(newPipelineShowCommand(ctx))
 	cmd.AddCommand(newPipelineRunCommand(ctx))
 	cmd.AddCommand(newPipelineCancelCommand(ctx))
-	cmd.AddCommand(newPipelineResumeCommand(ctx))
+	cmd.AddCommand(newPipelineCredentialCommand(ctx))
 	cmd.AddCommand(newPipelineDoneCommand(ctx))
 	cmd.AddCommand(newPipelineFailCommand(ctx))
 	return cmd
@@ -166,7 +188,7 @@ func newPipelineRunsCommand(ctx *commandContext) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&opts.project, "project", "p", "", "Project id to scope to")
 	f.StringVar(&opts.pipeline, "pipeline", "", "Filter by pipeline name")
-	f.StringVar(&opts.status, "status", "", "Filter by loop state (running|awaiting_context|done|stalled|terminated)")
+	f.StringVar(&opts.status, "status", "", "Filter by run status (pending|running|succeeded|failed|cancelled)")
 	f.IntVar(&opts.limit, "limit", 0, "Cap the number of runs returned")
 	f.BoolVar(&opts.json, "json", false, "Output as JSON")
 	return cmd
@@ -176,7 +198,7 @@ func newPipelineShowCommand(ctx *commandContext) *cobra.Command {
 	var opts pipelineShowOptions
 	cmd := &cobra.Command{
 		Use:   "show <runId>",
-		Short: "Show run detail (stages, attempts, verdicts, findings)",
+		Short: "Show run detail (stage outcomes, attempts, reasons, artifacts)",
 		Args:  onePipelineRunIDArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return ctx.pipelineShow(cmd, args[0], opts)
@@ -193,15 +215,19 @@ func newPipelineRunCommand(ctx *commandContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run <pipeline-ref>",
 		Short: "Trigger a manual run for a pipeline (by id or name)",
-		Args:  onePipelineRefArg,
+		Long: "Trigger a manual run for a pipeline (by id or name).\n\n" +
+			"The subject is resolved by the daemon: --session runs against a session, " +
+			"--pr against a tracked pull request (whose head SHA and fork provenance the " +
+			"daemon looks up), and neither makes it a project run.",
+		Args: onePipelineRefArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return ctx.pipelineRun(cmd, args[0], opts)
 		},
 	}
 	f := cmd.Flags()
 	f.StringVarP(&opts.project, "project", "p", "", "Project id to scope to")
-	f.StringVar(&opts.session, "session", "", "Session id to scope the run's loop key")
-	f.StringVar(&opts.headSHA, "head-sha", "", "Head commit SHA to pin the run to")
+	f.StringVar(&opts.session, "session", "", "Run against this session as the subject")
+	f.IntVar(&opts.prNumber, "pr", 0, "Run against this tracked pull request as the subject")
 	f.BoolVar(&opts.json, "json", false, "Output as JSON")
 	return cmd
 }
@@ -213,21 +239,7 @@ func newPipelineCancelCommand(ctx *commandContext) *cobra.Command {
 		Short: "Cancel an in-flight run",
 		Args:  onePipelineRunIDArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ctx.pipelineLifecycle(cmd, args[0], project, "cancel")
-		},
-	}
-	cmd.Flags().StringVarP(&project, "project", "p", "", "Project id to scope to")
-	return cmd
-}
-
-func newPipelineResumeCommand(ctx *commandContext) *cobra.Command {
-	var project string
-	cmd := &cobra.Command{
-		Use:   "resume <runId>",
-		Short: "Resume a stalled or failed run",
-		Args:  onePipelineRunIDArg,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return ctx.pipelineLifecycle(cmd, args[0], project, "resume")
+			return ctx.pipelineCancel(cmd, args[0], project)
 		},
 	}
 	cmd.Flags().StringVarP(&project, "project", "p", "", "Project id to scope to")
@@ -264,6 +276,72 @@ func newPipelineFailCommand(ctx *commandContext) *cobra.Command {
 	return cmd
 }
 
+// ---------------------------------------------------------------------------
+// Credential verbs (decision D13)
+// ---------------------------------------------------------------------------
+
+// newPipelineCredentialCommand groups the engine-held credential verbs. Values
+// travel one way: in through `set`, out only into a command stage's process env
+// at exec time. No verb here prints one back, and `ls` answers with names.
+func newPipelineCredentialCommand(ctx *commandContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "credential",
+		Short: "Manage engine-held credentials for command stages",
+	}
+	cmd.AddCommand(newPipelineCredentialSetCommand(ctx))
+	cmd.AddCommand(newPipelineCredentialLsCommand(ctx))
+	cmd.AddCommand(newPipelineCredentialRmCommand(ctx))
+	return cmd
+}
+
+func newPipelineCredentialSetCommand(ctx *commandContext) *cobra.Command {
+	var project string
+	cmd := &cobra.Command{
+		Use:   "set <name> KEY=VALUE...",
+		Short: "Create or replace a credential (values are never printed back)",
+		Long: "Create or replace a credential.\n\n" +
+			"The variables given replace the credential's whole environment, so dropping " +
+			"a KEY=VALUE removes that variable. Values live in the daemon and are injected " +
+			"into a command stage's process env at exec time; no command prints one back.\n\n" +
+			"Values passed here land in your shell history: prefer a shell that skips " +
+			"history for the command, or set the credential from a script.",
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ctx.pipelineCredentialSet(cmd, args, project)
+		},
+	}
+	cmd.Flags().StringVarP(&project, "project", "p", "", "Project id to scope to")
+	return cmd
+}
+
+func newPipelineCredentialLsCommand(ctx *commandContext) *cobra.Command {
+	var project string
+	cmd := &cobra.Command{
+		Use:   "ls",
+		Short: "List credential names for a project",
+		Args:  noArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return ctx.pipelineCredentialLs(cmd, project)
+		},
+	}
+	cmd.Flags().StringVarP(&project, "project", "p", "", "Project id to scope to")
+	return cmd
+}
+
+func newPipelineCredentialRmCommand(ctx *commandContext) *cobra.Command {
+	var project string
+	cmd := &cobra.Command{
+		Use:   "rm <name>",
+		Short: "Delete a credential",
+		Args:  onePipelineCredentialNameArg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ctx.pipelineCredentialRm(cmd, args[0], project)
+		},
+	}
+	cmd.Flags().StringVarP(&project, "project", "p", "", "Project id to scope to")
+	return cmd
+}
+
 func onePipelineRunIDArg(cmd *cobra.Command, args []string) error {
 	if err := cobra.ExactArgs(1)(cmd, args); err != nil {
 		return usageError{err}
@@ -280,6 +358,16 @@ func onePipelineRefArg(cmd *cobra.Command, args []string) error {
 	}
 	if strings.TrimSpace(args[0]) == "" {
 		return usageError{fmt.Errorf("pipeline id or name is required")}
+	}
+	return nil
+}
+
+func onePipelineCredentialNameArg(cmd *cobra.Command, args []string) error {
+	if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+		return usageError{err}
+	}
+	if strings.TrimSpace(args[0]) == "" {
+		return usageError{fmt.Errorf("credential name is required")}
 	}
 	return nil
 }
@@ -375,12 +463,12 @@ func (c *commandContext) pipelineRun(cmd *cobra.Command, ref string, opts pipeli
 	}
 	params := url.Values{}
 	params.Set("project", projectID)
-	body := map[string]string{"pipeline": strings.TrimSpace(ref)}
+	body := map[string]any{"pipeline": strings.TrimSpace(ref)}
 	if s := strings.TrimSpace(opts.session); s != "" {
 		body["sessionId"] = s
 	}
-	if s := strings.TrimSpace(opts.headSHA); s != "" {
-		body["headSha"] = s
+	if opts.prNumber > 0 {
+		body["prNumber"] = opts.prNumber
 	}
 
 	var raw json.RawMessage
@@ -398,7 +486,7 @@ func (c *commandContext) pipelineRun(cmd *cobra.Command, ref string, opts pipeli
 	return err
 }
 
-func (c *commandContext) pipelineLifecycle(cmd *cobra.Command, runID, project, action string) error {
+func (c *commandContext) pipelineCancel(cmd *cobra.Command, runID, project string) error {
 	ctx := cmd.Context()
 	projectID, err := c.resolvePipelineProjectID(ctx, project)
 	if err != nil {
@@ -406,19 +494,124 @@ func (c *commandContext) pipelineLifecycle(cmd *cobra.Command, runID, project, a
 	}
 	params := url.Values{}
 	params.Set("project", projectID)
-	path := apiPath("pipelines/runs/"+url.PathEscape(strings.TrimSpace(runID))+"/"+action, params)
+	path := apiPath("pipelines/runs/"+url.PathEscape(strings.TrimSpace(runID))+"/cancel", params)
 
 	var res pipelineRunDetailResponse
 	if err := c.postJSON(ctx, path, struct{}{}, &res); err != nil {
 		return err
 	}
 	run := res.Run
-	line := fmt.Sprintf("run %s → %s", run.RunID, run.LoopState)
-	if run.TerminationReason != "" {
-		line += fmt.Sprintf(" (%s)", run.TerminationReason)
+	line := fmt.Sprintf("run %s → %s", run.RunID, run.Status)
+	if run.CancelReason != "" {
+		line += fmt.Sprintf(" (%s)", run.CancelReason)
 	}
 	_, err = fmt.Fprintln(cmd.OutOrStdout(), line)
 	return err
+}
+
+// pipelineCredentialSet stores one credential's whole environment. The
+// KEY=VALUE arguments are parsed here rather than server-side so a malformed
+// pair is caught before the value travels anywhere.
+func (c *commandContext) pipelineCredentialSet(cmd *cobra.Command, args []string, project string) error {
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return usageError{fmt.Errorf("credential name is required")}
+	}
+	name := strings.TrimSpace(args[0])
+	env, err := parseCredentialPairs(args[1:])
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	projectID, err := c.resolvePipelineProjectID(ctx, project)
+	if err != nil {
+		return err
+	}
+	params := url.Values{}
+	params.Set("project", projectID)
+	path := apiPath("pipelines/credentials/"+url.PathEscape(name), params)
+
+	var res pipelineCredentialResponse
+	if err := c.putJSON(ctx, path, map[string]any{"env": env}, &res); err != nil {
+		return err
+	}
+	// Variable names, never their values: this line is the receipt for what
+	// landed, and it has to be safe to paste into an issue.
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "credential %s set (%d variable%s: %s)\n",
+		res.Name, len(res.Keys), pluralS(len(res.Keys)), strings.Join(res.Keys, ", "))
+	return err
+}
+
+func (c *commandContext) pipelineCredentialLs(cmd *cobra.Command, project string) error {
+	ctx := cmd.Context()
+	projectID, err := c.resolvePipelineProjectID(ctx, project)
+	if err != nil {
+		return err
+	}
+	params := url.Values{}
+	params.Set("project", projectID)
+
+	// Decoded into a names-only struct on purpose: whatever else a response
+	// carries, this verb has no field to put a value in.
+	var res listPipelineCredentialsResponse
+	if err := c.getJSON(ctx, apiPath("pipelines/credentials", params), &res); err != nil {
+		return err
+	}
+	out := cmd.OutOrStdout()
+	if len(res.Names) == 0 {
+		_, err := fmt.Fprintf(out, "(no credentials for %s)\n", projectID)
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "Credentials for %s:\n", projectID); err != nil {
+		return err
+	}
+	names := append([]string(nil), res.Names...)
+	sort.Strings(names)
+	for _, name := range names {
+		if _, err := fmt.Fprintf(out, "  %s\n", name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *commandContext) pipelineCredentialRm(cmd *cobra.Command, name, project string) error {
+	ctx := cmd.Context()
+	projectID, err := c.resolvePipelineProjectID(ctx, project)
+	if err != nil {
+		return err
+	}
+	params := url.Values{}
+	params.Set("project", projectID)
+	path := apiPath("pipelines/credentials/"+url.PathEscape(strings.TrimSpace(name)), params)
+
+	if err := c.deleteJSON(ctx, path, nil); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "credential %s removed\n", strings.TrimSpace(name))
+	return err
+}
+
+// parseCredentialPairs turns KEY=VALUE arguments into the environment map.
+//
+// A malformed argument is reported by position and never quoted back: the most
+// likely way to mistype one of these is to paste the secret on its own, and an
+// error message that echoed it would put it in the terminal scrollback, the
+// shell's error log and any CI transcript.
+func parseCredentialPairs(args []string) (map[string]string, error) {
+	if len(args) == 0 {
+		return nil, usageError{fmt.Errorf("at least one KEY=VALUE is required")}
+	}
+	env := make(map[string]string, len(args))
+	for i, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return nil, usageError{fmt.Errorf("argument %d is not KEY=VALUE (not echoed here, in case it is the secret)", i+1)}
+		}
+		env[key] = value
+	}
+	return env, nil
 }
 
 // pipelineSignal settles the stage the caller is running inside, by posting to
@@ -522,29 +715,57 @@ func writePipelineRuns(cmd *cobra.Command, projectID string, runs []pipelineRunS
 		return err
 	}
 	for _, run := range runs {
-		state := run.LoopState
-		if run.TerminationReason != "" {
-			state += fmt.Sprintf(" (%s)", run.TerminationReason)
+		status := run.Status
+		if run.CancelReason != "" {
+			status += fmt.Sprintf(" (%s)", run.CancelReason)
 		}
-		if _, err := fmt.Fprintf(out, "  %s  %s  %s  %s\n",
-			run.RunID, run.PipelineName, state, formatPipelineTime(run.CreatedAt)); err != nil {
+		if _, err := fmt.Fprintf(out, "  %s  %s  %s  %s  %s\n",
+			run.RunID, run.PipelineName, status, describePipelineSubject(run),
+			formatPipelineTime(run.CreatedAt)); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
+// describePipelineSubject names what the run is about, which is what tells two
+// runs of the same pipeline apart.
+func describePipelineSubject(run pipelineRunSummary) string {
+	switch run.SubjectKind {
+	case "pr":
+		s := fmt.Sprintf("pr #%d", run.PRNumber)
+		if run.HeadSHA != "" {
+			s += " " + run.HeadSHA
+		}
+		return s
+	case "session":
+		if run.SessionID != "" {
+			return "session " + run.SessionID
+		}
+		return "session"
+	case "":
+		return "-"
+	default:
+		return run.SubjectKind
+	}
+}
+
+// writePipelineRunDetail renders a run's v2 outcomes. The stage table carries
+// attempt and reason columns so a nudged stage (attempt 2) and a stage that
+// produced nothing (outcome no_output, artifact missing) read differently at a
+// glance instead of collapsing into one "failed" line.
 func writePipelineRunDetail(cmd *cobra.Command, run pipelineRunDetail) error {
 	out := cmd.OutOrStdout()
 	fields := [][2]string{
 		{"pipeline", run.PipelineName},
+		{"status", run.Status},
+		{"subject", describePipelineSubject(run.pipelineRunSummary)},
 		{"session", run.SessionID},
-		{"state", run.LoopState},
-		{"reason", run.TerminationReason},
-		{"rounds", strconv.Itoa(run.LoopRounds)},
-		{"headSha", run.HeadSHA},
+		{"cancelled", run.CancelReason},
+		{"runDir", run.RunDir},
 		{"created", formatPipelineTime(run.CreatedAt)},
 		{"updated", formatPipelineTime(run.UpdatedAt)},
+		{"settled", formatPipelineTimePtr(run.SettledAt)},
 	}
 	if _, err := fmt.Fprintf(out, "Run %s\n", run.RunID); err != nil {
 		return err
@@ -562,59 +783,64 @@ func writePipelineRunDetail(cmd *cobra.Command, run pipelineRunDetail) error {
 		return err
 	}
 	if len(run.Stages) == 0 {
-		if _, err := fmt.Fprintln(out, "  (none)"); err != nil {
-			return err
-		}
-	}
-	for _, st := range run.Stages {
-		line := fmt.Sprintf("  %s  %s", st.StageName, st.Status)
-		if st.Verdict != "" {
-			line += fmt.Sprintf(" verdict=%s", st.Verdict)
-		}
-		line += fmt.Sprintf("  attempt=%d  artifacts=%d", st.Attempt, len(st.ArtifactIDs))
-		if _, err := fmt.Fprintln(out, line); err != nil {
-			return err
-		}
-		if st.ErrorMessage != "" {
-			if _, err := fmt.Fprintf(out, "    error: %s\n", st.ErrorMessage); err != nil {
-				return err
-			}
-		}
-	}
-
-	return writePipelineFindings(out, run.Findings)
-}
-
-func writePipelineFindings(out io.Writer, findings []pipelineFinding) error {
-	open := 0
-	for _, f := range findings {
-		if f.Kind == "finding" && f.Status == "open" {
-			open++
-		}
-	}
-	if len(findings) == 0 {
-		return nil
-	}
-	if _, err := fmt.Fprintf(out, "\nFindings: %d open, %d total\n", open, len(findings)); err != nil {
+		_, err := fmt.Fprintln(out, "  (none)")
 		return err
 	}
-	for _, f := range findings {
-		if f.Kind != "finding" {
-			continue
+	return writePipelineStageTable(out, run.Stages)
+}
+
+func writePipelineStageTable(out io.Writer, stages []pipelineStageView) error {
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "  STAGE\tOUTCOME\tATTEMPT\tVIA\tARTIFACT\tREASON"); err != nil {
+		return err
+	}
+	for _, st := range stages {
+		reason := st.Reason
+		if reason == "" {
+			reason = "-"
 		}
-		loc := f.FilePath
-		if loc == "" {
-			loc = f.StageName
-		}
-		sev := f.Severity
-		if sev == "" {
-			sev = "-"
-		}
-		if _, err := fmt.Fprintf(out, "  [%s] %s  %s  (%s)\n", sev, f.Title, loc, f.Status); err != nil {
+		if _, err := fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\t%s\n",
+			st.StageID, st.Outcome, describeStageAttempt(st), describeStageEntry(st),
+			describeStageArtifact(st), reason); err != nil {
 			return err
 		}
 	}
-	return nil
+	return tw.Flush()
+}
+
+// describeStageAttempt tags the one nudge an agent stage gets (spec section
+// 6.4): attempt 2 exists only because the engine nudged an idle stage, so
+// saying so is more useful than the bare number.
+func describeStageAttempt(st pipelineStageView) string {
+	if st.Attempt >= 2 {
+		return fmt.Sprintf("%d (nudged)", st.Attempt)
+	}
+	return strconv.Itoa(st.Attempt)
+}
+
+// describeStageEntry names the edge the stage was entered by, and for a failure
+// edge the stage whose failure routed here.
+func describeStageEntry(st pipelineStageView) string {
+	if st.EnteredVia == "" {
+		return "-"
+	}
+	if st.FailedStage != "" {
+		return fmt.Sprintf("%s(%s)", st.EnteredVia, st.FailedStage)
+	}
+	return st.EnteredVia
+}
+
+// describeStageArtifact renders the stage's declared `produces` file and
+// whether the engine found it, which is the evidence behind a no_output
+// outcome.
+func describeStageArtifact(st pipelineStageView) string {
+	if st.ProducedArtifact == nil || st.ProducedArtifact.Name == "" {
+		return "-"
+	}
+	if st.ProducedArtifact.Exists {
+		return st.ProducedArtifact.Name
+	}
+	return st.ProducedArtifact.Name + " (missing)"
 }
 
 // pipelineStageCount counts stages in the authored YAML for the list view. A
@@ -635,4 +861,11 @@ func formatPipelineTime(t time.Time) string {
 		return ""
 	}
 	return t.Format(time.RFC3339)
+}
+
+func formatPipelineTimePtr(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return formatPipelineTime(*t)
 }

--- a/backend/internal/cli/pipeline_test.go
+++ b/backend/internal/cli/pipeline_test.go
@@ -38,6 +38,38 @@ func pipelineServer(t *testing.T, status int, respBody string) (*httptest.Server
 	return srv, capture
 }
 
+// TestPipelineVerbSet pins the v2 surface: resume is gone with the semantics
+// behind it, and the credential verbs are here.
+func TestPipelineVerbSet(t *testing.T) {
+	cmd := newPipelineCommand(&commandContext{})
+	got := map[string]bool{}
+	for _, sub := range cmd.Commands() {
+		got[sub.Name()] = true
+	}
+	for _, want := range []string{"list", "runs", "show", "run", "cancel", "credential", "done", "fail"} {
+		if !got[want] {
+			t.Errorf("verb %q is missing", want)
+		}
+	}
+	if got["resume"] {
+		t.Error("resume is still registered: v2 has no resume, a failed run is dead")
+	}
+
+	credentialVerbs := map[string]bool{}
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "credential" {
+			for _, verb := range sub.Commands() {
+				credentialVerbs[verb.Name()] = true
+			}
+		}
+	}
+	for _, want := range []string{"set", "ls", "rm"} {
+		if !credentialVerbs[want] {
+			t.Errorf("credential verb %q is missing", want)
+		}
+	}
+}
+
 func TestPipelineList_Human(t *testing.T) {
 	cfg := setConfigEnv(t)
 	body := `{"definitions":[{"id":"pl-1","projectId":"proj","name":"review","yamlSource":"name: review\nstages:\n  - name: a\n    trigger: {on: [manual]}\n  - name: b\n    trigger: {on: [manual]}\n","createdAt":"2026-07-15T00:00:00Z","updatedAt":"2026-07-15T01:00:00Z"}]}`
@@ -95,7 +127,9 @@ func TestPipelineList_Empty(t *testing.T) {
 
 func TestPipelineRuns_HumanAndFilters(t *testing.T) {
 	cfg := setConfigEnv(t)
-	body := `{"runs":[{"runId":"run-1","pipelineName":"review","loopState":"running","createdAt":"2026-07-15T00:00:00Z"},{"runId":"run-2","pipelineName":"review","loopState":"stalled","terminationReason":"retry_exhausted","createdAt":"2026-07-14T00:00:00Z"}]}`
+	body := `{"runs":[` +
+		`{"runId":"run-1","pipelineName":"review","status":"running","subjectKind":"session","sessionId":"sess-7","stageCount":3,"createdAt":"2026-07-15T00:00:00Z"},` +
+		`{"runId":"run-2","pipelineName":"review","status":"cancelled","subjectKind":"pr","prNumber":42,"cancelReason":"head moved","stageCount":3,"createdAt":"2026-07-14T00:00:00Z"}]}`
 	srv, capture := pipelineServer(t, http.StatusOK, body)
 	writeRunFileFor(t, cfg, srv)
 
@@ -113,15 +147,16 @@ func TestPipelineRuns_HumanAndFilters(t *testing.T) {
 			t.Fatalf("query %q missing %q", q, want)
 		}
 	}
-	if !strings.Contains(out, "run-1") || !strings.Contains(out, "running") ||
-		!strings.Contains(out, "stalled (retry_exhausted)") {
-		t.Fatalf("stdout = %q", out)
+	for _, want := range []string{"run-1", "running", "session sess-7", "cancelled (head moved)", "pr #42"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q\nstdout=%s", want, out)
+		}
 	}
 }
 
 func TestPipelineRuns_JSON(t *testing.T) {
 	cfg := setConfigEnv(t)
-	srv, _ := pipelineServer(t, http.StatusOK, `{"runs":[{"runId":"run-1","pipelineName":"review","loopState":"done"}]}`)
+	srv, _ := pipelineServer(t, http.StatusOK, `{"runs":[{"runId":"run-1","pipelineName":"review","status":"succeeded"}]}`)
 	writeRunFileFor(t, cfg, srv)
 
 	out, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "runs", "--project", "proj", "--json")
@@ -137,10 +172,45 @@ func TestPipelineRuns_JSON(t *testing.T) {
 	}
 }
 
-func TestPipelineShow_Human(t *testing.T) {
+// settledRunBody is a settled v2 run with one nudged stage: `review` was idle
+// with `produces` declared, got its one nudge (attempt 2), still wrote nothing,
+// and settled no_output, which routed the failure edge to `notify`.
+const settledRunBody = `{"run":{"runId":"run-1","pipelineId":"pl-1","pipelineName":"review",` +
+	`"status":"failed","subjectKind":"pr","sessionId":"sess-7","prNumber":42,"headSha":"abc1234",` +
+	`"stageCount":3,"stageOutcomes":{"build":"succeeded","review":"no_output","notify":"succeeded"},` +
+	`"createdAt":"2026-07-26T12:00:00Z","updatedAt":"2026-07-26T12:30:00Z","settledAt":"2026-07-26T12:30:00Z",` +
+	`"runDir":"/data/pipelines/proj/run-1","stages":[` +
+	`{"stageId":"build","outcome":"succeeded","attempt":1,"enteredVia":"trigger","workspaceKind":"run",` +
+	`"startedAt":"2026-07-26T12:00:00Z","settledAt":"2026-07-26T12:05:00Z"},` +
+	`{"stageId":"review","outcome":"no_output","attempt":2,"enteredVia":"success","sessionId":"sess-9",` +
+	`"workspaceKind":"stage","startedAt":"2026-07-26T12:05:00Z","settledAt":"2026-07-26T12:25:00Z",` +
+	`"reason":"no review.md after the nudge","producedArtifact":{"name":"review.md","exists":false}},` +
+	`{"stageId":"notify","outcome":"succeeded","attempt":1,"enteredVia":"failure","failedStage":"review",` +
+	`"workspaceKind":"run","startedAt":"2026-07-26T12:25:00Z","settledAt":"2026-07-26T12:30:00Z"}]}}`
+
+// The golden view of a settled run. The attempt column says a stage was nudged
+// and the outcome column says it produced nothing, so the two are distinct at a
+// glance instead of collapsing into one "failed" line.
+const settledRunGolden = `Run run-1
+  pipeline: review
+  status:   failed
+  subject:  pr #42 abc1234
+  session:  sess-7
+  runDir:   /data/pipelines/proj/run-1
+  created:  2026-07-26T12:00:00Z
+  updated:  2026-07-26T12:30:00Z
+  settled:  2026-07-26T12:30:00Z
+
+Stages:
+  STAGE   OUTCOME    ATTEMPT     VIA              ARTIFACT             REASON
+  build   succeeded  1           trigger          -                    -
+  review  no_output  2 (nudged)  success          review.md (missing)  no review.md after the nudge
+  notify  succeeded  1           failure(review)  -                    -
+`
+
+func TestPipelineShow_GoldenSettledRunWithNudgedStage(t *testing.T) {
 	cfg := setConfigEnv(t)
-	body := `{"run":{"runId":"run-1","pipelineName":"review","sessionId":"sess","loopState":"stalled","terminationReason":"retry_exhausted","loopRounds":2,"headSha":"abc123","createdAt":"2026-07-15T00:00:00Z","updatedAt":"2026-07-15T02:00:00Z","stages":[{"stageName":"lint","stageRunId":"sr-1","status":"failed","attempt":1,"errorMessage":"boom","artifactIds":["a1"]}],"findings":[{"artifactId":"a1","kind":"finding","stageName":"lint","title":"bad import","filePath":"x.go","severity":"high","status":"open"}]}}`
-	srv, capture := pipelineServer(t, http.StatusOK, body)
+	srv, capture := pipelineServer(t, http.StatusOK, settledRunBody)
 	writeRunFileFor(t, cfg, srv)
 
 	out, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "show", "run-1")
@@ -150,17 +220,14 @@ func TestPipelineShow_Human(t *testing.T) {
 	if capture.path != "/api/v1/pipelines/runs/run-1" {
 		t.Fatalf("path = %q", capture.path)
 	}
-	for _, want := range []string{"Run run-1", "pipeline:", "review", "state:", "stalled",
-		"lint", "failed", "attempt=1", "artifacts=1", "error: boom", "Findings: 1 open, 1 total", "bad import"} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("stdout missing %q\nstdout=%s", want, out)
-		}
+	if out != settledRunGolden {
+		t.Fatalf("stdout mismatch\n--- got ---\n%s\n--- want ---\n%s", out, settledRunGolden)
 	}
 }
 
 func TestPipelineShow_JSON(t *testing.T) {
 	cfg := setConfigEnv(t)
-	srv, _ := pipelineServer(t, http.StatusOK, `{"run":{"runId":"run-1","pipelineName":"review","loopState":"done","stages":[],"findings":[]}}`)
+	srv, _ := pipelineServer(t, http.StatusOK, settledRunBody)
 	writeRunFileFor(t, cfg, srv)
 
 	out, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "show", "run-1", "--json")
@@ -171,7 +238,7 @@ func TestPipelineShow_JSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &res); err != nil {
 		t.Fatalf("stdout is not raw JSON: %v\nstdout=%s", err, out)
 	}
-	if res.Run.RunID != "run-1" {
+	if res.Run.RunID != "run-1" || len(res.Run.Stages) != 3 {
 		t.Fatalf("run = %+v", res.Run)
 	}
 }
@@ -199,7 +266,7 @@ func TestPipelineRun_Human(t *testing.T) {
 	writeRunFileFor(t, cfg, srv)
 
 	out, errOut, err := executeCLI(t, aliveDeps(),
-		"pipeline", "run", "review", "--project", "proj", "--session", "sess", "--head-sha", "deadbeef")
+		"pipeline", "run", "review", "--project", "proj", "--session", "sess")
 	if err != nil {
 		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
 	}
@@ -209,15 +276,35 @@ func TestPipelineRun_Human(t *testing.T) {
 	if capture.query != "project=proj" {
 		t.Fatalf("query = %q", capture.query)
 	}
-	var reqBody map[string]string
+	var reqBody map[string]any
 	if err := json.Unmarshal([]byte(capture.body), &reqBody); err != nil {
 		t.Fatalf("decode body: %v", err)
 	}
-	if reqBody["pipeline"] != "review" || reqBody["sessionId"] != "sess" || reqBody["headSha"] != "deadbeef" {
+	if reqBody["pipeline"] != "review" || reqBody["sessionId"] != "sess" {
 		t.Fatalf("body = %+v", reqBody)
 	}
 	if !strings.Contains(out, "run-9") {
 		t.Fatalf("stdout = %q", out)
+	}
+}
+
+// The subject is resolved server-side from a PR number: v2 has no --head-sha,
+// because the head SHA and the fork flag come from the PR the daemon knows.
+func TestPipelineRun_PRSubject(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineServer(t, http.StatusCreated, `{"runId":"run-9"}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "run", "review", "--project", "proj", "--pr", "42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var reqBody map[string]any
+	if err := json.Unmarshal([]byte(capture.body), &reqBody); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if reqBody["prNumber"] != float64(42) {
+		t.Fatalf("body = %+v", reqBody)
 	}
 }
 
@@ -255,7 +342,8 @@ func TestPipelineRun_PipelineNotFound(t *testing.T) {
 
 func TestPipelineCancel_Human(t *testing.T) {
 	cfg := setConfigEnv(t)
-	srv, capture := pipelineServer(t, http.StatusOK, `{"run":{"runId":"run-1","loopState":"terminated","terminationReason":"manual_cancel"}}`)
+	srv, capture := pipelineServer(t, http.StatusOK,
+		`{"run":{"runId":"run-1","status":"cancelled","cancelReason":"manual"}}`)
 	writeRunFileFor(t, cfg, srv)
 
 	out, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "cancel", "run-1", "--project", "proj")
@@ -268,25 +356,165 @@ func TestPipelineCancel_Human(t *testing.T) {
 	if capture.query != "project=proj" {
 		t.Fatalf("query = %q", capture.query)
 	}
-	if !strings.Contains(out, "run run-1 → terminated (manual_cancel)") {
+	if !strings.Contains(out, "run run-1 → cancelled (manual)") {
 		t.Fatalf("stdout = %q", out)
 	}
 }
 
-func TestPipelineResume_Human(t *testing.T) {
+// v2 deleted resume with the semantics behind it. Like every other unknown
+// verb under a command group, it falls through to the group's help; what must
+// not happen is the CLI reaching for a resume route that no longer exists.
+func TestPipelineResume_IsGone(t *testing.T) {
 	cfg := setConfigEnv(t)
-	srv, capture := pipelineServer(t, http.StatusOK, `{"run":{"runId":"run-1","loopState":"running"}}`)
+	srv, capture := pipelineServer(t, http.StatusOK, `{}`)
 	writeRunFileFor(t, cfg, srv)
 
-	out, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "resume", "run-1", "--project", "proj")
+	out, _, _ := executeCLI(t, aliveDeps(), "pipeline", "resume", "run-1")
+	if strings.Contains(capture.path, "resume") {
+		t.Fatalf("CLI called a resume route: %s %s", capture.method, capture.path)
+	}
+	if strings.Contains(out, "resume") {
+		t.Fatalf("help still advertises resume:\n%s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Credentials (decision D13)
+// ---------------------------------------------------------------------------
+
+func TestPipelineCredentialSet_PutsEnvAndPrintsKeysOnly(t *testing.T) {
+	cfg := setConfigEnv(t)
+	const secret = "s3cret-value"
+	srv, capture := pipelineServer(t, http.StatusOK, `{"name":"npm","keys":["NPM_SCOPE","NPM_TOKEN"]}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(),
+		"pipeline", "credential", "set", "npm", "NPM_TOKEN="+secret, "NPM_SCOPE=@ao", "--project", "proj")
 	if err != nil {
 		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
 	}
-	if capture.path != "/api/v1/pipelines/runs/run-1/resume" {
-		t.Fatalf("path = %q", capture.path)
+	if capture.method != http.MethodPut || capture.path != "/api/v1/pipelines/credentials/npm" {
+		t.Fatalf("request = %s %s", capture.method, capture.path)
 	}
-	if !strings.Contains(out, "run run-1 → running") {
+	if capture.query != "project=proj" {
+		t.Fatalf("query = %q", capture.query)
+	}
+	var body struct {
+		Env map[string]string `json:"env"`
+	}
+	if err := json.Unmarshal([]byte(capture.body), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Env["NPM_TOKEN"] != secret || body.Env["NPM_SCOPE"] != "@ao" {
+		t.Fatalf("env = %+v", body.Env)
+	}
+	if strings.Contains(out+errOut, secret) {
+		t.Fatalf("set echoed the value back: stdout=%q stderr=%q", out, errOut)
+	}
+	if !strings.Contains(out, "NPM_TOKEN") || !strings.Contains(out, "npm") {
 		t.Fatalf("stdout = %q", out)
+	}
+}
+
+// A KEY=VALUE that is not one must not be echoed: the mistyped argument may be
+// the secret itself.
+func TestPipelineCredentialSet_MalformedPairNeverEchoesIt(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineServer(t, http.StatusOK, `{"name":"npm","keys":[]}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "credential", "set", "npm", "oops-a-bare-secret", "--project", "proj")
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+	if strings.Contains(err.Error()+errOut, "oops-a-bare-secret") {
+		t.Fatalf("the malformed argument was echoed: %v / %s", err, errOut)
+	}
+	if strings.Contains(capture.path, "credentials") {
+		t.Fatalf("CLI sent the credential anyway: %s %s", capture.method, capture.path)
+	}
+}
+
+func TestPipelineCredentialSet_RequiresAPair(t *testing.T) {
+	setConfigEnv(t)
+	_, _, err := executeCLI(t, aliveDeps(), "pipeline", "credential", "set", "npm", "--project", "proj")
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+}
+
+// `ls` is names only. Even if a daemon somehow answered with values attached,
+// nothing the CLI prints may carry one.
+func TestPipelineCredentialLs_PrintsNoValueBytes(t *testing.T) {
+	cfg := setConfigEnv(t)
+	const secret = "s3cret-value"
+	srv, capture := pipelineServer(t, http.StatusOK,
+		`{"names":["apple","npm"],"env":{"NPM_TOKEN":"`+secret+`"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "credential", "ls", "--project", "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodGet || capture.path != "/api/v1/pipelines/credentials" {
+		t.Fatalf("request = %s %s", capture.method, capture.path)
+	}
+	if strings.Contains(out+errOut, secret) {
+		t.Fatalf("ls printed a value: stdout=%q stderr=%q", out, errOut)
+	}
+	for _, want := range []string{"Credentials for proj:", "apple", "npm"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q\nstdout=%s", want, out)
+		}
+	}
+}
+
+func TestPipelineCredentialLs_Empty(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := pipelineServer(t, http.StatusOK, `{"names":[]}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "credential", "ls", "--project", "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if !strings.Contains(out, "(no credentials for proj)") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestPipelineCredentialRm_Human(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineServer(t, http.StatusOK, `{"name":"npm","deleted":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "credential", "rm", "npm", "--project", "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodDelete || capture.path != "/api/v1/pipelines/credentials/npm" {
+		t.Fatalf("request = %s %s", capture.method, capture.path)
+	}
+	if capture.query != "project=proj" {
+		t.Fatalf("query = %q", capture.query)
+	}
+	if !strings.Contains(out, "credential npm removed") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestPipelineCredentialRm_NotFound(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := pipelineServer(t, http.StatusNotFound,
+		`{"message":"no credential \"nope\" in this project","code":"PIPELINE_CREDENTIAL_NOT_FOUND"}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, aliveDeps(), "pipeline", "credential", "rm", "nope", "--project", "proj")
+	if err == nil {
+		t.Fatal("expected error for 404 credential")
+	}
+	if !strings.Contains(err.Error(), "PIPELINE_CREDENTIAL_NOT_FOUND") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -771,6 +771,145 @@ paths:
       summary: Update a pipeline definition's YAML
       tags:
       - pipelines
+  /api/v1/pipelines/credentials:
+    get:
+      operationId: listPipelineCredentials
+      parameters:
+      - description: Project id the pipeline belongs to (required).
+        in: query
+        name: project
+        schema:
+          description: Project id the pipeline belongs to (required).
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControllersListPipelineCredentialsResponse'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Bad Request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: List a project's pipeline credential names (never their values)
+      tags:
+      - pipelines
+  /api/v1/pipelines/credentials/{name}:
+    delete:
+      operationId: deletePipelineCredential
+      parameters:
+      - description: Credential name as stages reference it in credentials:.
+        in: path
+        name: name
+        required: true
+        schema:
+          description: Credential name as stages reference it in credentials:.
+          type: string
+      - description: Project id the pipeline belongs to (required).
+        in: query
+        name: project
+        schema:
+          description: Project id the pipeline belongs to (required).
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControllersDeletePipelineCredentialResponse'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Bad Request
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Delete a pipeline credential
+      tags:
+      - pipelines
+    put:
+      operationId: setPipelineCredential
+      parameters:
+      - description: Credential name as stages reference it in credentials:.
+        in: path
+        name: name
+        required: true
+        schema:
+          description: Credential name as stages reference it in credentials:.
+          type: string
+      - description: Project id the pipeline belongs to (required).
+        in: query
+        name: project
+        schema:
+          description: Project id the pipeline belongs to (required).
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ControllersSetPipelineCredentialRequest'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControllersPipelineCredentialResponse'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Bad Request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Create or replace a pipeline credential
+      tags:
+      - pipelines
   /api/v1/pipelines/runs:
     get:
       operationId: listPipelineRuns
@@ -2820,6 +2959,39 @@ components:
       - sessionId
       - reason
       type: object
+    ControllersDeletePipelineCredentialResponse:
+      properties:
+        deleted:
+          type: boolean
+        name:
+          type: string
+      required:
+      - name
+      - deleted
+      type: object
+    ControllersListPipelineCredentialsResponse:
+      properties:
+        names:
+          items:
+            type: string
+          type: array
+      required:
+      - names
+      type: object
+    ControllersPipelineCredentialResponse:
+      properties:
+        keys:
+          description: Names of the environment variables stored, sorted. Never their
+            values.
+          items:
+            type: string
+          type: array
+        name:
+          type: string
+      required:
+      - name
+      - keys
+      type: object
     ControllersSessionView:
       properties:
         activity:
@@ -2885,6 +3057,19 @@ components:
       - updatedAt
       - status
       - prs
+      type: object
+    ControllersSetPipelineCredentialRequest:
+      properties:
+        env:
+          additionalProperties:
+            type: string
+          description: 'Environment variables the credential injects, keyed by variable
+            name. Values are write-only: no read path returns them.'
+          type:
+          - object
+          - "null"
+      required:
+      - env
       type: object
     DegradedProject:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -487,6 +487,41 @@ func pipelineOperations() []operation {
 			},
 		},
 		{
+			method: http.MethodGet, path: "/api/v1/pipelines/credentials", id: "listPipelineCredentials", tag: "pipelines",
+			summary:    "List a project's pipeline credential names (never their values)",
+			pathParams: []any{controllers.PipelineProjectQuery{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.ListPipelineCredentialsResponse{}},
+				{http.StatusBadRequest, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+		{
+			method: http.MethodPut, path: "/api/v1/pipelines/credentials/{name}", id: "setPipelineCredential", tag: "pipelines",
+			summary:    "Create or replace a pipeline credential",
+			pathParams: []any{controllers.PipelineCredentialNameParam{}, controllers.PipelineProjectQuery{}},
+			reqBody:    controllers.SetPipelineCredentialRequest{},
+			resps: []respUnit{
+				{http.StatusOK, controllers.PipelineCredentialResponse{}},
+				{http.StatusBadRequest, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+		{
+			method: http.MethodDelete, path: "/api/v1/pipelines/credentials/{name}", id: "deletePipelineCredential", tag: "pipelines",
+			summary:    "Delete a pipeline credential",
+			pathParams: []any{controllers.PipelineCredentialNameParam{}, controllers.PipelineProjectQuery{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.DeletePipelineCredentialResponse{}},
+				{http.StatusBadRequest, envelope.APIError{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+		{
 			method: http.MethodGet, path: "/api/v1/pipelines/runs", id: "listPipelineRuns", tag: "pipelines",
 			summary:    "List a project's pipeline runs, newest first",
 			pathParams: []any{controllers.PipelineRunsQuery{}},

--- a/backend/internal/httpd/controllers/pipelines.go
+++ b/backend/internal/httpd/controllers/pipelines.go
@@ -49,6 +49,12 @@ type PipelineOutputParam struct {
 	Filename string `path:"filename" description:"Artifact filename. Only a name the run's frozen definition declares as a stage's produces is served."`
 }
 
+// PipelineCredentialNameParam is the {name} path parameter of the credential
+// write routes.
+type PipelineCredentialNameParam struct {
+	Name string `path:"name" description:"Credential name as stages reference it in credentials:."`
+}
+
 // PipelineProjectQuery is the shared `project` scoping query for the collection
 // and lifecycle routes.
 type PipelineProjectQuery struct {
@@ -248,6 +254,34 @@ type SignalPipelineStageResponse struct {
 	Accepted bool `json:"accepted"`
 }
 
+// SetPipelineCredentialRequest is the body of the credential upsert: the whole
+// environment the credential stands for. It replaces any previous environment
+// under that name rather than merging, so a variable can be removed.
+type SetPipelineCredentialRequest struct {
+	Env map[string]string `json:"env" description:"Environment variables the credential injects, keyed by variable name. Values are write-only: no read path returns them."`
+}
+
+// PipelineCredentialResponse acknowledges a stored credential by name and the
+// variable names it carries. Values are never in a response body (decision
+// D13): they exist to be injected into a command stage's process env, and that
+// is the only place they go.
+type PipelineCredentialResponse struct {
+	Name string   `json:"name"`
+	Keys []string `json:"keys" description:"Names of the environment variables stored, sorted. Never their values."`
+}
+
+// ListPipelineCredentialsResponse is the body of GET /api/v1/pipelines/credentials.
+// Names only, by design.
+type ListPipelineCredentialsResponse struct {
+	Names []string `json:"names"`
+}
+
+// DeletePipelineCredentialResponse is the body of the credential delete.
+type DeletePipelineCredentialResponse struct {
+	Name    string `json:"name"`
+	Deleted bool   `json:"deleted"`
+}
+
 // ---------------------------------------------------------------------------
 // Controller
 // ---------------------------------------------------------------------------
@@ -269,6 +303,10 @@ func (c *PipelinesController) Register(r chi.Router) {
 	r.Post("/pipelines", c.createDefinition)
 	r.Post("/pipelines/validate", c.validateDefinition)
 	r.Get("/pipelines/schema", c.schema)
+
+	r.Get("/pipelines/credentials", c.listCredentials)
+	r.Put("/pipelines/credentials/{name}", c.setCredential)
+	r.Delete("/pipelines/credentials/{name}", c.deleteCredential)
 
 	r.Get("/pipelines/runs", c.listRuns)
 	r.Post("/pipelines/runs", c.triggerRun)
@@ -645,6 +683,85 @@ func (c *PipelinesController) cancelRun(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	envelope.WriteJSON(w, http.StatusOK, PipelineRunDetailResponse{Run: runDetail(run)})
+}
+
+// ---------------------------------------------------------------------------
+// Credentials
+// ---------------------------------------------------------------------------
+
+const (
+	credentialsPath     = "/api/v1/pipelines/credentials"
+	credentialNamePath  = "/api/v1/pipelines/credentials/{name}"
+	credentialNameParam = "name"
+)
+
+// listCredentials answers with the project's credential names. There is no
+// route that returns a value: a credential leaves the daemon only as an
+// environment variable inside a command stage's process (decision D13).
+func (c *PipelinesController) listCredentials(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "GET", credentialsPath)
+		return
+	}
+	projectID, ok := requirePipelineProject(w, r)
+	if !ok {
+		return
+	}
+	names, err := c.Svc.ListCredentialNames(r.Context(), projectID)
+	if err != nil {
+		writePipelineError(w, r, err)
+		return
+	}
+	if names == nil {
+		names = []string{}
+	}
+	envelope.WriteJSON(w, http.StatusOK, ListPipelineCredentialsResponse{Names: names})
+}
+
+// setCredential creates or replaces one credential. The receipt echoes the
+// variable names that landed, never their values.
+func (c *PipelinesController) setCredential(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "PUT", credentialNamePath)
+		return
+	}
+	projectID, ok := requirePipelineProject(w, r)
+	if !ok {
+		return
+	}
+	var in SetPipelineCredentialRequest
+	if err := decodeJSONStrict(r, &in); err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
+		return
+	}
+	name := chi.URLParam(r, credentialNameParam)
+	if err := c.Svc.SetCredential(r.Context(), projectID, name, in.Env); err != nil {
+		writePipelineError(w, r, err)
+		return
+	}
+	keys := make([]string, 0, len(in.Env))
+	for key := range in.Env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	envelope.WriteJSON(w, http.StatusOK, PipelineCredentialResponse{Name: name, Keys: keys})
+}
+
+func (c *PipelinesController) deleteCredential(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "DELETE", credentialNamePath)
+		return
+	}
+	projectID, ok := requirePipelineProject(w, r)
+	if !ok {
+		return
+	}
+	name := chi.URLParam(r, credentialNameParam)
+	if err := c.Svc.DeleteCredential(r.Context(), projectID, name); err != nil {
+		writePipelineError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, DeletePipelineCredentialResponse{Name: name, Deleted: true})
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/httpd/controllers/pipelines_test.go
+++ b/backend/internal/httpd/controllers/pipelines_test.go
@@ -627,6 +627,9 @@ func TestPipelineRoutes_NilServiceReturns501(t *testing.T) {
 		{"DELETE", "/api/v1/pipelines/pl-1", ""},
 		{"POST", "/api/v1/pipelines/validate?project=proj", `{"yamlSource":"name: x"}`},
 		{"GET", "/api/v1/pipelines/schema", ""},
+		{"GET", "/api/v1/pipelines/credentials?project=proj", ""},
+		{"PUT", "/api/v1/pipelines/credentials/npm?project=proj", `{"env":{"A":"1"}}`},
+		{"DELETE", "/api/v1/pipelines/credentials/npm?project=proj", ""},
 		{"GET", "/api/v1/pipelines/runs?project=proj", ""},
 		{"POST", "/api/v1/pipelines/runs?project=proj", `{"pipeline":"review"}`},
 		{"GET", "/api/v1/pipelines/runs/run-1", ""},
@@ -659,4 +662,69 @@ func TestPipelineRoutes_ResumeAndArtifactsAreGone(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Decision D13: a credential's value is write-only. It goes in through the set
+// route and comes out only inside a command stage's process env, so no response
+// body on these routes may carry one.
+func TestPipelineCredentials_SetListDelete_NeverEchoValues(t *testing.T) {
+	srv, _ := newPipelineV2Server(t)
+	const secret = "s3cret-value"
+
+	body, status, headers := doRequest(t, srv, "PUT", "/api/v1/pipelines/credentials/npm?project=proj",
+		`{"env":{"NPM_TOKEN":"`+secret+`","NPM_SCOPE":"@ao"}}`)
+	assertJSON(t, headers)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", status, body)
+	}
+	if strings.Contains(string(body), secret) {
+		t.Fatalf("set response echoed the value: %s", body)
+	}
+	var set controllers.PipelineCredentialResponse
+	mustJSON(t, body, &set)
+	if set.Name != "npm" || !slices.Equal(set.Keys, []string{"NPM_SCOPE", "NPM_TOKEN"}) {
+		t.Fatalf("set response = %+v", set)
+	}
+
+	body, status, _ = doRequest(t, srv, "GET", "/api/v1/pipelines/credentials?project=proj", "")
+	if status != http.StatusOK {
+		t.Fatalf("list status = %d; body=%s", status, body)
+	}
+	if strings.Contains(string(body), secret) {
+		t.Fatalf("list response echoed the value: %s", body)
+	}
+	var list controllers.ListPipelineCredentialsResponse
+	mustJSON(t, body, &list)
+	if !slices.Equal(list.Names, []string{"npm"}) {
+		t.Fatalf("names = %v", list.Names)
+	}
+
+	body, status, _ = doRequest(t, srv, "DELETE", "/api/v1/pipelines/credentials/npm?project=proj", "")
+	if status != http.StatusOK {
+		t.Fatalf("delete status = %d; body=%s", status, body)
+	}
+	body, _, _ = doRequest(t, srv, "GET", "/api/v1/pipelines/credentials?project=proj", "")
+	mustJSON(t, body, &list)
+	if len(list.Names) != 0 {
+		t.Fatalf("names after delete = %v", list.Names)
+	}
+}
+
+func TestPipelineCredentials_Errors(t *testing.T) {
+	srv, _ := newPipelineV2Server(t)
+
+	body, status, _ := doRequest(t, srv, "DELETE", "/api/v1/pipelines/credentials/nope?project=proj", "")
+	assertErrorCode(t, body, status, http.StatusNotFound, "PIPELINE_CREDENTIAL_NOT_FOUND")
+
+	body, status, _ = doRequest(t, srv, "PUT", "/api/v1/pipelines/credentials/npm?project=proj", `{"env":{}}`)
+	assertErrorCode(t, body, status, http.StatusBadRequest, "PIPELINE_CREDENTIAL_ENV_REQUIRED")
+
+	body, status, _ = doRequest(t, srv, "PUT", "/api/v1/pipelines/credentials/npm?project=proj", `{"env":{"not a key":"v"}}`)
+	assertErrorCode(t, body, status, http.StatusBadRequest, "PIPELINE_CREDENTIAL_ENV_INVALID")
+	if strings.Contains(string(body), `"v"`) {
+		t.Fatalf("rejection echoed the value: %s", body)
+	}
+
+	body, status, _ = doRequest(t, srv, "GET", "/api/v1/pipelines/credentials", "")
+	assertErrorCode(t, body, status, http.StatusBadRequest, "PROJECT_REQUIRED")
 }

--- a/backend/internal/service/pipeline/credentials.go
+++ b/backend/internal/service/pipeline/credentials.go
@@ -1,0 +1,86 @@
+package pipelinesvc
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
+)
+
+// The write half of decision D13. Values enter here and leave only into a
+// command stage's process env at exec time: there is deliberately no service
+// method that returns one, so no HTTP response and no CLI output can carry a
+// secret back out. Listing answers with names.
+
+// SetCredential creates or replaces a project's named credential. The
+// environment is stored wholesale, so setting a name again is how a variable is
+// removed from it.
+func (s *Service) SetCredential(ctx context.Context, projectID domain.ProjectID, name string, env map[string]string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return apierr.Invalid("PIPELINE_CREDENTIAL_NAME_REQUIRED", "a credential name is required", nil)
+	}
+	if len(env) == 0 {
+		return apierr.Invalid("PIPELINE_CREDENTIAL_ENV_REQUIRED",
+			fmt.Sprintf("credential %q needs at least one KEY=VALUE variable", name), nil)
+	}
+	for key := range env {
+		if err := validEnvKey(key); err != nil {
+			return err
+		}
+	}
+	return s.store.SetPipelineCredential(ctx, projectID, name, env, s.now())
+}
+
+// ListCredentialNames returns the project's declared credential names, sorted.
+func (s *Service) ListCredentialNames(ctx context.Context, projectID domain.ProjectID) ([]string, error) {
+	names, err := s.store.ListPipelineCredentialNames(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// DeleteCredential removes a credential. Deleting one that is not there is a
+// not-found error rather than a silent success, so a typo does not read as a
+// secret having been revoked.
+func (s *Service) DeleteCredential(ctx context.Context, projectID domain.ProjectID, name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return apierr.Invalid("PIPELINE_CREDENTIAL_NAME_REQUIRED", "a credential name is required", nil)
+	}
+	ok, err := s.store.DeletePipelineCredential(ctx, projectID, name)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return apierr.NotFound("PIPELINE_CREDENTIAL_NOT_FOUND", fmt.Sprintf("no credential %q in this project", name))
+	}
+	return nil
+}
+
+// validEnvKey rejects anything that cannot be an environment variable name, so
+// a mistyped KEY=VALUE fails at set time instead of vanishing into a stage's
+// env. The message names the key and never the value.
+func validEnvKey(key string) error {
+	bad := func() error {
+		return apierr.Invalid("PIPELINE_CREDENTIAL_ENV_INVALID",
+			fmt.Sprintf("%q is not a valid environment variable name", key), nil)
+	}
+	if key == "" {
+		return bad()
+	}
+	for i, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r == '_':
+		case r >= '0' && r <= '9' && i > 0:
+		default:
+			return bad()
+		}
+	}
+	return nil
+}

--- a/backend/internal/service/pipeline/credentials_test.go
+++ b/backend/internal/service/pipeline/credentials_test.go
@@ -1,0 +1,129 @@
+package pipelinesvc_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	pipelinesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/pipeline"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+// newCredentialService stands up a real store with one project, which is all a
+// credential needs to exist.
+func newCredentialService(t *testing.T) (*pipelinesvc.Service, *sqlite.Store) {
+	t.Helper()
+	s, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := s.UpsertProject(context.Background(), domain.ProjectRecord{ID: "proj", Path: t.TempDir(), RegisteredAt: now}); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	return pipelinesvc.New(s), s
+}
+
+func TestSetCredential_RoundTripsNamesOnly(t *testing.T) {
+	svc, store := newCredentialService(t)
+	ctx := context.Background()
+
+	if err := svc.SetCredential(ctx, "proj", "npm", map[string]string{"NPM_TOKEN": "s3cret"}); err != nil {
+		t.Fatalf("SetCredential: %v", err)
+	}
+	if err := svc.SetCredential(ctx, "proj", "apple", map[string]string{"ASC_KEY": "k"}); err != nil {
+		t.Fatalf("SetCredential: %v", err)
+	}
+
+	names, err := svc.ListCredentialNames(ctx, "proj")
+	if err != nil {
+		t.Fatalf("ListCredentialNames: %v", err)
+	}
+	if len(names) != 2 || names[0] != "apple" || names[1] != "npm" {
+		t.Fatalf("names = %v, want [apple npm]", names)
+	}
+
+	// The value is reachable only through the daemon-internal read path the
+	// engine injects from, never through the service's user-facing surface.
+	env, ok, err := store.GetPipelineCredential(ctx, "proj", "npm")
+	if err != nil || !ok {
+		t.Fatalf("GetPipelineCredential: ok=%v err=%v", ok, err)
+	}
+	if env["NPM_TOKEN"] != "s3cret" {
+		t.Fatalf("stored env = %v", env)
+	}
+}
+
+func TestSetCredential_ReplacesWholeEnv(t *testing.T) {
+	svc, store := newCredentialService(t)
+	ctx := context.Background()
+
+	if err := svc.SetCredential(ctx, "proj", "npm", map[string]string{"A": "1", "B": "2"}); err != nil {
+		t.Fatalf("SetCredential: %v", err)
+	}
+	if err := svc.SetCredential(ctx, "proj", "npm", map[string]string{"A": "3"}); err != nil {
+		t.Fatalf("SetCredential: %v", err)
+	}
+
+	env, _, err := store.GetPipelineCredential(ctx, "proj", "npm")
+	if err != nil {
+		t.Fatalf("GetPipelineCredential: %v", err)
+	}
+	if len(env) != 1 || env["A"] != "3" {
+		t.Fatalf("env = %v, want a wholesale replacement", env)
+	}
+}
+
+func TestSetCredential_Rejects(t *testing.T) {
+	svc, _ := newCredentialService(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		cred string
+		env  map[string]string
+	}{
+		{"blank name", "  ", map[string]string{"A": "1"}},
+		{"no variables", "npm", nil},
+		{"blank key", "npm", map[string]string{"  ": "1"}},
+		{"key with =", "npm", map[string]string{"A=B": "1"}},
+		{"key starting with a digit", "npm", map[string]string{"1A": "1"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := svc.SetCredential(ctx, "proj", tc.cred, tc.env)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			// A rejection message must not carry the value it rejected.
+			if strings.Contains(err.Error(), "1") && tc.name != "key starting with a digit" {
+				t.Fatalf("error %q leaks a credential value", err)
+			}
+		})
+	}
+}
+
+func TestDeleteCredential(t *testing.T) {
+	svc, _ := newCredentialService(t)
+	ctx := context.Background()
+
+	if err := svc.SetCredential(ctx, "proj", "npm", map[string]string{"A": "1"}); err != nil {
+		t.Fatalf("SetCredential: %v", err)
+	}
+	if err := svc.DeleteCredential(ctx, "proj", "npm"); err != nil {
+		t.Fatalf("DeleteCredential: %v", err)
+	}
+	names, err := svc.ListCredentialNames(ctx, "proj")
+	if err != nil {
+		t.Fatalf("ListCredentialNames: %v", err)
+	}
+	if len(names) != 0 {
+		t.Fatalf("names = %v, want none", names)
+	}
+	if err := svc.DeleteCredential(ctx, "proj", "npm"); err == nil {
+		t.Fatal("expected a not-found error deleting a credential twice")
+	}
+}

--- a/backend/internal/service/pipeline/pipeline.go
+++ b/backend/internal/service/pipeline/pipeline.go
@@ -45,6 +45,13 @@ type Store interface {
 
 	ListPipelineRuns(ctx context.Context, projectID domain.ProjectID, filter pipeline.RunFilter) ([]pipeline.RunState, error)
 
+	// Credential writes and the names-only read (decision D13). Reading a
+	// credential's values is not part of this seam: only the engine's resolver
+	// does that, and only into a command stage's env.
+	SetPipelineCredential(ctx context.Context, projectID domain.ProjectID, name string, env map[string]string, now time.Time) error
+	ListPipelineCredentialNames(ctx context.Context, projectID domain.ProjectID) ([]string, error)
+	DeletePipelineCredential(ctx context.Context, projectID domain.ProjectID, name string) (bool, error)
+
 	// Sessions and their PRs are how a manual trigger resolves a PR subject
 	// server-side: the pr table reaches a project only through its session.
 	ListSessions(ctx context.Context, projectID domain.ProjectID) ([]domain.SessionRecord, error)
@@ -123,6 +130,13 @@ type Manager interface {
 	// The read side is not here: the agent executor polls the concrete Service
 	// through executors.SignalReader, not through this HTTP-facing seam.
 	SignalStage(ctx context.Context, runID pipeline.RunID, stageID string, kind pipeline.SignalKind, reason string) error
+
+	// Credentials (decision D13): set and delete take values in, listing gives
+	// names back. Nothing here returns a value, which is what keeps a secret
+	// out of every HTTP response and every line the CLI prints.
+	SetCredential(ctx context.Context, projectID domain.ProjectID, name string, env map[string]string) error
+	ListCredentialNames(ctx context.Context, projectID domain.ProjectID) ([]string, error)
+	DeleteCredential(ctx context.Context, projectID domain.ProjectID, name string) error
 }
 
 // Service is the concrete Manager over a Store plus, once wired, the engine

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -217,22 +217,41 @@ CDC event bus: `pr.opened`, `pr.updated`, `pr.merge_ready`, `pr.merged`.
 
 ```
 ao pipeline list [--project ID] [--json]
-ao pipeline runs [--project ID] [--pipeline NAME] [--status STATE] [--limit N] [--json]
+ao pipeline runs [--project ID] [--pipeline NAME] [--status STATUS] [--limit N] [--json]
 ao pipeline show <runId> [--project ID] [--json]
-ao pipeline run <pipeline-ref> [--project ID] [--session ID] [--head-sha SHA] [--json]
+ao pipeline run <pipeline-ref> [--project ID] [--session ID] [--pr N] [--json]
 ao pipeline cancel <runId> [--project ID]
-ao pipeline resume <runId> [--project ID]
+ao pipeline credential set <name> KEY=VALUE... [--project ID]
+ao pipeline credential ls [--project ID]
+ao pipeline credential rm <name> [--project ID]
+ao pipeline done
+ao pipeline fail --reason "..."
 ```
 
 `--project` falls back to `AO_PROJECT_ID`, then the CLI's usual
-cwd/session-based project resolution. `--status` filters `runs` by loop
-state (`running`, `awaiting_context`, `done`, `stalled`, `terminated`).
-`pipeline run` accepts either a pipeline id or its name.
+cwd/session-based project resolution. `--status` filters `runs` by run
+status (`pending`, `running`, `succeeded`, `failed`, `cancelled`).
+`pipeline run` accepts either a pipeline id or its name, and resolves the
+subject from `--session` or `--pr` (the PR's head SHA and fork provenance
+come from the daemon, so there is no `--head-sha`).
+
+There is no `resume`: a settled run is final, and re-running means
+triggering a new one.
+
+`done` and `fail` settle the stage the caller is running inside; they read
+`AO_RUN_ID` and `AO_STAGE` from the ambient stage environment and error by
+name if either is missing.
+
+Credential values live in the daemon and are injected into a command
+stage's process environment at exec time. No command prints one back: `ls`
+lists names, and `set` acknowledges the variable names it stored. Setting a
+name again replaces its whole environment, so dropping a `KEY=VALUE`
+removes that variable.
 
 ```bash
-ao pipeline runs --pipeline pr-review --status stalled
-ao pipeline run pr-review --head-sha abc1234
-ao pipeline resume run_01hz...
+ao pipeline runs --pipeline pr-review --status failed
+ao pipeline run pr-review --pr 42
+ao pipeline credential set npm NPM_TOKEN=... NPM_SCOPE=@ao
 ```
 
 ## Where findings land

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -314,6 +314,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/pipelines/credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List a project's pipeline credential names (never their values) */
+        get: operations["listPipelineCredentials"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pipelines/credentials/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Create or replace a pipeline credential */
+        put: operations["setPipelineCredential"];
+        post?: never;
+        /** Delete a pipeline credential */
+        delete: operations["deletePipelineCredential"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/pipelines/runs": {
         parameters: {
             query?: never;
@@ -1009,6 +1044,18 @@ export interface components {
             reason: string;
             sessionId: string;
         };
+        ControllersDeletePipelineCredentialResponse: {
+            deleted: boolean;
+            name: string;
+        };
+        ControllersListPipelineCredentialsResponse: {
+            names: string[];
+        };
+        ControllersPipelineCredentialResponse: {
+            /** @description Names of the environment variables stored, sorted. Never their values. */
+            keys: string[];
+            name: string;
+        };
         ControllersSessionView: {
             activity: components["schemas"]["DomainActivity"];
             branch?: string;
@@ -1031,6 +1078,12 @@ export interface components {
             terminalHandleId?: string;
             /** Format: date-time */
             updatedAt: string;
+        };
+        ControllersSetPipelineCredentialRequest: {
+            /** @description Environment variables the credential injects, keyed by variable name. Values are write-only: no read path returns them. */
+            env: {
+                [key: string]: string;
+            } | null;
         };
         DegradedProject: {
             id: string;
@@ -2728,6 +2781,175 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DeletePipelineDefinitionResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    listPipelineCredentials: {
+        parameters: {
+            query?: {
+                /** @description Project id the pipeline belongs to (required). */
+                project?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllersListPipelineCredentialsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    setPipelineCredential: {
+        parameters: {
+            query?: {
+                /** @description Project id the pipeline belongs to (required). */
+                project?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Credential name as stages reference it in credentials:. */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllersSetPipelineCredentialRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllersPipelineCredentialResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    deletePipelineCredential: {
+        parameters: {
+            query?: {
+                /** @description Project id the pipeline belongs to (required). */
+                project?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Credential name as stages reference it in credentials:. */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllersDeletePipelineCredentialResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
                 };
             };
             /** @description Not Found */


### PR DESCRIPTION
## What

Task 19 of the pipelines v2 plan: the CLI surface.

- **Kept and updated**: `list`, `runs`, `show <runId>`, `run <ref>`, `cancel <runId>`. The DTOs move from v1's loop state / termination reason / findings to v2's run status rollup, subject, and stage outcome taxonomy.
- **`show` renders v2 outcomes** as a table with attempt and reason columns, so a nudged stage (attempt 2) and a stage that produced nothing (`no_output`, artifact missing) read differently at a glance instead of collapsing into one "failed" line. Pinned by a golden test.
- **Added**: `credential set <name> KEY=VALUE... --project <p>`, `credential ls`, `credential rm <name>`.
- **Removed**: `resume`, with the semantics behind it. A settled run is final.
- `run` trades `--head-sha` for `--pr`: v2 resolves the subject, its head SHA and its fork provenance server-side.
- `done` and `fail` are untouched.

## Credentials never echo a value (decision D13)

The values are real secrets, so the surface is built so there is nowhere for one to come back out:

- No service method returns a value; only the engine's resolver reads them, into a command stage's process env.
- `ls` decodes into a names-only struct, so whatever a response carries there is no field to print a value from.
- The `set` receipt lists variable names, never values.
- A malformed `KEY=VALUE` is reported by position and the argument is **not** quoted back: the likeliest way to mistype one of these is to paste the secret on its own, and an echo would put it in the scrollback, the shell error log and any CI transcript.

Tests cover the verb set (resume absent, credential verbs present), the golden `show` output, and that no credential command prints value bytes.

## Out-of-plan piece: the credential HTTP endpoints

The CLI talks to the daemon over HTTP, and no task in the plan owned the credential routes: Task 12 built the store and resolver, Task 18 shipped the v2 API without them. So this PR also adds the thin surface the verbs need:

- `GET /api/v1/pipelines/credentials` (names), `PUT /api/v1/pipelines/credentials/{name}`, `DELETE /api/v1/pipelines/credentials/{name}`
- `Manager.SetCredential | ListCredentialNames | DeleteCredential` over the existing store methods, with env-key validation whose messages name the key and never the value
- OpenAPI regenerated, `frontend/src/api/schema.ts` regenerated

## Docs

`docs/pipelines.md` still describes v1 throughout (findings, loop states). Only its CLI commands section is updated here, since this PR is what made it wrong. The rest belongs to the docs pass.

## Verification

- `go build ./...`, `go test ./...`, `gofmt -l .` (empty), `golangci-lint run ./...` (0 issues)
- 4 pre-existing `TestSpawn*` failures in `internal/cli` also fail on `origin/pipelines` at the same commit; verified by running them in a worktree of the base branch.

Closes #331
