### PR TITLE
feat(settings): gate the Pipelines section behind Developer Mode

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -27,8 +27,9 @@ place the two differ on purpose.
 Pipelines are off by default and experimental. There are two ways to turn them
 on: a persisted setting for normal use, and an env override for dev/CI.
 
-**Settings toggle (recommended).** In the desktop app open Global settings and
-flip **Pipelines** to enabled, then Save. The choice persists in the daemon's
+**Settings toggle (recommended).** In the desktop app open Global settings, turn
+**Developer Mode** on to reveal the **Pipelines** card, flip **Pipelines** to
+enabled, then Save. The choice persists in the daemon's
 own store (a `pipelines.enabled` row in the `app_settings` table under `~/.ao`),
 so it survives restarts and applies no matter who launches the daemon (the
 Electron supervisor or a headless `ao start`). Saving restarts the daemon so the
@@ -54,6 +55,17 @@ When pipelines are off (whichever source resolved it):
 
 The settings endpoint itself (`/api/v1/settings/pipelines`) is never gated by
 the flag, so the toggle is always reachable.
+
+**Developer Mode is a visibility gate, nothing more.** Developer Mode lives in
+the renderer's `localStorage` (`ao.developerMode`) and a headless daemon has no
+renderer, so it never decides whether engines start: `AO_PIPELINES`, then the
+persisted `pipelines.enabled` setting, remain the only sources of truth. Turning
+Developer Mode off with pipelines already enabled therefore changes nothing on
+the daemon: the engines keep running, the routes keep serving, and the sidebar's
+Pipelines entry stays. To avoid stranding that choice behind a hidden toggle,
+the Pipelines card stays visible while pipelines are enabled even with Developer
+Mode off, so it can always be turned back off (the same escape `UpdatesSection`
+keeps for a persisted feature-build pin).
 
 ```bash
 # dev/CI override; forces pipelines on regardless of the persisted setting

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -163,10 +163,40 @@ describe("GlobalSettingsForm", () => {
 		expect(screen.getByRole("button", { name: "Report a problem" })).toBeInTheDocument();
 	});
 
-	it("renders the Pipelines section inside the settings panel", async () => {
+	it("hides the Pipelines section when Developer Mode is off", async () => {
 		renderForm();
 		await screen.findByText("Updates");
-		expect(screen.getByText("Pipelines")).toBeInTheDocument();
+		expect(screen.queryByText("Pipelines")).not.toBeInTheDocument();
+	});
+
+	it("reveals the Pipelines section when Developer Mode is turned on", async () => {
+		renderForm();
+		await screen.findByText("Updates");
+		await userEvent.click(screen.getByRole("switch", { name: "Developer Mode" }));
+		expect(await screen.findByText("Pipelines")).toBeInTheDocument();
+		expect(screen.getByLabelText("Pipelines (experimental)")).toBeInTheDocument();
+	});
+
+	it("hides the Pipelines section again when Developer Mode is turned back off", async () => {
+		useUiStore.getState().setDeveloperMode(true);
+		renderForm();
+		expect(await screen.findByText("Pipelines")).toBeInTheDocument();
+		await userEvent.click(screen.getByRole("switch", { name: "Developer Mode" }));
+		await waitFor(() => expect(screen.queryByText("Pipelines")).not.toBeInTheDocument());
+	});
+
+	it("keeps the Pipelines section reachable with Developer Mode off once pipelines are enabled", async () => {
+		// The persisted daemon-side flag is on; Developer Mode is off (default).
+		// This is a visibility gate only, so the setting must be untouched and the
+		// card must stay reachable rather than stranding the user without a toggle.
+		getMock.mockResolvedValue({ data: { enabled: true }, error: undefined });
+		renderForm();
+		expect(await screen.findByText("Pipelines")).toBeInTheDocument();
+		expect(
+			screen.getByText(/Pipelines stay enabled while Developer Mode is off\./i),
+		).toBeInTheDocument();
+		expect(putMock).not.toHaveBeenCalled();
+		expect(daemonRestart).not.toHaveBeenCalled();
 	});
 
 	it("closes settings with Escape", async () => {

--- a/frontend/src/renderer/components/PipelinesSection.tsx
+++ b/frontend/src/renderer/components/PipelinesSection.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { aoBridge } from "../lib/bridge";
 import { pipelinesEnabledQueryKey } from "../hooks/usePipelinesEnabled";
 import { usePipelinesSetting, useSetPipelinesSetting } from "../hooks/usePipelinesSetting";
+import { useUiStore } from "../stores/ui-store";
 import { Button } from "./ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Label } from "./ui/label";
@@ -13,10 +14,17 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from ".
 // the daemon HTTP API. The flag only takes effect on daemon boot, so saving
 // restarts the daemon, then invalidates usePipelinesEnabled's capability probe
 // so the sidebar picks up the change without a manual app restart.
+//
+// The card is developer-only: it is hidden unless Developer Mode is on. That is
+// a visibility gate ONLY. Developer Mode lives in the renderer's localStorage
+// and a headless daemon has no renderer, so the daemon-side resolution
+// (AO_PIPELINES override, then the persisted `pipelines.enabled` setting) stays
+// the single source of truth for whether engines start.
 export function PipelinesSection() {
 	const queryClient = useQueryClient();
 	const setting = usePipelinesSetting();
 	const save = useSetPipelinesSetting();
+	const developerMode = useUiStore((state) => state.developerMode);
 
 	const [enabled, setEnabled] = useState(false);
 	const [savedAt, setSavedAt] = useState<number | null>(null);
@@ -27,6 +35,13 @@ export function PipelinesSection() {
 	useEffect(() => {
 		if (setting.enabled !== undefined) setEnabled(setting.enabled);
 	}, [setting.enabled]);
+
+	// Turning Developer Mode off never touches the persisted flag: engines keep
+	// running and the routes keep serving. To avoid stranding that choice behind
+	// a hidden toggle, the card stays visible while pipelines are enabled, the
+	// same way UpdatesSection still surfaces a Return action for a persisted
+	// feature pin with Developer Mode off.
+	if (!developerMode && !setting.enabled) return null;
 
 	const handleSave = () => {
 		setSavedAt(null);
@@ -50,6 +65,13 @@ export function PipelinesSection() {
 				<p className="text-xs leading-row text-passive">
 					Experimental. Toggling this restarts the AO daemon to apply the change.
 				</p>
+
+				{!developerMode && (
+					<p className="text-xs leading-row text-passive">
+						Pipelines stay enabled while Developer Mode is off. Disable them here, or turn Developer Mode
+						back on to keep this setting in view.
+					</p>
+				)}
 
 				<div className="flex flex-col gap-1.5">
 					<Label htmlFor="pipelinesEnabled" className="text-xs text-muted-foreground">


### PR DESCRIPTION
Closes Untrivial-ai/agent-orchestrator#3446.

Pipelines are experimental and off by default, but their settings card rendered for every user, right above the Developer Mode toggle. This hides it behind Developer Mode, the same opt-in that already guards the Feature Releases update channel.

## The design decision

**Developer Mode is a visibility gate only.** It lives in the renderer's `localStorage` (`ao.developerMode`) and a headless daemon has no renderer, so it never decides whether engines start. `AO_PIPELINES` (hard override) and then the persisted `pipelines.enabled` app_setting stay the single source of truth, unchanged. Nothing in `backend/` was touched.

**Stranded state: leave the daemon alone, keep an escape.** Turning Developer Mode off with pipelines enabled changes nothing daemon-side: engines keep running, routes keep serving, the sidebar entry stays. Force-disabling would mean a UI toggle silently restarts the daemon and tears down in-flight runs, which is the bigger hammer the issue warns about. To avoid stranding that choice behind a hidden toggle, the card stays visible while pipelines are enabled even with Developer Mode off, with a short note explaining it. That mirrors `UpdatesSection`, which still surfaces a Return action for a persisted feature-build pin when Developer Mode is off.

## Where the gate lives

Inside `PipelinesSection` rather than at the `GlobalSettingsForm.tsx:35` call site, for two reasons: it mirrors `UpdatesSection`, which reads `developerMode` itself, and the component already holds the `usePipelinesSetting()` query the escape case needs, so the parent would otherwise have to duplicate it.

## Tests

`GlobalSettingsForm.test.tsx` gets the same shape as the Feature Releases gating:

- hidden when Developer Mode is off (replaces the old unconditional render assertion)
- revealed when Developer Mode is turned on
- hidden again when Developer Mode is turned back off
- with `pipelines.enabled` true and Developer Mode off: card stays reachable, note shown, and no PUT to `/api/v1/settings/pipelines` and no daemon restart fire (proves it is a UI gate, not a functional one)

## Docs

`docs/pipelines.md` "Enabling the feature" now says the toggle is behind Developer Mode, and spells out the visibility-gate-only rule plus the stranded-state behaviour.

## Verification

- `npm run typecheck` clean (there is no `build` script in `frontend/`; `tsc --noEmit` is the equivalent gate)
- `npx vitest run src/renderer/components/GlobalSettingsForm.test.tsx`: 29/29 pass
- `npm test`: 1600 passed, 5 failed, all 5 in `src/landing/scripts/generate-markdown-twins.test.mjs`. **Pre-existing and unrelated:** that generator imports `cheerio`, which is not declared in `frontend/package.json` on this base branch (`git show origin/pipelines-upstream:frontend/package.json | grep -c cheerio` returns 0), so the spawned script dies with `ERR_MODULE_NOT_FOUND` on a clean checkout of the base. Introduced by #3395, not fixed here.