### PR TITLE
feat(pipelines-ui): contextual $AO env var autocomplete and reference

### DIFF
--- a/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, CheckCircle2, Loader2, Pencil, Plus, Settings2, Trash2, Wo
 import { apiErrorMessage } from "../lib/api-client";
 import { formatTimeCompact } from "../lib/format-time";
 import { serializeToYaml, type StageDraft } from "../lib/pipeline-draft";
+import { stageEnvVars } from "../lib/pipeline-env";
 import { removeStage, stageIndexFromNodeId } from "../lib/pipeline-graph";
 import { issueStageNodeId, stageIssueMessages, stageYamlLine } from "../lib/pipeline-problems";
 import { countStagesFromYaml, parsePipelineValidationIssues, type PipelineValidationIssue } from "../lib/pipeline-yaml";
@@ -172,7 +173,7 @@ function DefinitionRow({
 						Edit
 					</Button>
 					<Button
-								variant="ghost"
+						variant="ghost"
 						className="h-6 px-2 text-caption text-destructive hover:text-destructive"
 						onClick={() => setConfirmOpen(true)}
 						aria-label={`Delete ${def.name || def.id}`}
@@ -196,7 +197,7 @@ function DefinitionRow({
 					destructive
 					busy={remove.isPending}
 					error={remove.isError ? apiErrorMessage(remove.error) : null}
-						onConfirm={() =>
+					onConfirm={() =>
 						remove.mutate(def.id, {
 							onSuccess: () => setConfirmOpen(false),
 						})
@@ -358,6 +359,9 @@ function DefinitionEditor({
 									// pr.* trigger (spec §5.3) and the inherited deadline.
 									prTriggered={(draft.on?.pr?.length ?? 0) > 0}
 									defaultDeadline={draft.defaults?.deadline}
+									// The ambient set this stage resolves to, which only the
+									// whole draft can answer (triggers plus the entry edges).
+									envVars={stageEnvVars(draft, selectedStageDraft)}
 									onChange={updateSelectedStage}
 									onClose={() => selection.selectStage(null)}
 									onDelete={deleteSelectedStage}

--- a/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
@@ -173,7 +173,7 @@ function DefinitionRow({
 						Edit
 					</Button>
 					<Button
-						variant="ghost"
+								variant="ghost"
 						className="h-6 px-2 text-caption text-destructive hover:text-destructive"
 						onClick={() => setConfirmOpen(true)}
 						aria-label={`Delete ${def.name || def.id}`}
@@ -197,7 +197,7 @@ function DefinitionRow({
 					destructive
 					busy={remove.isPending}
 					error={remove.isError ? apiErrorMessage(remove.error) : null}
-					onConfirm={() =>
+						onConfirm={() =>
 						remove.mutate(def.id, {
 							onSuccess: () => setConfirmOpen(false),
 						})

--- a/frontend/src/renderer/components/StageInspector.test.tsx
+++ b/frontend/src/renderer/components/StageInspector.test.tsx
@@ -2,7 +2,8 @@ import { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import type { StageDraft } from "../lib/pipeline-draft";
+import type { PipelineDraft, StageDraft } from "../lib/pipeline-draft";
+import { stageEnvVars } from "../lib/pipeline-env";
 import { StageInspector, type StageInspectorProps } from "./StageInspector";
 
 const STAGE_IDS = ["fix", "triage", "tests"];
@@ -234,5 +235,131 @@ describe("StageInspector", () => {
 	it("hides the delete button while onDelete is unwired", () => {
 		renderInspector(agentStage());
 		expect(screen.queryByRole("button", { name: "Delete stage" })).not.toBeInTheDocument();
+	});
+});
+
+// The catalog the editor really passes: derived from the draft the stage lives
+// in, so availability here is what a run of this pipeline would produce.
+function envFor(stage: StageDraft, rest: Partial<PipelineDraft> = {}): StageInspectorProps["envVars"] {
+	return stageEnvVars({ name: "p", stages: [stage], ...rest }, stage);
+}
+
+describe("StageInspector $AO completion", () => {
+	const promptStage = () => agentStage();
+
+	async function typeInPrompt(text: string, stage = promptStage(), rest: Partial<PipelineDraft> = {}) {
+		const { last } = renderInspector({ ...stage, prompt: "" }, { envVars: envFor(stage, rest) });
+		const prompt = screen.getByRole("textbox", { name: "Prompt" });
+		await userEvent.click(prompt);
+		await userEvent.type(prompt, text);
+		return { prompt, last };
+	}
+
+	it("opens the menu on $AO and lists the stage's variables", async () => {
+		await typeInPrompt("Write to $AO");
+		const options = screen.getAllByRole("option");
+		expect(options.length).toBeGreaterThan(10);
+		expect(options[0]).toHaveTextContent("$AO_PROJECT");
+	});
+
+	it("stays shut for a bare $ and for other shell variables", async () => {
+		await typeInPrompt("cd $HOME");
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+	});
+
+	it("narrows as the name is typed", async () => {
+		await typeInPrompt("Write to $AO_RU");
+		expect(screen.getAllByRole("option").map((o) => o.textContent)).toHaveLength(2);
+		expect(screen.getByRole("option", { name: /AO_RUN_ID/ })).toBeInTheDocument();
+	});
+
+	it("inserts the highlighted entry on Enter", async () => {
+		const { last } = await typeInPrompt("Write to $AO_CON");
+		await userEvent.keyboard("{Enter}");
+		expect(last().prompt).toBe("Write to $AO_CONTEXT");
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+	});
+
+	it("moves the highlight with the arrow keys", async () => {
+		const { last } = await typeInPrompt("Write to $AO_PREV");
+		await userEvent.keyboard("{ArrowDown}{Enter}");
+		expect(last().prompt).toBe("Write to $AO_PREV_OUTCOME");
+	});
+
+	it("dismisses on Escape without inserting", async () => {
+		const { last } = await typeInPrompt("Write to $AO_CON");
+		await userEvent.keyboard("{Escape}");
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+		expect(last().prompt).toBe("Write to $AO_CON");
+	});
+
+	it("does not reopen on the token it just completed", async () => {
+		await typeInPrompt("Write to $AO_CON");
+		await userEvent.keyboard("{Enter}");
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+	});
+
+	it("keeps the text after the caret when completing mid-line", async () => {
+		const stage = promptStage();
+		const { last } = renderInspector(
+			{ ...stage, prompt: "" },
+			{ envVars: envFor({ ...stage, produces: "review.md" }) },
+		);
+		const prompt = screen.getByRole("textbox", { name: "Prompt" });
+		await userEvent.type(prompt, "cat  then stop");
+		// Park the caret in the gap and complete there.
+		await userEvent.type(prompt, "$AO_OUT", { initialSelectionStart: 4, initialSelectionEnd: 4 });
+		await userEvent.keyboard("{Enter}");
+		expect(last().prompt).toBe("cat $AO_OUTPUT then stop");
+	});
+
+	it("still lists what the stage lacks, greyed and with the reason", async () => {
+		// No `produces:`, so AO_OUTPUT cannot resolve; the menu says why instead
+		// of hiding it.
+		await typeInPrompt("Write to $AO_OUT");
+		const option = screen.getByRole("option", { name: /AO_OUTPUT/ });
+		expect(option).toHaveAttribute("aria-disabled", "true");
+		expect(option).toHaveTextContent("needs `produces:`");
+	});
+
+	it("offers the same completion in a command stage's run script", async () => {
+		const cmd: StageDraft = { id: "tests", executor: "command", run: "" };
+		const { last } = renderInspector(cmd, { envVars: envFor(cmd) });
+		const run = screen.getByRole("textbox", { name: "Run" });
+		await userEvent.type(run, "cd $AO_WORK");
+		await userEvent.keyboard("{Enter}");
+		expect(last().run).toBe("cd $AO_WORKSPACE");
+	});
+});
+
+describe("StageInspector environment reference", () => {
+	it("summarizes reach and expands to the full catalog", async () => {
+		const stage = agentStage();
+		renderInspector(stage, { envVars: envFor(stage) });
+		const toggle = screen.getByRole("button", { name: /\$AO variables reach this stage/ });
+		expect(toggle).toHaveAttribute("aria-expanded", "false");
+		// 7 always-present of the 16 the engine can inject; nothing else resolves
+		// for a lone agent stage with no triggers and no produces.
+		expect(toggle).toHaveTextContent("7 of 16 $AO variables reach this stage");
+
+		await userEvent.click(toggle);
+		const list = screen.getByTestId("stage-env-reference");
+		expect(list).toHaveTextContent("$AO_RUN_ID");
+		expect(list).toHaveTextContent("$AO_FAILED_STAGE");
+		expect(list).toHaveTextContent("only on stages entered via `on_failure`");
+		// AO_ATTEMPT is described as it behaves, not as the spec's table says.
+		expect(list).toHaveTextContent(/Always 1\./);
+	});
+
+	it("counts the ones a pr trigger and a produces unlock", async () => {
+		const stage = agentStage();
+		renderInspector(stage, { envVars: envFor({ ...stage, produces: "review.md" }, { on: { pr: ["created"] } }) });
+		// The pr trio, AO_SESSION_ID and AO_OUTPUT join the seven.
+		expect(screen.getByRole("button", { name: /\$AO variables reach this stage/ })).toHaveTextContent("12 of 16");
+	});
+
+	it("stays out of the panel when no catalog is wired", () => {
+		renderInspector(agentStage());
+		expect(screen.queryByRole("button", { name: /\$AO variables/ })).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/StageInspector.tsx
+++ b/frontend/src/renderer/components/StageInspector.tsx
@@ -595,14 +595,16 @@ function EnvTextarea({
 							}}
 							onMouseMove={() => setActive(i)}
 							className={cn(
+								// bg-surface is the same token as bg-popover, so the
+								// highlight is the accent wash the kill-on chips use.
 								"cursor-default rounded-md px-2 py-1.5 transition-colors",
-								i === activeIndex && "bg-surface",
+								i === activeIndex && "bg-accent-weak",
 								!isAvailable(v) && "opacity-60",
 							)}
 						>
 							<div className="flex items-baseline justify-between gap-2">
-								<span className="font-mono text-caption text-foreground">${v.name}</span>
-								{v.note && <span className="shrink-0 text-micro text-passive">{v.note}</span>}
+								<span className="shrink-0 font-mono text-caption text-foreground">${v.name}</span>
+								{v.note && <span className="text-right text-micro text-passive">{v.note}</span>}
 							</div>
 							<p className="text-micro text-passive">{v.description}</p>
 						</li>
@@ -643,8 +645,8 @@ function EnvReference({ vars, executor }: { vars: StageEnvVar[]; executor: Execu
 						{vars.map((v) => (
 							<li key={v.name} className={cn(!isAvailable(v) && "opacity-60")}>
 								<div className="flex items-baseline justify-between gap-2">
-									<span className="font-mono text-caption text-foreground">${v.name}</span>
-									{v.note && <span className="shrink-0 text-micro text-passive">{v.note}</span>}
+									<span className="shrink-0 font-mono text-caption text-foreground">${v.name}</span>
+									{v.note && <span className="text-right text-micro text-passive">{v.note}</span>}
 								</div>
 								<p className="text-micro text-passive">{v.description}</p>
 								<p className="truncate font-mono text-micro text-passive/80" title={v.example}>

--- a/frontend/src/renderer/components/StageInspector.tsx
+++ b/frontend/src/renderer/components/StageInspector.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { AlertTriangle, Trash2, X } from "lucide-react";
+import { useId, useRef, useState } from "react";
+import { AlertTriangle, ChevronRight, Trash2, X } from "lucide-react";
 import { cn } from "../lib/utils";
 import { AGENT_OPTIONS } from "../lib/agent-options";
 import {
@@ -12,6 +12,14 @@ import {
 	type StageOutcome,
 	type WorkspaceKind,
 } from "../lib/pipeline-draft";
+import {
+	applyEnvCompletion,
+	envCompletionAt,
+	isAvailable,
+	matchEnvVars,
+	type EnvCompletion,
+	type StageEnvVar,
+} from "../lib/pipeline-env";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
@@ -34,6 +42,11 @@ import { Switch } from "./ui/switch";
 // `produces` with a path separator (spec §13), and `workspace: session` under a
 // `pr.*` trigger, which is legal but fails at plan time when the PR has no
 // local session (spec §5.3).
+//
+// The prompt and the run script complete `$AO...` from the stage's own ambient
+// set, and the Environment section lists that set in full (lib/pipeline-env.ts
+// derives both). Both are resolved by the parent, which owns the draft the
+// availability rules read.
 
 export interface StageInspectorProps {
 	stage: StageDraft;
@@ -50,6 +63,10 @@ export interface StageInspectorProps {
 	// `defaults.deadline`, shown as the deadline placeholder so the effective
 	// bound is visible even when this stage does not override it (spec §13.1).
 	defaultDeadline?: string;
+	// The ambient `$AO_*` set for this stage (stageEnvVars), which drives both
+	// the completion menu and the Environment reference. Unwired means neither
+	// renders rather than a catalog guessed from partial context.
+	envVars?: StageEnvVar[];
 }
 
 // A `produces` value names a file inside the stage's output directory, so a
@@ -82,6 +99,7 @@ export function StageInspector({
 	onDelete,
 	prTriggered,
 	defaultDeadline,
+	envVars = [],
 }: StageInspectorProps) {
 	const update = (patch: Partial<StageDraft>) => onChange({ ...stage, ...patch });
 
@@ -156,14 +174,16 @@ export function StageInspector({
 					/>
 					<div className="mt-2.5">
 						{stage.executor === "agent" ? (
-							<AgentFields stage={stage} update={update} />
+							<AgentFields stage={stage} update={update} envVars={envVars} />
 						) : (
 							// `credentials` lives here and nowhere else, so an agent stage
 							// cannot express it at all (spec §6.2).
-							<CommandFields stage={stage} update={update} />
+							<CommandFields stage={stage} update={update} envVars={envVars} />
 						)}
 					</div>
 				</Section>
+
+				{envVars.length > 0 && <EnvReference vars={envVars} executor={stage.executor} />}
 
 				{stage.executor === "agent" && (
 					<Section label="Session · kill-on">
@@ -322,9 +342,9 @@ export function StageInspector({
 
 // --- executor sub-forms ------------------------------------------------------
 
-type FieldsProps = { stage: StageDraft; update: (patch: Partial<StageDraft>) => void };
+type FieldsProps = { stage: StageDraft; update: (patch: Partial<StageDraft>) => void; envVars: StageEnvVar[] };
 
-function AgentFields({ stage, update }: FieldsProps) {
+function AgentFields({ stage, update, envVars }: FieldsProps) {
 	const producesIssue = producesError(stage.produces);
 	return (
 		<div className="flex flex-col gap-2.5">
@@ -343,13 +363,13 @@ function AgentFields({ stage, update }: FieldsProps) {
 				</Select>
 			</LabeledControl>
 			<LabeledControl label="Prompt">
-				<textarea
-					aria-label="Prompt"
-					className={textareaClass}
+				<EnvTextarea
+					ariaLabel="Prompt"
 					rows={4}
 					value={stage.prompt ?? ""}
-					onChange={(e) => update({ prompt: e.target.value || undefined })}
+					onValueChange={(prompt) => update({ prompt: prompt || undefined })}
 					placeholder="What this stage should do."
+					envVars={envVars}
 				/>
 			</LabeledControl>
 			<LabeledControl label="Produces">
@@ -371,7 +391,7 @@ function AgentFields({ stage, update }: FieldsProps) {
 	);
 }
 
-function CommandFields({ stage, update }: FieldsProps) {
+function CommandFields({ stage, update, envVars }: FieldsProps) {
 	const credentials = stage.credentials ?? [];
 	// The pending chip text. The inspector is remounted per selected node, so
 	// this never leaks between stages.
@@ -390,13 +410,13 @@ function CommandFields({ stage, update }: FieldsProps) {
 	return (
 		<div className="flex flex-col gap-2.5">
 			<LabeledControl label="Run">
-				<textarea
-					aria-label="Run"
-					className={textareaClass}
+				<EnvTextarea
+					ariaLabel="Run"
 					rows={4}
 					value={stage.run ?? ""}
-					onChange={(e) => update({ run: e.target.value || undefined })}
+					onValueChange={(run) => update({ run: run || undefined })}
 					placeholder="npm test"
+					envVars={envVars}
 				/>
 			</LabeledControl>
 			<LabeledControl label="Credentials">
@@ -432,6 +452,217 @@ function CommandFields({ stage, update }: FieldsProps) {
 				</span>
 			</LabeledControl>
 		</div>
+	);
+}
+
+// --- $AO completion ----------------------------------------------------------
+
+// EnvTextarea is the prompt / run field with the `$AO` completion menu on it.
+// Typing `$AO` opens a list of this stage's ambient variables; arrow keys move,
+// Enter or Tab inserts, Escape dismisses.
+//
+// Entries the stage will not have are listed too, greyed and with the reason,
+// because the menu is where the availability model is learned. They stay
+// insertable: someone completing `$AO_OUTPUT` before typing `produces:` is
+// writing the stage they mean to have, and the reason is on screen either way.
+function EnvTextarea({
+	ariaLabel,
+	value,
+	onValueChange,
+	envVars,
+	rows,
+	placeholder,
+}: {
+	ariaLabel: string;
+	value: string;
+	onValueChange: (next: string) => void;
+	envVars: StageEnvVar[];
+	rows: number;
+	placeholder: string;
+}) {
+	const ref = useRef<HTMLTextAreaElement>(null);
+	const [completion, setCompletion] = useState<EnvCompletion | null>(null);
+	const [active, setActive] = useState(0);
+	// The `caret:value` signature the menu must stay shut at: set by Escape and
+	// by an insertion, so neither the caret move nor the resulting change event
+	// reopens the menu on the token that was just completed. Cleared as soon as
+	// the caret or the text moves off it.
+	const closedAt = useRef<string | null>(null);
+	const listId = useId();
+
+	const matches = completion ? matchEnvVars(envVars, completion.query) : [];
+	const open = matches.length > 0;
+	const activeIndex = Math.min(active, matches.length - 1);
+
+	const sync = (el: HTMLTextAreaElement) => {
+		const signature = `${el.selectionStart}:${el.value}`;
+		if (closedAt.current === signature) {
+			setCompletion(null);
+			return;
+		}
+		closedAt.current = null;
+		const next = envCompletionAt(el.value, el.selectionStart);
+		// Same token means same menu; keeping the object stable avoids a render
+		// on every caret move through unrelated text.
+		setCompletion((prev) => (prev?.start === next?.start && prev?.query === next?.query ? prev : next));
+		setActive(0);
+	};
+
+	const insert = (chosen: StageEnvVar) => {
+		const el = ref.current;
+		if (!el || !completion) return;
+		const next = applyEnvCompletion(el.value, completion, chosen.name);
+		closedAt.current = `${next.caret}:${next.value}`;
+		setCompletion(null);
+		el.focus();
+		el.setSelectionRange(completion.start, completion.start + 1 + completion.query.length);
+		// A native insertText keeps the textarea's own undo stack: ⌘Z takes back
+		// the completion and leaves the typed `$AO...` rather than clearing the
+		// whole field. React sees the resulting input event like any keystroke.
+		if (typeof document.execCommand === "function" && document.execCommand("insertText", false, `$${chosen.name}`)) {
+			return;
+		}
+		// No execCommand (jsdom, and any engine that drops it): write the value
+		// through, then place the caret. The DOM node is set first so React's
+		// re-render finds it already correct and leaves the selection alone.
+		el.value = next.value;
+		el.setSelectionRange(next.caret, next.caret);
+		onValueChange(next.value);
+	};
+
+	const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		if (!open) return;
+		if (e.key === "ArrowDown") {
+			e.preventDefault();
+			setActive((activeIndex + 1) % matches.length);
+		} else if (e.key === "ArrowUp") {
+			e.preventDefault();
+			setActive((activeIndex - 1 + matches.length) % matches.length);
+		} else if (e.key === "Enter" || e.key === "Tab") {
+			e.preventDefault();
+			insert(matches[activeIndex]);
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			// The editor also listens for Escape; a dismissal is not a close.
+			e.stopPropagation();
+			closedAt.current = `${e.currentTarget.selectionStart}:${e.currentTarget.value}`;
+			setCompletion(null);
+		}
+	};
+
+	return (
+		<div className="relative">
+			<textarea
+				ref={ref}
+				aria-label={ariaLabel}
+				className={textareaClass}
+				rows={rows}
+				value={value}
+				onChange={(e) => {
+					onValueChange(e.target.value);
+					sync(e.target);
+				}}
+				// Fires on caret moves and selection changes, which is what closes
+				// the menu when the caret leaves the token.
+				onSelect={(e) => sync(e.currentTarget)}
+				onKeyDown={onKeyDown}
+				onBlur={() => setCompletion(null)}
+				placeholder={placeholder}
+				aria-autocomplete="list"
+				aria-expanded={open}
+				aria-controls={open ? listId : undefined}
+				aria-activedescendant={open ? `${listId}-${activeIndex}` : undefined}
+			/>
+			{open && (
+				<ul
+					id={listId}
+					role="listbox"
+					aria-label="Ambient variables"
+					className="absolute inset-x-0 top-full z-overlay mt-1 max-h-64 overflow-y-auto rounded-lg border border-border bg-popover p-1 shadow-md"
+				>
+					{matches.map((v, i) => (
+						<li
+							key={v.name}
+							id={`${listId}-${i}`}
+							role="option"
+							aria-selected={i === activeIndex}
+							aria-disabled={!isAvailable(v)}
+							// mousedown, not click: the textarea must keep focus so the
+							// insertion lands where the caret already is.
+							onMouseDown={(e) => {
+								e.preventDefault();
+								insert(v);
+							}}
+							onMouseMove={() => setActive(i)}
+							className={cn(
+								"cursor-default rounded-md px-2 py-1.5 transition-colors",
+								i === activeIndex && "bg-surface",
+								!isAvailable(v) && "opacity-60",
+							)}
+						>
+							<div className="flex items-baseline justify-between gap-2">
+								<span className="font-mono text-caption text-foreground">${v.name}</span>
+								{v.note && <span className="shrink-0 text-micro text-passive">{v.note}</span>}
+							</div>
+							<p className="text-micro text-passive">{v.description}</p>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}
+
+// EnvReference is the same catalog without the typing: collapsed by default so
+// the panel stays a form, expanded when someone wants to know what a stage
+// actually gets. Collapsed by hand rather than with a primitive, because
+// components/ui has no collapsible and this is one boolean.
+function EnvReference({ vars, executor }: { vars: StageEnvVar[]; executor: ExecutorKind }) {
+	const [open, setOpen] = useState(false);
+	const reach = vars.filter(isAvailable).length;
+
+	return (
+		<Section label="Environment">
+			<button
+				type="button"
+				aria-expanded={open}
+				onClick={() => setOpen(!open)}
+				className="flex w-full items-center gap-1.5 text-caption text-muted-foreground transition-colors hover:text-foreground"
+			>
+				<ChevronRight
+					className={cn("size-icon-xs shrink-0 transition-transform", open && "rotate-90")}
+					aria-hidden="true"
+				/>
+				<span>
+					{reach} of {vars.length} $AO variables reach this stage
+				</span>
+			</button>
+			{open && (
+				<>
+					<ul className="mt-2 flex flex-col gap-2.5" data-testid="stage-env-reference">
+						{vars.map((v) => (
+							<li key={v.name} className={cn(!isAvailable(v) && "opacity-60")}>
+								<div className="flex items-baseline justify-between gap-2">
+									<span className="font-mono text-caption text-foreground">${v.name}</span>
+									{v.note && <span className="shrink-0 text-micro text-passive">{v.note}</span>}
+								</div>
+								<p className="text-micro text-passive">{v.description}</p>
+								<p className="truncate font-mono text-micro text-passive/80" title={v.example}>
+									{v.example}
+								</p>
+							</li>
+						))}
+					</ul>
+					<p className="mt-3 text-caption text-passive">
+						{executor === "command"
+							? "The run script is shell interpolated, so $AO_OUTPUT expands before the command sees it."
+							: "The prompt is handed to the agent verbatim; the agent reads these from its own environment."}{" "}
+						Type $AO in the {executor === "command" ? "run script" : "prompt"} to insert one. A manual run names its own
+						subject, so it can be about a session or a PR the triggers never mention.
+					</p>
+				</>
+			)}
+		</Section>
 	);
 }
 

--- a/frontend/src/renderer/lib/pipeline-env.test.ts
+++ b/frontend/src/renderer/lib/pipeline-env.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "vitest";
+import type { PipelineDraft, StageDraft } from "./pipeline-draft";
+import { applyEnvCompletion, envCompletionAt, matchEnvVars, stageEnvVars, type StageEnvVar } from "./pipeline-env";
+
+function stage(id: string, extra: Partial<StageDraft> = {}): StageDraft {
+	return { id, executor: "agent", agent: "claude-code", ...extra };
+}
+
+function draftOf(stages: StageDraft[], rest: Partial<PipelineDraft> = {}): PipelineDraft {
+	return { name: "p", stages, ...rest };
+}
+
+// The catalog is keyed by name everywhere, so every assertion goes through this
+// rather than an index into the array.
+function look(draft: PipelineDraft, target: StageDraft, name: string): StageEnvVar {
+	const found = stageEnvVars(draft, target).find((v) => v.name === name);
+	if (!found) throw new Error(`no catalog entry for ${name}`);
+	return found;
+}
+
+// The shape the availability rules all key off:
+//
+//   build --success--> test --success--> ship
+//   build --failure--> triage
+const routedDraft = () =>
+	draftOf([
+		stage("build", { onSuccess: ["test"], onFailure: "triage" }),
+		stage("test", { onSuccess: ["ship"] }),
+		stage("ship"),
+		stage("triage"),
+	]);
+
+describe("stageEnvVars", () => {
+	it("always offers the seven the engine never omits", () => {
+		const draft = routedDraft();
+		const vars = stageEnvVars(draft, draft.stages[1]);
+		const always = vars.filter((v) => v.availability === "always").map((v) => v.name);
+		expect(always).toEqual([
+			"AO_PROJECT",
+			"AO_RUN_ID",
+			"AO_RUN_DIR",
+			"AO_STAGE",
+			"AO_ATTEMPT",
+			"AO_CONTEXT",
+			"AO_WORKSPACE",
+			"AO_PREV_STAGE",
+			"AO_PREV_OUTCOME",
+		]);
+	});
+
+	// The spec says "1, or 2 after a nudge"; the engine stamps it at launch and a
+	// nudge never relaunches, so the reference must not repeat the spec here.
+	it("describes AO_ATTEMPT as always 1, not as the spec's 1-or-2", () => {
+		const draft = routedDraft();
+		const attempt = look(draft, draft.stages[0], "AO_ATTEMPT");
+		expect(attempt.example).toBe("1");
+		expect(attempt.description).toMatch(/always 1/i);
+		expect(attempt.description).not.toMatch(/\b2 after a nudge\b/);
+	});
+
+	it("takes the contextual examples from the stage itself", () => {
+		const draft = routedDraft();
+		expect(look(draft, draft.stages[1], "AO_STAGE").example).toBe("test");
+		expect(look(draft, draft.stages[1], "AO_PREV_STAGE").example).toBe("build");
+		const produces = stage("review", { produces: "review.md" });
+		expect(look(draftOf([produces]), produces, "AO_OUTPUT").example).toMatch(/agent-outputs\/review\.md$/);
+		const staged = stage("lint", { workspace: "stage" });
+		expect(look(draftOf([staged]), staged, "AO_WORKSPACE").example).toMatch(/workspaces\/lint$/);
+	});
+
+	describe("AO_OUTPUT", () => {
+		it("is available exactly when an agent stage declares produces", () => {
+			const withProduces = stage("review", { produces: "review.md" });
+			expect(look(draftOf([withProduces]), withProduces, "AO_OUTPUT").availability).toBe("always");
+		});
+
+		it("is greyed with the missing key as the reason", () => {
+			const bare = stage("review");
+			const out = look(draftOf([bare]), bare, "AO_OUTPUT");
+			expect(out.availability).toBe("never");
+			expect(out.note).toMatch(/produces/);
+		});
+
+		it("is greyed on a command stage, which cannot declare produces at all", () => {
+			const cmd: StageDraft = { id: "tests", executor: "command", run: "npm test" };
+			const out = look(draftOf([cmd]), cmd, "AO_OUTPUT");
+			expect(out.availability).toBe("never");
+			expect(out.note).toMatch(/agent stages only/);
+		});
+	});
+
+	describe("subject variables", () => {
+		const only = (on: PipelineDraft["on"]) => {
+			const s = stage("build");
+			return (name: string) => look(draftOf([s], { on }), s, name);
+		};
+
+		it("guarantees the session id under a session-only trigger", () => {
+			expect(only({ session: ["idle"] })("AO_SESSION_ID").availability).toBe("always");
+		});
+
+		it("keeps the session id conditional under a pr trigger, where sessionless is normal", () => {
+			expect(only({ pr: ["created"] })("AO_SESSION_ID").availability).toBe("sometimes");
+			expect(only({ pr: ["created"], session: ["idle"] })("AO_SESSION_ID").availability).toBe("sometimes");
+		});
+
+		it("greys the session id on a manual-only pipeline", () => {
+			const v = only({})("AO_SESSION_ID");
+			expect(v.availability).toBe("never");
+			expect(v.note).toMatch(/session\.\*/);
+		});
+
+		it("offers the pr trio under a pr trigger and greys it without one", () => {
+			for (const name of ["AO_PR_NUMBER", "AO_PR_REPO", "AO_PR_HEAD"]) {
+				expect(only({ pr: ["merge-ready"] })(name).availability).toBe("always");
+				expect(only({ pr: ["merge-ready"], session: ["idle"] })(name).availability).toBe("sometimes");
+				const missing = only({ session: ["idle"] })(name);
+				expect(missing.availability).toBe("never");
+				expect(missing.note).toMatch(/pr\.\*/);
+			}
+		});
+	});
+
+	describe("AO_PREV_STAGE", () => {
+		it("is unset at the stage a run starts from", () => {
+			const draft = routedDraft();
+			const prev = look(draft, draft.stages[0], "AO_PREV_STAGE");
+			expect(prev.availability).toBe("never");
+			expect(prev.note).toMatch(/no predecessor/);
+		});
+
+		it("is set on the single success successor", () => {
+			const draft = routedDraft();
+			expect(look(draft, draft.stages[1], "AO_PREV_STAGE").availability).toBe("always");
+		});
+
+		it("is unset at a join, where the predecessor would be ambiguous", () => {
+			const draft = draftOf([
+				stage("a", { onSuccess: ["j"] }),
+				stage("b", { onSuccess: ["j"] }),
+				stage("j", { needs: ["a", "b"] }),
+			]);
+			const prev = look(draft, draft.stages[2], "AO_PREV_STAGE");
+			expect(prev.availability).toBe("never");
+			expect(prev.note).toMatch(/join/);
+		});
+
+		it("is conditional on a stage a failure edge can also enter", () => {
+			const draft = draftOf([stage("build", { onSuccess: ["report"], onFailure: "report" }), stage("report")]);
+			expect(look(draft, draft.stages[1], "AO_PREV_STAGE").availability).toBe("sometimes");
+		});
+	});
+
+	describe("AO_FAILED_STAGE", () => {
+		it("is greyed where nothing routes here on failure", () => {
+			const draft = routedDraft();
+			const failed = look(draft, draft.stages[1], "AO_FAILED_STAGE");
+			expect(failed.availability).toBe("never");
+			expect(failed.note).toMatch(/on_failure/);
+		});
+
+		it("is guaranteed on a stage only a failure edge reaches", () => {
+			const draft = routedDraft();
+			const failed = look(draft, draft.stages[3], "AO_FAILED_STAGE");
+			expect(failed.availability).toBe("always");
+			expect(failed.example).toBe("build");
+		});
+
+		it("counts the synthetic defaults.on_failure edge", () => {
+			const draft = draftOf([stage("build"), stage("notify")], { defaults: { onFailure: "notify" } });
+			expect(look(draft, draft.stages[1], "AO_FAILED_STAGE").availability).toBe("always");
+		});
+
+		it("is conditional where success can also enter", () => {
+			const draft = draftOf([stage("build", { onSuccess: ["notify"] }), stage("notify")], {
+				defaults: { onFailure: "notify" },
+			});
+			expect(look(draft, draft.stages[1], "AO_FAILED_STAGE").availability).toBe("sometimes");
+		});
+	});
+});
+
+describe("envCompletionAt", () => {
+	const at = (text: string) => envCompletionAt(text, text.length);
+
+	it("opens on $AO and reports the token", () => {
+		expect(at("Write to $AO")).toEqual({ start: 9, query: "AO" });
+		expect(at("Write to $AO_PR")).toEqual({ start: 9, query: "AO_PR" });
+		expect(at("$ao_out")).toEqual({ start: 0, query: "ao_out" });
+	});
+
+	it("stays shut on a bare $ and on other shell variables", () => {
+		expect(at("cd $")).toBeNull();
+		expect(at("echo $HOME")).toBeNull();
+		expect(at("echo $A")).toBeNull();
+	});
+
+	it("stays shut without a $, and on the braced form", () => {
+		expect(at("AO_OUTPUT")).toBeNull();
+		expect(at("echo ${AO_OUT")).toBeNull();
+	});
+
+	it("reads the token at the caret, not at the end of the text", () => {
+		const text = "echo $AO_OUT and $AO_RUN_ID";
+		expect(envCompletionAt(text, 12)).toEqual({ start: 5, query: "AO_OUT" });
+		// Caret inside a word but not at its end still completes the prefix.
+		expect(envCompletionAt(text, 8)).toEqual({ start: 5, query: "AO" });
+	});
+});
+
+describe("matchEnvVars", () => {
+	const draft = draftOf([stage("build")]);
+	const vars = stageEnvVars(draft, draft.stages[0]);
+
+	it("prefix-matches on the name, case-insensitively", () => {
+		expect(matchEnvVars(vars, "AO_PR").map((v) => v.name)).toEqual([
+			// AO_PROJECT shares the prefix and is the only offered one here, so it
+			// leads; the greyed ones keep catalog order behind it.
+			"AO_PROJECT",
+			"AO_PR_NUMBER",
+			"AO_PR_REPO",
+			"AO_PR_HEAD",
+			"AO_PREV_STAGE",
+			"AO_PREV_OUTCOME",
+		]);
+		expect(matchEnvVars(vars, "ao_ru").map((v) => v.name)).toEqual(["AO_RUN_ID", "AO_RUN_DIR"]);
+	});
+
+	it("sorts the unavailable ones last so a greyed entry never leads", () => {
+		// This stage has no produces and no triggers, so AO_OUTPUT and the PR
+		// trio are all greyed; every offered entry must come first.
+		const names = matchEnvVars(vars, "AO").map((v) => v.availability !== "never");
+		expect(names).toEqual([...names].sort((a, b) => Number(b) - Number(a)));
+	});
+
+	it("returns nothing when the token matches no variable", () => {
+		expect(matchEnvVars(vars, "AO_ZZ")).toEqual([]);
+	});
+});
+
+describe("applyEnvCompletion", () => {
+	it("replaces the typed token and leaves the caret after the name", () => {
+		const value = "Write your review to $AO_OU then stop.";
+		const completion = envCompletionAt(value, 27);
+		expect(completion).not.toBeNull();
+		const next = applyEnvCompletion(value, completion!, "AO_OUTPUT");
+		expect(next.value).toBe("Write your review to $AO_OUTPUT then stop.");
+		expect(next.caret).toBe("Write your review to $AO_OUTPUT".length);
+	});
+
+	it("keeps the rest of the line intact when completing mid-text", () => {
+		const value = "cat $AO/x";
+		const next = applyEnvCompletion(value, { start: 4, query: "AO" }, "AO_CONTEXT");
+		expect(next.value).toBe("cat $AO_CONTEXT/x");
+	});
+});

--- a/frontend/src/renderer/lib/pipeline-env.ts
+++ b/frontend/src/renderer/lib/pipeline-env.ts
@@ -1,0 +1,332 @@
+// The ambient `$AO_*` variables a stage runs with, resolved for one stage of a
+// draft, plus the text helpers the prompt/run autocomplete needs.
+//
+// The catalog mirrors `ambientEnv` in
+// backend/internal/pipeline/engine/engine.go, which is the only place the env
+// map is built. Spec section 12.2 tabulates the same set, but where the two
+// disagree the code is what runs and this file follows the code:
+//
+//   - AO_ATTEMPT is documented as "1, or 2 after a nudge". It is always 1. A
+//     nudge deliberately does not relaunch the stage, and a running process's
+//     environment cannot be rewritten, so the launch value stands
+//     (docs/plans/2026-07-26-pipelines-v2-followups.md).
+//   - AO_PREV_STAGE is set from the entry edge, so "exactly one predecessor"
+//     means: entered on a success edge, and not a join (`len(needs) > 1`).
+//   - AO_PR_HEAD is set for every PR subject, including one whose tracked head
+//     sha is unknown, in which case it is present but empty.
+//
+// Availability is derived from the draft alone, so it is what the pipeline as
+// written will produce. Three states, because two would have to lie: `always`
+// (every run of this stage has it), `sometimes` (only some runs, `note` says
+// which), `never` (`note` says what is missing). A `never` entry is still
+// offered, greyed: the menu is where the model is learned.
+//
+// One caveat the per-entry notes cannot carry: a manual run names its own
+// subject (service/pipeline resolveSubject), so it can be about a PR or a
+// session that the `on:` block never mentions. The reference section states
+// that once instead of qualifying every row with it.
+
+import { draftEdges } from "./pipeline-graph";
+import type { PipelineDraft, StageDraft } from "./pipeline-draft";
+
+export type EnvAvailability = "always" | "sometimes" | "never";
+
+export interface StageEnvVar {
+	name: string;
+	// One line, present tense, what the value is.
+	description: string;
+	// A representative value. Contextual where the draft knows the real one
+	// (this stage's id, its `produces`, its sole predecessor).
+	example: string;
+	availability: EnvAvailability;
+	// When `sometimes`, which runs have it. When `never`, what is missing.
+	// Absent on `always`.
+	note?: string;
+}
+
+// isAvailable is the greyed/not-greyed split the menu and the reference render.
+export function isAvailable(v: StageEnvVar): boolean {
+	return v.availability !== "never";
+}
+
+// The run folder root, written the way the engine's own comment does. The real
+// path is absolute; the shape is what a prompt author needs.
+const RUN_DIR = "<AO_DATA_DIR>/pipelines/<project>/<run-id>";
+
+// stageEnvVars is the catalog for one stage of one draft, in spec section 12.2
+// order: the seven that are always there, then the conditional ones.
+export function stageEnvVars(draft: PipelineDraft, stage: StageDraft): StageEnvVar[] {
+	const edges = draftEdges(draft);
+	// A stage id is the config-level identity, so predecessors resolve by id.
+	// An empty id cannot be routed to at all, so it has no predecessors.
+	const successPreds = stage.id
+		? edges.filter((e) => e.to === stage.id && e.kind === "success").map((e) => e.from)
+		: [];
+	const failurePreds = stage.id
+		? edges.filter((e) => e.to === stage.id && e.kind !== "success").map((e) => e.from)
+		: [];
+	// The run starts at the first stage in document order (Pipeline.EntryStage),
+	// which is therefore reachable without any inbound edge. Matched by identity
+	// first so a stage with no id still resolves.
+	const first = draft.stages[0];
+	const isEntry = !!first && (first === stage || (!!stage.id && first.id === stage.id));
+	// A join is where AO_PREV_* would be ambiguous. The engine tests `needs`,
+	// not the inbound edge count, so this does too; the canvas keeps the two in
+	// sync (reconcileNeeds).
+	const isJoin = (stage.needs?.length ?? 0) > 1;
+
+	const prTriggered = (draft.on?.pr?.length ?? 0) > 0;
+	const sessionTriggered = (draft.on?.session?.length ?? 0) > 0;
+
+	return [
+		{
+			name: "AO_PROJECT",
+			description: "Id of the project this run belongs to.",
+			example: "agent-orchestrator",
+			availability: "always",
+		},
+		{
+			name: "AO_RUN_ID",
+			description: "Id of this run. `ao pipeline done|fail` resolves itself from it, so it is never absent.",
+			example: "run-3f77f931-27ee-4185-ad3d-891226c9f874",
+			availability: "always",
+		},
+		{
+			name: "AO_RUN_DIR",
+			description: "The run folder: frozen definition, run.json, Context.md, agent-outputs, stage-logs.",
+			example: RUN_DIR,
+			availability: "always",
+		},
+		{
+			name: "AO_STAGE",
+			description: "This stage's id. The other half of what `ao pipeline done|fail` resolves itself from.",
+			example: stage.id || "review",
+			availability: "always",
+		},
+		{
+			name: "AO_ATTEMPT",
+			description:
+				"Always 1. A nudge does not relaunch the stage, so the environment keeps its launch value; the nudge message is what tells an agent it is on its last attempt.",
+			example: "1",
+			availability: "always",
+		},
+		{
+			name: "AO_CONTEXT",
+			description: "Path to Context.md, the engine's index of what earlier stages produced.",
+			example: `${RUN_DIR}/Context.md`,
+			availability: "always",
+		},
+		{
+			name: "AO_WORKSPACE",
+			description: "Path to the tree this stage runs in, resolved from `workspace:`.",
+			example: workspaceExample(stage),
+			availability: "always",
+		},
+		{
+			name: "AO_SESSION_ID",
+			description: "Id of the session the run is about.",
+			example: "agent-orchestrator-152",
+			...sessionAvailability(sessionTriggered, prTriggered),
+		},
+		...prVars(prTriggered, sessionTriggered),
+		{
+			name: "AO_OUTPUT",
+			description:
+				"Where this stage writes its declared artifact. The stage only succeeds if that file exists and is not empty.",
+			example: `${RUN_DIR}/agent-outputs/${stage.produces || "review.md"}`,
+			...outputAvailability(stage),
+		},
+		...prevVars(successPreds, failurePreds.length > 0, isEntry, isJoin),
+		...failedVars(failurePreds, successPreds.length > 0, isEntry),
+	];
+}
+
+// workspaceExample names the tree the stage's own `workspace:` resolves to, so
+// the example is the one this stage will actually get rather than a generic
+// path. `auto`/`inherit` depend on the subject and the entry edge at run time,
+// which is exactly when the shape cannot be stated up front.
+function workspaceExample(stage: StageDraft): string {
+	switch (stage.workspace) {
+		case "run":
+			return `${RUN_DIR}/workspace`;
+		case "stage":
+			return `${RUN_DIR}/workspaces/${stage.id || "review"}`;
+		case "session":
+			return "<AO_DATA_DIR>/worktrees/<project>/<session-id>";
+		default:
+			return `${RUN_DIR}/workspace`;
+	}
+}
+
+type Availability = Pick<StageEnvVar, "availability" | "note">;
+
+function sessionAvailability(sessionTriggered: boolean, prTriggered: boolean): Availability {
+	// A PR subject may or may not carry a local session, and sessionless is
+	// first-class (pipeline.Subject), so a pr.* trigger alone never guarantees
+	// it.
+	if (sessionTriggered && !prTriggered) return { availability: "always" };
+	if (sessionTriggered)
+		return {
+			availability: "sometimes",
+			note: "PR runs only have it when a local session tracks the PR",
+		};
+	if (prTriggered)
+		return {
+			availability: "sometimes",
+			note: "only when a local session tracks the PR",
+		};
+	return {
+		availability: "never",
+		note: "needs a `session.*` trigger, or a manual run naming a session",
+	};
+}
+
+function prVars(prTriggered: boolean, sessionTriggered: boolean): StageEnvVar[] {
+	const availability: Availability = prTriggered
+		? sessionTriggered
+			? { availability: "sometimes", note: "PR runs only" }
+			: { availability: "always" }
+		: {
+				availability: "never",
+				note: "needs a `pr.*` trigger, or a manual run naming a PR",
+			};
+	return [
+		{
+			name: "AO_PR_NUMBER",
+			description: "Number of the pull request the run is about.",
+			example: "412",
+			...availability,
+		},
+		{
+			name: "AO_PR_REPO",
+			description: "The pull request's repository, as owner/name.",
+			example: "AgentWrapper/agent-orchestrator",
+			...availability,
+		},
+		{
+			name: "AO_PR_HEAD",
+			description: "Head commit sha of the pull request. Present but empty when no head sha is recorded for it.",
+			example: "9f3c1ab4c0d2e77a1b5f8c3d9e0a2b4c6d8e0f13",
+			...availability,
+		},
+	];
+}
+
+function outputAvailability(stage: StageDraft): Availability {
+	// `produces:` is agent-only (validation), and the inspector drops it when a
+	// stage switches to command, so a command stage can never express it.
+	if (stage.executor !== "agent") return { availability: "never", note: "agent stages only" };
+	if (!stage.produces) return { availability: "never", note: "needs `produces:`" };
+	return { availability: "always" };
+}
+
+function prevVars(successPreds: string[], failureReachable: boolean, isEntry: boolean, isJoin: boolean): StageEnvVar[] {
+	const availability: Availability = isJoin
+		? {
+				availability: "never",
+				note: "unset at a join, where the predecessor would be ambiguous",
+			}
+		: successPreds.length === 0
+			? {
+					availability: "never",
+					note: isEntry ? "the stage a run starts at has no predecessor" : "no stage routes here on success",
+				}
+			: isEntry || failureReachable
+				? {
+						availability: "sometimes",
+						note: isEntry ? "unset when this stage starts the run" : "unset when a failure edge routes here instead",
+					}
+				: { availability: "always" };
+	const prev = successPreds.length === 1 ? successPreds[0] : "build";
+	return [
+		{
+			name: "AO_PREV_STAGE",
+			description: "Id of the single stage that routed here on success.",
+			example: prev,
+			...availability,
+		},
+		{
+			name: "AO_PREV_OUTCOME",
+			description: "The outcome that stage settled on.",
+			example: "succeeded",
+			...availability,
+		},
+	];
+}
+
+function failedVars(failurePreds: string[], successReachable: boolean, isEntry: boolean): StageEnvVar[] {
+	const availability: Availability =
+		failurePreds.length === 0
+			? {
+					availability: "never",
+					note: "only on stages entered via `on_failure`",
+				}
+			: successReachable || isEntry
+				? { availability: "sometimes", note: "only when a failure routes here" }
+				: { availability: "always" };
+	const failed = failurePreds.length === 1 ? failurePreds[0] : "build";
+	return [
+		{
+			name: "AO_FAILED_STAGE",
+			description: "Id of the stage whose failure routed here.",
+			example: failed,
+			...availability,
+		},
+		{
+			name: "AO_FAILED_OUTCOME",
+			description: "The outcome that stage failed with.",
+			example: "timed_out",
+			...availability,
+		},
+	];
+}
+
+// --- completion over the prompt / run text ----------------------------------
+
+export interface EnvCompletion {
+	// Index of the `$`, i.e. where the replacement starts.
+	start: number;
+	// What was typed after the `$`, e.g. "AO_PR".
+	query: string;
+}
+
+const WORD = /[A-Za-z0-9_]/;
+
+// envCompletionAt reports the `$AO...` token the caret sits at the end of, or
+// null. `$` alone does not open the menu: the trigger is `$AO`, so ordinary
+// shell variables in a `run:` script are left alone.
+//
+// ponytail: the braced form `${AO_OUTPUT}` does not trigger. Extend the scan
+// past a `{` if anyone writes prompts that way.
+export function envCompletionAt(value: string, caret: number): EnvCompletion | null {
+	if (caret < 0 || caret > value.length) return null;
+	let i = caret;
+	while (i > 0 && WORD.test(value[i - 1])) i -= 1;
+	if (i === 0 || value[i - 1] !== "$") return null;
+	const query = value.slice(i, caret);
+	if (!/^ao/i.test(query)) return null;
+	return { start: i - 1, query };
+}
+
+// matchEnvVars is the menu's contents for a query: prefix matches on the name,
+// available ones first so a greyed entry never sits above an offered one.
+export function matchEnvVars(vars: StageEnvVar[], query: string): StageEnvVar[] {
+	const needle = query.toUpperCase();
+	const hits = vars.filter((v) => v.name.startsWith(needle));
+	return [...hits.filter(isAvailable), ...hits.filter((v) => !isAvailable(v))];
+}
+
+// applyEnvCompletion replaces the typed token with the full `$NAME` and reports
+// where the caret lands.
+export function applyEnvCompletion(
+	value: string,
+	completion: EnvCompletion,
+	name: string,
+): { value: string; caret: number } {
+	const end = completion.start + 1 + completion.query.length;
+	const inserted = `$${name}`;
+	return {
+		value: value.slice(0, completion.start) + inserted + value.slice(end),
+		caret: completion.start + inserted.length,
+	};
+}


### PR DESCRIPTION
Typing `$AO` in a stage's prompt or run script now completes from the ambient variables that stage will actually have, and the inspector carries a visible reference for the same set.

Closes #342

## What is here

- `lib/pipeline-env.ts`: the catalog, resolved per stage from the draft (`stageEnvVars`), plus the completion text helpers (`envCompletionAt`, `matchEnvVars`, `applyEnvCompletion`).
- `StageInspector.tsx`: the prompt and run textareas get the completion menu (arrows, Enter/Tab to insert, Escape to dismiss, click to insert), and a collapsible **Environment** section lists the whole catalog with descriptions, examples and reasons.
- The parent (`PipelineDefinitionsPage`) resolves the catalog, since availability needs the whole draft (triggers plus the entry edges), not one stage.

Availability has three states rather than two, because two would have to lie:

- **always**: every run of this stage has it.
- **sometimes**: only some runs, with the note saying which ("only when a local session tracks the PR", "unset when a failure edge routes here instead").
- **never**: greyed, with what is missing ("needs `produces:`", "needs a `pr.*` trigger, or a manual run naming a PR", "only on stages entered via `on_failure`"). Greyed entries are still listed and still insertable: the menu is where the model is learned, and someone completing `$AO_OUTPUT` before typing `produces:` is writing the stage they mean to have.

Examples are contextual where the draft knows the real value: `$AO_STAGE` shows this stage's id, `$AO_OUTPUT` its `produces` path, `$AO_PREV_STAGE` its sole predecessor.

## The catalog was read off the engine, not the spec

Built from `ambientEnv` in `backend/internal/pipeline/engine/engine.go` (the only place the env map is assembled) and the reducer's entry-edge rules. Three places where the code and spec section 12.2 differ, all resolved in favour of the code and noted in the lib's header comment:

1. **`AO_ATTEMPT` is always 1.** The spec table says "1, or 2 after a nudge"; the engine stamps it at launch and a nudge deliberately never relaunches the stage, so a nudged agent reads 1 (already recorded in the followups doc). The UI says "Always 1" and explains that the nudge message, not the environment, is what tells an agent it is on its last attempt. A test pins that wording so the spec's version cannot creep back in.
2. **"exactly one predecessor" is really "entered on a success edge and not a join".** `startSuccessTargets` passes `prev` only when `len(needs) <= 1`, and `startFailureTarget` passes `""` deliberately, so the UI keys off the same two facts rather than counting inbound edges.
3. **`AO_PR_HEAD` is set for every PR subject**, including one whose tracked head sha is unknown, in which case it is present but empty. The description says so.

One thing the per-entry notes cannot carry: a manual run resolves its own subject (`resolveSubject` in `service/pipeline`), so it can be about a PR or a session the `on:` block never mentions. Rather than qualify every row with it, the notes name the trigger ("needs a `pr.*` trigger, or a manual run naming a PR") and the reference section states it once at the bottom.

Also worth stating, since section 12.3 says everything in a `run:` or a `prompt:` is shell interpolated: that is true of `run:` and not of `prompt:`. `buildAgentPrompt` appends the prompt verbatim, and the agent resolves `$AO_*` from its own environment. The reference section says which one applies to the stage you are looking at instead of repeating the spec sentence.

## Verification

- `npx vitest run`: 103 files, 1357 tests green. 27 new lib tests, 13 new inspector tests.
- `npm run typecheck` and `npm run typecheck:e2e` clean.
- Full renderer build (`vite build`), not just the typecheck.
- Prettier clean on the changed files at the repo's effective style (tabs, 120 columns). Note the repo ships no prettier config; `PipelineDefinitionsPage.tsx` has two pre-existing lines prettier would reindent and I left them alone rather than add unrelated churn.
- `ao preview` from inside the session, against the live daemon (`AO_PIPELINES` is on) with the renderer served from this branch. What I actually saw, driving the real editor: the PR review template's `review` stage reports "12 of 16 $AO variables reach this stage"; typing `$AO` opens 16 entries, `$AO_RU` narrows to `AO_RUN_ID`/`AO_RUN_DIR`, `$AO_OUT` narrows to the single `AO_OUTPUT` row and Enter completes it in place with the rest of the line intact; Escape closes the menu without touching the editor; the menu does not reopen on the token it just completed. On a bare stage the reference reads "7 of 16" and the greyed rows carry their reasons. `⌘Z` after a completion restores the typed `$AO_WORK` rather than clearing the field, which is the native `insertText` path doing its job in a real Chromium.
- I did not produce a live run whose failure branch was taken, so the `AO_FAILED_*` "always" state was verified from the draft rules and unit tests, not from a running stage.

## Notes

- No `backend/` changes and no `schema.ts` regeneration.
- The menu highlight uses the accent wash, not `bg-surface`: that token resolves to the same value as `bg-popover`, so the highlight was invisible against the menu.
- The braced form `${AO_OUTPUT}` does not trigger the menu (`ponytail:` comment marks the extension point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
