### PR TITLE
feat(cli): pipeline definition CRUD, pipelines alias, real root help

### DIFF
--- a/backend/internal/cli/pipeline.go
+++ b/backend/internal/cli/pipeline.go
@@ -211,8 +211,9 @@ There are two stage executors:
 
   command  a shell script run with sh; its exit status is the outcome
   agent    a real AO session, which settles itself from inside the session
-           with "ao pipeline done" or "ao pipeline fail --reason ...". Going
-           idle or closing the pane never settles an agent stage.
+           with "ao pipeline done" or "ao pipeline fail --reason ...".
+           Idling or losing the session is not success: the engine nudges an
+           idle session once, then settles the stage no_signal.
 
 Outcomes are wider than pass/fail. A stage is pending or running until it
 settles on one of: succeeded, succeeded_unverified, failed, no_output,

--- a/backend/internal/cli/pipeline.go
+++ b/backend/internal/cli/pipeline.go
@@ -36,6 +36,29 @@ type listPipelineDefinitionsResponse struct {
 	Definitions []pipelineDefinitionSummary `json:"definitions"`
 }
 
+type pipelineDefinitionResponse struct {
+	Definition pipelineDefinitionSummary `json:"definition"`
+}
+
+type deletePipelineDefinitionResponse struct {
+	ID      string `json:"id"`
+	Deleted bool   `json:"deleted"`
+}
+
+type pipelineValidationIssue struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+// validatePipelineDefinitionResponse carries both lists whether or not the
+// document is valid: a warned pipeline still saves and still runs, so the two
+// render differently.
+type validatePipelineDefinitionResponse struct {
+	Valid    bool                      `json:"valid"`
+	Issues   []pipelineValidationIssue `json:"issues"`
+	Warnings []pipelineValidationIssue `json:"warnings"`
+}
+
 // pipelineRunSummary is v2's run shape: a run status rollup and the subject the
 // run is about, in place of v1's loop state and termination reason.
 type pipelineRunSummary struct {
@@ -140,18 +163,115 @@ type pipelineRunOptions struct {
 	json     bool
 }
 
+type pipelineCreateOptions struct {
+	project string
+	file    string
+	json    bool
+}
+
+type pipelineGetOptions struct {
+	project string
+	json    bool
+}
+
+type pipelineUpdateOptions struct {
+	project string
+	file    string
+	json    bool
+}
+
+type pipelineDeleteOptions struct {
+	project string
+	yes     bool
+	json    bool
+}
+
+type pipelineValidateOptions struct {
+	project string
+	file    string
+	json    bool
+}
+
 // ---------------------------------------------------------------------------
 // Command wiring
 // ---------------------------------------------------------------------------
+
+// pipelineLongHelp is the root help text: enough for someone who has never
+// used the feature. Every claim here is grounded in docs/pipelines.md and the
+// engine code, not the design spec.
+const pipelineLongHelp = `Pipelines run multi-stage automation against your project, a pull request, or
+a session. A pipeline is a set of stages joined by on_success and on_failure
+edges: when a stage settles, the engine follows the matching edge to whatever
+comes next. Runs are triggered by PR events (created, updated, merge-ready,
+merged), session events (idle, exited, blocked), or manually with
+"ao pipeline run". A run freezes its definition at trigger time and executes
+that copy, so editing a definition never affects a run in flight.
+
+There are two stage executors:
+
+  command  a shell script run with sh; its exit status is the outcome
+  agent    a real AO session, which settles itself from inside the session
+           with "ao pipeline done" or "ao pipeline fail --reason ...". Going
+           idle or closing the pane never settles an agent stage.
+
+Outcomes are wider than pass/fail. A stage is pending or running until it
+settles on one of: succeeded, succeeded_unverified, failed, no_output,
+no_signal, timed_out, cancelled, skipped. The width is the point: an agent
+that claimed success but never wrote the artifact it declared (no_output) is
+a different failure from one that went quiet without claiming anything
+(no_signal), and each calls for a different fix.
+
+An agent stage may declare "produces: <filename>", one artifact the engine
+verifies exists non-empty before calling the stage succeeded. When the signal
+or the artifact is missing, the engine sends the still-live session exactly
+one nudge (two attempts total) before settling the stage.
+
+Each stage picks the tree it runs in with "workspace:": session (the subject
+session's worktree), run (one worktree shared by the run), stage (a fresh
+worktree per entry), checkout (the project's primary checkout), or inherit
+(the tree of the stage that routed here). The default is auto, which is
+session when the subject has one and otherwise run; a stage entered via a
+failure edge defaults to inherit instead.
+
+Concurrency groups (scope plus group name) decide which runs collide: runs
+sharing an effective key serialize, and cancel-in-progress: true makes a new
+run cancel the in-flight one.
+
+Engine-held credentials (see "ao pipeline credential") are injected into
+command stages only, never agent stages, and no verb prints a value back.
+
+Every run keeps its record on disk under ~/.ao/data/pipelines/<project>/<run>/
+(more precisely <AO_DATA_DIR>/pipelines/): the frozen definition, run.json,
+stage logs, and declared artifacts.
+
+Pipelines are experimental and off by default: toggle them in Settings, or
+set AO_PIPELINES=on in the daemon's environment. While off, every pipeline
+API route answers 501.
+
+A typical first session:
+
+  ao pipeline validate -f pipeline.yaml   # dry-run the document
+  ao pipeline create -f pipeline.yaml     # store it
+  ao pipeline run pr-review --pr 42       # trigger a run
+  ao pipeline runs                        # list runs, newest first
+  ao pipeline show <runId>                # stage outcomes for one run`
 
 // newPipelineCommand builds the v2 verb set. There is no `resume`: a settled
 // run is final (spec section 14.1), and re-running means triggering a new run.
 func newPipelineCommand(ctx *commandContext) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "pipeline",
-		Short: "Manage AO pipelines (definitions, runs, credentials)",
+		Use:     "pipeline",
+		Aliases: []string{"pipelines"},
+		Short:   "Manage AO pipelines (definitions, runs, credentials)",
+		Long:    pipelineLongHelp,
 	}
 	cmd.AddCommand(newPipelineListCommand(ctx))
