### PR TITLE
feat(pipelines-ui): GitHub Actions style run detail and stage graph

### DIFF
--- a/frontend/src/renderer/components/PipelineCanvas.test.tsx
+++ b/frontend/src/renderer/components/PipelineCanvas.test.tsx
@@ -1,9 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { edgeAppearance, PipelineCanvas } from "./PipelineCanvas";
+import { PipelineCanvas } from "./PipelineCanvas";
 import type { StageSelection } from "../hooks/useStageSelection";
 import type { PipelineDraft, StageDraft } from "../lib/pipeline-draft";
+import { edgeAppearance } from "../lib/pipeline-graph";
 
 function stage(id: string, overrides?: Partial<StageDraft>): StageDraft {
 	return { id, executor: "agent", agent: "claude-code", ...overrides };

--- a/frontend/src/renderer/components/PipelineCanvas.tsx
+++ b/frontend/src/renderer/components/PipelineCanvas.tsx
@@ -24,6 +24,7 @@ import {
 	applyConnection,
 	cycleStageIds,
 	draftEdges,
+	edgeAppearance,
 	effectiveDeadline,
 	isEdgeInCycle,
 	layoutPositions,
@@ -388,30 +389,6 @@ const EDGE_KIND_LABEL: Record<EdgeKind, string> = {
 	failure: "Failure",
 	"default-failure": "Default failure",
 };
-
-// edgeAppearance is the three-way visual split the graph's edge kinds need:
-// on_success solid in the accent, on_failure dashed in the destructive tone,
-// and the synthetic defaults.on_failure edge dashed in a faded version of the
-// same tone (it is inherited boilerplate, so it must not compete with the
-// routes the author actually wrote). A cycle overrides all three: the edge is
-// already invalid, so what kind it was stops mattering.
-//
-// The synthetic edge fades through its color rather than through `opacity` so
-// that its arrowhead marker, which does not inherit path opacity, fades with
-// the line instead of staying solid.
-export function edgeAppearance(
-	kind: EdgeKind,
-	inCycle: boolean,
-): { stroke: string; strokeWidth: number; strokeDasharray?: string } {
-	if (inCycle) return { stroke: "var(--color-error)", strokeWidth: 2, strokeDasharray: "6 4" };
-	if (kind === "success") return { stroke: "var(--color-accent)", strokeWidth: 2 };
-	if (kind === "failure") return { stroke: "var(--color-destructive)", strokeWidth: 1.75, strokeDasharray: "6 4" };
-	return {
-		stroke: "color-mix(in oklab, var(--color-destructive) 45%, transparent)",
-		strokeWidth: 1.5,
-		strokeDasharray: "3 5",
-	};
-}
 
 // --- stage node card ---------------------------------------------------------
 

--- a/frontend/src/renderer/components/PipelineRunDetail.test.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PipelineRunDetail } from "./PipelineRunDetail";
@@ -39,8 +39,24 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 }));
 
 type StageView = RunDetail["stages"][number];
+type DefinitionSummary = components["schemas"]["PipelineDefinitionSummary"];
 
 const LOG_URL = "/api/v1/pipelines/runs/{runId}/stages/{stageId}/log";
