### PR TITLE
docs(pipelines): v2 followups and dogfood notes

### DIFF
--- a/backend/internal/pipeline/definition.go
+++ b/backend/internal/pipeline/definition.go
@@ -421,3 +421,20 @@ func (s *Stage) EffectiveKillOn() []Outcome {
 	copy(out, s.Session.KillOn)
 	return out
 }
+
+// KillsOn reports whether this stage's disposition kills its session for the
+// given outcome.
+//
+// The list is matched literally with one exception: `succeeded` also covers
+// `succeeded_unverified`. The two differ by whether there was an artifact to
+// verify, not by whether the agent finished, so a stage with no `produces:`
+// would otherwise keep its session alive after every clean run. That is the
+// same subsumption Outcome.IsSuccess makes for the on_success edge.
+func (s *Stage) KillsOn(outcome Outcome) bool {
+	for _, killOn := range s.EffectiveKillOn() {
+		if killOn == outcome || (killOn == OutcomeSucceeded && outcome == OutcomeSucceededUnverified) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/pipeline/definition_test.go
+++ b/backend/internal/pipeline/definition_test.go
@@ -285,3 +285,39 @@ func TestStage_EffectiveKillOn(t *testing.T) {
 		t.Errorf("empty session block kill-on = %v, want %v", got, want)
 	}
 }
+
+// TestStage_KillsOn pins the one place the kill-on list is not matched
+// literally: an author who wrote `succeeded` means the stage worked, and a
+// stage with no `produces:` can only ever reach succeeded_unverified. Matching
+// the two strings exactly kept a session alive after every clean run of every
+// unverified stage, which the live drill showed as an orphan badge on a stage
+// that had nothing wrong with it.
+func TestStage_KillsOn(t *testing.T) {
+	def := Stage{}
+	if !def.KillsOn(OutcomeSucceededUnverified) {
+		t.Error("default kill-on did not kill on succeeded_unverified")
+	}
+	if !def.KillsOn(OutcomeSucceeded) || !def.KillsOn(OutcomeFailed) {
+		t.Error("default kill-on did not kill on its own two outcomes")
+	}
+	for _, kept := range []Outcome{OutcomeNoOutput, OutcomeNoSignal, OutcomeTimedOut, OutcomeCancelled} {
+		if def.KillsOn(kept) {
+			t.Errorf("default kill-on killed on %s, which must keep the session", kept)
+		}
+	}
+
+	never := Stage{Session: &SessionSpec{KillOn: []Outcome{}}}
+	if never.KillsOn(OutcomeSucceeded) || never.KillsOn(OutcomeSucceededUnverified) {
+		t.Error("an explicit empty kill-on killed a session")
+	}
+
+	// The subsumption is one-way: asking for the unverified outcome alone does
+	// not kill a stage that verified its artifact.
+	unverifiedOnly := Stage{Session: &SessionSpec{KillOn: []Outcome{OutcomeSucceededUnverified}}}
+	if unverifiedOnly.KillsOn(OutcomeSucceeded) {
+		t.Error("kill-on [succeeded_unverified] killed on succeeded")
+	}
+	if !unverifiedOnly.KillsOn(OutcomeSucceededUnverified) {
+		t.Error("kill-on [succeeded_unverified] did not kill on its own outcome")
+	}
+}

--- a/backend/internal/pipeline/engine/adapters.go
+++ b/backend/internal/pipeline/engine/adapters.go
@@ -121,6 +121,10 @@ func (a *SessionAdapter) Get(ctx context.Context, sessionID string) (executors.S
 	return executors.SessionSnapshot{
 		Activity:   rec.Activity.State,
 		Terminated: rec.IsTerminated,
+		// FirstSignalAt is the platform's own record of the first hook callback
+		// for this spawn, cleared on every spawn/restore. Zero means the row
+		// still carries its seeded activity and nothing has been observed yet.
+		Signalled: !rec.FirstSignalAt.IsZero(),
 	}, true, nil
 }
 

--- a/backend/internal/pipeline/engine/adapters_test.go
+++ b/backend/internal/pipeline/engine/adapters_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/pipeline/executors"
@@ -204,6 +205,39 @@ func TestSessionAdapterAliveAndWorkspace(t *testing.T) {
 	path, ok, err := adapter.SessionWorkspaces().Get(context.Background(), "sess-1")
 	if err != nil || !ok || path != "/trees/sess-1" {
 		t.Fatalf("session workspace = %q, %v, %v", path, ok, err)
+	}
+}
+
+// TestSessionAdapterGetReportsFirstSignal pins the fact the agent executor
+// reads to tell a launching session from an idle one: a row whose
+// FirstSignalAt is zero has never had a hook callback, so its seeded idle is
+// not an observation.
+func TestSessionAdapterGetReportsFirstSignal(t *testing.T) {
+	launching := liveSession()
+	launching.ID = "sess-launching"
+	launching.Activity = domain.Activity{State: domain.ActivityIdle}
+	reported := liveSession()
+	reported.ID = "sess-reported"
+	reported.Activity = domain.Activity{State: domain.ActivityIdle}
+	reported.FirstSignalAt = time.Unix(1, 0)
+	rows := fakeSessionRows{rows: map[domain.SessionID]domain.SessionRecord{
+		"sess-launching": launching,
+		"sess-reported":  reported,
+	}}
+	adapter := NewSessionAdapter(newFakeCommander(), rows, nil, nil)
+
+	snap, ok, err := adapter.Get(context.Background(), "sess-launching")
+	if err != nil || !ok {
+		t.Fatalf("Get(sess-launching) = %v, %v", ok, err)
+	}
+	if snap.Signalled {
+		t.Error("signalled = true for a session with no hook callback yet")
+	}
+	if snap, ok, err = adapter.Get(context.Background(), "sess-reported"); err != nil || !ok {
+		t.Fatalf("Get(sess-reported) = %v, %v", ok, err)
+	}
+	if !snap.Signalled {
+		t.Error("signalled = false for a session whose first hook callback landed")
 	}
 }
 

--- a/backend/internal/pipeline/engine/engine.go
+++ b/backend/internal/pipeline/engine/engine.go
@@ -732,10 +732,7 @@ func (e *Engine) settleSession(runID pipeline.RunID, eff pipeline.SettleSession)
 	if def == nil {
 		return
 	}
-	for _, killOn := range def.EffectiveKillOn() {
-		if killOn != eff.Outcome {
-			continue
-		}
+	if def.KillsOn(eff.Outcome) {
 		if e.sessions == nil {
 			e.log.Warn("pipeline session kill skipped: no session seam wired", "run", runID, "stage", eff.Stage)
 			return

--- a/backend/internal/pipeline/engine/engine_test.go
+++ b/backend/internal/pipeline/engine/engine_test.go
@@ -1015,6 +1015,25 @@ stages:
 	if killed := h2.sess.killedIDs(); len(killed) != 0 {
 		t.Fatalf("killed %v, want kill-on: [] to never kill", killed)
 	}
+
+	// A stage with no `produces:` settles succeeded_unverified and can never
+	// settle succeeded, so the default kill-on has to cover it or every clean
+	// run of an unverified stage leaks its session.
+	const unverifiedYAML = `
+name: unverified-session
+stages:
+  - id: review
+    executor: agent
+    agent: claude-code
+    prompt: review
+`
+	h3 := newHarness(t)
+	h3.trigger(t, unverifiedYAML, userSessionSubject())
+	h3.execs.script(t, "review", executors.Poll{State: executors.PollSignaledDone})
+	h3.engine.Tick()
+	if killed := h3.sess.killedIDs(); len(killed) != 1 || killed[0] != "sess-review" {
+		t.Fatalf("killed %v, want the session killed on succeeded_unverified", killed)
+	}
 }
 
 // TestKeptSessionIsMarkedPipelineOrphaned: the kept half of the kill-on rule.

--- a/backend/internal/pipeline/executors/agent.go
+++ b/backend/internal/pipeline/executors/agent.go
@@ -45,10 +45,16 @@ type SpawnedSession struct {
 }
 
 // SessionSnapshot is the subset of session state the executor polls: how busy
-// the agent is, and whether the session row went terminal.
+// the agent is, whether the session row went terminal, and whether any of that
+// activity was ever reported.
 type SessionSnapshot struct {
 	Activity   domain.ActivityState
 	Terminated bool
+	// Signalled reports whether a hook callback has arrived for this spawn.
+	// A session row is seeded `idle` when it is created and stays there until
+	// the harness reports, so idle before the first callback is the spawn
+	// placeholder rather than an observation of the agent.
+	Signalled bool
 }
 
 // SessionSpawner is the session-manager seam the agent executor needs. The
@@ -183,6 +189,15 @@ func (e *AgentExecutor) Poll(ctx context.Context, h Handle) (Poll, error) {
 	case snap.Activity == domain.ActivityIdle,
 		snap.Activity == domain.ActivityWaitingInput,
 		snap.Activity == domain.ActivityBlocked:
+		if !snap.Signalled {
+			// Still in the spawn window: the row is seeded idle and no hook has
+			// reported yet, so this reading describes the launch, not the agent.
+			// Treating it as idle nudges and settles the stage within a couple
+			// of ticks, before the agent has read its prompt. A harness that
+			// never reports at all is bounded by the stage deadline, which is
+			// what deadlines are for (spec section 13.1).
+			return Poll{State: PollRunning}, nil
+		}
 		// Alive but not working, so the missing signal will not arrive on its
 		// own. Whether that earns a nudge or a settlement is the reducer's call.
 		return Poll{State: PollIdle}, nil

--- a/backend/internal/pipeline/executors/agent_test.go
+++ b/backend/internal/pipeline/executors/agent_test.go
@@ -70,11 +70,13 @@ func (s *fakeSpawner) Kill(_ context.Context, _ string) error {
 	return nil
 }
 
-// activity sets what the next Get reports.
+// activity sets what the next Get reports for a session that has already
+// reported at least one hook callback, which is the state every reading other
+// than the spawn window describes.
 func (s *fakeSpawner) activity(state domain.ActivityState, exists bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.snap = SessionSnapshot{Activity: state}
+	s.snap = SessionSnapshot{Activity: state, Signalled: true}
 	s.exists = exists
 }
 
@@ -352,6 +354,49 @@ func TestAgentPollIdleAndGone(t *testing.T) {
 				t.Errorf("state = %q, want %q", got.State, tc.want)
 			}
 		})
+	}
+}
+
+// TestAgentPollIdleBeforeFirstSignalIsStillStarting pins the spawn window. A
+// session row is seeded `idle` at spawn and stays there until the harness's
+// first hook callback lands, so reading that seed as "the agent stopped" nudges
+// and settles the stage seconds after launch, before the agent has read a
+// token. Live drill: a real claude-code stage settled no_signal 9s after spawn
+// with first_signal_at still NULL.
+func TestAgentPollIdleBeforeFirstSignalIsStillStarting(t *testing.T) {
+	for _, state := range []domain.ActivityState{domain.ActivityIdle, domain.ActivityWaitingInput, domain.ActivityBlocked} {
+		t.Run(string(state), func(t *testing.T) {
+			exec, spawner, _, h := startAgent(t, agentInput(t))
+			spawner.mu.Lock()
+			spawner.snap = SessionSnapshot{Activity: state, Signalled: false}
+			spawner.mu.Unlock()
+
+			got, err := exec.Poll(context.Background(), h)
+			if err != nil {
+				t.Fatalf("Poll: %v", err)
+			}
+			if got.State != PollRunning {
+				t.Errorf("state = %q, want %q: the spawn seed is not an observation", got.State, PollRunning)
+			}
+		})
+	}
+}
+
+// TestAgentPollGoneBeforeFirstSignal keeps the exit path unconditional: a
+// session that ended during its spawn window is gone whether or not a hook ever
+// reported, and waiting for the deadline there would be a lie.
+func TestAgentPollGoneBeforeFirstSignal(t *testing.T) {
+	exec, spawner, _, h := startAgent(t, agentInput(t))
+	spawner.mu.Lock()
+	spawner.snap = SessionSnapshot{Activity: domain.ActivityExited, Signalled: false}
+	spawner.mu.Unlock()
+
+	got, err := exec.Poll(context.Background(), h)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if got.State != PollGone {
+		t.Errorf("state = %q, want %q", got.State, PollGone)
 	}
 }
 