+	cmd.AddCommand(newPipelineCreateCommand(ctx))
+	cmd.AddCommand(newPipelineGetCommand(ctx))
+	cmd.AddCommand(newPipelineUpdateCommand(ctx))
+	cmd.AddCommand(newPipelineDeleteCommand(ctx))
+	cmd.AddCommand(newPipelineValidateCommand(ctx))
+	cmd.AddCommand(newPipelineSchemaCommand(ctx))
 	cmd.AddCommand(newPipelineRunsCommand(ctx))
 	cmd.AddCommand(newPipelineShowCommand(ctx))
 	cmd.AddCommand(newPipelineRunCommand(ctx))
@@ -175,6 +295,128 @@ func newPipelineListCommand(ctx *commandContext) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&opts.project, "project", "p", "", "Project id to scope to")
 	f.BoolVar(&opts.json, "json", false, "Output as JSON")
+	return cmd
+}
+
+func newPipelineCreateCommand(ctx *commandContext) *cobra.Command {
+	var opts pipelineCreateOptions
+	cmd := &cobra.Command{
+		Use:   "create -f <file>",
+		Short: "Create a pipeline definition from a YAML document",
+		Long: "Create a pipeline definition from a YAML document.\n\n" +
+			"The document is validated server-side and stored only if it is valid; its " +
+			"name comes from the document's name: key. Pass `-f -` to read stdin.",
+		Args: noArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return ctx.pipelineCreate(cmd, opts)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVarP(&opts.file, "file", "f", "", "Path to the YAML definition (- for stdin)")
+	f.StringVarP(&opts.project, "project", "p", "", "Project id to scope to")
+	f.BoolVar(&opts.json, "json", false, "Output as JSON")
+	return cmd
+}
+
+func newPipelineGetCommand(ctx *commandContext) *cobra.Command {
+	var opts pipelineGetOptions
+	cmd := &cobra.Command{
+		Use:     "get <pipeline-ref>",
+		Aliases: []string{"cat"},
+		Short:   "Print a stored pipeline definition's YAML (by id or name)",
+		Long: "Print a stored pipeline definition's YAML exactly as authored.\n\n" +
+			"The ref is the definition's id or its name, the same as `run` takes. The " +
+			"output is the raw document, so it pipes cleanly into a file or an editor.",
+		Args: onePipelineRefArg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ctx.pipelineGet(cmd, args[0], opts)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVarP(&opts.project, "project", "p", "", "Project id to scope to")
+	f.BoolVar(&opts.json, "json", false, "Output as JSON")
+	return cmd
+}
+
+func newPipelineUpdateCommand(ctx *commandContext) *cobra.Command {
+	var opts pipelineUpdateOptions
+	cmd := &cobra.Command{
+		Use:   "update <pipeline-ref> -f <file>",
+		Short: "Replace a stored pipeline definition (by id or name)",
+		Long: "Replace a stored pipeline definition with a new YAML document.\n\n" +
+			"The ref is the definition's id or its name. The new document is validated " +
+			"server-side and replaces the stored one only if it is valid; runs already " +
+			"in flight keep their frozen copy. Pass `-f -` to read stdin.",
+		Args: onePipelineRefArg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ctx.pipelineUpdate(cmd, args[0], opts)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVarP(&opts.file, "file", "f", "", "Path to the YAML definition (- for stdin)")
+	f.StringVarP(&opts.project, "project", "p", "", "Project id to scope to")
+	f.BoolVar(&opts.json, "json", false, "Output as JSON")
+	return cmd
+}
+
+func newPipelineDeleteCommand(ctx *commandContext) *cobra.Command {
+	var opts pipelineDeleteOptions
+	cmd := &cobra.Command{
+		Use:     "delete <pipeline-ref>",
+		Aliases: []string{"rm"},
+		Short:   "Delete a stored pipeline definition (by id or name)",
+		Long: "Delete a stored pipeline definition.\n\n" +
+			"A definition is user-authored content and deleting one is not recoverable " +
+			"from the CLI, so an interactive session is asked to confirm; pass --yes to " +
+			"skip the prompt. Non-interactive sessions require --yes. Past runs are kept.",
+		Args: onePipelineRefArg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ctx.pipelineDelete(cmd, args[0], opts)
+		},
+	}
+	f := cmd.Flags()
+	f.BoolVarP(&opts.yes, "yes", "y", false, "Skip the confirmation prompt (required when not interactive)")
+	f.StringVarP(&opts.project, "project", "p", "", "Project id to scope to")
+	f.BoolVar(&opts.json, "json", false, "Output as JSON")
+	return cmd
+}
+
+func newPipelineValidateCommand(ctx *commandContext) *cobra.Command {
+	var opts pipelineValidateOptions
+	cmd := &cobra.Command{
+		Use:   "validate -f <file>",
+		Short: "Validate a pipeline YAML document without storing it",
+		Long: "Validate a pipeline YAML document without storing anything.\n\n" +
+			"Errors block saving; warnings do not, and arrive even for a valid document. " +
+			"An invalid document lists its problems and exits 1, so the verb gates CI " +
+			"cleanly. Pass `-f -` to read stdin.",
+		Args: noArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return ctx.pipelineValidate(cmd, opts)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVarP(&opts.file, "file", "f", "", "Path to the YAML definition (- for stdin)")
+	f.StringVarP(&opts.project, "project", "p", "", "Project id to scope to")
+	f.BoolVar(&opts.json, "json", false, "Output as JSON")
+	return cmd
+}
+
+func newPipelineSchemaCommand(ctx *commandContext) *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "schema",
+		Short: "Print the JSON schema for pipeline definition documents",
+		Long: "Print the JSON schema for pipeline definition documents.\n\n" +
+			"This is the same schema the visual editor consumes; point an editor or a " +
+			"linter at it for completion and validation while authoring YAML.",
+		Args: noArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return ctx.pipelineSchema(cmd)
+		},
+	}
+	// The schema is JSON in both modes; the flag exists so every verb takes it.
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON (the schema always is)")
 	return cmd
 }
 
