### PR TITLE
fix(pipelines): reap a lost command stage's process group on restart

### DIFF
--- a/backend/internal/pipeline/engine/engine.go
+++ b/backend/internal/pipeline/engine/engine.go
@@ -85,6 +85,12 @@ type Config struct {
 	// plan-time unknown-name check is skipped and a stage declaring
 	// credentials fails to launch.
 	Credentials Credentials
+	// ProcessGroups reaps the process group of a command stage a previous
+	// daemon left running, so restart reconciliation does not settle a stage
+	// and leak its work. Defaults to the OS reaper: a nil here would make the
+	// leak come back silently, and the OS reaper is safe to run against a
+	// stage that recorded no group.
+	ProcessGroups executors.ProcessGroupReaper
 	// BaseDir is the run-folder root, <AO_DATA_DIR>/pipelines. No app state
 	// ever lands anywhere else.
 	BaseDir string
@@ -121,6 +127,7 @@ type Engine struct {
 	orphans     *OrphanRegistry
 	messenger   executors.SessionMessenger
 	creds       Credentials
+	procGroups  executors.ProcessGroupReaper
 	baseDir     string
 	concurrency *ConcurrencyTable
 	startQueued func(pendingTrigger)
@@ -164,6 +171,7 @@ func New(cfg Config) *Engine {
 		orphans:      cfg.Orphans,
 		messenger:    cfg.Messenger,
 		creds:        cfg.Credentials,
+		procGroups:   cfg.ProcessGroups,
 		baseDir:      cfg.BaseDir,
 		concurrency:  cfg.Concurrency,
 		startQueued:  cfg.StartQueued,
@@ -190,6 +198,9 @@ func New(cfg Config) *Engine {
 	}
 	if e.concurrency == nil {
 		e.concurrency = &ConcurrencyTable{}
+	}
+	if e.procGroups == nil {
+		e.procGroups = executors.NewProcessGroupReaper()
 	}
 	if e.tickInterval <= 0 {
 		e.tickInterval = defaultTickInterval
@@ -575,9 +586,16 @@ func (e *Engine) startStage(runID pipeline.RunID, eff pipeline.StartStage) {
 	if holder, ok := handle.(executors.SessionHolder); ok {
 		sessionID = holder.SessionID()
 	}
+	// The process group is what a later daemon reaps by: this handle is the
+	// only other thing that can stop the work, and it dies with this process.
+	pgid := 0
+	if holder, ok := handle.(executors.ProcessGroupHolder); ok {
+		pgid = holder.ProcessGroup()
+	}
 	e.dispatch(runID, pipeline.StageLaunched{
 		Stage:         eff.Stage,
 		SessionID:     sessionID,
+		PGID:          pgid,
 		WorkspacePath: path,
 		Now:           e.now(),
 	})
@@ -958,24 +976,32 @@ func (e *Engine) reconcileLostStages() {
 			if _, live := e.inflight[stageKey{RunID: runID, Stage: stageID}]; live {
 				continue
 			}
-			e.dispatch(runID, lostStageEvent(run.Def.StageByID(stageID), stageID, e.now()))
+			e.dispatch(runID, e.lostStageEvent(run.Def.StageByID(stageID), stageID, st))
 		}
 	}
 }
 
 // lostStageEvent is the honest settlement for a stage whose handle died with
-// the previous process.
-func lostStageEvent(def *pipeline.Stage, stageID string, now time.Time) pipeline.Event {
+// the previous process. A command stage's process group is reaped before it
+// settles, because settling a stage while its work keeps running is the one
+// outcome worse than either: the reap's finding goes into the reason so the
+// stage says what actually happened to its process.
+func (e *Engine) lostStageEvent(def *pipeline.Stage, stageID string, st *pipeline.StageState) pipeline.Event {
+	now := e.now()
 	if def != nil && def.Executor == pipeline.ExecutorAgent {
 		// no_signal: the session may well still be alive, but nothing in this
-		// process is listening to it any more.
+		// process is listening to it any more. Agent stages are not reaped
+		// here; session teardown owns them.
 		return pipeline.SessionGone{Stage: stageID, Now: now}
 	}
-	return pipeline.StageLaunchFailed{
-		Stage:  stageID,
-		Reason: "the pipeline engine restarted while this stage was running; its process handle is lost",
-		Now:    now,
+	reason := "the pipeline engine restarted while this stage was running; its process handle is lost"
+	if clause, leaked := e.procGroups.Reap(st.PGID, st.StartedAt); clause != "" {
+		reason += "; " + clause
+		if leaked {
+			e.log.Error("pipeline stage process group left running", "stage", stageID, "pgid", st.PGID, "detail", clause)
+		}
 	}
+	return pipeline.StageLaunchFailed{Stage: stageID, Reason: reason, Now: now}
 }
 
 // pruneInflight drops handles for stages that have settled, so a later poll

--- a/backend/internal/pipeline/engine/engine_test.go
+++ b/backend/internal/pipeline/engine/engine_test.go
@@ -36,6 +36,18 @@ func (h *fakeHandle) StageID() string       { return h.in.Stage.ID }
 func (h *fakeHandle) Attempt() int          { return h.in.Attempt }
 func (h *fakeHandle) SessionID() string     { return "sess-" + h.in.Stage.ID }
 
+// fakeHandlePGID is the group every fake command stage claims to run in.
+const fakeHandlePGID = 7331
+
+// ProcessGroup mirrors the real handles: a command stage runs in a process
+// group of its own, an agent stage runs in a session and has none.
+func (h *fakeHandle) ProcessGroup() int {
+	if h.in.Stage.Executor == pipeline.ExecutorCommand {
+		return fakeHandlePGID
+	}
+	return 0
+}
+
 // fakeExecutor records every Start and replays scripted poll results.
 type fakeExecutor struct {
 	mu      sync.Mutex
@@ -239,6 +251,34 @@ func (s *fakeSessions) Kill(_ context.Context, sessionID string) error {
 	defer s.mu.Unlock()
 	s.killed = append(s.killed, sessionID)
 	return nil
+}
+
+// fakeReaper records every process group reconciliation asked it about, so a
+// test can assert what was reaped without a real process anywhere near it.
+// The clause it returns stands in for whatever the OS reaper would have found.
+type fakeReaper struct {
+	mu     sync.Mutex
+	calls  []reapCall
+	clause string
+	leaked bool
+}
+
+type reapCall struct {
+	pgid      int
+	startedAt time.Time
+}
+
+func (r *fakeReaper) Reap(pgid int, startedAt time.Time) (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, reapCall{pgid: pgid, startedAt: startedAt})
+	return r.clause, r.leaked
+}
+
+func (r *fakeReaper) reaped() []reapCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]reapCall(nil), r.calls...)
 }
 
 // fakeCredentials serves engine-held credentials from a map.
@@ -785,6 +825,139 @@ func TestRestartSettlesLostCommandStageAsFailed(t *testing.T) {
 	}
 	if ids := execs.startedIDs(); len(ids) != 1 || ids[0] != "diagnose" {
 		t.Fatalf("started %v, want the failure target", ids)
+	}
+}
+
+// A launched command stage records the process group it runs in. That id is
+// the only thing a later daemon can find the work by, so it has to be on the
+// stage before anything else can go wrong.
+func TestLaunchedCommandStageRecordsItsProcessGroup(t *testing.T) {
+	h := newHarness(t)
+	runID := h.trigger(t, failureRouteYAML, userSessionSubject())
+
+	run, _ := h.engine.Run(runID)
+	if got := run.Stages["build"].PGID; got != fakeHandlePGID {
+		t.Fatalf("build pgid = %d, want %d from the command handle", got, fakeHandlePGID)
+	}
+	if run.Stages["build"].StartedAt.IsZero() {
+		t.Fatal("a recorded pgid with no start time cannot be identity checked")
+	}
+}
+
+// The leak this fixes: reconciliation settled the stage and left its process
+// running. The reap goes first, and its finding is in the reason, so the stage
+// says what actually happened to the work it was doing.
+func TestRestartReapsALostCommandStageProcessGroup(t *testing.T) {
+	base := t.TempDir()
+	store := newFakeStore()
+	cfg, err := pipeline.ParseDefinition([]byte(failureRouteYAML))
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	launchedAt := time.Date(2026, 7, 26, 12, 30, 0, 0, time.UTC)
+	store.hydra = []pipeline.RunState{{
+		RunID:        "run-lost",
+		ProjectID:    "proj-1",
+		PipelineName: cfg.Name,
+		Subject:      userSessionSubject(),
+		Status:       pipeline.RunRunning,
+		RunDir:       filepath.Join(base, "pipelines", "proj-1", "run-lost"),
+		Def:          *cfg,
+		Stages: map[string]*pipeline.StageState{
+			"build":    {ID: "build", Outcome: pipeline.OutcomeRunning, Attempt: 1, StartedAt: launchedAt, PGID: 48211},
+			"diagnose": {ID: "diagnose", Outcome: pipeline.OutcomePending},
+		},
+	}}
+	if err := os.MkdirAll(filepath.Join(base, "pipelines", "proj-1", "run-lost"), 0o750); err != nil {
+		t.Fatalf("seed run dir: %v", err)
+	}
+
+	reaper := &fakeReaper{clause: "its process group 48211 was still alive and has been killed"}
+	eng := New(Config{
+		ProjectID:     "proj-1",
+		Store:         store,
+		Executors:     newFakeExecutor(),
+		Workspaces:    newFakeProvisioner(filepath.Join(base, "trees")),
+		Sessions:      &fakeSessions{},
+		Messenger:     &fakeMessenger{},
+		ProcessGroups: reaper,
+		BaseDir:       filepath.Join(base, "pipelines"),
+		TickInterval:  time.Hour,
+	})
+	if err := eng.Start(context.Background()); err != nil {
+		t.Fatalf("start engine: %v", err)
+	}
+	t.Cleanup(func() { _ = eng.Stop(context.Background()) })
+
+	calls := reaper.reaped()
+	if len(calls) != 1 {
+		t.Fatalf("reaped %d groups, want exactly the lost command stage's", len(calls))
+	}
+	// The pair the identity check runs on: the persisted group and the moment
+	// the stage recorded launching it.
+	if calls[0].pgid != 48211 || !calls[0].startedAt.Equal(launchedAt) {
+		t.Fatalf("reaped (%d, %s), want (48211, %s)", calls[0].pgid, calls[0].startedAt, launchedAt)
+	}
+
+	run, _ := eng.Run("run-lost")
+	if got := run.Stages["build"].Outcome; got != pipeline.OutcomeFailed {
+		t.Fatalf("build outcome = %q, want failed", got)
+	}
+	if got := run.Stages["build"].Reason; !strings.Contains(got, reaper.clause) {
+		t.Fatalf("build reason = %q, want it to carry what the reap found", got)
+	}
+}
+
+// An agent stage is a session, and session teardown already owns it: a reap
+// keyed on a stage that never recorded a process group has nothing right to
+// kill.
+func TestRestartDoesNotReapALostAgentStage(t *testing.T) {
+	base := t.TempDir()
+	store := newFakeStore()
+	cfg, err := pipeline.ParseDefinition([]byte(failureRouteYAML))
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	store.hydra = []pipeline.RunState{{
+		RunID:        "run-lost",
+		ProjectID:    "proj-1",
+		PipelineName: cfg.Name,
+		Subject:      userSessionSubject(),
+		Status:       pipeline.RunRunning,
+		RunDir:       filepath.Join(base, "pipelines", "proj-1", "run-lost"),
+		Def:          *cfg,
+		Stages: map[string]*pipeline.StageState{
+			"build":    {ID: "build", Outcome: pipeline.OutcomeSucceeded, Attempt: 1},
+			"diagnose": {ID: "diagnose", Outcome: pipeline.OutcomeRunning, Attempt: 1, SessionID: "sess-old"},
+		},
+	}}
+	if err := os.MkdirAll(filepath.Join(base, "pipelines", "proj-1", "run-lost"), 0o750); err != nil {
+		t.Fatalf("seed run dir: %v", err)
+	}
+
+	reaper := &fakeReaper{}
+	eng := New(Config{
+		ProjectID:     "proj-1",
+		Store:         store,
+		Executors:     newFakeExecutor(),
+		Workspaces:    newFakeProvisioner(filepath.Join(base, "trees")),
+		Sessions:      &fakeSessions{},
+		Messenger:     &fakeMessenger{},
+		ProcessGroups: reaper,
+		BaseDir:       filepath.Join(base, "pipelines"),
+		TickInterval:  time.Hour,
+	})
+	if err := eng.Start(context.Background()); err != nil {
+		t.Fatalf("start engine: %v", err)
+	}
+	t.Cleanup(func() { _ = eng.Stop(context.Background()) })
+
+	if calls := reaper.reaped(); len(calls) != 0 {
+		t.Fatalf("reaped %+v, want nothing for an agent stage", calls)
+	}
+	run, _ := eng.Run("run-lost")
+	if got := run.Stages["diagnose"].Outcome; got != pipeline.OutcomeNoSignal {
+		t.Fatalf("diagnose outcome = %q, want no_signal", got)
 	}
 }
 

--- a/backend/internal/pipeline/events.go
+++ b/backend/internal/pipeline/events.go
@@ -44,8 +44,12 @@ func (TriggerFired) isEvent()          {}
 // StageLaunched reports that the driver provisioned the stage's workspace and
 // started its executor.
 type StageLaunched struct {
-	Stage         string
-	SessionID     string
+	Stage     string
+	SessionID string
+	// PGID is the process group a command stage was started in, 0 when it has
+	// none. It is carried on the same event as Now so the stage's recorded
+	// start time always describes the process the group id names.
+	PGID          int
 	WorkspacePath string
 	Now           time.Time
 }

--- a/backend/internal/pipeline/executors/command.go
+++ b/backend/internal/pipeline/executors/command.go
@@ -49,6 +49,11 @@ type commandHandle struct {
 	log   *stageLog
 }
 
+// ProcessGroup returns the group the command was started in, so the driver can
+// persist it against the stage. Restart reconciliation is the only reader: it
+// is the one thing that can still find this work after the handle is gone.
+func (h *commandHandle) ProcessGroup() int { return h.child.PGID() }
+
 // OutputTail returns the capped copy of the stage's output.
 func (h *commandHandle) OutputTail() (string, bool) {
 	if h.log == nil {

--- a/backend/internal/pipeline/executors/command_test.go
+++ b/backend/internal/pipeline/executors/command_test.go
@@ -16,15 +16,18 @@ import (
 // what it wrote, and observes whether it was killed.
 type fakeProcess struct {
 	done chan struct{}
+	pgid int
 
 	mu     sync.Mutex
 	result CommandResult
 	kills  int
 }
 
-func newFakeProcess() *fakeProcess { return &fakeProcess{done: make(chan struct{})} }
+func newFakeProcess() *fakeProcess { return &fakeProcess{done: make(chan struct{}), pgid: 4242} }
 
 func (p *fakeProcess) Done() <-chan struct{} { return p.done }
+
+func (p *fakeProcess) PGID() int { return p.pgid }
 
 func (p *fakeProcess) Result() CommandResult {
 	p.mu.Lock()

--- a/backend/internal/pipeline/executors/executor.go
+++ b/backend/internal/pipeline/executors/executor.go
@@ -88,6 +88,11 @@ type OutputTailer interface {
 	OutputTail() (text string, truncated bool)
 }
 
+// ProcessGroupHolder is implemented by handles whose stage runs in an OS
+// process group of its own. An agent stage runs in a session and implements
+// nothing here: session teardown already owns it.
+type ProcessGroupHolder interface{ ProcessGroup() int }
+
 // stageIdentity is embedded in every concrete handle to satisfy the Handle
 // accessors without repetition.
 type stageIdentity struct {
@@ -153,6 +158,16 @@ func (h setHandle) SessionID() string {
 		return holder.SessionID()
 	}
 	return ""
+}
+
+// ProcessGroup forwards to the wrapped handle when the stage runs in one, so
+// the driver can persist it from StageLaunched without unwrapping the routing
+// layer. An agent stage has no process group and returns 0.
+func (h setHandle) ProcessGroup() int {
+	if holder, ok := h.inner.(ProcessGroupHolder); ok {
+		return holder.ProcessGroup()
+	}
+	return 0
 }
 
 func (s *Set) executorFor(kind pipeline.ExecutorKind) (StageExecutor, error) {

--- a/backend/internal/pipeline/executors/reaper.go
+++ b/backend/internal/pipeline/executors/reaper.go
@@ -1,0 +1,28 @@
+package executors
+
+import "time"
+
+// ProcessGroupReaper terminates a process group a previous daemon started and
+// then lost. Restart reconciliation settles such a stage, but the handle that
+// could stop it died with the process that held it (decision D16), so without
+// this the settled stage's work keeps running unowned.
+//
+// Reap is deliberately timid about pid reuse: a pgid recorded before a reboot
+// can name something else entirely afterwards, and killing a stranger's process
+// group is far worse than leaking one of ours. When it cannot confirm the group
+// is the one the stage launched, it leaves it running and says so.
+type ProcessGroupReaper interface {
+	// Reap terminates process group pgid when its leader still looks like the
+	// process launched at startedAt. clause is the honest phrase for the
+	// stage's settle reason, empty when there was no group to reap at all;
+	// leaked is true when a live group had to be left running.
+	Reap(pgid int, startedAt time.Time) (clause string, leaked bool)
+}
+
+// reapStartSkew is how far the OS-reported start time of a process group's
+// leader may sit from the moment the engine recorded launching it before the
+// group counts as somebody else's. The two are stamped within milliseconds of
+// each other, so the window only has to cover spawn latency and the one-second
+// resolution ps reports a start time at. Anything wider starts admitting the
+// reused pid it exists to exclude.
+const reapStartSkew = 5 * time.Second

--- a/backend/internal/pipeline/executors/reaper_unix.go
+++ b/backend/internal/pipeline/executors/reaper_unix.go
@@ -1,0 +1,70 @@
+//go:build !windows
+
+package executors
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// psStartLayout is the format `ps -o lstart=` prints under LC_ALL=C on both
+// macOS and Linux, for instance "Mon Jul 27 19:27:59 2026". The day of month is
+// space padded, which _2 accepts.
+const psStartLayout = "Mon Jan _2 15:04:05 2006"
+
+// osProcessGroupReaper is the production ProcessGroupReaper.
+type osProcessGroupReaper struct{}
+
+// NewProcessGroupReaper builds the production reaper.
+func NewProcessGroupReaper() ProcessGroupReaper { return osProcessGroupReaper{} }
+
+// Reap kills the group only when the group leader's start time, which the
+// kernel keeps across an exec, matches the moment the stage was launched. That
+// is the identity check: `sh -c cmd` usually execs into cmd, so the leader's
+// argv is not stable across the life of a stage, but its start time is.
+func (osProcessGroupReaper) Reap(pgid int, startedAt time.Time) (string, bool) {
+	if pgid <= 0 {
+		return "", false
+	}
+	// Signal 0 against the whole group. ESRCH means every member is gone, so
+	// there is nothing to reap and nothing to be careful about. EPERM means the
+	// group exists but belongs to another user, which the identity check below
+	// is about to reject anyway.
+	if err := syscall.Kill(-pgid, 0); err != nil && !errors.Is(err, syscall.EPERM) {
+		return fmt.Sprintf("its process group %d had already exited", pgid), false
+	}
+	started, ok := processStartTime(pgid)
+	if !ok {
+		// The group still has members but its leader is gone, so nothing is
+		// left to identify it by. Leak it rather than guess.
+		return fmt.Sprintf("its process group %d is still alive but its leader is gone, so it could not be identified and was left running", pgid), true
+	}
+	if skew := started.Sub(startedAt); skew > reapStartSkew || skew < -reapStartSkew {
+		return fmt.Sprintf("process group %d now leads a process started at %s, not the one launched at %s, so it was left running",
+			pgid, started.UTC().Format(time.RFC3339), startedAt.UTC().Format(time.RFC3339)), true
+	}
+	killProcessGroup(pgid)
+	return fmt.Sprintf("its process group %d was still alive and has been killed", pgid), false
+}
+
+// processStartTime asks ps when pid started. LC_ALL=C pins lstart's format,
+// which is otherwise locale dependent. A pid with no row, or a row that does
+// not parse, reports not-found: every caller treats that as "cannot identify".
+func processStartTime(pid int) (time.Time, bool) {
+	cmd := exec.Command("ps", "-o", "lstart=", "-p", strconv.Itoa(pid))
+	cmd.Env = append(cmd.Environ(), "LC_ALL=C")
+	out, err := cmd.Output()
+	if err != nil {
+		return time.Time{}, false
+	}
+	started, err := time.ParseInLocation(psStartLayout, strings.TrimSpace(string(out)), time.Local)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return started, true
+}

--- a/backend/internal/pipeline/executors/reaper_unix_test.go
+++ b/backend/internal/pipeline/executors/reaper_unix_test.go
@@ -3,6 +3,7 @@
 package executors
 
 import (
+	"errors"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -22,15 +23,25 @@ func startGroup(t *testing.T) (pgid int, startedAt time.Time) {
 		t.Fatalf("start group: %v", err)
 	}
 	pgid = processGroupID(cmd)
+	// Reap the child as it exits, the way the real runner's wait goroutine
+	// does. Without it a killed child lingers as a zombie, which still answers
+	// signal 0 on Linux and would read as a group that survived the reap.
+	waited := make(chan struct{})
+	go func() { defer close(waited); _ = cmd.Wait() }()
 	t.Cleanup(func() {
 		_ = syscall.Kill(-pgid, syscall.SIGKILL)
-		_ = cmd.Wait()
+		<-waited
 	})
 	return pgid, startedAt
 }
 
-// groupAlive reports whether any member of the process group is still around.
-func groupAlive(pgid int) bool { return syscall.Kill(-pgid, 0) == nil }
+// groupAlive reports whether any member of the process group is still around,
+// on the same terms the reaper reads: EPERM means it exists and is somebody
+// else's, which is still alive.
+func groupAlive(pgid int) bool {
+	err := syscall.Kill(-pgid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
 
 // waitGroupGone polls for the group to disappear. The reaper's SIGTERM is
 // asynchronous, so the assertion has to wait for the signal to land.

--- a/backend/internal/pipeline/executors/reaper_unix_test.go
+++ b/backend/internal/pipeline/executors/reaper_unix_test.go
@@ -1,0 +1,130 @@
+//go:build !windows
+
+package executors
+
+import (
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// startGroup spawns a shell that sleeps in a process group of its own, the way
+// a command stage's `run:` block does, and returns its pgid and the moment it
+// was launched. The child is killed on cleanup whether or not the test reaps it.
+func startGroup(t *testing.T) (pgid int, startedAt time.Time) {
+	t.Helper()
+	cmd := exec.Command("sh", "-c", "sleep 60")
+	configureProcAttr(cmd)
+	startedAt = time.Now().UTC()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start group: %v", err)
+	}
+	pgid = processGroupID(cmd)
+	t.Cleanup(func() {
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		_ = cmd.Wait()
+	})
+	return pgid, startedAt
+}
+
+// groupAlive reports whether any member of the process group is still around.
+func groupAlive(pgid int) bool { return syscall.Kill(-pgid, 0) == nil }
+
+// waitGroupGone polls for the group to disappear. The reaper's SIGTERM is
+// asynchronous, so the assertion has to wait for the signal to land.
+func waitGroupGone(t *testing.T, pgid int) bool {
+	t.Helper()
+	for range 100 {
+		if !groupAlive(pgid) {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+func TestReapKillsALiveProcessGroup(t *testing.T) {
+	pgid, startedAt := startGroup(t)
+
+	clause, leaked := NewProcessGroupReaper().Reap(pgid, startedAt)
+
+	if leaked {
+		t.Fatalf("leaked a group it launched itself: %q", clause)
+	}
+	if !strings.Contains(clause, "killed") {
+		t.Fatalf("clause = %q, want it to say the group was killed", clause)
+	}
+	if !waitGroupGone(t, pgid) {
+		t.Fatal("process group survived the reap")
+	}
+}
+
+// The pid-reuse guard. A pgid recorded before a reboot can name a stranger's
+// process afterwards, and killing that is far worse than leaking ours: a start
+// time that does not match what the stage recorded means hands off.
+func TestReapLeavesAGroupWhoseStartTimeDoesNotMatch(t *testing.T) {
+	pgid, startedAt := startGroup(t)
+
+	clause, leaked := NewProcessGroupReaper().Reap(pgid, startedAt.Add(-2*time.Hour))
+
+	if !leaked {
+		t.Fatalf("reaped a group that failed the identity check: %q", clause)
+	}
+	if !strings.Contains(clause, "left running") {
+		t.Fatalf("clause = %q, want it to say the group was left running", clause)
+	}
+	// Give any stray signal the same window a real kill would have needed.
+	time.Sleep(100 * time.Millisecond)
+	if !groupAlive(pgid) {
+		t.Fatal("a group that failed the identity check was killed anyway")
+	}
+}
+
+func TestReapOnAGroupThatAlreadyExited(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 0")
+	configureProcAttr(cmd)
+	startedAt := time.Now().UTC()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pgid := processGroupID(cmd)
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	clause, leaked := NewProcessGroupReaper().Reap(pgid, startedAt)
+
+	if leaked {
+		t.Fatalf("leaked = true for a group that is gone: %q", clause)
+	}
+	if !strings.Contains(clause, "already exited") {
+		t.Fatalf("clause = %q, want it to say the group had already exited", clause)
+	}
+}
+
+// A stage that recorded no group (an agent stage, or one that never launched)
+// has nothing to reap and nothing to say about it.
+func TestReapWithoutAProcessGroupIsSilent(t *testing.T) {
+	clause, leaked := NewProcessGroupReaper().Reap(0, time.Now())
+	if clause != "" || leaked {
+		t.Fatalf("Reap(0) = %q, %v; want an empty clause and no leak", clause, leaked)
+	}
+}
+
+func TestProcessStartTimeMatchesTheSpawnMoment(t *testing.T) {
+	pgid, startedAt := startGroup(t)
+
+	started, ok := processStartTime(pgid)
+	if !ok {
+		t.Fatal("ps reported no start time for a process that is running")
+	}
+	if skew := started.Sub(startedAt); skew > reapStartSkew || skew < -reapStartSkew {
+		t.Fatalf("start time %s is %s from the spawn at %s, more than the %s the reaper allows",
+			started, skew, startedAt, reapStartSkew)
+	}
+	if _, ok := processStartTime(-1); ok {
+		t.Fatal("processStartTime(-1) reported a start time")
+	}
+}

--- a/backend/internal/pipeline/executors/reaper_windows.go
+++ b/backend/internal/pipeline/executors/reaper_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package executors
+
+import "time"
+
+// osProcessGroupReaper is the production ProcessGroupReaper.
+type osProcessGroupReaper struct{}
+
+// NewProcessGroupReaper builds the production reaper.
+func NewProcessGroupReaper() ProcessGroupReaper { return osProcessGroupReaper{} }
+
+// Reap does nothing on Windows: configureProcAttr puts a command stage in no
+// process group there, so processGroupID never records one and pgid is always
+// 0. A Job Object would be the way to make this reapable, the same gap
+// killProcessTree already has.
+func (osProcessGroupReaper) Reap(int, time.Time) (string, bool) { return "", false }

--- a/backend/internal/pipeline/executors/runner.go
+++ b/backend/internal/pipeline/executors/runner.go
@@ -47,6 +47,8 @@ func (p *osProcess) Result() CommandResult {
 	return p.result
 }
 
+func (p *osProcess) PGID() int { return processGroupID(p.cmd) }
+
 func (p *osProcess) Kill() {
 	// Terminate the process group (SIGTERM then SIGKILL) so a shell's children
 	// die with it. Best-effort: a race with natural exit is benign.

--- a/backend/internal/pipeline/executors/runner_port.go
+++ b/backend/internal/pipeline/executors/runner_port.go
@@ -39,6 +39,10 @@ type CommandProcess interface {
 	Done() <-chan struct{}
 	Result() CommandResult
 	Kill()
+	// PGID is the id of the process group the command runs in, or 0 where the
+	// platform gave it none. It is persisted with the stage so a later daemon
+	// can reap a group this one would otherwise leak on restart.
+	PGID() int
 }
 
 // CommandRunner starts a subprocess for a command stage. The production impl

--- a/backend/internal/pipeline/executors/runner_unix.go
+++ b/backend/internal/pipeline/executors/runner_unix.go
@@ -15,21 +15,36 @@ func configureProcAttr(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
+// processGroupID returns the id of the process group the child leads.
+// configureProcAttr made it a group leader, so the group id is its pid.
+func processGroupID(cmd *exec.Cmd) int {
+	if cmd.Process == nil {
+		return 0
+	}
+	return cmd.Process.Pid
+}
+
 // killProcessTree sends SIGTERM to the child's process group, then escalates to
 // SIGKILL after a short grace. Best-effort: a process that already exited makes
 // the signals no-op.
+func killProcessTree(cmd *exec.Cmd) {
+	if pgid := processGroupID(cmd); pgid > 0 {
+		killProcessGroup(pgid)
+	}
+}
+
+// killProcessGroup terminates a process group, escalating SIGTERM to SIGKILL
+// after a short grace. The restart reaper shares it with killProcessTree
+// because a group left by a dead daemon deserves the same drain window as one
+// this process is tearing down itself.
 //
 // ponytail: fixed 2s grace; make it configurable only if a slow-draining shim
 // ever needs a longer window.
-func killProcessTree(cmd *exec.Cmd) {
-	if cmd.Process == nil {
-		return
-	}
-	pgid := cmd.Process.Pid
+func killProcessGroup(pgid int) {
 	_ = syscall.Kill(-pgid, syscall.SIGTERM)
-	go func(pid int) {
+	go func(pgid int) {
 		time.Sleep(2 * time.Second)
-		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
 	}(pgid)
 }
 

--- a/backend/internal/pipeline/executors/runner_windows.go
+++ b/backend/internal/pipeline/executors/runner_windows.go
@@ -11,6 +11,10 @@ import (
 // exec.CommandContext already terminates the child on ctx cancel.
 func configureProcAttr(cmd *exec.Cmd) {}
 
+// processGroupID returns 0 on Windows: configureProcAttr puts the child in no
+// group of its own, so there is none to record and none to reap later.
+func processGroupID(cmd *exec.Cmd) int { return 0 }
+
 // killProcessTree kills the child process. Best-effort.
 //
 // ponytail: single-process kill; a Job Object would be needed to reap a full

--- a/backend/internal/pipeline/reducer.go
+++ b/backend/internal/pipeline/reducer.go
@@ -155,6 +155,7 @@ func reduceStageLaunched(run RunState, e StageLaunched) (RunState, []Effect) {
 	st.Outcome = OutcomeRunning
 	st.StartedAt = e.Now
 	st.SessionID = e.SessionID
+	st.PGID = e.PGID
 	st.WorkspacePath = e.WorkspacePath
 	if st.Attempt == 0 {
 		st.Attempt = 1

--- a/backend/internal/pipeline/state.go
+++ b/backend/internal/pipeline/state.go
@@ -37,6 +37,13 @@ type StageState struct {
 	FailedOutcome Outcome `json:"failedOutcome,omitempty"`
 
 	SessionID string `json:"sessionId,omitempty"`
+	// PGID is the OS process group a command stage was launched in, 0 for an
+	// agent stage and on a platform that gives a command none. It is persisted
+	// because a daemon restart drops the handle that could stop the work:
+	// without the group id, reconciliation settles the stage and leaves its
+	// process running. Read together with StartedAt, which the same event
+	// stamps: the pair is what makes a reap safe against pid reuse.
+	PGID int `json:"pgid,omitempty"`
 	// WorkspaceKind is the resolved tree kind, never "auto", "inherit" or
 	// unset: those are plan-time symbols, resolved to a concrete kind by the
 	// time the stage launches.

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -190,6 +190,7 @@ type PipelineStageRun struct {
 	Reason        string
 	OutputTail    string
 	Nudged        int64
+	Pgid          int64
 }
 
 type PipelineStageSignal struct {

--- a/backend/internal/storage/sqlite/gen/pipeline.sql.go
+++ b/backend/internal/storage/sqlite/gen/pipeline.sql.go
@@ -358,7 +358,7 @@ func (q *Queries) ListPipelineRuns(ctx context.Context, arg ListPipelineRunsPara
 }
 
 const listPipelineStageRunsByRun = `-- name: ListPipelineStageRunsByRun :many
-SELECT run_id, project_id, stage_id, outcome, attempt, entered_via, prev_stage, failed_stage, failed_outcome, session_id, workspace_kind, workspace_path, deadline_at, started_at, settled_at, reason, output_tail, nudged FROM pipeline_stage_runs WHERE run_id = ? ORDER BY stage_id ASC
+SELECT run_id, project_id, stage_id, outcome, attempt, entered_via, prev_stage, failed_stage, failed_outcome, session_id, workspace_kind, workspace_path, deadline_at, started_at, settled_at, reason, output_tail, nudged, pgid FROM pipeline_stage_runs WHERE run_id = ? ORDER BY stage_id ASC
 `
 
 func (q *Queries) ListPipelineStageRunsByRun(ctx context.Context, runID string) ([]PipelineStageRun, error) {
@@ -389,6 +389,7 @@ func (q *Queries) ListPipelineStageRunsByRun(ctx context.Context, runID string) 
 			&i.Reason,
 			&i.OutputTail,
 			&i.Nudged,
+			&i.Pgid,
 		); err != nil {
 			return nil, err
 		}
@@ -594,8 +595,8 @@ const upsertPipelineStageRun = `-- name: UpsertPipelineStageRun :exec
 INSERT INTO pipeline_stage_runs (
     run_id, project_id, stage_id, outcome, attempt, entered_via, prev_stage,
     failed_stage, failed_outcome, session_id, workspace_kind, workspace_path,
-    deadline_at, started_at, settled_at, reason, output_tail, nudged
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    deadline_at, started_at, settled_at, reason, output_tail, nudged, pgid
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (run_id, stage_id) DO UPDATE SET
     outcome = excluded.outcome,
     attempt = excluded.attempt,
@@ -611,7 +612,8 @@ ON CONFLICT (run_id, stage_id) DO UPDATE SET
     settled_at = excluded.settled_at,
     reason = excluded.reason,
     output_tail = excluded.output_tail,
-    nudged = excluded.nudged
+    nudged = excluded.nudged,
+    pgid = excluded.pgid
 `
 
 type UpsertPipelineStageRunParams struct {
@@ -633,6 +635,7 @@ type UpsertPipelineStageRunParams struct {
 	Reason        string
 	OutputTail    string
 	Nudged        int64
+	Pgid          int64
 }
 
 // Pipeline stage runs --------------------------------------------------------
@@ -656,6 +659,7 @@ func (q *Queries) UpsertPipelineStageRun(ctx context.Context, arg UpsertPipeline
 		arg.Reason,
 		arg.OutputTail,
 		arg.Nudged,
+		arg.Pgid,
 	)
 	return err
 }

--- a/backend/internal/storage/sqlite/migrations/0050_pipeline_stage_run_pgid.sql
+++ b/backend/internal/storage/sqlite/migrations/0050_pipeline_stage_run_pgid.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- pgid is the OS process group a command stage was launched in. The engine's
+-- handle on that process dies with the daemon, so a restart could settle the
+-- stage as lost while its work kept running unowned; the group id is the only
+-- thing that lets the next boot find it and reap it. 0 means no group was
+-- recorded (an agent stage, a stage that never launched, or a platform that
+-- gives a command none).
+--
+-- Read with started_at, which is stamped by the same event: the pair is the
+-- identity check that keeps a reused pid from being killed as if it were ours.
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs ADD COLUMN pgid INTEGER NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs DROP COLUMN pgid;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/pipeline.sql
+++ b/backend/internal/storage/sqlite/queries/pipeline.sql
@@ -75,8 +75,8 @@ ORDER BY created_at ASC, id ASC;
 INSERT INTO pipeline_stage_runs (
     run_id, project_id, stage_id, outcome, attempt, entered_via, prev_stage,
     failed_stage, failed_outcome, session_id, workspace_kind, workspace_path,
-    deadline_at, started_at, settled_at, reason, output_tail, nudged
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    deadline_at, started_at, settled_at, reason, output_tail, nudged, pgid
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (run_id, stage_id) DO UPDATE SET
     outcome = excluded.outcome,
     attempt = excluded.attempt,
@@ -92,7 +92,8 @@ ON CONFLICT (run_id, stage_id) DO UPDATE SET
     settled_at = excluded.settled_at,
     reason = excluded.reason,
     output_tail = excluded.output_tail,
-    nudged = excluded.nudged;
+    nudged = excluded.nudged,
+    pgid = excluded.pgid;
 
 -- name: ListPipelineStageRunsByRun :many
 SELECT * FROM pipeline_stage_runs WHERE run_id = ? ORDER BY stage_id ASC;

--- a/backend/internal/storage/sqlite/store/pipeline_store.go
+++ b/backend/internal/storage/sqlite/store/pipeline_store.go
@@ -472,6 +472,7 @@ func stageUpsertParams(run pipeline.RunState, stageID string, st *pipeline.Stage
 		Reason:        st.Reason,
 		OutputTail:    st.OutputTail,
 		Nudged:        boolToInt64(run.Nudged[stageID]),
+		Pgid:          int64(st.PGID),
 	}
 }
 
@@ -492,6 +493,7 @@ func stageStateFromRow(r gen.PipelineStageRun) pipeline.StageState {
 		SettledAt:     timeFromNullTime(r.SettledAt),
 		Reason:        r.Reason,
 		OutputTail:    r.OutputTail,
+		PGID:          int(r.Pgid),
 	}
 }
 

--- a/backend/internal/storage/sqlite/store/pipeline_store_test.go
+++ b/backend/internal/storage/sqlite/store/pipeline_store_test.go
@@ -130,6 +130,7 @@ func prRun(now time.Time) pipeline.RunState {
 			WorkspacePath: "/runs/run-1/workspace",
 			DeadlineAt:    now.Add(20 * time.Minute),
 			StartedAt:     started,
+			PGID:          9000 + i,
 			Reason:        "because " + string(outcome),
 			OutputTail:    "tail for " + string(outcome),
 		}
@@ -349,6 +350,43 @@ func TestPipelineHydrateReturnsUnsettledRunsOnly(t *testing.T) {
 	}
 	if len(runs[0].Stages) != 1 || runs[0].Stages["entry"].Outcome != pipeline.OutcomeRunning {
 		t.Fatalf("hydrated run lost its stages: %+v", runs[0].Stages)
+	}
+}
+
+// A restart is the only reader of a stage's pgid, and by then the engine has
+// nothing but the row: if hydration drops it, reconciliation settles the stage
+// and leaks the process it was still running.
+func TestPipelineStageRunRoundTripsPGID(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	now := time.Now().UTC().Truncate(time.Second)
+
+	run := pipeline.RunState{
+		RunID: "run-pgid", ProjectID: "mer", PipelineID: "pl-review", PipelineName: "review",
+		Subject: pipeline.Subject{Kind: pipeline.SubjectProject, ProjectID: "mer"},
+		Status:  pipeline.RunRunning, Def: samplePipelineV2("review"),
+		Stages: map[string]*pipeline.StageState{
+			"build":  {ID: "build", Outcome: pipeline.OutcomeRunning, Attempt: 1, StartedAt: now, PGID: 48211},
+			"review": {ID: "review", Outcome: pipeline.OutcomeRunning, Attempt: 1, StartedAt: now, SessionID: "mer-1"},
+		},
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.SavePipelineRun(ctx, run); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	hydrated, err := s.HydratePipelineEngineState(ctx, "mer")
+	if err != nil || len(hydrated) != 1 {
+		t.Fatalf("hydrate: %d runs, err=%v", len(hydrated), err)
+	}
+	if got := hydrated[0].Stages["build"].PGID; got != 48211 {
+		t.Fatalf("build pgid = %d, want 48211", got)
+	}
+	// An agent stage records none, and a zero must stay a zero: a reap keyed on
+	// a bogus group id is exactly what the identity check exists to prevent.
+	if got := hydrated[0].Stages["review"].PGID; got != 0 {
+		t.Fatalf("review pgid = %d, want 0 for a stage that runs in a session", got)
 	}
 }
 


### PR DESCRIPTION
## The leak

`kill -9` the daemon mid-run, boot it again. Reconciliation correctly settles
the lost command stage `failed` and routes the failure (D16), but the OS
process it started keeps running: the handle that could stop it died with the
process that held it, and nothing else knew where the work was. The drill's
`sleep 300` was still alive afterwards with nothing tracking it.

## The fix

Command stages already run in their own process group. That group id is now
persisted alongside the stage, and on engine start reconciliation reaps it
**before** settling, recording what it found in the stage's reason:

> the pipeline engine restarted while this stage was running; its process
> handle is lost; its process group 48211 was still alive and has been killed

## Pid reuse

A pgid recorded before a reboot can name a stranger's process afterwards, and
killing that is far worse than leaking one of ours. The reap kills only when
the group leader's start time (via `ps -o lstart=` under `LC_ALL=C`) matches
the moment the stage recorded launching it, within 5s. Anything else leaks the
group and logs at `Error` with the group id and why.

The identity check is the start time rather than argv because `sh -c cmd`
usually execs into `cmd`, so the leader's argv is not stable across a stage's
life while its start time is. `PGID` and `StartedAt` are written by the same
event (`StageLaunched`), so the pair cannot drift apart.

Agent stages are untouched: those are sessions and session teardown owns them.
Windows records no group (`configureProcAttr` is a no-op there) so its reaper
is a no-op, the same gap `killProcessTree` already has.

## Changes

- `pipeline_stage_runs.pgid` (migration 0050) plus the sqlc query and mapping
- `StageState.PGID`, `StageLaunched.PGID`, set in `reduceStageLaunched`
- `executors.ProcessGroupReaper` with a unix impl, wired as the engine's
  default so a nil config cannot silently bring the leak back
- `CommandProcess.PGID()` and the `ProcessGroupHolder` handle interface
- `killProcessGroup` extracted from `killProcessTree` and shared with the reap

## Tests

- a stage row round-trips its pgid, and an agent stage's stays 0
- a launched command stage records its group and a start time
- reconciliation reaps the persisted group, with the finding in the reason
- reconciliation does not reap an agent stage at all
- the reaper kills a real live process group
- the reaper leaves a real group whose start time does not match, and it
  survives

## Verification

`go build ./...`, `go test ./...` (93 packages), `gofmt -l .` empty, and
`golangci-lint run` over the changed packages: 0 issues. The 45 findings a
whole-repo `golangci-lint run` reports locally are all in
`internal/storage/sqlite/gen/` and reproduce identically on
`origin/pipelines-upstream`.

## Risks

The 5s skew window is the one tunable. Too tight and a clock step between spawn
and reap makes us leak (safe direction); too wide and it starts admitting a
reused pid. It is documented at `reapStartSkew`.

Closes #347