+// The stage graph reads routing and triggers off the project's definitions: the
+// run DTO names its pipeline but carries neither.
+const DEFINITIONS_URL = "/api/v1/pipelines";
+
+// The definition run-1 came from, as the definitions endpoint returns it.
+function definition(yamlSource: string, id = "def-1"): DefinitionSummary {
+	return {
+		id,
+		name: "review",
+		projectId: "proj-1",
+		yamlSource,
+		createdAt: "2026-07-15T00:00:00Z",
+		updatedAt: "2026-07-15T00:00:00Z",
+	};
+}
 
 function stage(overrides: Partial<StageView> & { stageId: string }): StageView {
 	return {
@@ -104,11 +120,14 @@ function setRun(run: RunDetail) {
 function setApi({
 	log,
 	logError,
+	definitions = [],
 }: {
 	log?: components["schemas"]["PipelineStageLogResponse"];
 	logError?: { code?: string; message: string };
+	definitions?: DefinitionSummary[];
 } = {}) {
 	getMock.mockImplementation((url: string) => {
+		if (url === DEFINITIONS_URL) return Promise.resolve({ data: { definitions }, error: undefined });
 		if (url === LOG_URL) {
 			if (logError) return Promise.resolve({ data: undefined, error: logError });
 			return Promise.resolve(log ? { data: log, error: undefined } : { data: undefined, error: { message: "no log" } });
@@ -130,6 +149,41 @@ function row(stageId: string): HTMLElement {
 	if (!found) throw new Error(`no row for stage ${stageId}`);
 	return found as HTMLElement;
 }
+
+// One stage's node in the read-only graph, which carries the same stage id as
+// its detail card but only the glyph and the duration.
+function graphNode(stageId: string): HTMLElement {
+	const found = document.querySelector(`[data-graph-stage="${stageId}"]`);
+	if (!found) throw new Error(`no graph node for stage ${stageId}`);
+	return found as HTMLElement;
+}
+
+// Where dagre put a node. react-flow writes the layout into a transform, so this
+// is how a test sees that the definition's edges reached the layout at all.
+function graphNodeX(index: number): number {
+	const el = document.querySelector(`[data-testid="pipeline-run-graph"] .react-flow__node[data-id="${index}"]`);
+	if (!el) throw new Error(`no graph node at index ${index}`);
+	const match = /translate\((-?[\d.]+)px/.exec((el as HTMLElement).style.transform);
+	return match ? Number(match[1]) : NaN;
+}
+
+// A two-stage definition whose first stage routes into its second, so the graph
+// has both a trigger list and one real edge to lay out.
+const CHAIN_YAML = `name: review
+on:
+  pr:
+    - created
+    - updated
+stages:
+  - id: build
+    executor: command
+    run: make
+    on_success:
+      - test
+  - id: test
+    executor: command
+    run: make test
+`;
 
 beforeEach(() => {
 	usePipelineRunMock.mockReset();
@@ -528,7 +582,7 @@ describe("PipelineRunDetail actions", () => {
 		setRun(detail({ status: "running" }));
 		renderDetail("proj-7");
 
-		await userEvent.setup().click(screen.getByRole("button", { name: "Cancel" }));
+		await userEvent.setup().click(screen.getByRole("button", { name: "Cancel workflow" }));
 
 		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
 		expect(postMock).toHaveBeenCalledWith("/api/v1/pipelines/runs/{runId}/cancel", {
@@ -542,7 +596,7 @@ describe("PipelineRunDetail actions", () => {
 		setRun(detail({ status: "failed" }));
 		renderDetail("proj-1");
 
-		expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Cancel workflow" })).not.toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Resume" })).not.toBeInTheDocument();
 		expect(screen.queryByText(/finding/i)).not.toBeInTheDocument();
 	});
@@ -551,6 +605,173 @@ describe("PipelineRunDetail actions", () => {
 		setRun(detail({ status: "running" }));
 		renderDetail(undefined);
 
-		expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Cancel workflow" })).toBeDisabled();
+	});
+});
+
+describe("PipelineRunDetail summary card", () => {
+	it("reports what triggered the run, how it settled, how long it took and what it left behind", () => {
+		setRun(
+			detail({
+				status: "succeeded",
+				subjectKind: "pr",
+				prNumber: 7,
+				sessionId: "",
+				createdAt: "2026-07-15T00:00:00Z",
+				settledAt: "2026-07-15T00:05:00Z",
+				stages: [
+					stage({ stageId: "audit", producedArtifact: { name: "audit.md", exists: true } }),
+					stage({ stageId: "assess", producedArtifact: { name: "assess.md", exists: false } }),
+				],
+			}),
+		);
+		renderDetail("proj-1");
+
+		const summary = screen.getByRole("region", { name: "Run summary" });
+		expect(within(summary).getByText("Triggered via pull request")).toBeInTheDocument();
+		expect(within(summary).getByText("succeeded")).toBeInTheDocument();
+		expect(within(summary).getByText("5m 0s")).toBeInTheDocument();
+		// Only the artifact that is actually in the run folder counts.
+		expect(within(summary).getByText("1")).toBeInTheDocument();
+	});
+
+	it("says a run left no artifacts rather than showing a bare zero", () => {
+		setRun(detail({ status: "succeeded", stages: [stage({ stageId: "lint" })] }));
+		renderDetail("proj-1");
+
+		expect(within(screen.getByRole("region", { name: "Run summary" })).getByText("None")).toBeInTheDocument();
+	});
+});
+
+describe("PipelineRunDetail job rail", () => {
+	it("lists Summary, every stage of the run, and the run's own details", () => {
+		setRun(
+			detail({
+				runDir: "/tmp/ao/run-1",
+				stages: [stage({ stageId: "build" }), stage({ stageId: "test", outcome: "failed" })],
+			}),
+		);
+		renderDetail("proj-1");
+
+		const rail = screen.getByRole("navigation", { name: "Run navigation" });
+		expect(within(rail).getByRole("button", { name: "Summary" })).toBeInTheDocument();
+		expect(within(rail).getByText("All jobs")).toBeInTheDocument();
+		expect(within(rail).getByRole("button", { name: "build" })).toBeInTheDocument();
+		expect(within(rail).getByRole("button", { name: "test" })).toBeInTheDocument();
+		expect(within(rail).getByText("Run details")).toBeInTheDocument();
+		expect(within(rail).getByText("/tmp/ao/run-1")).toBeInTheDocument();
+	});
+
+	// Selecting a job on GitHub scrolls its output into view; ours does the same
+	// to the stage's detail card, which is where everything about it lives.
+	it("focuses a stage's detail card when its rail entry is picked", async () => {
+		const scrollIntoView = vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(() => undefined);
+		setRun(detail({ stages: [stage({ stageId: "build" }), stage({ stageId: "test" })] }));
+		renderDetail("proj-1");
+
+		const rail = screen.getByRole("navigation", { name: "Run navigation" });
+		expect(within(rail).getByRole("button", { name: "Summary" })).toHaveAttribute("aria-current", "true");
+
+		await userEvent.setup().click(within(rail).getByRole("button", { name: "test" }));
+
+		expect(within(rail).getByRole("button", { name: "test" })).toHaveAttribute("aria-current", "true");
+		expect(within(rail).getByRole("button", { name: "Summary" })).not.toHaveAttribute("aria-current");
+		expect(scrollIntoView).toHaveBeenCalled();
+	});
+
+	it("takes the back link to the runs board and the definition entry to the pipelines page", async () => {
+		setRun(detail({ stages: [] }));
+		renderDetail("proj-1");
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: "Runs" }));
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/pipelines/runs" });
+
+		await user.click(screen.getByRole("button", { name: "Pipeline definition" }));
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/pipelines" });
+	});
+});
+
+describe("PipelineRunDetail stage graph", () => {
+	it("draws a node per stage of the run with its duration", async () => {
+		setRun(
+			detail({
+				stages: [
+					stage({ stageId: "build", startedAt: "2026-07-15T00:00:00Z", settledAt: "2026-07-15T00:00:26Z" }),
+					stage({ stageId: "test", outcome: "skipped", startedAt: null, settledAt: null }),
+				],
+			}),
+		);
+		setApi({ definitions: [definition(CHAIN_YAML)] });
+		renderDetail("proj-1");
+
+		await waitFor(() => expect(graphNode("build")).toBeInTheDocument());
+		expect(within(graphNode("build")).getByText("26s")).toBeInTheDocument();
+		// A stage that never ran has no duration to show, in the graph as in its card.
+		expect(within(graphNode("test")).queryByText(/\d+s/)).not.toBeInTheDocument();
+	});
+
+	// The run DTO has no edges, so a stage placed to the right of the one that
+	// routes into it is the proof that the definition's routing reached dagre.
+	it("ranks a stage after the stage that routes into it", async () => {
+		setRun(detail({ stages: [stage({ stageId: "build" }), stage({ stageId: "test" })] }));
+		setApi({ definitions: [definition(CHAIN_YAML)] });
+		renderDetail("proj-1");
+
+		await waitFor(() => expect(graphNodeX(1)).toBeGreaterThan(graphNodeX(0)));
+	});
+
+	it("names the pipeline and the triggers it runs on above the graph", async () => {
+		setRun(detail({ stages: [stage({ stageId: "build" })] }));
+		setApi({ definitions: [definition(CHAIN_YAML)] });
+		renderDetail("proj-1");
+
+		expect(await screen.findByText("on: pr.created, pr.updated")).toBeInTheDocument();
+	});
+
+	it("says a definition with no triggers only runs when asked", async () => {
+		setRun(detail({ stages: [stage({ stageId: "build" })] }));
+		setApi({ definitions: [definition("name: review\nstages:\n  - id: build\n    executor: command\n    run: make\n")] });
+		renderDetail("proj-1");
+
+		expect(await screen.findByText("on: manual")).toBeInTheDocument();
+	});
+
+	// A definition can be edited or deleted after the run it produced. The nodes
+	// are the run's own, so they still render; only the routing is gone.
+	it("still graphs the stages when the run's definition cannot be loaded", async () => {
+		setRun(detail({ stages: [stage({ stageId: "build" })] }));
+		setApi({ definitions: [] });
+		renderDetail("proj-1");
+
+		await waitFor(() => expect(graphNode("build")).toBeInTheDocument());
+		expect(
+			screen.getByText("routing unavailable: this run's pipeline definition could not be loaded"),
+		).toBeInTheDocument();
+	});
+
+	it("offers no editing affordances on the run's graph", async () => {
+		setRun(detail({ stages: [stage({ stageId: "build" })] }));
+		setApi({ definitions: [definition(CHAIN_YAML)] });
+		renderDetail("proj-1");
+
+		await waitFor(() => expect(graphNode("build")).toBeInTheDocument());
+		expect(screen.queryByRole("button", { name: "Add stage" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Auto-layout" })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Fit graph" })).toBeInTheDocument();
+	});
+
+	it("focuses a stage when its graph node is clicked", async () => {
+		setRun(detail({ stages: [stage({ stageId: "build" }), stage({ stageId: "test" })] }));
+		setApi({ definitions: [definition(CHAIN_YAML)] });
+		renderDetail("proj-1");
+
+		await waitFor(() => expect(graphNode("test")).toBeInTheDocument());
+		// fireEvent, not userEvent: a full pointer sequence trips d3-drag's
+		// window access on the zoom pane under jsdom (same as PipelineCanvas).
+		fireEvent.click(graphNode("test"));
+
+		const rail = screen.getByRole("navigation", { name: "Run navigation" });
+		expect(within(rail).getByRole("button", { name: "test" })).toHaveAttribute("aria-current", "true");
 	});
 });

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import { ArrowLeft, FileText, Folder, LayoutList } from "lucide-react";
 import { cn } from "../lib/utils";
 import { formatTimeCompact } from "../lib/format-time";
 import { apiClient, apiErrorCode, apiErrorMessage, getApiBaseUrl } from "../lib/api-client";
@@ -11,16 +12,19 @@ import {
 	stageOutcomeDotTone,
 	stageOutcomeLabel,
 } from "../lib/pipeline-display";
+import { parseYamlToDraft, type PipelineDraft, type RunStatus, type StageOutcome } from "../lib/pipeline-draft";
 import { useKillSession } from "../hooks/useKillSession";
+import { usePipelineDefinitionsQuery } from "../hooks/usePipelineDefinitions";
 import { pipelineRunQueryKey, usePipelineRun } from "../hooks/usePipelineRuns";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
-import type { RunStatus, StageOutcome } from "../lib/pipeline-draft";
 import type { WorkspaceSession } from "../types/workspace";
 import type { components } from "../../api/schema";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
+import { PipelineRunGraph, RunStatusIcon, StageStatusIcon } from "./PipelineRunGraph";
 
 type PipelineStageView = components["schemas"]["PipelineStageView"];
+type RunDetail = components["schemas"]["PipelineRunDetail"];
 
 // How much of a stage log the viewer asks for. The log is the main debugging
 // surface for a command stage that failed, and the interesting part of a failure
@@ -31,16 +35,44 @@ const LOG_TAIL_LINES = 200;
 // as an empty log rather than as a failure.
 const LOG_NOT_FOUND_CODE = "PIPELINE_STAGE_LOG_NOT_FOUND";
 
-// Read-only detail for one pipeline run. Its job is to make the outcome taxonomy
-// (spec section 7) legible: which stage settled how, whether it was nudged,
-// which failure routed into it, what it produced or failed to produce, and what
-// its log says. There is no resume (spec section 14.1) and no findings panel:
-// the findings subsystem is deleted (D10), and a stage's contract is its one
-// declared artifact.
+// Read-only detail for one pipeline run, laid out like a GitHub Actions run page
+// (workflow = pipeline definition, job = stage, workflow run = pipeline run):
+// a status header with the live run's one destructive action, a job rail down
+// the left, and a main column of summary, stage graph, and per-stage detail.
+//
+// The per-stage detail is where the outcome taxonomy (spec section 7) stays
+// legible: which stage settled how, whether it was nudged, which failure routed
+// into it, what it produced or failed to produce, and what its log says. There
+// is no resume (spec section 14.1) and no findings panel: the findings subsystem
+// is deleted (D10), and a stage's contract is its one declared artifact.
 export function PipelineRunDetail({ runId, project }: { runId: string; project?: string }) {
 	const queryClient = useQueryClient();
+	const navigate = useNavigate();
 	const { data: run, isLoading, isError, error } = usePipelineRun(runId);
 	const [actionError, setActionError] = useState<string | null>(null);
+	// Which stage the rail or the graph has focused. Null is the Summary entry:
+	// no stage is singled out and the main column reads from the top.
+	const [focusedStage, setFocusedStage] = useState<string | null>(null);
+	const stageRefs = useRef<Record<string, HTMLElement | null>>({});
+	const mainRef = useRef<HTMLDivElement | null>(null);
+
+	// The run DTO names its pipeline but carries neither its routing nor its
+	// triggers, so the graph reads both off the project's definitions, which the
+	// definitions page has usually already cached. Without a project scope there
+	// is no definitions endpoint to ask.
+	const definitions = usePipelineDefinitionsQuery(project).data;
+	const definition = useMemo<PipelineDraft | undefined>(() => {
+		const source = definitions?.find((candidate) => candidate.id === run?.pipelineId)?.yamlSource;
+		return source ? (parseYamlToDraft(source).draft ?? undefined) : undefined;
+	}, [definitions, run?.pipelineId]);
+
+	// Focusing a stage scrolls its card into view; Summary scrolls back to the
+	// top, because that is what the entry means on GitHub's rail.
+	const focusStage = useCallback((stageId: string | null) => {
+		setFocusedStage(stageId);
+		if (stageId) stageRefs.current[stageId]?.scrollIntoView({ behavior: "smooth", block: "start" });
+		else mainRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+	}, []);
 
 	const cancel = useMutation({
 		mutationFn: async () => {
@@ -75,14 +107,29 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 	const canCancel = status === "pending" || status === "running";
 
 	return (
-		<div className="flex h-full min-h-0 flex-col overflow-y-auto bg-background text-foreground">
-			<header className="border-b border-border px-6 py-5">
-				<div className="flex flex-wrap items-center gap-2">
-					<h1 className="truncate text-subtitle font-bold tracking-tight text-foreground">{run.pipelineName}</h1>
-					<Badge variant="outline" className={cn("gap-1.5", runStatusTone(status))} data-run-status={status}>
-						<span className={cn("h-1.5 w-1.5 rounded-full", stageOutcomeDotTone(status as StageOutcome))} />
-						{status}
-					</Badge>
+		<div className="flex h-full min-h-0 flex-col bg-background text-foreground">
+			<header className="shrink-0 border-b border-border px-6 pb-4 pt-4">
+				<button
+					type="button"
+					onClick={() => void navigate({ to: "/pipelines/runs" })}
+					className="flex items-center gap-1.5 rounded text-caption text-passive underline-offset-2 hover:text-foreground hover:underline"
+				>
+					<ArrowLeft className="size-icon-xs" aria-hidden="true" />
+					Runs
+				</button>
+				<div className="mt-2 flex flex-wrap items-center gap-2">
+					<RunStatusIcon status={status} className="size-icon-base" />
+					{/* A settled run's header goes quiet: the screen is a record, not a
+					    thing to act on, which is the difference the red Cancel marks. */}
+					<h1
+						className={cn(
+							"truncate text-subtitle font-bold tracking-tight",
+							canCancel ? "text-foreground" : "text-muted-foreground",
+						)}
+					>
+						{run.pipelineName}
+					</h1>
+					<span className="font-mono text-caption text-passive">{run.runId}</span>
 					{run.cancelReason && <span className="text-caption text-passive">· {run.cancelReason}</span>}
 					<div className="ml-auto flex items-center gap-2">
 						{actionError && <span className="text-caption text-error">{actionError}</span>}
@@ -90,21 +137,172 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 							<Button
 								size="sm"
 								variant="outline"
+								className="border-error/40 text-error hover:bg-error/10 hover:text-error"
 								disabled={cancel.isPending || !project}
 								title={project ? undefined : "Open this run from the board to cancel it"}
 								onClick={() => cancel.mutate()}
 							>
-								{cancel.isPending ? "Cancelling…" : "Cancel"}
+								{cancel.isPending ? "Cancelling…" : "Cancel workflow"}
 							</Button>
 						)}
 					</div>
 				</div>
+			</header>
 
-				<div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-micro text-passive">
-					<span>{run.runId}</span>
-					<span aria-hidden="true">·</span>
+			<div className="flex min-h-0 flex-1">
+				<RunRail
+					run={run}
+					focusedStage={focusedStage}
+					onFocusStage={focusStage}
+					onOpenDefinitions={() => void navigate({ to: "/pipelines" })}
+				/>
+
+				<div ref={mainRef} className="flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-4">
+					<RunSummaryCard run={run} />
+
+					<section aria-label="Stage graph" className="rounded-lg border border-border bg-card">
+						<div className="border-b border-border px-5 py-3">
+							<p className="truncate text-control font-semibold text-foreground">{run.pipelineName}</p>
+							<p className="mt-0.5 font-mono text-micro text-passive">
+								{definition
+									? triggerSummary(definition)
+									: "routing unavailable: this run's pipeline definition could not be loaded"}
+							</p>
+						</div>
+						<div className="h-72">
+							<PipelineRunGraph
+								stages={stages}
+								definition={definition}
+								selectedStageId={focusedStage}
+								onSelectStage={focusStage}
+							/>
+						</div>
+					</section>
+
+					<section aria-label="Stages" className="flex flex-col gap-3">
+						{stages.map((stage) => (
+							<StageCard
+								key={stage.stageId}
+								runId={run.runId}
+								stage={stage}
+								focused={focusedStage === stage.stageId}
+								cardRef={(el) => {
+									stageRefs.current[stage.stageId] = el;
+								}}
+							/>
+						))}
+						{stages.length === 0 && <p className="text-caption text-passive">No stages yet.</p>}
+					</section>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// The left rail: Summary, every stage of the run with its status glyph, then the
+// run-level details that are not stage facts. GitHub's `Usage` has no analogue
+// here (the daemon bills nothing), so the group carries the two things a human
+// actually goes looking for: the definition this run came from and the folder
+// its artifacts and logs live in.
+function RunRail({
+	run,
+	focusedStage,
+	onFocusStage,
+	onOpenDefinitions,
+}: {
+	run: RunDetail;
+	focusedStage: string | null;
+	onFocusStage: (stageId: string | null) => void;
+	onOpenDefinitions: () => void;
+}) {
+	return (
+		<nav aria-label="Run navigation" className="w-60 shrink-0 overflow-y-auto border-r border-border px-3 py-4">
+			<RailItem
+				icon={<LayoutList className="size-icon-sm text-muted-foreground" aria-hidden="true" />}
+				label="Summary"
+				active={focusedStage === null}
+				onClick={() => onFocusStage(null)}
+			/>
+
+			<p className="mb-1 mt-4 px-2 text-micro font-semibold uppercase tracking-wide text-passive">All jobs</p>
+			{run.stages.map((stage) => (
+				<RailItem
+					key={stage.stageId}
+					icon={<StageStatusIcon outcome={stage.outcome as StageOutcome} />}
+					label={stage.stageId}
+					active={focusedStage === stage.stageId}
+					onClick={() => onFocusStage(stage.stageId)}
+				/>
+			))}
+			{run.stages.length === 0 && <p className="px-2 text-micro text-passive">No stages yet.</p>}
+
+			<p className="mb-1 mt-4 px-2 text-micro font-semibold uppercase tracking-wide text-passive">Run details</p>
+			<RailItem
+				icon={<FileText className="size-icon-sm text-muted-foreground" aria-hidden="true" />}
+				label="Pipeline definition"
+				active={false}
+				onClick={onOpenDefinitions}
+			/>
+			{run.runDir && (
+				<div className="mt-1 flex items-start gap-2 px-2 py-1.5">
+					<Folder className="mt-px size-icon-sm shrink-0 text-muted-foreground" aria-hidden="true" />
+					<span className="min-w-0 flex-1 break-all font-mono text-micro text-passive" title={run.runDir}>
+						{run.runDir}
+					</span>
+				</div>
+			)}
+		</nav>
+	);
+}
+
+function RailItem({
+	icon,
+	label,
+	active,
+	onClick,
+}: {
+	icon: ReactNode;
+	label: string;
+	active: boolean;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			aria-current={active ? "true" : undefined}
+			className={cn(
+				"flex w-full items-center gap-2 rounded-md border-l-2 px-2 py-1.5 text-left text-control transition-colors",
+				active
+					? "border-l-accent bg-raised text-foreground"
+					: "border-l-transparent text-muted-foreground hover:bg-surface hover:text-foreground",
+			)}
+		>
+			{icon}
+			<span className="min-w-0 flex-1 truncate">{label}</span>
+		</button>
+	);
+}
+
+// The summary card: what triggered the run, how it settled, how long it took and
+// what it left behind, in GitHub's four-field layout. Total duration is measured
+// from the run's creation, which is the only clock the run DTO carries.
+function RunSummaryCard({ run }: { run: RunDetail }) {
+	const status = run.status as RunStatus;
+	const duration = formatStageDuration(run.createdAt, run.settledAt);
+	const artifacts = run.stages.filter((stage) => stage.producedArtifact?.exists).length;
+
+	return (
+		<section
+			aria-label="Run summary"
+			className="grid gap-x-8 gap-y-4 rounded-lg border border-border bg-card px-5 py-4 sm:grid-cols-[minmax(0,1fr)_repeat(3,minmax(6rem,auto))]"
+		>
+			<div className="min-w-0">
+				<p className="text-caption text-muted-foreground">Triggered via {SUBJECT_LABEL[run.subjectKind]}</p>
+				<div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-caption text-passive">
 					<RunSubject run={run} />
-					<span aria-hidden="true">·</span>
+				</div>
+				<div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-micro text-passive">
 					<span title={absoluteTime(run.createdAt)}>created {formatTimeCompact(run.createdAt)}</span>
 					<span aria-hidden="true">·</span>
 					{run.settledAt ? (
@@ -113,32 +311,50 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 						<span>not settled</span>
 					)}
 				</div>
+			</div>
 
-				{run.runDir && (
-					<p className="mt-1 truncate font-mono text-micro text-passive" title={run.runDir}>
-						{run.runDir}
-					</p>
-				)}
-			</header>
+			<SummaryField label="Status">
+				<span className={runStatusTone(status)} data-run-status={status}>
+					{status}
+				</span>
+			</SummaryField>
+			<SummaryField label="Total duration">{duration || "0s"}</SummaryField>
+			<SummaryField label="Artifacts">{artifacts > 0 ? String(artifacts) : "None"}</SummaryField>
+		</section>
+	);
+}
 
-			<section aria-label="Stages" className="px-6 py-4">
-				<h2 className="mb-2 text-micro font-semibold uppercase tracking-wide text-passive">Stages</h2>
-				<div className="flex flex-col gap-2">
-					{stages.map((stage) => (
-						<StageRow key={stage.stageId} runId={run.runId} stage={stage} />
-					))}
-					{stages.length === 0 && <p className="text-caption text-passive">No stages yet.</p>}
-				</div>
-			</section>
+function SummaryField({ label, children }: { label: string; children: ReactNode }) {
+	return (
+		<div>
+			<p className="text-micro text-passive">{label}</p>
+			<p className="mt-2 text-control font-semibold text-foreground">{children}</p>
 		</div>
 	);
+}
+
+const SUBJECT_LABEL: Record<RunDetail["subjectKind"], string> = {
+	session: "session",
+	pr: "pull request",
+	project: "project",
+};
+
+// `on: pr.created, pr.updated`, the pipeline's own trigger list, in the same
+// place GitHub prints `on: pull_request`. A definition with no triggers only
+// runs when someone asks it to.
+function triggerSummary(definition: PipelineDraft): string {
+	const events = [
+		...(definition.on?.pr ?? []).map((event) => `pr.${event}`),
+		...(definition.on?.session ?? []).map((event) => `session.${event}`),
+	];
+	return events.length > 0 ? `on: ${events.join(", ")}` : "on: manual";
 }
 
 // What the run is about. A PR subject only has a url when a local session tracks
 // it (the run DTO carries the number, not the link), and a sessionless PR is
 // first-class (spec section 4), so the number renders as plain text rather than
 // as a link to a guessed url.
-function RunSubject({ run }: { run: components["schemas"]["PipelineRunDetail"] }) {
+function RunSubject({ run }: { run: RunDetail }) {
 	const session = useSessionFacts(run.sessionId);
 	if (run.subjectKind === "pr" && run.prNumber) {
 		const prUrl = session?.prs?.find((pr) => pr.number === run.prNumber)?.url;
@@ -167,10 +383,20 @@ function RunSubject({ run }: { run: components["schemas"]["PipelineRunDetail"] }
 	return <span>{run.subjectKind}</span>;
 }
 
-// One stage row: how it settled, how long it took, why it was entered, what it
-// produced, and the two things a human reaches for when it went wrong (the log
-// and the session that is still alive).
-function StageRow({ runId, stage }: { runId: string; stage: PipelineStageView }) {
+// One stage's detail card: how it settled, how long it took, why it was entered,
+// what it produced, and the two things a human reaches for when it went wrong
+// (the log and the session that is still alive).
+function StageCard({
+	runId,
+	stage,
+	focused,
+	cardRef,
+}: {
+	runId: string;
+	stage: PipelineStageView;
+	focused: boolean;
+	cardRef: (el: HTMLElement | null) => void;
+}) {
 	const [showLog, setShowLog] = useState(false);
 	const outcome = stage.outcome as StageOutcome;
 	const settled = Boolean(stage.settledAt);
@@ -180,9 +406,17 @@ function StageRow({ runId, stage }: { runId: string; stage: PipelineStageView })
 	const hasLog = Boolean(stage.startedAt);
 
 	return (
-		<div data-stage={stage.stageId} className="rounded-md border border-border bg-card px-3 py-2.5">
+		<div
+			ref={cardRef}
+			data-stage={stage.stageId}
+			className={cn(
+				"scroll-mt-4 rounded-lg border bg-card px-4 py-3 transition-colors",
+				focused ? "border-accent ring-1 ring-accent/40" : "border-border",
+			)}
+		>
 			<div className="flex flex-wrap items-center gap-2">
-				<span className="font-mono text-caption font-medium text-foreground">{stage.stageId}</span>
+				<StageStatusIcon outcome={outcome} />
+				<span className="font-mono text-control font-medium text-foreground">{stage.stageId}</span>
 				<Badge variant="outline" className="gap-1.5">
 					<span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", stageOutcomeDotTone(outcome))} />
 					{stageOutcomeLabel(outcome)}

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -378,9 +378,10 @@ function RunSubject({ run }: { run: RunDetail }) {
 		);
 	}
 	if (run.sessionId) return <SessionLink sessionId={run.sessionId} />;
-	// A project subject (a manual trigger) has neither a PR nor a session to
-	// point at, and saying so is the whole of it.
-	return <span>{run.subjectKind}</span>;
+	// A project subject has neither a PR nor a session to point at: nothing but
+	// a person asked for it, and the card's "Triggered via project" line has
+	// already said the rest.
+	return <span>{run.subjectKind === "project" ? "manual trigger" : run.subjectKind}</span>;
 }
 
 // One stage's detail card: how it settled, how long it took, why it was entered,

--- a/frontend/src/renderer/components/PipelineRunGraph.tsx
+++ b/frontend/src/renderer/components/PipelineRunGraph.tsx
@@ -1,0 +1,252 @@
+import { useMemo } from "react";
+import {
+	Handle,
+	MarkerType,
+	Panel,
+	Position,
+	ReactFlow,
+	ReactFlowProvider,
+	useReactFlow,
+	type Edge,
+	type Node,
+	type NodeProps,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import {
+	AlertCircle,
+	CheckCircle2,
+	Circle,
+	CircleDashed,
+	CircleDot,
+	Maximize,
+	Minus,
+	MinusCircle,
+	Plus,
+	XCircle,
+} from "lucide-react";
+import { draftEdges, edgeAppearance, layoutPositions, stageNodeId } from "../lib/pipeline-graph";
+import { formatStageDuration } from "../lib/pipeline-display";
+import type { PipelineDraft, RunStatus, StageOutcome } from "../lib/pipeline-draft";
+import type { components } from "../../api/schema";
+import { Button } from "./ui/button";
+import { cn } from "../lib/utils";
+
+type PipelineStageView = components["schemas"]["PipelineStageView"];
+
+// The run graph's node is a compact row (icon, stage id, duration), not the
+// editor's tall config card, so it reserves its own footprint in the dagre pass.
+const RUN_NODE_WIDTH = 224;
+const RUN_NODE_HEIGHT = 44;
+
+// The read-only stage graph for one run: a node per stage of the run, carrying
+// the outcome the stage settled on and how long it took, wired by the edges the
+// pipeline definition declares. It is the same react-flow plus dagre setup the
+// editor canvas uses (lib/pipeline-graph), with every editing affordance off:
+// no connect handles, no dragging, no delete key, no add-stage panel.
+//
+// Nodes come from the run and edges from the definition, which is the only pair
+// that stays honest when the definition has been edited since: a stage the run
+// does not have cannot appear, and a route to a stage that is not in the run is
+// dropped by draftEdges rather than drawn into nothing.
+export function PipelineRunGraph({
+	stages,
+	definition,
+	selectedStageId,
+	onSelectStage,
+}: {
+	stages: PipelineStageView[];
+	// The parsed pipeline definition, when it could be loaded. Without it the
+	// graph still renders every stage; it just has no routing to draw.
+	definition?: PipelineDraft;
+	selectedStageId: string | null;
+	onSelectStage: (stageId: string) => void;
+}) {
+	return (
+		<ReactFlowProvider>
+			<RunGraphInner
+				stages={stages}
+				definition={definition}
+				selectedStageId={selectedStageId}
+				onSelectStage={onSelectStage}
+			/>
+		</ReactFlowProvider>
+	);
+}
+
+function RunGraphInner({
+	stages,
+	definition,
+	selectedStageId,
+	onSelectStage,
+}: {
+	stages: PipelineStageView[];
+	definition?: PipelineDraft;
+	selectedStageId: string | null;
+	onSelectStage: (stageId: string) => void;
+}) {
+	// A draft whose stage list is the run's, so the graph lib's index-keyed node
+	// ids address run stages directly. A stage the definition no longer declares
+	// still gets a node (as a routeless placeholder) rather than disappearing.
+	const graphDraft = useMemo<PipelineDraft>(
+		() => ({
+			name: definition?.name ?? "",
+			defaults: definition?.defaults,
+			stages: stages.map(
+				(stage) =>
+					definition?.stages.find((candidate) => candidate.id === stage.stageId) ?? {
+						id: stage.stageId,
+						executor: "command" as const,
+					},
+			),
+		}),
+		[stages, definition],
+	);
+
+	const nodes = useMemo<Node[]>(() => {
+		const positions = layoutPositions(graphDraft, { width: RUN_NODE_WIDTH, height: RUN_NODE_HEIGHT });
+		return stages.map((stage, i) => {
+			const id = stageNodeId(i);
+			return {
+				id,
+				type: "runStage",
+				position: positions[id] ?? { x: 0, y: i * (RUN_NODE_HEIGHT + 16) },
+				width: RUN_NODE_WIDTH,
+				draggable: false,
+				connectable: false,
+				data: { stage, focused: stage.stageId === selectedStageId },
+			};
+		});
+	}, [graphDraft, stages, selectedStageId]);
+
+	const edges = useMemo<Edge[]>(
+		() =>
+			draftEdges(graphDraft).map((edge) => {
+				const style = edgeAppearance(edge.kind, false);
+				return {
+					id: edge.id,
+					source: edge.source,
+					target: edge.target,
+					focusable: false,
+					selectable: false,
+					deletable: false,
+					ariaLabel: `${edge.kind === "success" ? "Success" : "Failure"} edge from ${edge.from} to ${edge.to}`,
+					style,
+					markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16, color: style.stroke },
+				};
+			}),
+		[graphDraft],
+	);
+
+	return (
+		<div className="h-full w-full" data-testid="pipeline-run-graph">
+			<ReactFlow
+				nodes={nodes}
+				edges={edges}
+				nodeTypes={NODE_TYPES}
+				onNodeClick={(_, node) => {
+					const stage = stages[Number(node.id)];
+					if (stage) onSelectStage(stage.stageId);
+				}}
+				nodesConnectable={false}
+				nodesDraggable={false}
+				edgesFocusable={false}
+				elementsSelectable={false}
+				deleteKeyCode={null}
+				fitView
+				fitViewOptions={{ padding: 0.25 }}
+				minZoom={0.25}
+				maxZoom={2}
+				proOptions={{ hideAttribution: true }}
+			>
+				<Panel position="bottom-right">
+					<GraphZoomBar />
+				</Panel>
+			</ReactFlow>
+		</div>
+	);
+}
+
+// The corner zoom cluster: fit, out, in. GitHub's run graph puts exactly these
+// three in the bottom-right, and a read-only graph has no use for the editor's
+// zoom-percentage readout.
+function GraphZoomBar() {
+	const { zoomIn, zoomOut, fitView } = useReactFlow();
+	return (
+		<div className="flex items-center gap-0.5 rounded-md border border-border bg-surface p-0.5">
+			<Button
+				size="icon-sm"
+				variant="ghost"
+				aria-label="Fit graph"
+				onClick={() => void fitView({ padding: 0.25, duration: 200 })}
+			>
+				<Maximize className="size-icon-sm" aria-hidden="true" />
+			</Button>
+			<Button size="icon-sm" variant="ghost" aria-label="Zoom out" onClick={() => zoomOut({ duration: 150 })}>
+				<Minus className="size-icon-sm" aria-hidden="true" />
+			</Button>
+			<Button size="icon-sm" variant="ghost" aria-label="Zoom in" onClick={() => zoomIn({ duration: 150 })}>
+				<Plus className="size-icon-sm" aria-hidden="true" />
+			</Button>
+		</div>
+	);
+}
+
+type RunStageNodeType = Node<{ stage: PipelineStageView; focused: boolean }, "runStage">;
+
+function RunStageNode({ data }: NodeProps<RunStageNodeType>) {
+	const { stage, focused } = data;
+	const duration = formatStageDuration(stage.startedAt, stage.settledAt);
+	return (
+		<div
+			data-graph-stage={stage.stageId}
+			className={cn(
+				"flex w-56 items-center gap-2 rounded-md border bg-surface px-3 py-2 transition-colors",
+				focused ? "border-accent ring-1 ring-accent/40" : "border-border hover:border-border-strong",
+			)}
+		>
+			{/* Hidden handles: edges need an anchor, but this graph is not connectable. */}
+			<Handle type="target" position={Position.Left} isConnectable={false} className="!invisible" />
+			<StageStatusIcon outcome={stage.outcome as StageOutcome} />
+			<span className="min-w-0 flex-1 truncate text-control text-foreground">{stage.stageId}</span>
+			{duration && <span className="shrink-0 font-mono text-micro text-passive">{duration}</span>}
+			<Handle type="source" position={Position.Right} isConnectable={false} className="!invisible" />
+		</div>
+	);
+}
+
+const NODE_TYPES = { runStage: RunStageNode };
+
+// --- status icons ------------------------------------------------------------
+
+// The icon vocabulary for the eight settled outcomes plus the two live ones,
+// tone-matched to stageOutcomeDotTone so the graph, the job rail and the board
+// say the same thing about the same stage. The shapes carry the pairs the tones
+// already collapse: failed and timed_out are both a cross, no_output and
+// no_signal are both a warning, cancelled and skipped are both "nothing ran".
+// succeeded_unverified is the dashed ring: the success hue, not a closed circle.
+const OUTCOME_ICON: Record<StageOutcome, { Icon: typeof Circle; className: string }> = {
+	succeeded: { Icon: CheckCircle2, className: "text-success" },
+	succeeded_unverified: { Icon: CircleDashed, className: "text-success" },
+	failed: { Icon: XCircle, className: "text-error" },
+	timed_out: { Icon: XCircle, className: "text-error" },
+	no_output: { Icon: AlertCircle, className: "text-warning" },
+	no_signal: { Icon: AlertCircle, className: "text-warning" },
+	cancelled: { Icon: MinusCircle, className: "text-passive" },
+	skipped: { Icon: MinusCircle, className: "text-passive" },
+	running: { Icon: CircleDot, className: "text-accent animate-pulse" },
+	pending: { Icon: Circle, className: "text-muted-foreground" },
+};
+
+// StageStatusIcon is the one status glyph the run screen uses everywhere a
+// stage is named without room for its full outcome wording.
+export function StageStatusIcon({ outcome, className }: { outcome: StageOutcome; className?: string }) {
+	const { Icon, className: tone } = OUTCOME_ICON[outcome] ?? OUTCOME_ICON.pending;
+	return <Icon className={cn("size-icon-sm shrink-0", tone, className)} aria-hidden="true" />;
+}
+
+// A run status is the rollup of its stages, and its five values are a subset of
+// the outcome vocabulary, so the header reuses the same glyphs rather than
+// inventing a second set.
+export function RunStatusIcon({ status, className }: { status: RunStatus; className?: string }) {
+	return <StageStatusIcon outcome={status as StageOutcome} className={className} />;
+}

--- a/frontend/src/renderer/lib/pipeline-graph.ts
+++ b/frontend/src/renderer/lib/pipeline-graph.ts
@@ -110,13 +110,19 @@ export function draftEdges(draft: PipelineDraft): DraftEdge[] {
 }
 
 // layoutPositions runs dagre left-to-right (execution order flows rightwards)
-// and returns top-left positions keyed by node id.
-export function layoutPositions(draft: PipelineDraft): Record<string, StagePosition> {
+// and returns top-left positions keyed by node id. `size` is the node footprint
+// the layout reserves; it defaults to the editor's card so callers that render
+// a different node (the read-only run graph's compact row) can space their own
+// nodes correctly without a second dagre setup.
+export function layoutPositions(
+	draft: PipelineDraft,
+	size: { width: number; height: number } = { width: STAGE_NODE_WIDTH, height: STAGE_NODE_HEIGHT },
+): Record<string, StagePosition> {
 	const g = new dagre.graphlib.Graph();
 	g.setGraph({ rankdir: "LR", nodesep: 32, ranksep: 64 });
 	g.setDefaultEdgeLabel(() => ({}));
 	draft.stages.forEach((_stage, i) => {
-		g.setNode(stageNodeId(i), { width: STAGE_NODE_WIDTH, height: STAGE_NODE_HEIGHT });
+		g.setNode(stageNodeId(i), { width: size.width, height: size.height });
 	});
 	for (const edge of draftEdges(draft)) g.setEdge(edge.source, edge.target);
 	dagre.layout(g);
@@ -125,9 +131,38 @@ export function layoutPositions(draft: PipelineDraft): Record<string, StagePosit
 	draft.stages.forEach((_stage, i) => {
 		const id = stageNodeId(i);
 		const node = g.node(id);
-		if (node) positions[id] = { x: node.x - STAGE_NODE_WIDTH / 2, y: node.y - STAGE_NODE_HEIGHT / 2 };
+		if (node) positions[id] = { x: node.x - size.width / 2, y: node.y - size.height / 2 };
 	});
 	return positions;
+}
+
+// --- edge treatments ---------------------------------------------------------
+
+// edgeAppearance is the three-way visual split the graph's edge kinds need:
+// on_success solid in the accent, on_failure dashed in the destructive tone,
+// and the synthetic defaults.on_failure edge dashed in a faded version of the
+// same tone (it is inherited boilerplate, so it must not compete with the
+// routes the author actually wrote). A cycle overrides all three: the edge is
+// already invalid, so what kind it was stops mattering.
+//
+// The synthetic edge fades through its color rather than through `opacity` so
+// that its arrowhead marker, which does not inherit path opacity, fades with
+// the line instead of staying solid.
+//
+// It lives here rather than on the editor canvas because the read-only run
+// graph draws the same edge kinds and must not diverge from the editor.
+export function edgeAppearance(
+	kind: EdgeKind,
+	inCycle: boolean,
+): { stroke: string; strokeWidth: number; strokeDasharray?: string } {
+	if (inCycle) return { stroke: "var(--color-error)", strokeWidth: 2, strokeDasharray: "6 4" };
+	if (kind === "success") return { stroke: "var(--color-accent)", strokeWidth: 2 };
+	if (kind === "failure") return { stroke: "var(--color-destructive)", strokeWidth: 1.75, strokeDasharray: "6 4" };
+	return {
+		stroke: "color-mix(in oklab, var(--color-destructive) 45%, transparent)",
+		strokeWidth: 1.5,
+		strokeDasharray: "3 5",
+	};
 }
 
 // --- cycles -----------------------------------------------------------------


### PR DESCRIPTION
Pipelines v2 UI. Run detail restyled to GitHub Actions' run page, with a read-only stage graph on the existing react-flow plus dagre setup. Closes #341.

Mapping throughout: **workflow = pipeline definition, job = stage, workflow run = pipeline run.**

## What the screen is now

**Header.** `← Runs` breadcrumb, the run's status glyph, the pipeline name, the run id, and the primary action on the right. A live run gets a red `Cancel workflow`; a settled run gets no action at all (v2 has no re-run, and #333's rule that a settled run is a record stands), and its title drops to the muted tone, which is the "GitHub greys a settled header" behaviour in this app's palette.

**Left rail.** `Summary`, then `All jobs` with a status glyph per stage, then `Run details`. Picking a stage marks the rail entry, rings its node in the graph, and scrolls its detail card into view; `Summary` scrolls back to the top. GitHub's `Usage` has no analogue (the daemon bills nothing), so `Run details` carries the two things a human actually goes looking for: the pipeline definition and the run folder.

**Summary card.** GitHub's four fields: triggered via (subject kind, the subject itself, created and settled), status, total duration, artifacts. `Artifacts` counts the stages whose declared file is verified present in the run folder, so it moves with `producedArtifact.exists` rather than with what was declared.

**Stage graph card.** Header line is the pipeline name and `on: pr.created, pr.updated`, matching GitHub's `frontend.yml / on: pull_request`. Below it, a node per stage of the run carrying its outcome glyph and duration, wired by the definition's routing, with fit and zoom controls in the corner. Read-only: not connectable, not draggable, no delete key, no add-stage or auto-layout panel, handles hidden.

**Per-stage detail** below, which is where everything #333 built keeps living.

## Where the graph's data comes from

The run DTO names its pipeline but carries neither its routing nor its triggers, so the graph reads both off `GET /api/v1/pipelines?project=` (the definitions the definitions page has usually already cached) and parses the YAML with the editor's own `parseYamlToDraft`.

Nodes come from the run and edges from the definition, which is the only pairing that stays honest when the definition has been edited since the run: a stage the run does not have cannot appear, and a route to a stage that is not in the run is dropped by `draftEdges` rather than drawn into nothing. When the definition cannot be loaded at all (deleted, or a run opened with no project scope) every stage still gets a node and the header line says `routing unavailable: this run's pipeline definition could not be loaded` instead of showing an edgeless graph as if that were the shape of the pipeline.

## Extracted from the editor canvas

Two additive changes so the run graph reuses the editor's graph code rather than forking it:

- `edgeAppearance` moved from `PipelineCanvas.tsx` to `lib/pipeline-graph.ts` unchanged. It is a pure edge-kind lookup and both graphs draw the same three edge kinds; leaving it on the editor component would have meant the run graph either importing the editor or growing a second copy that could drift. `PipelineCanvas` imports it, its test imports it from the new home, and its behaviour is identical.
- `layoutPositions(draft, size?)` takes an optional node footprint, defaulting to the editor's card. The run graph's node is a compact row, not a config card, so it needs its own spacing; the editor's call site is unchanged.

Nothing else in `PipelineCanvas.tsx` moved. `PipelineWorkbench.tsx`, `PipelineRunCard.tsx` and `PipelineFilterBar.tsx` are untouched, and `lib/pipeline-display.ts` is untouched (the new status-glyph vocabulary lives in `PipelineRunGraph.tsx`, tone-matched to `stageOutcomeDotTone` so the graph, the rail and the board say the same thing about the same stage).

## Nothing #333 shipped regressed

Every one of its affordances is still on the screen and still tested: the collapsible log viewer over the log endpoint (fetch-on-open, 5s refetch while running, missing-file as empty rather than an error code, truncation notice, no button for a stage that never started), all three artifact states, the `nudged` tag at attempt 2, the `via <stage> failing` badge, the session link with the orphan `kept` marker and its Kill button, and the absence of resume and findings. Its 31 tests all still pass; the file is at 43.

Two deliberate changes to its copy:

- The cancel button is `Cancel workflow`, not `Cancel` (its test was updated to match).
- A project-subject run's subject line reads `manual trigger` rather than repeating the word `project` under `Triggered via project`.

## Live verification

Real engine, real runs, no seeded DTOs. A second daemon built from this branch (`AO_PORT=3157`, `AO_DATA_DIR=/tmp/ao-157/data`, `AO_PIPELINES=on`), the daemon's own scratch project, and the renderer served by vite against it, driven through a headless chromium so the screen could actually be read back. What rendered:

1. **Fan-out, join and failure routing.** A five-stage `frontend` pipeline (`build → test, lint`; `lint → publish`; `defaults.on_failure: notify-failure`). Graph drew build at rank 0, test and lint at rank 1, publish and notify-failure downstream, success edges solid in the accent and the inherited default-failure edges faint and dashed. Header `on: pr.created, pr.updated`. Summary read `failed`, `10s`, `Artifacts None`. Stage cards: build succeeded 4s, test failed 4s `command exited 1`, lint and publish succeeded, notify-failure succeeded with `via test failing`.
2. **Focus.** Clicking `test` in the rail marked the rail entry, ringed the `test` node in the graph, ringed and scrolled to the `test` card; opening its log showed the real captured stdout (`check 4 of 7 failed: ...`) and the button flipped to `Hide log`.
3. **Live run and cancel.** A `release` pipeline with a 120s soak stage rendered the accent running glyph, `not settled`, `running for 12s`, a red `Cancel workflow`, and pending downstream stages. Clicking Cancel settled it: header `cancelled from the API`, `soak cancelled`, `ship`/`notify-failure` skipped, button gone, header greyed.
4. **timed_out.** An agent stage on the `fake` harness with a 2m deadline settled `timed out` / `deadline exceeded`, routed to notify-failure, and showed `review.md is not in the run folder.` (the settled-but-missing artifact state, distinct from `no_output`). #333 could not drive this one live.
5. **Artifact link.** Writing `agent-outputs/review.md` into that run folder flipped `producedArtifact.exists` on the next poll: the row rendered the accent link through the outputs endpoint (which serves the file, 200) and the summary's `Artifacts` field went from `None` to `1`.
6. **Nudge and no_output.** Signalling the agent stage done with no artifact nudged it: `attempt 2` plus the `nudged` badge while it re-ran, then `no output` with `declared artifact agent-outputs/review.md is missing or empty` and `review.md is missing: the agent signalled done and the file was not there.`, `post-review skipped`, `notify-failure succeeded via review failing`.

No console errors on any of these screens.

**Not driven live:** `succeeded_unverified` and `no_signal`, and the `kept` badge plus `Kill session` button. The last one is a limitation of the browser preview, not of the code: under `VITE_NO_ELECTRON=1` the workspace query returns mock workspaces, so `useSessionFacts` cannot resolve the real session behind a stage and the orphan marker has nothing to match against. That path is unchanged from #333 and is covered by its three orphan tests (matched, foreign-run, terminated) plus the kill call.

## Verification

- Full renderer build (`vite build`) green, `tsc --noEmit` clean, `typecheck:e2e` clean, **1373 renderer tests pass** with no unhandled errors.
- 43 tests on this component, up from 31: every #333 assertion kept, plus the summary card's four fields and its artifact count, the rail's three groups and its focus behaviour, the back link and the definition entry, and the graph's nodes, durations, trigger line, manual-trigger line, definition-missing fallback, read-only affordances and node-click focus.
- Mutation-checked the graph tests that could most easily be vacuous: dropping the definition parse fails exactly the three tests that claim to cover routing and triggers (`ranks a stage after the stage that routes into it`, `names the pipeline and the triggers it runs on above the graph`, `says a definition with no triggers only runs when asked`) and nothing else. The ranking test reads dagre's own output off the node transform, so it can only pass if the definition's edges reached the layout.

## Notes for review

- **No run number.** GitHub's header carries `#199`; `PipelineRunDetail` exposes no run number, so the run id sits in that slot. Adding one is backend work this PR does not touch, per the brief.
- **Prettier.** The brief asked for prettier-clean changed files, but #3090 removed the repo's prettier setup and no CI job runs it, so there is no config for these files to be clean against. The new file matches the surrounding style (tabs, ~125 columns); the pre-existing files in this diff are byte-identical to their base under any prettier invocation I tried.