@@ -400,6 +642,231 @@ func (c *commandContext) pipelineList(cmd *cobra.Command, opts pipelineListOptio
 		return fmt.Errorf("decode response: %w", err)
 	}
 	return writePipelineList(cmd, projectID, res.Definitions)
+}
+
+func (c *commandContext) pipelineCreate(cmd *cobra.Command, opts pipelineCreateOptions) error {
+	yamlSource, err := readPipelineDocument(cmd.InOrStdin(), opts.file)
+	if err != nil {
+		return err
+	}
+	ctx := cmd.Context()
+	projectID, err := c.resolvePipelineProjectID(ctx, opts.project)
+	if err != nil {
+		return err
+	}
+	params := url.Values{}
+	params.Set("project", projectID)
+
+	var raw json.RawMessage
+	if err := c.postJSON(ctx, apiPath("pipelines", params), map[string]string{"yamlSource": yamlSource}, &raw); err != nil {
+		return err
+	}
+	if opts.json {
+		return writeJSON(cmd.OutOrStdout(), raw)
+	}
+	var res pipelineDefinitionResponse
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "pipeline %s created (%s)\n", res.Definition.Name, res.Definition.ID)
+	return err
+}
+
+func (c *commandContext) pipelineGet(cmd *cobra.Command, ref string, opts pipelineGetOptions) error {
+	ctx := cmd.Context()
+	projectID, err := c.resolvePipelineProjectID(ctx, opts.project)
+	if err != nil {
+		return err
+	}
+	def, err := c.resolvePipelineDefinition(ctx, projectID, ref)
+	if err != nil {
+		return err
+	}
+	if opts.json {
+		// There is no single-definition GET route to re-emit; the decoded
+		// summary is the whole daemon-provided record for this definition.
+		return writeJSON(cmd.OutOrStdout(), def)
+	}
+	src := def.YAMLSource
+	if !strings.HasSuffix(src, "\n") {
+		src += "\n"
+	}
+	_, err = io.WriteString(cmd.OutOrStdout(), src)
+	return err
+}
+
+func (c *commandContext) pipelineUpdate(cmd *cobra.Command, ref string, opts pipelineUpdateOptions) error {
+	yamlSource, err := readPipelineDocument(cmd.InOrStdin(), opts.file)
+	if err != nil {
+		return err
+	}
+	ctx := cmd.Context()
+	projectID, err := c.resolvePipelineProjectID(ctx, opts.project)
+	if err != nil {
+		return err
+	}
+	def, err := c.resolvePipelineDefinition(ctx, projectID, ref)
+	if err != nil {
+		return err
+	}
+
+	var raw json.RawMessage
+	if err := c.putJSON(ctx, "pipelines/"+url.PathEscape(def.ID), map[string]string{"yamlSource": yamlSource}, &raw); err != nil {
+		return err
+	}
+	if opts.json {
+		return writeJSON(cmd.OutOrStdout(), raw)
+	}
+	var res pipelineDefinitionResponse
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "pipeline %s updated (%s)\n", res.Definition.Name, res.Definition.ID)
+	return err
+}
+
+func (c *commandContext) pipelineDelete(cmd *cobra.Command, ref string, opts pipelineDeleteOptions) error {
+	ctx := cmd.Context()
+	projectID, err := c.resolvePipelineProjectID(ctx, opts.project)
+	if err != nil {
+		return err
+	}
+	def, err := c.resolvePipelineDefinition(ctx, projectID, ref)
+	if err != nil {
+		return err
+	}
+	// A definition is user-authored content and this delete is not recoverable
+	// from the CLI, so it is confirmed interactively. A non-interactive caller
+	// must say --yes; silently proceeding (or silently cancelling) would both
+	// be wrong in a script.
+	if !opts.yes {
+		if !stdinIsInteractive(cmd.InOrStdin()) {
+			return usageError{fmt.Errorf("deleting pipeline %s needs confirmation: pass --yes when not running interactively", def.Name)}
+		}
+		ok, err := confirm(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete pipeline %s (%s)? Past runs are kept.", def.Name, def.ID), false)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), "Delete cancelled.")
+			return err
+		}
+	}
+
+	var raw json.RawMessage
+	if err := c.deleteJSON(ctx, "pipelines/"+url.PathEscape(def.ID), &raw); err != nil {
+		return err
+	}
+	if opts.json {
+		return writeJSON(cmd.OutOrStdout(), raw)
+	}
+	var res deletePipelineDefinitionResponse
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "pipeline %s deleted (%s)\n", def.Name, res.ID)
+	return err
+}
+
+func (c *commandContext) pipelineValidate(cmd *cobra.Command, opts pipelineValidateOptions) error {
+	yamlSource, err := readPipelineDocument(cmd.InOrStdin(), opts.file)
+	if err != nil {
+		return err
+	}
+	ctx := cmd.Context()
+	projectID, err := c.resolvePipelineProjectID(ctx, opts.project)
+	if err != nil {
+		return err
+	}
+	params := url.Values{}
+	params.Set("project", projectID)
+
+	var raw json.RawMessage
+	if err := c.postJSON(ctx, apiPath("pipelines/validate", params), map[string]string{"yamlSource": yamlSource}, &raw); err != nil {
+		return err
+	}
+	var res validatePipelineDefinitionResponse
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if opts.json {
+		if err := writeJSON(cmd.OutOrStdout(), raw); err != nil {
+			return err
+		}
+		return pipelineValidationVerdict(res)
+	}
+	if err := writePipelineValidation(cmd, res); err != nil {
+		return err
+	}
+	return pipelineValidationVerdict(res)
+}
+
+// pipelineValidationVerdict turns an invalid document into a non-zero exit.
+// The problems are already on stdout as data; this is deliberately a plain
+// error (exit 1), not a usageError, because the CLI was used correctly.
+func pipelineValidationVerdict(res validatePipelineDefinitionResponse) error {
+	if res.Valid {
+		return nil
+	}
+	n := len(res.Issues)
+	return fmt.Errorf("pipeline definition is invalid (%d error%s)", n, pluralS(n))
+}
+
+func (c *commandContext) pipelineSchema(cmd *cobra.Command) error {
+	raw, err := c.getPipelineRaw(cmd.Context(), "pipelines/schema")
+	if err != nil {
+		return err
+	}
+	return writeJSON(cmd.OutOrStdout(), raw)
+}
+
+// readPipelineDocument reads the YAML document for create/update/validate from
+// the given path, or from stdin when the path is "-".
+func readPipelineDocument(in io.Reader, path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", usageError{fmt.Errorf("-f/--file is required (use `-f -` to read stdin)")}
+	}
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(in)
+	} else {
+		data, err = os.ReadFile(path) // #nosec G304 -- the path is the user's own -f argument.
+	}
+	if err != nil {
+		return "", fmt.Errorf("read pipeline definition: %w", err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return "", usageError{fmt.Errorf("pipeline definition is empty")}
+	}
+	return string(data), nil
+}
+
+// resolvePipelineDefinition resolves a pipeline ref (id or name) against the
+// project's stored definitions. There is no GET /pipelines/{id} route, so the
+// CLI lists and matches client-side, the same reference shape `run` resolves
+// server-side. Ids win over names; names are unique per project.
+func (c *commandContext) resolvePipelineDefinition(ctx context.Context, projectID, ref string) (pipelineDefinitionSummary, error) {
+	var res listPipelineDefinitionsResponse
+	params := url.Values{}
+	params.Set("project", projectID)
+	if err := c.getJSON(ctx, apiPath("pipelines", params), &res); err != nil {
+		return pipelineDefinitionSummary{}, err
+	}
+	ref = strings.TrimSpace(ref)
+	for _, d := range res.Definitions {
+		if d.ID == ref {
+			return d, nil
+		}
+	}
+	for _, d := range res.Definitions {
+		if d.Name == ref {
+			return d, nil
+		}
+	}
+	return pipelineDefinitionSummary{}, fmt.Errorf("no pipeline %q in project %s", ref, projectID)
 }
 
 func (c *commandContext) pipelineRuns(cmd *cobra.Command, opts pipelineRunsOptions) error {
@@ -703,6 +1170,44 @@ func writePipelineList(cmd *cobra.Command, projectID string, defs []pipelineDefi
 		if _, err := fmt.Fprintf(out, "  %s  %s  %d stage%s  %s\n",
 			d.ID, d.Name, n, pluralS(n), formatPipelineTime(d.UpdatedAt)); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// writePipelineValidation renders the two lists distinctly because they mean
+// different things: errors block saving, warnings do not, and warnings arrive
+// whether or not the document is valid.
+func writePipelineValidation(cmd *cobra.Command, res validatePipelineDefinitionResponse) error {
+	out := cmd.OutOrStdout()
+	verdict := "valid"
+	if !res.Valid {
+		verdict = "invalid"
+	}
+	if _, err := fmt.Fprintf(out, "pipeline definition is %s\n", verdict); err != nil {
+		return err
+	}
+	for _, group := range []struct {
+		label  string
+		issues []pipelineValidationIssue
+	}{
+		{"Errors", res.Issues},
+		{"Warnings", res.Warnings},
+	} {
+		if len(group.issues) == 0 {
+			continue
+		}
+		if _, err := fmt.Fprintf(out, "\n%s:\n", group.label); err != nil {
+			return err
+		}
+		for _, issue := range group.issues {
+			line := issue.Message
+			if issue.Path != "" {
+				line = issue.Path + ": " + issue.Message
+			}
+			if _, err := fmt.Fprintf(out, "  %s\n", line); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/backend/internal/cli/pipeline_test.go
+++ b/backend/internal/cli/pipeline_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -46,7 +48,10 @@ func TestPipelineVerbSet(t *testing.T) {
 	for _, sub := range cmd.Commands() {
 		got[sub.Name()] = true
 	}
-	for _, want := range []string{"list", "runs", "show", "run", "cancel", "credential", "done", "fail"} {
+	for _, want := range []string{
+		"list", "create", "get", "update", "delete", "validate", "schema",
+		"runs", "show", "run", "cancel", "credential", "done", "fail",
+	} {
 		if !got[want] {
 			t.Errorf("verb %q is missing", want)
 		}
@@ -66,6 +71,21 @@ func TestPipelineVerbSet(t *testing.T) {
 	for _, want := range []string{"set", "ls", "rm"} {
 		if !credentialVerbs[want] {
 			t.Errorf("credential verb %q is missing", want)
+		}
+	}
+
+	// The alias pins: `ao pipelines`, `delete`/`rm`, `get`/`cat`.
+	if len(cmd.Aliases) != 1 || cmd.Aliases[0] != "pipelines" {
+		t.Errorf("root aliases = %v, want [pipelines]", cmd.Aliases)
+	}
+	wantAliases := map[string]string{"delete": "rm", "get": "cat"}
+	for _, sub := range cmd.Commands() {
+		want, ok := wantAliases[sub.Name()]
+		if !ok {
+			continue
+		}
+		if len(sub.Aliases) != 1 || sub.Aliases[0] != want {
+			t.Errorf("%s aliases = %v, want [%s]", sub.Name(), sub.Aliases, want)
 		}
 	}
 }
@@ -650,5 +670,415 @@ func TestPipelineRun_MissingRefIsUsageError(t *testing.T) {
 	_, _, err := executeCLI(t, aliveDeps(), "pipeline", "run")
 	if got := ExitCode(err); got != 2 {
 		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Definition CRUD (create, get, update, delete, validate, schema)
+// ---------------------------------------------------------------------------
+
+// pipelineRoutedServer answers each "METHOD /path" key with its own canned
+// body, for verbs that resolve a ref (a GET of the list) before mutating. The
+// capture records the last request, which for those verbs is the mutation.
+func pipelineRoutedServer(t *testing.T, routes map[string]string) (*httptest.Server, *pipelineCapture) {
+	t.Helper()
+	capture := &pipelineCapture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capture.method = r.Method
+		capture.path = r.URL.Path
+		capture.query = r.URL.RawQuery
+		capture.body = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		resp, ok := routes[r.Method+" "+r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"message":"no such route","code":"NOT_FOUND"}`)
+			return
+		}
+		_, _ = io.WriteString(w, resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, capture
+}
+
+const (
+	pipelineDefYAML     = "name: review\nstages:\n  - id: a\n"
+	pipelineDefListBody = `{"definitions":[{"id":"pl-1","projectId":"proj","name":"review","yamlSource":"name: review\nstages:\n  - id: a\n","createdAt":"2026-07-15T00:00:00Z","updatedAt":"2026-07-15T01:00:00Z"}]}`
+	pipelineDefBody     = `{"definition":{"id":"pl-1","projectId":"proj","name":"review","yamlSource":"name: review\nstages:\n  - id: a\n","createdAt":"2026-07-15T00:00:00Z","updatedAt":"2026-07-15T01:00:00Z"}}`
+)
+
+// writePipelineYAML puts a definition document on disk for the -f flag.
+func writePipelineYAML(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pipeline.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestPipelinesAlias_RoutesToPipeline(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineServer(t, http.StatusOK, `{"definitions":[]}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, aliveDeps(), "pipelines", "list", "--project", "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodGet || capture.path != "/api/v1/pipelines" {
+		t.Fatalf("request = %s %s", capture.method, capture.path)
+	}
+}
+
+func TestPipelineCreate_HumanFromFile(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineServer(t, http.StatusCreated, pipelineDefBody)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(),
+		"pipeline", "create", "-f", writePipelineYAML(t, pipelineDefYAML), "--project", "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodPost || capture.path != "/api/v1/pipelines" {
+		t.Fatalf("request = %s %s", capture.method, capture.path)
+	}
+	if capture.query != "project=proj" {
+		t.Fatalf("query = %q", capture.query)
+	}
+	var reqBody map[string]string
+	if err := json.Unmarshal([]byte(capture.body), &reqBody); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if reqBody["yamlSource"] != pipelineDefYAML {
+		t.Fatalf("yamlSource = %q", reqBody["yamlSource"])
+	}
+	if !strings.Contains(out, "pipeline review created (pl-1)") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestPipelineCreate_Stdin(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineServer(t, http.StatusCreated, pipelineDefBody)
+	writeRunFileFor(t, cfg, srv)
+
+	deps := aliveDeps()
+	deps.In = strings.NewReader(pipelineDefYAML)
+	_, errOut, err := executeCLI(t, deps, "pipeline", "create", "-f", "-", "--project", "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var reqBody map[string]string
+	if err := json.Unmarshal([]byte(capture.body), &reqBody); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if reqBody["yamlSource"] != pipelineDefYAML {
+		t.Fatalf("yamlSource = %q", reqBody["yamlSource"])
+	}
+}
+
+func TestPipelineCreate_JSON(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := pipelineServer(t, http.StatusCreated, pipelineDefBody)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(),
+		"pipeline", "create", "-f", writePipelineYAML(t, pipelineDefYAML), "--project", "proj", "--json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var res pipelineDefinitionResponse
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("stdout is not raw JSON: %v\nstdout=%s", err, out)
+	}
+	if res.Definition.ID != "pl-1" {
+		t.Fatalf("definition = %+v", res.Definition)
+	}
+}
+
+func TestPipelineCreate_MissingFileFlagIsUsageError(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineServer(t, http.StatusCreated, pipelineDefBody)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, aliveDeps(), "pipeline", "create", "--project", "proj")
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+	// The telemetry ping is the only call an aborted verb may make.
+	if strings.Contains(capture.path, "pipelines") {
+		t.Fatalf("CLI called the daemon anyway: %s %s", capture.method, capture.path)
+	}
+}
+
+func TestPipelineCreate_MissingFileIsRuntimeError(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineServer(t, http.StatusCreated, pipelineDefBody)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, aliveDeps(),
+		"pipeline", "create", "-f", filepath.Join(t.TempDir(), "nope.yaml"), "--project", "proj")
+	if got := ExitCode(err); got != 1 {
+		t.Fatalf("exit code = %d, want 1; err=%v", got, err)
+	}
+	if !strings.Contains(err.Error(), "read pipeline definition") {
+		t.Fatalf("error = %v", err)
+	}
+	// The telemetry ping is the only call an aborted verb may make.
+	if strings.Contains(capture.path, "pipelines") {
+		t.Fatalf("CLI called the daemon anyway: %s %s", capture.method, capture.path)
+	}
+}
+
+func TestPipelineGet_PrintsRawYAML(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineServer(t, http.StatusOK, pipelineDefListBody)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "get", "review", "--project", "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodGet || capture.path != "/api/v1/pipelines" {
+		t.Fatalf("request = %s %s", capture.method, capture.path)
+	}
+	if out != pipelineDefYAML {
+		t.Fatalf("stdout = %q, want the raw YAML document", out)
+	}
+}
+
+func TestPipelineGet_JSON(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := pipelineServer(t, http.StatusOK, pipelineDefListBody)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "get", "pl-1", "--project", "proj", "--json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var def pipelineDefinitionSummary
+	if err := json.Unmarshal([]byte(out), &def); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nstdout=%s", err, out)
+	}
+	if def.ID != "pl-1" || def.Name != "review" {
+		t.Fatalf("definition = %+v", def)
+	}
+}
+
+func TestPipelineGet_UnknownRef(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := pipelineServer(t, http.StatusOK, pipelineDefListBody)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, aliveDeps(), "pipeline", "get", "nope", "--project", "proj")
+	if got := ExitCode(err); got != 1 {
+		t.Fatalf("exit code = %d, want 1; err=%v", got, err)
+	}
+	if !strings.Contains(err.Error(), `no pipeline "nope" in project proj`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPipelineUpdate_ResolvesRefAndPuts(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineRoutedServer(t, map[string]string{
+		"GET /api/v1/pipelines":      pipelineDefListBody,
+		"PUT /api/v1/pipelines/pl-1": pipelineDefBody,
+	})
+	writeRunFileFor(t, cfg, srv)
+
+	const updated = "name: review\nstages:\n  - id: b\n"
+	out, errOut, err := executeCLI(t, aliveDeps(),
+		"pipeline", "update", "review", "-f", writePipelineYAML(t, updated), "--project", "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodPut || capture.path != "/api/v1/pipelines/pl-1" {
+		t.Fatalf("last request = %s %s", capture.method, capture.path)
+	}
+	var reqBody map[string]string
+	if err := json.Unmarshal([]byte(capture.body), &reqBody); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if reqBody["yamlSource"] != updated {
+		t.Fatalf("yamlSource = %q", reqBody["yamlSource"])
+	}
+	if !strings.Contains(out, "pipeline review updated (pl-1)") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestPipelineUpdate_UnknownRef(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineRoutedServer(t, map[string]string{
+		"GET /api/v1/pipelines": pipelineDefListBody,
+	})
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, aliveDeps(),
+		"pipeline", "update", "nope", "-f", writePipelineYAML(t, pipelineDefYAML), "--project", "proj")
+	if got := ExitCode(err); got != 1 {
+		t.Fatalf("exit code = %d, want 1; err=%v", got, err)
+	}
+	if capture.method != http.MethodGet {
+		t.Fatalf("CLI mutated anyway: %s %s", capture.method, capture.path)
+	}
+}
+
+func TestPipelineDelete_NonInteractiveWithoutYesIsUsageError(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineRoutedServer(t, map[string]string{
+		"GET /api/v1/pipelines": pipelineDefListBody,
+	})
+	writeRunFileFor(t, cfg, srv)
+
+	deps := aliveDeps()
+	deps.In = strings.NewReader("") // a pipe, not a TTY
+	_, _, err := executeCLI(t, deps, "pipeline", "delete", "review", "--project", "proj")
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("error does not point at --yes: %v", err)
+	}
+	if capture.method == http.MethodDelete {
+		t.Fatalf("CLI deleted anyway: %s %s", capture.method, capture.path)
+	}
+}
+
+func TestPipelineDelete_WithYes(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineRoutedServer(t, map[string]string{
+		"GET /api/v1/pipelines":         pipelineDefListBody,
+		"DELETE /api/v1/pipelines/pl-1": `{"id":"pl-1","deleted":true}`,
+	})
+	writeRunFileFor(t, cfg, srv)
+
+	deps := aliveDeps()
+	deps.In = strings.NewReader("")
+	out, errOut, err := executeCLI(t, deps, "pipeline", "delete", "review", "--yes", "--project", "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodDelete || capture.path != "/api/v1/pipelines/pl-1" {
+		t.Fatalf("last request = %s %s", capture.method, capture.path)
+	}
+	if !strings.Contains(out, "pipeline review deleted (pl-1)") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestPipelineDelete_RmAlias(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineRoutedServer(t, map[string]string{
+		"GET /api/v1/pipelines":         pipelineDefListBody,
+		"DELETE /api/v1/pipelines/pl-1": `{"id":"pl-1","deleted":true}`,
+	})
+	writeRunFileFor(t, cfg, srv)
+
+	deps := aliveDeps()
+	deps.In = strings.NewReader("")
+	_, errOut, err := executeCLI(t, deps, "pipeline", "rm", "pl-1", "--yes", "--project", "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodDelete || capture.path != "/api/v1/pipelines/pl-1" {
+		t.Fatalf("last request = %s %s", capture.method, capture.path)
+	}
+}
+
+func TestPipelineValidate_ValidWithWarnings(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineServer(t, http.StatusOK,
+		`{"valid":true,"issues":[],"warnings":[{"path":"stages[0]","message":"no on_failure anywhere"}]}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(),
+		"pipeline", "validate", "-f", writePipelineYAML(t, pipelineDefYAML), "--project", "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodPost || capture.path != "/api/v1/pipelines/validate" {
+		t.Fatalf("request = %s %s", capture.method, capture.path)
+	}
+	for _, want := range []string{"pipeline definition is valid", "Warnings:", "stages[0]: no on_failure anywhere"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q\nstdout=%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Errors:") {
+		t.Fatalf("a valid document printed an Errors section:\n%s", out)
+	}
+}
+
+// An invalid document is data plus exit 1, never a usage error (exit 2) and
+// never a bare daemon failure: the CLI was used correctly.
+func TestPipelineValidate_InvalidListsProblemsAndExitsOne(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := pipelineServer(t, http.StatusOK,
+		`{"valid":false,"issues":[{"path":"stages[1].needs","message":"needs does not match the inbound edges"}],`+
+			`"warnings":[{"path":"","message":"no on_failure anywhere"}]}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, _, err := executeCLI(t, aliveDeps(),
+		"pipeline", "validate", "-f", writePipelineYAML(t, "name: broken\n"), "--project", "proj")
+	if got := ExitCode(err); got != 1 {
+		t.Fatalf("exit code = %d, want 1; err=%v", got, err)
+	}
+	if !strings.Contains(err.Error(), "pipeline definition is invalid (1 error)") {
+		t.Fatalf("error = %v", err)
+	}
+	for _, want := range []string{
+		"pipeline definition is invalid",
+		"Errors:", "stages[1].needs: needs does not match the inbound edges",
+		"Warnings:", "no on_failure anywhere",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q\nstdout=%s", want, out)
+		}
+	}
+}
+
+func TestPipelineValidate_JSONStillExitsOneOnInvalid(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := pipelineServer(t, http.StatusOK,
+		`{"valid":false,"issues":[{"path":"name","message":"name is required"}],"warnings":[]}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, _, err := executeCLI(t, aliveDeps(),
+		"pipeline", "validate", "-f", writePipelineYAML(t, "stages: []\n"), "--project", "proj", "--json")
+	if got := ExitCode(err); got != 1 {
+		t.Fatalf("exit code = %d, want 1; err=%v", got, err)
+	}
+	var res validatePipelineDefinitionResponse
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("stdout is not raw JSON: %v\nstdout=%s", err, out)
+	}
+	if res.Valid || len(res.Issues) != 1 {
+		t.Fatalf("response = %+v", res)
+	}
+}
+
+func TestPipelineSchema_DumpsSchema(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := pipelineServer(t, http.StatusOK, `{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"Pipeline"}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(), "pipeline", "schema")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodGet || capture.path != "/api/v1/pipelines/schema" {
+		t.Fatalf("request = %s %s", capture.method, capture.path)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(out), &schema); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nstdout=%s", err, out)
+	}
+	if schema["title"] != "Pipeline" {
+		t.Fatalf("schema = %+v", schema)
 	}
 }

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -802,6 +802,12 @@ stage, inherited or explicit.
 
 ```
 ao pipeline list [--project ID] [--json]
+ao pipeline create -f FILE [--project ID] [--json]
+ao pipeline get <pipeline-ref> [--project ID] [--json]
+ao pipeline update <pipeline-ref> -f FILE [--project ID] [--json]
+ao pipeline delete <pipeline-ref> [--yes] [--project ID] [--json]
+ao pipeline validate -f FILE [--project ID] [--json]
+ao pipeline schema
 ao pipeline runs [--project ID] [--pipeline NAME] [--status STATUS] [--limit N] [--json]
 ao pipeline show <runId> [--project ID] [--json]
 ao pipeline run <pipeline-ref> [--project ID] [--session ID] [--pr N] [--json]
@@ -813,12 +819,27 @@ ao pipeline done
 ao pipeline fail --reason "..."
 ```
 
+`ao pipelines` is an alias for `ao pipeline`, and the destructive-verb aliases
+follow the usual shell shapes: `rm` for `delete`, `cat` for `get`.
+
 `--project` falls back to `AO_PROJECT_ID`, then the CLI's usual cwd and
 session-based project resolution. `--status` filters `runs` by run status
 (`pending`, `running`, `succeeded`, `failed`, `cancelled`). `pipeline run`
 accepts a pipeline id or its name and resolves the subject from `--session` or
 `--pr` (the PR's head sha and fork provenance come from the daemon, so there is
 no `--head-sha`); with neither, the subject is the project.
+
+**Definition verbs.** `get`, `update` and `delete` take the same pipeline ref
+`run` does: the definition's id or its name. `create`, `update` and `validate`
+read the YAML document from `-f FILE`, and `-f -` reads stdin, so a document
+pipes in the way you'd expect (`ao pipeline get review | ... | ao pipeline
+update review -f -`). `get` prints the stored YAML exactly as authored.
+`delete` asks for confirmation in an interactive session and requires `--yes`
+in a non-interactive one; past runs and their run folders are kept either way.
+`validate` prints the Errors and Warnings lists separately (warnings arrive
+even for a valid document and do not block saving) and exits 1 when the
+document is invalid, so it slots into CI. `schema` dumps the JSON schema the
+visual editor consumes.
 
 **There is no `resume`.** A settled run is final; re-running means triggering a
 new one.


### PR DESCRIPTION
## Summary

Adds the missing definition lifecycle to the `ao pipeline` CLI. All server endpoints already existed; this is CLI plumbing plus help text.

New verbs:

- `create -f <file>`: POST `/pipelines`, `-f -` reads stdin
- `get <ref>` (alias `cat`): resolves id-or-name client-side via the list route and prints the stored YAML exactly as authored
- `update <ref> -f <file>`: resolves the ref, PUT `/pipelines/{id}`
- `delete <ref>` (alias `rm`): confirms interactively, requires `--yes` when stdin is not a terminal; past runs are kept
- `validate -f <file>`: POST `/pipelines/validate`; renders Errors and Warnings as separate lists and exits 1 (not 2, not a crash) on an invalid document
- `schema`: dumps the JSON schema from `/pipelines/schema`

Also:

- `ao pipelines` is now an alias for `ao pipeline`
- The root command gained a real `Long:` covering edges and triggers, the two executors, the full ten-outcome taxonomy (with the no_output vs no_signal distinction), produces and the single nudge, workspaces, concurrency groups, credentials, the run folder under `~/.ao/data/pipelines/<project>/<run>/`, the `AO_PIPELINES` flag, and a worked example
- Each new subcommand has a short `Long:`; existing ones untouched
- `docs/pipelines.md` CLI section updated (no new `<!-- validated -->` blocks)

All verbs follow the file's settled conventions: `--project`/`-p` + `--json` pair, `usageError` for misuse (exit 2), raw daemon JSON re-emitted under `--json`, separate human-rendering functions.

## Tests

- `go build ./...`, `gofmt -l .`, `golangci-lint run ./...`: clean, 0 issues
- `env -u AO_PROJECT_ID -u AO_SESSION_ID go test ./internal/cli/...`: pass
- `env -u AO_PROJECT_ID -u AO_SESSION_ID go test ./...`: pass (93 packages ok, exit 0)
- New tests per verb: happy path, `--json`, missing `-f` (exit 2), missing file (exit 1, no daemon call), unknown ref, invalid document (exit 1 with both lists rendered), delete without `--yes` on a non-TTY (exit 2, no DELETE sent), `rm`/`cat`/`pipelines` aliases

## Risks / notes

- `get --json` emits the decoded definition summary rather than a raw daemon body, because there is no single-definition GET route to re-emit; noted in a comment.
- The non-interactive delete guard checks stdin interactivity (the codebase's existing `stdinIsInteractive`/`confirm` pattern), which is what a prompt actually needs; in every real piped scenario this matches a stdout TTY check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)