### PR TITLE
style(pipelines): conform pipeline screens to app primitives and chrome

### DIFF
--- a/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
+++ b/frontend/src/renderer/components/PipelineDefinitionsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { AlertCircle, CheckCircle2, Loader2, Pencil, Plus, Settings2, Trash2, Workflow } from "lucide-react";
+import { AlertCircle, CheckCircle2, Loader2, Pencil, Plus, Settings2, Trash2 } from "lucide-react";
 import { apiErrorMessage } from "../lib/api-client";
 import { formatTimeCompact } from "../lib/format-time";
 import { serializeToYaml, type StageDraft } from "../lib/pipeline-draft";
@@ -21,6 +21,7 @@ import { PipelineProblemsPanel, type PipelineProblem } from "./PipelineProblemsP
 import { PipelineSettingsModal } from "./PipelineSettingsModal";
 import { StageInspector } from "./StageInspector";
 import { YamlEditor } from "./YamlEditor";
+import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./ui/table";
 import { cn } from "../lib/utils";
@@ -105,12 +106,11 @@ export function PipelineDefinitionsPage({ projectId }: { projectId?: string }) {
 				) : definitions.length === 0 ? (
 					<div data-testid="pipelines-empty-state" className="flex h-full min-h-0 items-center justify-center">
 						<div className="flex max-w-sm flex-col items-center pb-10 text-center">
-							<Workflow className="size-icon-lg text-passive" aria-hidden="true" />
-							<h2 className="mt-3 text-control font-semibold text-foreground">No pipelines yet</h2>
-							<p className="mt-1.5 text-caption text-passive">
+							<h2 className="text-subtitle font-semibold tracking-tight text-foreground">No pipelines yet</h2>
+							<p className="mt-2 text-md-sm leading-relaxed text-muted-foreground">
 								Author your first pipeline visually, start from a template, or import YAML.
 							</p>
-							<Button size="sm" variant="primary" className="mt-4" onClick={() => setNewOpen(true)}>
+							<Button size="sm" variant="primary" className="mt-5" onClick={() => setNewOpen(true)}>
 								<Plus className="size-icon-md" aria-hidden="true" />
 								New pipeline
 							</Button>
@@ -173,7 +173,8 @@ function DefinitionRow({
 						Edit
 					</Button>
 					<Button
-								variant="ghost"
+						size="sm"
+						variant="ghost"
 						className="h-6 px-2 text-caption text-destructive hover:text-destructive"
 						onClick={() => setConfirmOpen(true)}
 						aria-label={`Delete ${def.name || def.id}`}
@@ -197,7 +198,7 @@ function DefinitionRow({
 					destructive
 					busy={remove.isPending}
 					error={remove.isError ? apiErrorMessage(remove.error) : null}
-						onConfirm={() =>
+					onConfirm={() =>
 						remove.mutate(def.id, {
 							onSuccess: () => setConfirmOpen(false),
 						})
@@ -484,13 +485,10 @@ function ValidityIndicator({
 }) {
 	if (problemCount > 0) {
 		return (
-			<span
-				className="flex items-center gap-1 rounded-full border border-error/40 bg-error/10 px-2 py-0.5 text-caption text-error"
-				aria-live="polite"
-			>
+			<Badge variant="error" aria-live="polite">
 				<AlertCircle className="size-icon-sm" aria-hidden="true" />
 				{`${problemCount} ${problemCount === 1 ? "problem" : "problems"}`}
-			</span>
+			</Badge>
 		);
 	}
 	if (validation.isValidating) {

--- a/frontend/src/renderer/components/PipelineFilterBar.tsx
+++ b/frontend/src/renderer/components/PipelineFilterBar.tsx
@@ -3,6 +3,7 @@ import { cn } from "../lib/utils";
 import { RUN_STATUSES, runStatusLabel } from "../lib/pipeline-display";
 import type { RunStatus } from "../lib/pipeline-draft";
 import type { PipelineRunRowModel, RunEvent } from "./PipelineRunRow";
+import { Button } from "./ui/button";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -116,16 +117,16 @@ function FilterMenu({
 
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger
-				disabled={options.length === 0}
-				className={cn(
-					"flex items-center gap-1 rounded-md px-2 py-1 text-control transition-colors",
-					"disabled:cursor-not-allowed disabled:opacity-40",
-					active ? "text-accent" : "text-muted-foreground hover:text-foreground",
-				)}
-			>
-				<span className="max-w-40 truncate">{active ? `${label}: ${active.label}` : label}</span>
-				<ChevronDown className="size-3.5 shrink-0" aria-hidden="true" />
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="ghost"
+					size="sm"
+					disabled={options.length === 0}
+					className={cn("gap-1", active && "text-accent hover:text-accent")}
+				>
+					<span className="max-w-40 truncate">{active ? `${label}: ${active.label}` : label}</span>
+					<ChevronDown className="size-3.5 shrink-0" aria-hidden="true" />
+				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end" className="max-h-80 overflow-y-auto">
 				<DropdownMenuItem onSelect={() => onSelect(undefined)}>

--- a/frontend/src/renderer/components/PipelineProblemsPanel.tsx
+++ b/frontend/src/renderer/components/PipelineProblemsPanel.tsx
@@ -1,4 +1,5 @@
 import { AlertCircle } from "lucide-react";
+import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 
 // The Problems panel (mockup 1d): docked under the editor surface, one row per
@@ -31,7 +32,7 @@ export function PipelineProblemsPanel({
 			<div className="flex items-center justify-between px-4.5 pt-2.5 pb-1.5">
 				<p className="flex items-center gap-1.5 text-caption font-semibold text-foreground">
 					Problems
-					<span className="rounded-full bg-error/15 px-1.5 font-mono text-2xs text-error">{problems.length}</span>
+					<Badge variant="error">{problems.length}</Badge>
 				</p>
 				<p className="text-caption text-passive">Must resolve before saving</p>
 			</div>

--- a/frontend/src/renderer/components/PipelineRunDetail.tsx
+++ b/frontend/src/renderer/components/PipelineRunDetail.tsx
@@ -92,11 +92,11 @@ export function PipelineRunDetail({ runId, project }: { runId: string; project?:
 	});
 
 	if (isLoading) {
-		return <p className="p-6 text-caption text-passive">Loading run…</p>;
+		return <p className="py-10 text-center text-xs text-passive">Loading run…</p>;
 	}
 	if (isError || !run) {
 		return (
-			<p className="p-6 text-caption text-error">
+			<p className="py-10 text-center text-xs text-error">
 				Could not load run{error instanceof Error ? `: ${error.message}` : ""}.
 			</p>
 		);
@@ -228,7 +228,7 @@ function RunRail({
 				onClick={() => onFocusStage(null)}
 			/>
 
-			<p className="mb-1 mt-4 px-2 text-micro font-semibold uppercase tracking-wide text-passive">All jobs</p>
+			<p className="mb-1 mt-4 px-2 font-mono text-2xs font-medium uppercase tracking-wide-sm text-passive">All jobs</p>
 			{run.stages.map((stage) => (
 				<RailItem
 					key={stage.stageId}
@@ -240,7 +240,7 @@ function RunRail({
 			))}
 			{run.stages.length === 0 && <p className="px-2 text-micro text-passive">No stages yet.</p>}
 
-			<p className="mb-1 mt-4 px-2 text-micro font-semibold uppercase tracking-wide text-passive">Run details</p>
+			<p className="mb-1 mt-4 px-2 font-mono text-2xs font-medium uppercase tracking-wide-sm text-passive">Run details</p>
 			<RailItem
 				icon={<FileText className="size-icon-sm text-muted-foreground" aria-hidden="true" />}
 				label="Pipeline definition"

--- a/frontend/src/renderer/components/PipelineRunRow.tsx
+++ b/frontend/src/renderer/components/PipelineRunRow.tsx
@@ -14,6 +14,7 @@ import { formatStageDuration, runStatusLabel, runStatusOf, runStatusTone } from 
 import type { RunStatus } from "../lib/pipeline-draft";
 import type { PipelineRunSummary } from "../hooks/usePipelineRuns";
 import type { WorkspaceSession } from "../types/workspace";
+import { Button } from "./ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./ui/dropdown-menu";
 
 // What fired a run. The DTO's `subjectKind` is the closest thing we have to
@@ -131,7 +132,7 @@ export function PipelineRunRow({
 			{row.branch && (
 				<span
 					title={row.branch}
-					className="hidden max-w-48 shrink-0 truncate rounded-md bg-accent-weak px-1.5 py-0.5 font-mono text-micro text-accent lg:inline-block"
+					className="hidden max-w-branch-chip shrink-0 truncate rounded-sm bg-accent/12 px-1.5 py-0.5 font-mono text-micro text-accent lg:inline-block"
 				>
 					{row.branch}
 				</span>
@@ -149,11 +150,10 @@ export function PipelineRunRow({
 			</div>
 
 			<DropdownMenu>
-				<DropdownMenuTrigger
-					aria-label={`Actions for ${row.title}`}
-					className="shrink-0 rounded-md p-1 text-passive transition-colors hover:bg-surface hover:text-foreground"
-				>
-					<MoreHorizontal className="size-4" />
+				<DropdownMenuTrigger asChild>
+					<Button variant="ghost" size="icon-sm" className="shrink-0" aria-label={`Actions for ${row.title}`}>
+						<MoreHorizontal className="size-4" aria-hidden="true" />
+					</Button>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align="end">
 					<DropdownMenuItem onSelect={onOpen}>View run detail</DropdownMenuItem>

--- a/frontend/src/renderer/components/PipelineWorkbench.tsx
+++ b/frontend/src/renderer/components/PipelineWorkbench.tsx
@@ -100,7 +100,7 @@ export function PipelineWorkbench({ projectId }: { projectId?: string }) {
 				/>
 
 				{isError ? (
-					<p className="py-10 text-center text-caption text-error">
+					<p className="py-10 text-center text-xs text-error">
 						Could not load pipeline runs{error instanceof Error ? `: ${error.message}` : ""}.
 					</p>
 				) : (


### PR DESCRIPTION
## Summary

Conformance pass over the pipelines UI (per the pipelines-ui-coherence brief): make the pipelines screens match the conventions the rest of the renderer already uses, with existing shadcn primitives and the token system. Presentation only, no behaviour changes.

An audit ran first (two sweeps: one cataloguing the app's living conventions, one inventorying all 13 pipelines files). Headline finding: the pipelines code contains **zero hardcoded colors and zero inline styles**; everything already resolves through the token system, including the react-flow edge strokes and the deliberate ten-outcome palette in `lib/pipeline-display.ts` (left fully intact). The divergence was structural: bespoke markup where a primitive exists, and inconsistent state-screen chrome.

## Changes

- **PipelineRunRow**: branch chip now uses the SessionsBoard chip classes (`max-w-branch-chip rounded-sm bg-accent/12`); the row overflow trigger composes `Button variant=ghost size=icon-sm` via `asChild` instead of a hand-styled trigger.
- **PipelineFilterBar**: filter menu triggers compose `Button variant=ghost size=sm` via `asChild` instead of hand-rolled chip classes with manual disabled styling.
- **PipelineProblemsPanel**: problem count is `Badge variant=error` instead of a bespoke pill span.
- **PipelineDefinitionsPage**: problems indicator is `Badge variant=error`; the empty state matches the ProjectBoardEmpty type scale (subtitle heading, muted relaxed body, decorative icon dropped); stray indentation fixed; delete button gets the same `size=sm` as its Edit sibling.
- **PipelineRunDetail**: loading/error states use the board's centered `py-10 text-xs` treatment; rail group labels use the app's mono uppercase eyebrow classes.
- **PipelineWorkbench**: error state aligned to the same treatment.

## Deliberately left alone

- The ten-outcome palette in `pipeline-display.ts` (already token classes, distinction preserved).
- `ViewToggle` and `StageInspector`'s `Segmented`: tests drive them via `role=radio`, and `ui/tabs` is unadopted anywhere in conforming code, so converting would change a11y roles for no conformance gain.
- Cross-file duplications (RailItem x2, zoom-toolbar shell, `Section`/`Warning`/`FieldLabel` helpers, `textareaClass`): deduping needs a new shared component, which the brief forbids.
- Destructive-button overrides (`text-error`/`text-destructive` on ghost/outline): `ui/button` has no destructive variant and adding one would touch shared ui.
- The EnvTextarea autocomplete, run-detail density, stage cards, KIND_BADGE glyphs: deliberate GitHub-Actions density per the brief.

## Verification

- `npm run typecheck` clean (no `build` script exists in frontend/package.json).
- `npm test`: 1595/1596 passed; the one failure was a 20s timeout in untouched `ConfirmDialog.test.tsx` during a heavily loaded full run, and it passes in isolation.
- No Go-generated surface touched, so `go build` not required.
- Previewed via `ao preview http://localhost:5174/pipelines`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)