--- a/docs/plans/2026-07-26-pipelines-v2-followups.md
+++ b/docs/plans/2026-07-26-pipelines-v2-followups.md
@@ -1,0 +1,250 @@
+# Pipelines v2 followups
+
+Written at the close of Task 26 (end-to-end dogfood). Everything here is either
+deliberately deferred, a divergence between the shipped code and the spec, or
+something a live drill turned up and this task did not fix. Two things the
+drills turned up **were** fixed and are not listed as open: agent stages settling
+`no_signal` seconds after spawn, and `kill-on: succeeded` not covering
+`succeeded_unverified`. Both are in this PR with tests.
+
+Spec is `docs/plans/2026-07-26-pipelines-v2.md`, plan is
+`docs/plans/2026-07-26-pipelines-v2-implementation.md`.
+
+---
+
+## Deliberately deferred
+
+### D9: run folder GC
+
+v2 never deletes a run folder, and it keeps every owned workspace belonging to a
+run that did not succeed (spec 5.5). Confirmed live: after ten drill runs the
+data dir held four kept worktrees plus every run's logs and artifacts, and
+nothing in the daemon will ever reclaim them.
+
+Disk therefore grows without bound, linearly in runs and in kept workspaces. The
+policy question, deliberately left open rather than answered under deadline:
+
+- Is the retention unit the run folder, the workspace inside it, or both? A
+  workspace is by far the larger of the two (a checkout each) and by far the
+  shorter-lived in usefulness; logs and artifacts stay readable at a few KB.
+- Is retention by age, by count per pipeline, or by total bytes? The kept-session
+  reaper already answers the same question for sessions with a cap of 3 per
+  pipeline plus a 24h TTL (D7), and consistency between the two is worth more
+  than picking the theoretically better rule for each.
+- Is a GC'd run folder deleted or tombstoned? SQLite is the store of record (D2),
+  so the run stays on the board after its folder is gone. Run detail already
+  distinguishes "the agent produced nothing" from "the file is no longer on
+  disk", so a tombstone is renderable, but nothing says that in the UI yet.
+- Does anything GC on a schedule, or only at run start / daemon boot?
+
+Until this is answered, a heavy user's remedy is `rm -rf ~/.ao/pipelines/<project>`,
+which is safe (SQLite keeps the run rows) and undocumented.
+
+### Credentials UI
+
+D13 ships credential management as CLI-only: `ao pipeline credential set|rm|ls`,
+values held in the daemon and injected into command-stage process env at exec
+time, never echoed back. The canvas renders a stage's declared credential names
+read-only. A settings surface for creating and rotating them is a later feature.
+The load-bearing half (the tier separation, `credentials:` schema-forbidden on
+agent stages) ships now and is what a UI would have to respect anyway.
+
+### Spec section 2, out of scope by design
+
+Wanted, deliberately later: cron and scheduled triggers, push-to-branch
+triggers, compensating actions / rollback after a point of no return (13.3),
+matrix expansion, reusable or composable pipeline fragments, hosted runner
+execution (15).
+
+Rejected rather than deferred, and not to be revisited casually: a parallel
+`pipeline2/` package, cutting any part of the v1 UI, an expression language
+(12.3), pasting agent output into the next stage's prompt, letting agents write
+`Context.md`, per-pipeline shared context across runs, explicit per-stage
+environment declaration, a `continue-on-error` equivalent, job-outputs-as-strings.
+Graph cycles are rejected at validation, not merely unimplemented (9.1).
+
+### Phase 2 items from the v1 handoff
+
+The v1 handoff document is not in this repo (it lived alongside the v1 branch and
+its "open gaps" section was superseded before v2 started), so this is sourced
+from what v1 actually shipped rather than from that document. Say so rather than
+inventing a list. What v1 carried that v2 has not re-answered:
+
+- **`docs/pipelines.md` still documents v1.** Predicates, findings, loop identity
+  and same-SHA dedup, retries, merge blocking and dismissing findings: all
+  deleted in v2, all still in the user-facing doc, which is now wrong from the
+  "Authoring a definition" section onward. No v2 task owned it. This is the most
+  user-visible piece of debt in the feature and should be the next thing written.
+- **Fork-PR trust UX.** D17 repurposes the v1 fork gate as the identity-only
+  rule. A run over a fork PR silently gets no credentials; nothing on the run
+  detail says "this run was identity-only because the PR came from a fork".
+- **Telemetry.** v1 emitted pipeline events; v2 has not re-litigated what a
+  pipeline run should report.
+
+---
+
+## Divergences between the spec and the shipped code
+
+Precedence is spec, then the plan's Part 1 decisions, then the boring option.
+These are the places where the code does not match the spec text and shipped
+anyway, each with what it would cost to close.
+
+### Agent stages do not run in the resolved workspace
+
+The biggest one. `SessionAdapter.Spawn` carries a `ponytail:` comment saying it:
+`ports.SpawnConfig` has no way to adopt an existing tree, so the session manager
+creates its own worktree per session and the agent runs there, while the
+driver-provisioned tree (spec 5) governs only command stages, `inherit` and
+teardown.
+
+Confirmed live: for a `workspace: run` pipeline, `run.json` recorded
+`workspacePath = <run>/workspace` for the agent stage while the session actually
+ran in `~/.ao/data/worktrees/scratch/scratch-2`, and `$AO_WORKSPACE` in the
+session's environment named the run tree the agent was not in.
+
+Consequences: an agent stage cannot share filesystem state with a command stage
+through `workspace: run`; `workspace: stage` and `inherit` mean nothing for agent
+stages (so the `diagnose-build` shape in spec 11, an agent inheriting the failed
+build's tree, does not work as written); and the run tree is destroyed on success
+while the session's own worktree follows session lifecycle instead.
+
+Closing it needs `ports.SpawnConfig.WorkspacePath` plus a session teardown that
+never destroys a pipeline-owned tree. That is a session-lifecycle change, not an
+engine one, which is why it is here and not in this PR.
+
+### `AO_ATTEMPT` stays 1 on the nudged attempt
+
+Spec 12.2 says `AO_ATTEMPT` is "1, or 2 after a nudge", and the plan's Task 26
+asks to verify `AO_ATTEMPT=2` in the session env. It is 1. Confirmed live: on a
+nudged stage the agent dumped its own environment and got `AO_ATTEMPT=1` while
+run detail showed `attempt 2 (nudged)`.
+
+This is not a small fix, because the nudge deliberately does not relaunch the
+stage (spec 7.1: the nudge works precisely because the session is still alive
+with its context), and a running process's environment cannot be rewritten. The
+agent learns it is on its last attempt from the nudge message itself. Options if
+this matters: state it in the nudge text ("this is attempt 2 of 2"), or drop the
+`AO_ATTEMPT` row from the spec's table for agent stages. Do not "fix" it by
+relaunching the stage.
+
+### Agent stages write no `stage-logs/<stage>.log`
+
+Spec 3 says stage logs are captured for "both executors, always". Command stages
+write one; agent stages write none, by design (the agent executor's own comment:
+its record is the session's scrollback, which outlives the stage on every outcome
+that keeps the session). Run detail renders the absence as "No log was captured
+for this stage." rather than an error, so nothing is broken, but the spec
+sentence is not true. Either capture the pane on settle or amend the spec line.
+
+### `Context.md` only exists once something is indexed
+
+Spec 3 lists `Context.md` in the run folder layout unconditionally. The engine
+writes it when a stage's declared artifact verifies, so a run with no `produces:`
+anywhere has no `Context.md` and `$AO_CONTEXT` names a path that does not exist.
+The agent preamble handles that ("It is empty: nothing ran before you"), so this
+is a documentation nit, not a defect.
+
+### `agent-outputs/<filename>`, not `agent-outputs/<stage>.md`
+
+Spec 3's layout sketch writes `agent-outputs/<stage>.md`; spec 6.2 says
+`produces:` takes a bare filename resolving to `<run>/agent-outputs/<filename>`.
+The code follows 6.2 (`produces: review.md` on stage `shirk` lands at
+`agent-outputs/review.md`). 6.2 is the load-bearing text; the sketch is loose.
+
+### Sessionless PR subjects are unreachable through the bridge
+
+Spec 4 makes a PR subject with no session first-class, and the engine and the run
+detail both handle it. The store cannot produce one: `pr.session_id` is a NOT NULL
+foreign key into `sessions`, so every PR row the CDC bridge can read names a
+session, and `PRBridge.process` always resolves one. The path is real in the
+engine and exercised by unit tests; it has no live producer today. It becomes
+reachable the moment PR discovery can record a PR nobody is working on.
+
+---
+
+## Found by the drills, not fixed
+
+### A daemon on a non-default run file cannot be signalled from its own sessions
+
+`ao pipeline done` resolves the daemon through the run file (`AO_RUN_FILE`,
+default `~/.ao/running.json`), while a spawned session's environment carries
+`AO_DATA_DIR` and a PATH pinned to the daemon binary but **not** `AO_RUN_FILE`.
+On the first drill this sent the agent's `ao pipeline done` to the developer's
+main daemon, which answered `ROUTE_NOT_FOUND`, and cost the same drill its
+activity hooks for the same reason.
+
+Harmless for a shipped single-daemon install, where the default run file is the
+only one. It bites any second daemon: dogfooding, CI, a scratch instance. The
+workaround used here was forwarding `AO_RUN_FILE` through the project's env
+config. A real fix is to include the daemon's run file path in the session env
+alongside `AO_DATA_DIR`, so a session always talks to the daemon that spawned it.
+
+### A restart settles the stage but leaks its process
+
+D16 reconciliation settles a lost command stage as `failed` and routes it, which
+is what the drill was for. The OS process it started keeps running: after
+`kill -9` on the daemon and a reboot, the stage's `sleep 300` was still alive with
+nothing tracking it, and only the run folder named it. Command stages run in
+their own process group, so recording the pgid alongside the stage would make a
+boot-time reap possible. Until then a restart mid-run can leave work running.
+
+### The reconciled agent stage's reason line is not true
+
+A lost agent stage settles `no_signal` with "session exited without signalling".
+The session usually has not exited: after the restart drill the session was alive
+in tmux with its scrollback, correctly marked pipeline-orphaned. The engine's own
+comment acknowledges it ("the session may well still be alive, but nothing in
+this process is listening to it any more"); only the reason string, which is
+shared with the genuine session-gone path, says otherwise. A distinct reason for
+the reconciliation path would fix it.
+
+### The nudge can tell an agent it signalled when it did not
+
+The nudge text is chosen by whether the artifact is on disk: no artifact gets
+"You signaled done but agent-outputs/X does not exist or is empty", and an
+artifact that is there gets "You appear to be finished but have not signalled."
+The discriminator is right for the `no_output` path, where the agent did signal.
+It is wrong for the idle-without-signal path, where the agent has not claimed
+anything: the first drill nudged an agent that had gone idle before writing, told
+it that it had signalled, and it dutifully rewrote a file it had already written.
+The reducer knows which event it is reacting to; passing that through instead of
+inferring from `artifactOK` would fix the wording.
+
+### A harness trust prompt can burn a whole deadline
+
+Every agent stage gets a fresh session worktree, and claude-code asks for
+directory trust the first time it sees a path. One drill session sat on that
+dialog until its deadline and settled `timed_out` with the agent never having
+read the prompt. The engine behaved correctly (that is what deadlines are for),
+but the failure mode is invisible unless someone opens the pane. Worth knowing
+before pipelines meet a fresh machine; a harness-level trust preseed would remove
+it.
+
+### Idle is only meaningful from a harness with hooks
+
+The fix in this PR treats an idle reading as the spawn placeholder until the
+session's first hook callback lands. For a harness with no hook pipeline that
+callback never comes, so its agent stages can no longer settle `no_signal` early
+and are bounded by their deadline instead. That is the honest direction (the old
+behavior settled them within seconds of spawn, always) but it means a hook-less
+harness wants an explicit short `deadline:` on its stages.
+
+---
+
+## Decision: the Go template fixtures stay
+
+`backend/internal/pipeline/testdata/templates/*.yaml` plus `templates_test.go`
+(from #322) exist because `POST /pipelines/validate` was 501 when they were
+written. It is live now, and the question was whether they should become an
+integration test.
+
+They stay, unchanged. What they buy is not "validation works" (the endpoint and
+its own tests cover that) but a byte-identical pin between the two sides: the TS
+test asserts `serializeToYaml(template.draft())` matches these files, and the Go
+test runs the real parser and the real validator over the same bytes, warnings
+included. A template edited in TypeScript that stops satisfying a Go rule fails
+in Go; a template edited without regenerating the fixture fails in TypeScript.
+An integration test through the daemon would prove less (it could not see the
+serializer) and cost more (a daemon per run). The cost of keeping them is one
+regeneration step when a starter template changes, which is exactly the step the
+pin exists to force.

--- a/frontend/src/renderer/components/PipelineRunDetail.test.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.test.tsx
@@ -76,7 +76,7 @@ function sessionView(overrides: Partial<WorkspaceSession> & { id: string }): Wor
 		workspaceId: "proj-1",
 		workspaceName: "proj-1",
 		title: overrides.id,
-		provider: "claude",
+		provider: "claude-code",
 		branch: `session/${overrides.id}`,
 		status: "idle",
 		createdAt: "2026-07-15T00:00:00Z",


### PR DESCRIPTION
Pipelines v2, Task 26: end-to-end dogfood and closeout. Closes #335.

This is the last task, so it is a drill report first and a diff second. Two of
the drills failed, both fixes are here with tests, and everything the drills
found and did not fix is written down in the followups doc.

## Setup

A second daemon built from this branch (`AO_PORT=3098`, `AO_DATA_DIR=/tmp/ao-t26/data`,
`AO_PIPELINES=on`), a scratch git repo registered as project `scratch`, `claude-code`
as the harness for every agent stage. All ten runs below are real: real engine, real
sessions, real worktrees, no seeded rows and no shimmed endpoints. #333 proved the UI
against `fake`; this proves the machinery against a genuine agent.

## The thing that had never been proven: a real agent settling its own stage

**Drill 1 (`t26-real-agent`)**: an agent stage with `produces: review.md`, then a
command stage that consumes the file.

First attempt, **the feature did not work**:

```
review          no_signal  attempt 2 (nudged)  9s   "session went idle without signalling"
consume         skipped
notify-failure  succeeded  via review failing
```

Nine seconds after spawn, while claude was still booting. `sessions.first_signal_at`
was NULL: no hook callback had ever arrived. A session row is seeded `idle` at
creation and stays there until the harness's first hook lands, and the agent
executor read that seed as "alive but not working", so the reducer nudged on the
first 2s tick and settled on the second. **No agent stage could ever have
succeeded**, which is why `succeeded` and `succeeded_unverified` were both
unproven going into this task. Unit tests could not catch it: they set an
activity state, and the bug is that the state is a placeholder.

Fixed in `fix(pipelines): do not read a launching session as idle`: an idle,
waiting_input or blocked reading is the spawn placeholder until the session has
actually reported (`FirstSignalAt`, the platform's own record of the first hook
callback, cleared on every spawn). A harness that never reports is bounded by the
stage deadline, which is what deadlines are for (spec 13.1).

Same pipeline, same prompt, after the fix:

```
review          succeeded  attempt 1  produces review.md
consume         succeeded  attempt 1
notify-failure  skipped
```

Run `succeeded` in 17s. The agent read its prompt, wrote `$AO_OUTPUT`, and ran
`ao pipeline done` under its own power. `consume` then read the file back:
`stage-logs/consume.log` reads `consumed: / scratch review ok`. That is the whole
point of the feature and it now works end to end.

## Every other drill

**2. `succeeded_unverified` (`t26-unverified`)**: agent stage with no `produces:`,
settling on its own signal. `announce succeeded_unverified` then `after succeeded`
with `AO_PREV_STAGE`/`AO_PREV_OUTCOME` in the log. The pane shows the agent's own
`ao pipeline done` returning `stage announce in run ... -> done`.

That drill exposed the second bug: the session stayed alive and got a
pipeline-orphaned badge with nothing wrong with it. `kill-on` was matched
literally, and a stage with no `produces:` can only ever settle
`succeeded_unverified`, so the default `kill-on: [succeeded, failed]` never
matched. Fixed in `fix(pipelines): kill-on succeeded covers succeeded_unverified`,
the same subsumption `Outcome.IsSuccess` already makes for the `on_success` edge.

**3. `timed_out` (`t26-timeout`)**: an agent stage with `deadline: 45s` told to run
`sleep 900`. At the deadline the pane shows `Bash(sleep 900) / Interrupted . What
should Claude do instead?`, the stage settled `timed_out`, `notify-failure` ran via
the failure edge, and the session stayed alive (`is_terminated=0`, tmux pane and
scrollback intact, orphan marker carrying `outcome timed_out`). InterruptStage
stopping the work while keeping the session is exactly spec 7.2.

**4. PR subject from CDC (`t26-pr-created`)**: a real branch and head SHA in the
scratch repo recorded as a PR row, which fires the real `pr_created` CDC event
through the real bridge. Run detail: `subject pr #7 4923ad17...`, and
`stage-logs/inspect.log` reads
`pr=7 repo=harshitsinghbhandari/scratch head=4923ad177e63...`. The run workspace
was a git worktree checked out at the PR head on branch
`ao/pipeline/run-b7d57f5c-.../run`: workspace resolution really is subject to
tree. **What was simulated:** GitHub discovery. The PR row was inserted into the
store rather than found by the SCM adapter, because the scratch repo has no
remote. Everything downstream of that row, the CDC trigger, the bridge, the
subject, the run, was live.

**5. Concurrency (`t26-cancel`, `cancel-in-progress: true`)**: two `pr.updated`
fires on PR #7, ten seconds apart, mid-soak.

```
run-9a14eee9  running                                              head 2222...
run-df6ba398  cancelled (superseded by a newer run of "t26-cancel") head 1111...
    soak   cancelled
    after  skipped
```

The first run cancelled, no failure routing (spec 13.2), owned workspace kept.

**6. Restart, D16 (`t26-restart`)**: a command soak and an agent soak running
concurrently, then `kill -9` on the daemon and a fresh boot.

```
fan             succeeded
soak-cmd        failed     "the pipeline engine restarted while this stage was running; its process handle is lost"
soak-agent      no_signal  "session exited without signalling"
notify-failure  succeeded  via soak-cmd failing
```

Both lost stages settled, the run proceeded through normal failure routing
(first-arrival-wins, so one notify), and nothing hung. Two things it also showed,
both in the followups doc: the orphaned `sleep 300` was still running afterwards
with nothing tracking it, and the agent stage's reason line says the session
exited when it was alive in tmux.

**7. Workspace policy (spec 5.5)**, on the filesystem, both halves:
`<run>/workspace` is gone from the successful run's folder, and present in the
failed PR run's folder with the `kept-marker.txt` the failing stage wrote in it.

**Nudge, `ao pipeline fail`, and `AO_ATTEMPT` (`t26-nudge-fail`)**: an agent told
to signal done without writing, then to answer the nudge by dumping its env and
declining. `shirk failed attempt 2 (nudged)` with reason
`declining on the second attempt` (the agent's own words through
`ao pipeline fail --reason`), routed to `notify-failure`. The env it dumped:
`AO_ATTEMPT=1`, on the attempt run detail calls 2. Spec 12.2 says that should read
2; a nudge deliberately does not relaunch the stage and a running process's
environment cannot be rewritten, so this is recorded as a divergence rather than
papered over.

**Run folder layout, checked against spec 3**: `definition.yaml` (frozen),
`run.json`, `Context.md` carrying exactly
``stage `review` finished, its output is at agent-outputs/review.md``,
`agent-outputs/review.md`, `stage-logs/<stage>.log` per command stage,
`workspace/` for `workspace: run`, `workspaces/soak-cmd/` for `workspace: stage`.
Two deviations, both in the followups doc: agent stages write no stage log by
design, and `Context.md` only exists once something has been indexed.

## Flag off

Booted the same binary with `AO_PIPELINES=off`. No `pipelines v2: engine started`
line and no pipeline log line at all, so no supervisor, no engine actor, no
trigger bridges. All 15 `/api/v1/pipelines/*` routes answer 501 (checked one by
one, including the signal, log and output endpoints), and `ao pipeline list`
renders the 501 cleanly. Then fired a `pr.updated` CDC event with the flag off:
`pipeline_runs` stayed at 10, so nothing is subscribed. The feature costs nothing
when it is off.

## Verification

- `go build ./...`, `go test ./...` (2937 tests, all packages green), `gofmt -l .`
  empty, `~/go/bin/golangci-lint run ./...` reports `0 issues`.
- Frontend: `tsc --noEmit` clean, `vite build` green, **1130 renderer tests pass**.
  `tsc` was failing on the branch before this PR: the run detail test's session
  fixture used `provider: "claude"`, which is not in the `AgentProvider` union
  (vitest does not typecheck, so the suite never noticed). One-word fix, own commit.
- The three new backend tests were mutation-checked: forcing the kill-on
  subsumption to `false` fails exactly the two tests that claim to cover it.
- Note for anyone running the suite inside an AO session: four `internal/cli`
  spawn tests fail if `AO_PROJECT_ID` is set in the environment. They fail
  identically on `origin/pipelines` in a clean worktree and pass with the variable
  unset. Pre-existing and environmental, verified against the base rather than
  assumed.

## Followups doc

`docs/plans/2026-07-26-pipelines-v2-followups.md`: D9 run folder GC stated as a
policy question rather than answered, CLI-only credentials, spec section 2
out-of-scope items, the v1 items still open (`docs/pipelines.md` still documents
predicates, findings and loops, which is the most user-visible debt left in the
feature), every divergence above, everything the drills found and this PR did not
fix, and the decision to keep the Go template fixtures from #322 as the
byte-identical pin between the TS serializer and the Go validator.

The one to read first is the agent workspace gap: agent stages do not run in the
tree the workspace resolver picked, so `workspace: run` cannot share filesystem
state with a command stage and the `diagnose-build` shape in spec 11 does not work
as written. It needs a session-lifecycle change, not an engine one.
